### PR TITLE
feat: Add optimized build profile and Debian packaging for ARMv6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,16 @@ members = ["server", "cli", "lib"]
 # Tauri build is deprecated, see
 # https://github.com/atomicdata-dev/atomic-server/issues/718
 exclude = ["desktop"]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = false
+
+[profile.dietpi]
+inherits = "release"
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true
+#panic = "abort"

--- a/Cross.toml
+++ b/Cross.toml
@@ -33,3 +33,18 @@ pre-build = [
   "apt-get update",
   "apt-get install --assume-yes nasm:$CROSS_DEB_ARCH",
 ]
+
+[target.arm-unknown-linux-gnueabihf]
+pre-build = [
+  # Update package list
+  "apt-get update",
+  # Upgrade installed packages
+  "apt-get upgrade --assume-yes",
+  "apt-get install --assume-yes nasm curl",
+  # Add NodeSource repository for Node.js 20
+  "curl -fsSL https://deb.nodesource.com/setup_20.x | bash",
+  "apt-get install --assume-yes nodejs",
+  # Install pnpm via npm
+  "npm install -g pnpm"
+]
+

--- a/Cross.toml
+++ b/Cross.toml
@@ -47,4 +47,3 @@ pre-build = [
   # Install pnpm via npm
   "npm install -g pnpm"
 ]
