### PR TITLE
Fix typos: `exsisting` and `implmenentations`

### DIFF
--- a/browser/data-browser/about.md
+++ b/browser/data-browser/about.md
@@ -32,5 +32,5 @@ The easiest way to run an [atomic-server](https://github.com/atomicdata-dev/atom
 Join the community
 ------------------
 
-Atomic Data is open and fully powered by volunteers. We're looking for people who want to help discuss various design challenges and work on implmenentations. If you have any questions, or want to help out, feel free to join our [Discord](https://discord.gg/a72Rv2P).
+Atomic Data is open and fully powered by volunteers. We're looking for people who want to help discuss various design challenges and work on implementations. If you have any questions, or want to help out, feel free to join our [Discord](https://discord.gg/a72Rv2P).
 Sign up to [our newsletter](https://docs.atomicdata.dev/newsletter.html) if you'd like to get updated.

--- a/docs/src/create-json-ad.md
+++ b/docs/src/create-json-ad.md
@@ -53,7 +53,7 @@ Adding a Class helps people to understand the data, and it can provide guarantee
 We can also use Classes to render Forms, which can be useful when the data should be edited later.
 For example, the BlogPost item
 
-## Using exsisting Ontologies, Classes and Ontologies
+## Using existing Ontologies, Classes and Ontologies
 
 Ontologies are groups of concepts that describe some domain.
 For example, we could have an Ontology for Blogs that links to a bunch of related _Classes_, such as BlogPost and Person.


### PR DESCRIPTION
Fixes 2 typos:
- `docs/src/create-json-ad.md:56` heading: `Using exsisting Ontologies` -> `Using existing Ontologies`
- `browser/data-browser/about.md:35`: `work on implmenentations` -> `work on implementations`