### PR TITLE
Set up Cursor Cloud dev environment (docs + notes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,3 +232,62 @@ cd browser/lib && pnpm test                      # 29 JS tests
 cd browser && pnpm run -r build                  # Full workspace build
 cd browser && pnpm run test-e2e                  # Full e2e test
 ```
+
+## Cursor Cloud specific instructions
+
+The startup update script only runs `pnpm install` (in `browser/`). Everything below is
+already handled in the VM snapshot; these notes capture the non-obvious gotchas for
+building/running the stack again after pulling changes.
+
+### Run the server on port 9885 (not the default 9883)
+
+The frontend's `browser/data-browser/.env.development` and the Vite proxy both point at
+`http://localhost:9885`, but `atomic-server` defaults to `9883`. For a standalone dev
+setup the two MUST be aligned, so start the server on 9885:
+
+```
+/workspace/target/debug/atomic-server --port 9885            # subsequent runs
+/workspace/target/debug/atomic-server --port 9885 --initialize   # first run / to reset the /setup invite
+```
+
+If they disagree, the app silently repoints drives to a server that isn't listening and
+auth/drive resolution fails. Then open `http://localhost:6747/app/dev-drive` for a clean
+authenticated agent + drive.
+
+### pnpm scripts need bash (`build:wasm` breaks under dash)
+
+`data-browser`'s `build:wasm` uses `CARGO_ENCODED_RUSTFLAGS=$'--cfg\x1f...'` (bash ANSI-C
+quoting). The VM's `/bin/sh` is `dash`, which doesn't understand `$'...'`, so pnpm scripts
+must run under bash. This is configured once (persisted in `~/.config/pnpm/rc`):
+
+```
+pnpm config set script-shell /usr/bin/bash
+```
+
+If `pnpm build:wasm` ever fails with `error: multiple input filenames provided (... $--cfg\x1f...)`,
+re-run that config command.
+
+### WASM build is required before the frontend works
+
+`browser/data-browser/public/wasm/{atomic_wasm.js,atomic_wasm_bg.wasm}` are git-ignored and
+must be generated (needs the `wasm32-unknown-unknown` target, already installed):
+
+```
+pnpm --filter @tomic/data-browser build:wasm
+```
+
+Only re-run this when the `wasm/` or `lib/` Rust changes; it is not part of `pnpm start`.
+
+### Running the frontend
+
+`cd browser && pnpm start` runs `@tomic/lib` + `@tomic/react` (tsup watch) and the Vite dev
+server (`:6747`) together. During `vite dev` you'll see `Compilation failed: <file>` lines
+from `babel-plugin-react-compiler` — these are non-fatal (the compiler skips auto-memoizing
+files with try/catch); the app still serves and HMRs normally.
+
+### Services summary
+
+| Service | Dir | Dev command | Port |
+| --- | --- | --- | --- |
+| AtomicServer (Rust: HTTP/WS, redb, tantivy, Loro sync) | `server/` | `cargo run -- --port 9885` | 9885 |
+| Frontend (Vite) + `@tomic/lib`/`@tomic/react` watch | `browser/` | `pnpm start` | 6747 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

N/A — sets up and documents the Cursor Cloud development environment for this repo.

## What this does

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the non-obvious gotchas discovered while bringing the full stack up in a fresh cloud VM. No application code was changed.

Key learnings documented:
- **Port alignment:** the frontend (`.env.development` + Vite proxy) targets `http://localhost:9885`, but `atomic-server` defaults to `9883`. Run the server with `--port 9885` for a standalone dev setup, otherwise drive/auth resolution silently fails.
- **pnpm needs bash:** `data-browser`'s `build:wasm` uses bash ANSI-C quoting (`$'\x1f'`), which the VM's `/bin/sh` (dash) can't parse. Fixed once with `pnpm config set script-shell /usr/bin/bash` (persisted in `~/.config/pnpm/rc`).
- **WASM build step:** `pnpm --filter @tomic/data-browser build:wasm` generates the git-ignored `browser/data-browser/public/wasm/*`, required before the frontend works (needs the `wasm32-unknown-unknown` target).
- React Compiler `Compilation failed: <file>` logs during `vite dev` are non-fatal.
- Services summary table (server on 9885, frontend on 6747).

The startup update script is set to a minimal `pnpm install` (in `browser/`); the WASM build, Rust build, and toolchain targets are captured in the VM snapshot.

## Verification

Brought the stack up end to end in the cloud VM:
- Built `atomic-wasm`, `@tomic/lib`, `@tomic/react`, and the Rust `atomic-server` binary.
- Ran `atomic-server --port 9885` and the Vite dev server on `:6747`.
- Created a "Hello World" document in the app; the server logged the incoming CRDT commit and `INDEXING title="Hello World"`, confirming the client → commit → server → search-index flow.
- `cargo test -p atomic_lib --no-default-features` → 190 passed, 4 ignored (+2 doctests).
- `cd browser/lib && pnpm test` → 187 passed.
- `pnpm --filter @tomic/data-browser lint` → passes (warnings only, formatting clean).

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [x] Update docs if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