-

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 name = "atomic-cli"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
+homepage = "https://atomicserver.eu/"
 version = "0.40.0"
 
 [dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,9 +30,9 @@ default = ["native"]
 native = ["edit"]
 
 [package.metadata.deb]
+maintainer = "Joep Meindertsma <joep@ontola.io>"
+copyright = "2020-2025, Joep Meindertsma"
 extended-description = "Atomic CLI - A command-line interface for headless CMS and real-time databases."
-maintainer = "tomoyan <https://www.tomoyan.net/>"
-copyright = "2025, tomoyan"
 license-file = ["../LICENSE", "0"]
 depends = "$auto"
 section = "web"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,3 +28,15 @@ assert_cmd = "2"
 default = ["native"]
 # Non-wasi interface. These features cannot be compiled to WASI.
 native = ["edit"]
+
+[package.metadata.deb]
+extended-description = "Atomic CLI - A command-line interface for headless CMS and real-time databases."
+maintainer = "tomoyan <https://www.tomoyan.net/>"
+copyright = "2025, tomoyan"
+license-file = ["../LICENSE", "0"]
+depends = "$auto"
+section = "web"
+priority = "optional"
+assets = [
+    ["../target/arm-unknown-linux-gnueabihf/dietpi/atomic-cli", "/usr/bin/atomic-cli", "755"],
+]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,9 +11,6 @@ readme = "./README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
 version = "0.40.2"
 
-[profile.release]
-lto = true
-
 [[bin]]
 name = "atomic-server"
 path = "src/bin.rs"
@@ -150,3 +147,19 @@ https = ["rustls", "instant-acme", "rcgen", "rustls-pemfile"]
 [lib]
 name = "atomic_server_lib"
 path = "src/lib.rs"
+
+[package.metadata.deb]
+extended-description = "Atomic Server - Headless CMS and real-time database."
+maintainer = "tomoyan <https://www.tomoyan.net/>"
+copyright = "2025, tomoyan"
+license-file = ["../LICENSE", "0"]
+depends = "$auto"
+section = "web"
+priority = "optional"
+maintainer-scripts = "debian/"
+assets = [
+    ["../target/arm-unknown-linux-gnueabihf/dietpi/atomic-server", "/usr/bin/atomic-server", "755"],
+    ["debian/atomic-server.service", "/lib/systemd/system/atomic-server.service", "644"],
+    ["debian/atomic-server.env", "/etc/atomic-server/atomic-server.env", "640"],
+]
+conf-files = ["/etc/atomic-server/atomic-server.env"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -149,9 +149,9 @@ name = "atomic_server_lib"
 path = "src/lib.rs"
 
 [package.metadata.deb]
+maintainer = "Joep Meindertsma <joep@ontola.io>"
+copyright = "2020-2025, Joep Meindertsma"
 extended-description = "Atomic Server - Headless CMS and real-time database."
-maintainer = "tomoyan <https://www.tomoyan.net/>"
-copyright = "2025, tomoyan"
 license-file = ["../LICENSE", "0"]
 depends = "$auto"
 section = "web"

--- a/server/debian/atomic-server.env
+++ b/server/debian/atomic-server.env
@@ -1,0 +1,63 @@
+# Recreates the `/setup` Invite for creating a new Root User.
+# Also re-runs various populate commands, and re-builds the index
+#ATOMIC_INITIALIZE=true
+
+# Re-builds the indexes. Parses all the resources.
+# Do this when updating requires it, or if you have issues with Collections / Queries / Search.
+#ATOMIC_REBUILD_INDEX=true
+
+# Use staging environments for services like LetsEncrypt
+#ATOMIC_DEVELOPMENT=true
+
+# The origin domain where the app is hosted, without the port and schema values.
+ATOMIC_DOMAIN=localhost
+
+# 9.883 is decimal for the `⚛` character.
+# The port where the HTTP app is available. Set to 80 if you want this to be available on the network.
+#ATOMIC_PORT=9883
+
+# The port where the HTTPS app is available. Set to 443 if you want this to be available on the network.
+#ATOMIC_PORT_HTTPS=9884
+
+# The IP address of the server. Set to :: if you want this to be available to other devices on your network.
+#ATOMIC_IP=::
+
+# Use HTTPS instead of HTTP.
+# Will get certificates from LetsEncrypt fully automated.
+#ATOMIC_HTTPS=true
+
+# Initializes DNS-01 challenge for LetsEncrypt. Use this if you want to use subdomains.
+#ATOMIC_HTTPS_DNS=true
+
+# The contact mail address for Let's Encrypt HTTPS setup
+#ATOMIC_EMAIL=domain-admin@atomicserver.eu
+
+# Custom JS script to include in the body of the HTML template
+#ATOMIC_SCRIPT=
+
+# Path for atomic data config directory. Defaults to "~/.config/atomic/""
+ATOMIC_CONFIG_DIR=/etc/atomic-server
+
+# Path for atomic data store folder. Contains your Store, uploaded files and more. Default value depends on your OS.
+ATOMIC_DATA_DIR=/var/lib/atomic-server/data
+
+# Path for the atomic data cache folder. Contains search index, temp files and more. Default value depends on your OS.
+ATOMIC_CACHE_DIR=/var/cache/atomic-server
+
+# CAUTION: Skip authentication checks, making all data publicly readable. Improves performance.
+#ATOMIC_PUBLIC_MODE=false
+
+# The full URL of the server. It should resolve to the home page.
+# Set this if you use an external server or tunnel, instead of directly exposing atomic-server.
+# If you leave this out, it will be generated from `domain`, `port` and `http` / `https`.
+#ATOMIC_SERVER_URL=http://localhost:9883
+
+# How much logs you want. Also influences what is sent to your trace service, if you've set one (e.g. OpenTelemetry)
+#RUST_LOG=info
+
+# How you want to trace what's going on with the server. Useful for monitoring performance and errors in production.
+# Combine with `log_level` to get more or less data (`trace` is the most verbose)
+#ATOMIC_TRACING=stdout
+
+# Introduces random delays in the server, to simulate a slow connection. Useful for testing.
+#ATOMIC_SLOW_MODE=false

--- a/server/debian/atomic-server.service
+++ b/server/debian/atomic-server.service
@@ -9,16 +9,16 @@ Type=simple
 User=atomic-server
 Group=atomic-server
 
-# systemdにディレクトリ作成を依頼
+# Request systemd to manage these directories
 ConfigurationDirectory=atomic-server
 StateDirectory=atomic-server
 CacheDirectory=atomic-server
 
-# 環境変数の指定
+# Environment variables
 Environment=ATOMIC_CONFIG_DIR=/etc/atomic-server
 Environment=ATOMIC_DATA_DIR=/var/lib/atomic-server/data
 Environment=ATOMIC_PORT=9883
-# 必要に応じてドメインやIPを指定
+# Use system hostname as the domain by default
 Environment=ATOMIC_DOMAIN=%H
 
 ExecStart=/usr/bin/atomic-server

--- a/server/debian/atomic-server.service
+++ b/server/debian/atomic-server.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Atomic Server
+Documentation=https://docs.atomicdata.dev
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=atomic-server
+Group=atomic-server
+
+# systemdにディレクトリ作成を依頼
+ConfigurationDirectory=atomic-server
+StateDirectory=atomic-server
+CacheDirectory=atomic-server
+
+# 環境変数の指定
+Environment=ATOMIC_CONFIG_DIR=/etc/atomic-server
+Environment=ATOMIC_DATA_DIR=/var/lib/atomic-server/data
+Environment=ATOMIC_PORT=9883
+# 必要に応じてドメインやIPを指定
+Environment=ATOMIC_DOMAIN=%H
+
+ExecStart=/usr/bin/atomic-server
+WorkingDirectory=/etc/atomic-server/
+EnvironmentFile=/etc/atomic-server/atomic-server.env
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/server/debian/atomic-server.service
+++ b/server/debian/atomic-server.service
@@ -14,13 +14,6 @@ ConfigurationDirectory=atomic-server
 StateDirectory=atomic-server
 CacheDirectory=atomic-server
 
-# Environment variables
-Environment=ATOMIC_CONFIG_DIR=/etc/atomic-server
-Environment=ATOMIC_DATA_DIR=/var/lib/atomic-server/data
-Environment=ATOMIC_PORT=9883
-# Use system hostname as the domain by default
-Environment=ATOMIC_DOMAIN=%H
-
 ExecStart=/usr/bin/atomic-server
 WorkingDirectory=/etc/atomic-server/
 EnvironmentFile=/etc/atomic-server/atomic-server.env

--- a/server/debian/postinst
+++ b/server/debian/postinst
@@ -1,20 +1,20 @@
 #!/bin/sh
 set -e
 
-# $1 が "configure" の時のみ実行（インストール・アップグレード時）
+# Only execute during the 'configure' phase (install and upgrade)
 if [ "$1" = "configure" ]; then
-    # ユーザーが存在しない場合に作成
+    # Create the system user if it doesn't exist
     if ! getent passwd atomic-server > /dev/null; then
         echo "Creating atomic-server system user..."
         adduser --system --group --no-create-home --home /var/lib/atomic-server --shell /usr/sbin/nologin atomic-server
     fi
 
-    # ディレクトリの所有権を確実に変更
-    # (systemdのStateDirectory等で作成されたディレクトリも含む)
+    # Ensure correct ownership for directories
+    # (Including those managed by systemd's StateDirectory etc.)
     chown -R atomic-server:atomic-server /var/lib/atomic-server || true
     chown -R atomic-server:atomic-server /etc/atomic-server || true
 
-    # .env内の localhost を実際のホスト名に置換
+    # Replace 'localhost' with the actual system hostname in the .env file
     if [ -f /etc/atomic-server/atomic-server.env ]; then
         HOSTNAME=$(hostname)
         sed -i "s/ATOMIC_DOMAIN=localhost/ATOMIC_DOMAIN=$HOSTNAME/g" /etc/atomic-server/atomic-server.env

--- a/server/debian/postinst
+++ b/server/debian/postinst
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# $1 が "configure" の時のみ実行（インストール・アップグレード時）
+if [ "$1" = "configure" ]; then
+    # ユーザーが存在しない場合に作成
+    if ! getent passwd atomic-server > /dev/null; then
+        echo "Creating atomic-server system user..."
+        adduser --system --group --no-create-home --home /var/lib/atomic-server --shell /usr/sbin/nologin atomic-server
+    fi
+
+    # ディレクトリの所有権を確実に変更
+    # (systemdのStateDirectory等で作成されたディレクトリも含む)
+    chown -R atomic-server:atomic-server /var/lib/atomic-server || true
+    chown -R atomic-server:atomic-server /etc/atomic-server || true
+
+    # .env内の localhost を実際のホスト名に置換
+    if [ -f /etc/atomic-server/atomic-server.env ]; then
+        HOSTNAME=$(hostname)
+        sed -i "s/ATOMIC_DOMAIN=localhost/ATOMIC_DOMAIN=$HOSTNAME/g" /etc/atomic-server/atomic-server.env
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
This PR introduces a dedicated build profile and Debian packaging setup to support low-resource devices, specifically tested on Raspberry Pi Zero WH (ARMv6).

### Key Changes
- **New Cargo Profile (`dietpi`)**: Optimized for binary size (`opt-level = 'z'`, `LTO`, `strip = true`). Reduces the server binary size from ~66MB to ~45MB (-31%).
- **Debian Packaging**: Added `package.metadata.deb` configuration for both `atomic-server` and `atomic-cli`.
- **Cross-build Support**: Updated Cross.toml for Node.js/pnpm environments.
- **Systemd Integration**: Included a service unit and an environment file (`/etc/atomic-server/atomic-server.env`) for professional service management.
- **Security**: The server now runs under a dedicated `atomic-server` system user (created via `postinst`).
- **Dynamic Configuration**: The `postinst` script automatically sets `ATOMIC_DOMAIN` to the system's hostname upon installation.

### Motivation
Standard release builds are somewhat heavy for older SBCs with limited RAM (e.g., 512MB). This PR makes Atomic Data more accessible for edge computing and lightweight server use cases.
Related to #151.

Verified on: Fedora 42 (Cross-build) -> DietPi (Raspberry Pi Zero WH)
The instructions are written in Japanese, but more detailed information is available on the following website, so please refer to it if you wish.
https://www.tomoyan.net/rust/cross-compilation_for_dietpi