### PR TITLE
Multi-select rows with bulk delete and set-property actions in Table

### DIFF
--- a/browser/data-browser/src/chunks/TableEditor/Cell.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/Cell.tsx
@@ -45,6 +45,9 @@ export interface CellProps {
 
 interface IndexCellProps extends CellProps {
   onExpand: (rowIndex: number) => void;
+  /** Optional selection control (a checkbox) shown to the left of the
+   * open-resource button. Rendered by the table when bulk selection is on. */
+  selector?: React.ReactNode;
 }
 
 export function Cell({
@@ -283,6 +286,7 @@ export function Cell({
 export function IndexCell({
   children,
   onExpand,
+  selector,
   ...props
 }: React.PropsWithChildren<IndexCellProps>): JSX.Element {
   const { markings } = useTableEditorContext();
@@ -290,7 +294,13 @@ export function IndexCell({
   const marking = markings.get(props.rowIndex);
 
   return (
-    <StyledIndexCell role='rowheader' {...props} hasMarking={!!marking}>
+    <StyledIndexCell
+      role='rowheader'
+      {...props}
+      hasMarking={!!marking}
+      hasSelector={!!selector}
+    >
+      {selector && <SelectorSlot>{selector}</SelectorSlot>}
       <IconButton
         title='Open resource'
         onClick={() => onExpand(props.rowIndex)}
@@ -304,12 +314,39 @@ export function IndexCell({
 
 const IndexNumber = styled.span``;
 
-const StyledIndexCell = styled(Cell)<{ hasMarking: boolean }>`
+/** Wraps the selection checkbox. Clicks here toggle the row, and must not
+ * bubble to the cell's mouse handlers (which would start a cell selection). */
+const SelectorSlot = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIndexCell = styled(Cell)<{
+  hasMarking: boolean;
+  hasSelector: boolean;
+}>`
   justify-content: flex-end !important;
+  gap: 0.35rem;
   color: ${p => p.theme.colors.textLight};
 
   & button {
     display: none;
+  }
+
+  /* The checkbox is hidden at rest, but stays visible once its row is checked
+   * (via :has) or while the row is hovered/focused, so a selection is always
+   * legible without cluttering every idle row. */
+  & ${SelectorSlot} {
+    display: none;
+  }
+
+  &:hover
+    ${SelectorSlot},
+    &:focus-within
+    ${SelectorSlot},
+    &:has(input:checked)
+    ${SelectorSlot} {
+    display: flex;
   }
 
   &:hover ${IndexNumber}, &:focus-within ${IndexNumber} {

--- a/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
@@ -80,6 +80,12 @@ interface FancyTableProps<T> {
    * about how many cells a row has.
    */
   FooterComponent?: React.ComponentType<{ columns: T[] }>;
+  /** Renders the per-row selection control (a checkbox) inside the index
+   * column. When provided, the index column widens to fit it and the grid is
+   * treated as selectable. */
+  renderRowSelector?: (rowIndex: number) => React.ReactNode;
+  /** Select-all control shown in the index column header. */
+  headerSelector?: React.ReactNode;
   ref?: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -126,6 +132,8 @@ function FancyTableInner<T>({
   HeadingComponent,
   NewColumnButtonComponent,
   FooterComponent,
+  renderRowSelector,
+  headerSelector,
 }: FancyTableProps<T>): JSX.Element {
   const ariaUsageId = useId();
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -148,6 +156,7 @@ function FancyTableInner<T>({
     columnSizes,
     columns,
     onCellResize,
+    !!renderRowSelector,
   );
 
   const handleClickOutside = useCallback(() => {
@@ -251,7 +260,12 @@ function FancyTableInner<T>({
           role='row'
           aria-rowindex={index + 2}
         >
-          <IndexCell rowIndex={index} columnIndex={0} onExpand={onRowExpand}>
+          <IndexCell
+            rowIndex={index}
+            columnIndex={0}
+            onExpand={onRowExpand}
+            selector={renderRowSelector?.(index)}
+          >
             {index + 1}
           </IndexCell>
           {children({ index })}
@@ -259,7 +273,7 @@ function FancyTableInner<T>({
         </TableRow>
       );
     },
-    [children, onRowExpand],
+    [children, onRowExpand, renderRowSelector],
   );
 
   const rowProps = useMemo(() => ({}), []);
@@ -336,6 +350,7 @@ function FancyTableInner<T>({
               onColumnReorder={onColumnReorder}
               HeadingComponent={HeadingComponent}
               NewColumnButtonComponent={NewColumnButtonComponent}
+              headerSelector={headerSelector}
             />
             <AutoSizeTamer role='rowgroup'>
               <AutoSizer renderProp={renderList} />

--- a/browser/data-browser/src/chunks/TableEditor/TableHeader.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/TableHeader.tsx
@@ -36,6 +36,9 @@ export interface TableHeaderProps<T> {
   HeadingComponent: TableHeadingComponent<T>;
   NewColumnButtonComponent: React.ComponentType;
   headerRef: React.Ref<HTMLDivElement>;
+  /** Optional control (a select-all checkbox) shown in the index column
+   * header instead of the `#` label. */
+  headerSelector?: React.ReactNode;
 }
 
 /** The entire first row of an Editable Table. */
@@ -47,6 +50,7 @@ export function TableHeader<T>({
   HeadingComponent,
   NewColumnButtonComponent,
   headerRef,
+  headerSelector,
 }: TableHeaderProps<T>): JSX.Element {
   const [activeIndex, setActiveIndex] = useState<number | undefined>();
 
@@ -96,7 +100,7 @@ export function TableHeader<T>({
     <div role='rowgroup'>
       <StyledTableRow ref={headerRef} aria-rowindex={1}>
         <TableHeadingWrapper align='end' aria-colindex={1} role='columnheader'>
-          #
+          {headerSelector ?? '#'}
         </TableHeadingWrapper>
         {columns.map((column, index) => (
           <TableHeading

--- a/browser/data-browser/src/chunks/TableEditor/hooks/useCellSizes.ts
+++ b/browser/data-browser/src/chunks/TableEditor/hooks/useCellSizes.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 
 const INDEX_CELL_WIDTH = '6ch';
+/** Wider first track when the index column also holds a selection checkbox
+ * (checkbox + the open-resource button need to sit side by side). */
+const SELECTABLE_INDEX_CELL_WIDTH = '4.5rem';
 
 const parseSize = (size: string) => {
   try {
@@ -21,6 +24,9 @@ export function useCellSizes<T>(
   externalSizes: number[] | undefined,
   columns: T[],
   onSizesChange: (sizes: number[]) => void,
+  /** Widen the index column to fit a row-selection checkbox next to the
+   * open-resource button. */
+  selectable = false,
 ) {
   // CSS values for column sizes
   const [sizes, setSizes] = useState<string[]>(
@@ -87,10 +93,14 @@ export function useCellSizes<T>(
         ? toPixels(externalSizes)
         : Array(columns.length).fill(DEFAULT_SIZE_STR);
 
-  const templateColumns = `${INDEX_CELL_WIDTH} ${effectiveSizes.join(
+  const indexCellWidth = selectable
+    ? SELECTABLE_INDEX_CELL_WIDTH
+    : INDEX_CELL_WIDTH;
+
+  const templateColumns = `${indexCellWidth} ${effectiveSizes.join(
     ' ',
   )} minmax(50px, 1fr)`;
-  const contentRowWidth = `calc(${INDEX_CELL_WIDTH} + ${effectiveSizes.join(
+  const contentRowWidth = `calc(${indexCellWidth} + ${effectiveSizes.join(
     ' + ',
   )})`;
 

--- a/browser/data-browser/src/chunks/TablePage/RowSelectCheckbox.tsx
+++ b/browser/data-browser/src/chunks/TablePage/RowSelectCheckbox.tsx
@@ -36,6 +36,7 @@ export function RowSelectCheckbox({
     <Checkbox
       title='Select row'
       aria-label='Select row'
+      data-testid='row-select-checkbox'
       checked={isSelected(subject)}
       onChange={() => onToggle(subject)}
       // Keep the click from reaching the cell, which would otherwise start a

--- a/browser/data-browser/src/chunks/TablePage/RowSelectCheckbox.tsx
+++ b/browser/data-browser/src/chunks/TablePage/RowSelectCheckbox.tsx
@@ -1,0 +1,47 @@
+import {
+  Collection,
+  unknownSubject,
+  useMemberFromCollection,
+} from '@tomic/react';
+import { type JSX } from 'react';
+import { Checkbox } from '@components/forms/Checkbox';
+
+interface RowSelectCheckboxProps {
+  collection: Collection;
+  index: number;
+  isSelected: (subject: string) => boolean;
+  onToggle: (subject: string) => void;
+}
+
+/**
+ * The per-row selection checkbox shown in the index column. Resolves its own
+ * subject from the collection (indices are all the grid hands down) so the
+ * checkbox reflects and toggles selection by stable subject.
+ */
+export function RowSelectCheckbox({
+  collection,
+  index,
+  isSelected,
+  onToggle,
+}: RowSelectCheckboxProps): JSX.Element | null {
+  const resource = useMemberFromCollection(collection, index);
+  const subject = resource.subject;
+
+  // Until the row's subject resolves there's nothing to select.
+  if (subject === unknownSubject) {
+    return null;
+  }
+
+  return (
+    <Checkbox
+      title='Select row'
+      aria-label='Select row'
+      checked={isSelected(subject)}
+      onChange={() => onToggle(subject)}
+      // Keep the click from reaching the cell, which would otherwise start a
+      // cell selection / active-cell move.
+      onMouseDown={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    />
+  );
+}

--- a/browser/data-browser/src/chunks/TablePage/TableBulkActionsBar.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableBulkActionsBar.tsx
@@ -1,0 +1,115 @@
+import { JSONValue, Property } from '@tomic/react';
+import { useState, type JSX } from 'react';
+import { styled } from 'styled-components';
+import { FaPen, FaTrash, FaXmark } from 'react-icons/fa6';
+import { Button } from '@components/Button';
+import {
+  ConfirmationDialog,
+  ConfirmationDialogTheme,
+} from '@components/ConfirmationDialog';
+import { TableSetPropertyDialog } from './TableSetPropertyDialog';
+
+interface TableBulkActionsBarProps {
+  count: number;
+  /** Properties (columns) that can be bulk-set. */
+  properties: Property[];
+  onSetProperty: (
+    propertySubject: string,
+    value: JSONValue | undefined,
+  ) => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+
+/**
+ * Appears above the grid whenever one or more rows are selected. Offers the
+ * bulk actions — set a property on every selected row, or delete them all —
+ * plus a way to clear the selection.
+ */
+export function TableBulkActionsBar({
+  count,
+  properties,
+  onSetProperty,
+  onDelete,
+  onClear,
+}: TableBulkActionsBarProps): JSX.Element | null {
+  const [showSetProperty, setShowSetProperty] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <Bar role='toolbar' aria-label='Bulk actions'>
+      <Count>
+        {count} {count === 1 ? 'row' : 'rows'} selected
+      </Count>
+      <Button
+        subtle
+        onClick={() => setShowSetProperty(true)}
+        disabled={properties.length === 0}
+        title={
+          properties.length === 0
+            ? 'No columns available to set'
+            : 'Set a property on all selected rows'
+        }
+      >
+        <FaPen /> Set property
+      </Button>
+      <Button
+        alert
+        onClick={() => setShowDeleteConfirm(true)}
+        title='Delete all selected rows'
+      >
+        <FaTrash /> Delete
+      </Button>
+      <Spacer />
+      <Button subtle onClick={onClear} title='Clear selection'>
+        <FaXmark /> Clear
+      </Button>
+
+      <TableSetPropertyDialog
+        properties={properties}
+        count={count}
+        show={showSetProperty}
+        bindShow={setShowSetProperty}
+        onApply={onSetProperty}
+      />
+      <ConfirmationDialog
+        title={`Delete ${count} ${count === 1 ? 'row' : 'rows'}?`}
+        confirmLabel='Delete'
+        theme={ConfirmationDialogTheme.Alert}
+        show={showDeleteConfirm}
+        bindShow={setShowDeleteConfirm}
+        onConfirm={onDelete}
+      >
+        <p>
+          This permanently deletes the {count} selected{' '}
+          {count === 1 ? 'row' : 'rows'}. This cannot be undone from here.
+        </p>
+      </ConfirmationDialog>
+    </Bar>
+  );
+}
+
+const Bar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: ${p => p.theme.radius};
+  background-color: ${p => p.theme.colors.bg1};
+  border: 1px solid ${p => p.theme.colors.bg2};
+`;
+
+const Count = styled.span`
+  font-weight: bold;
+  margin-right: 0.5rem;
+`;
+
+const Spacer = styled.span`
+  flex: 1;
+`;

--- a/browser/data-browser/src/chunks/TablePage/TableBulkActionsBar.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableBulkActionsBar.tsx
@@ -41,14 +41,15 @@ export function TableBulkActionsBar({
   }
 
   return (
-    <Bar role='toolbar' aria-label='Bulk actions'>
-      <Count>
+    <Bar role='toolbar' aria-label='Bulk actions' data-testid='table-bulk-actions'>
+      <Count data-testid='bulk-selected-count'>
         {count} {count === 1 ? 'row' : 'rows'} selected
       </Count>
       <Button
         subtle
         onClick={() => setShowSetProperty(true)}
         disabled={properties.length === 0}
+        data-testid='bulk-set-property-button'
         title={
           properties.length === 0
             ? 'No columns available to set'
@@ -60,12 +61,18 @@ export function TableBulkActionsBar({
       <Button
         alert
         onClick={() => setShowDeleteConfirm(true)}
+        data-testid='bulk-delete-button'
         title='Delete all selected rows'
       >
         <FaTrash /> Delete
       </Button>
       <Spacer />
-      <Button subtle onClick={onClear} title='Clear selection'>
+      <Button
+        subtle
+        onClick={onClear}
+        data-testid='bulk-clear-button'
+        title='Clear selection'
+      >
         <FaXmark /> Clear
       </Button>
 

--- a/browser/data-browser/src/chunks/TablePage/TableResource.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableResource.tsx
@@ -7,6 +7,7 @@ import {
   useStore,
   type DataBrowser,
   type ExpressionFilter,
+  type JSONValue,
   type Property,
   type PropVal,
   type Resource,
@@ -21,6 +22,8 @@ import { useHandlePaste } from '@chunks/TablePage/helpers/useHandlePaste';
 import {
   useTableHistory,
   createResourceDeletedHistoryItem,
+  createValueChangedHistoryItem,
+  type HistoryItemBatch,
 } from '@chunks/TablePage/helpers/useTableHistory';
 import {
   TablePageContext,
@@ -62,6 +65,10 @@ import { toAggregation } from './tableAggregates';
 import { stringToSlug } from '@helpers/stringToSlug';
 import { orderColumns, reorderColumnKeys } from './columnOrder';
 import { TableSummaryBar } from './TableSummaryBar';
+import { useRowSelection } from './useRowSelection';
+import { RowSelectCheckbox } from './RowSelectCheckbox';
+import { TableBulkActionsBar } from './TableBulkActionsBar';
+import { Checkbox } from '@components/forms/Checkbox';
 import type { GroupGranularity } from './tableAggregates';
 import type { AggregateTarget } from './tablePageContext';
 import type { DerivedColumnSpec } from './derivedColumns';
@@ -931,6 +938,96 @@ export const TableResource: React.FC<TableResourceProps> = ({
     ],
   );
 
+  // Bulk row selection (by subject, so it survives sort/filter/paging).
+  const selection = useRowSelection(collection);
+  const { clear: clearSelection, deselect: deselectRow } = selection;
+
+  // A filter/sort/view change rebuilds the row set; a selection made against
+  // the old one no longer means anything, so drop it.
+  useEffect(() => {
+    clearSelection();
+  }, [queryKey, clearSelection]);
+
+  const handleBulkDelete = useCallback(async () => {
+    const subjects = selection.selectedList.filter(s => !s.startsWith('_new:'));
+
+    if (subjects.length === 0) {
+      return;
+    }
+
+    const batch: HistoryItemBatch = [];
+    let failures = 0;
+
+    for (const subject of subjects) {
+      try {
+        const rowResource = store.getResourceLoading(subject);
+        batch.push(createResourceDeletedHistoryItem(rowResource));
+        await rowResource.destroy();
+        decrementMemberCount();
+      } catch (e) {
+        failures++;
+        console.error('Failed to delete row', subject, e);
+      }
+    }
+
+    addItemsToHistoryStack(batch);
+    clearSelection();
+
+    if (failures > 0) {
+      toast.error(`Failed to delete ${failures} of ${subjects.length} rows`);
+    } else {
+      toast.success(
+        `Deleted ${subjects.length} ${subjects.length === 1 ? 'row' : 'rows'}`,
+      );
+    }
+  }, [
+    selection.selectedList,
+    store,
+    addItemsToHistoryStack,
+    decrementMemberCount,
+    clearSelection,
+  ]);
+
+  const handleBulkSetProperty = useCallback(
+    async (propertySubject: string, value: JSONValue | undefined) => {
+      const subjects = selection.selectedList.filter(
+        s => !s.startsWith('_new:'),
+      );
+
+      if (subjects.length === 0) {
+        return;
+      }
+
+      const batch: HistoryItemBatch = [];
+      let failures = 0;
+
+      // Sequential: keeps a burst of commits off the shared server, and mirrors
+      // how the clear-cells helper writes.
+      for (const subject of subjects) {
+        try {
+          const res = await store.getResource(subject);
+          batch.push(createValueChangedHistoryItem(res, propertySubject));
+          await res.set(propertySubject, value, true);
+          await res.save();
+        } catch (e) {
+          failures++;
+          console.error('Failed to set property on row', subject, e);
+        }
+      }
+
+      addItemsToHistoryStack(batch);
+
+      if (failures > 0) {
+        toast.error(`Failed to update ${failures} of ${subjects.length} rows`);
+      } else {
+        toast.success(
+          `Updated ${subjects.length} ${subjects.length === 1 ? 'row' : 'rows'}`,
+        );
+      }
+    },
+    [selection.selectedList, store, addItemsToHistoryStack],
+  );
+
   const handleDeleteRow = useCallback(
     async (index: number) => {
       // Resolve the row by the SAME index→row mapping the grid renders with:
@@ -946,6 +1043,9 @@ export const TableResource: React.FC<TableResourceProps> = ({
       if (!subject) {
         return;
       }
+
+      // Keep a deleted row from lingering in the selection set.
+      deselectRow(subject);
 
       // Drop a session row from the render list immediately (optimistic).
       if (!isMember) {
@@ -1057,6 +1157,42 @@ export const TableResource: React.FC<TableResourceProps> = ({
     ],
   );
 
+  // Selection controls are writer-only: selecting rows to bulk-edit or delete
+  // is pointless without the rights to do either.
+  const { isSelected, toggle: toggleSelected } = selection;
+  const renderRowSelector = useCallback(
+    (rowIndex: number) => {
+      // Session/new rows have no persisted resource to act on.
+      if (rowIndex >= memberCount) {
+        return null;
+      }
+
+      return (
+        <RowSelectCheckbox
+          collection={collection}
+          index={rowIndex}
+          isSelected={isSelected}
+          onToggle={toggleSelected}
+        />
+      );
+    },
+    [collection, memberCount, isSelected, toggleSelected],
+  );
+
+  const headerSelector = (
+    <Checkbox
+      title={selection.allSelected ? 'Deselect all' : 'Select all'}
+      aria-label={selection.allSelected ? 'Deselect all' : 'Select all'}
+      checked={selection.allSelected}
+      selected={selection.someSelected}
+      onChange={() =>
+        selection.allSelected ? clearSelection() : void selection.selectAll()
+      }
+      onMouseDown={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    />
+  );
+
   return (
     <TablePageContext value={tablePageContext}>
       <TablePresenceContext value={presenceValue}>
@@ -1142,10 +1278,21 @@ export const TableResource: React.FC<TableResourceProps> = ({
                 onEntryCreated={notifyEntryCreated}
               />
             )}
+            {canWrite && (
+              <TableBulkActionsBar
+                count={selection.count}
+                properties={uniqueColumnProperties}
+                onSetProperty={handleBulkSetProperty}
+                onDelete={handleBulkDelete}
+                onClear={clearSelection}
+              />
+            )}
             <FancyTable
               readOnly={!canWrite}
               columns={gridColumns}
               columnSizes={gridColumnSizes}
+              renderRowSelector={canWrite ? renderRowSelector : undefined}
+              headerSelector={canWrite ? headerSelector : undefined}
               itemCount={
                 ready
                   ? memberCount + newRowSubjects.length

--- a/browser/data-browser/src/chunks/TablePage/TableResource.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableResource.tsx
@@ -1183,6 +1183,7 @@ export const TableResource: React.FC<TableResourceProps> = ({
     <Checkbox
       title={selection.allSelected ? 'Deselect all' : 'Select all'}
       aria-label={selection.allSelected ? 'Deselect all' : 'Select all'}
+      data-testid='select-all-checkbox'
       checked={selection.allSelected}
       selected={selection.someSelected}
       onChange={() =>

--- a/browser/data-browser/src/chunks/TablePage/TableSetPropertyDialog.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableSetPropertyDialog.tsx
@@ -1,0 +1,125 @@
+import { JSONValue, Property, useResource, useStore } from '@tomic/react';
+import { useEffect, useId, useMemo, useState, type JSX } from 'react';
+import { styled } from 'styled-components';
+import { ConfirmationDialog } from '@components/ConfirmationDialog';
+import { BasicSelect } from '@components/forms/BasicSelect';
+import InputSwitcher from '@components/forms/InputSwitcher';
+
+interface TableSetPropertyDialogProps {
+  /** Properties the user can choose to set (the view's columns). */
+  properties: Property[];
+  /** Number of rows the value will be written to. */
+  count: number;
+  show: boolean;
+  bindShow: (show: boolean) => void;
+  /** Writes `value` to `propertySubject` on every selected row. */
+  onApply: (propertySubject: string, value: JSONValue | undefined) => void;
+}
+
+/**
+ * Bulk "set property" editor: pick one of the view's columns and a value, then
+ * write it to every selected row. The value is captured on a throwaway
+ * in-memory resource so we can reuse the normal per-datatype inputs
+ * (`InputSwitcher`) and read the typed value back on confirm.
+ */
+export function TableSetPropertyDialog({
+  properties,
+  count,
+  show,
+  bindShow,
+  onApply,
+}: TableSetPropertyDialogProps): JSX.Element | null {
+  const store = useStore();
+  const propertySelectId = useId();
+  const valueInputId = useId();
+  // A throwaway subject to hold the value being entered. Never saved.
+  const [scratchSubject] = useState(() => store.createSubject());
+  const scratch = useResource(scratchSubject);
+
+  const [selectedSubject, setSelectedSubject] = useState<string>(
+    properties[0]?.subject ?? '',
+  );
+
+  // Keep the selection valid if the column set changes while open.
+  useEffect(() => {
+    if (
+      properties.length > 0 &&
+      !properties.some(p => p.subject === selectedSubject)
+    ) {
+      setSelectedSubject(properties[0].subject);
+    }
+  }, [properties, selectedSubject]);
+
+  const selectedProperty = useMemo(
+    () => properties.find(p => p.subject === selectedSubject),
+    [properties, selectedSubject],
+  );
+
+  if (properties.length === 0) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    if (!selectedProperty) {
+      return;
+    }
+
+    onApply(selectedProperty.subject, scratch.get(selectedProperty.subject));
+  };
+
+  return (
+    <ConfirmationDialog
+      title={`Set a property on ${count} ${count === 1 ? 'row' : 'rows'}`}
+      confirmLabel='Apply'
+      show={show}
+      bindShow={bindShow}
+      onConfirm={handleConfirm}
+    >
+      <Fields>
+        <Field>
+          <label htmlFor={propertySelectId}>Property</label>
+          <BasicSelect
+            id={propertySelectId}
+            value={selectedSubject}
+            onChange={e => setSelectedSubject(e.target.value)}
+          >
+            {properties.map(property => (
+              <option key={property.subject} value={property.subject}>
+                {property.shortname}
+              </option>
+            ))}
+          </BasicSelect>
+        </Field>
+        {selectedProperty && (
+          <Field>
+            <label htmlFor={valueInputId}>Value</label>
+            <InputSwitcher
+              // Remount the input when the property changes so it binds to the
+              // new datatype and starts empty.
+              key={selectedProperty.subject}
+              id={valueInputId}
+              resource={scratch}
+              property={selectedProperty}
+            />
+          </Field>
+        )}
+      </Fields>
+    </ConfirmationDialog>
+  );
+}
+
+const Fields = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  & > label {
+    color: ${p => p.theme.colors.textLight};
+  }
+`;

--- a/browser/data-browser/src/chunks/TablePage/TableSetPropertyDialog.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableSetPropertyDialog.tsx
@@ -80,6 +80,7 @@ export function TableSetPropertyDialog({
           <label htmlFor={propertySelectId}>Property</label>
           <BasicSelect
             id={propertySelectId}
+            data-testid='bulk-set-property-select'
             value={selectedSubject}
             onChange={e => setSelectedSubject(e.target.value)}
           >

--- a/browser/data-browser/src/chunks/TablePage/useRowSelection.ts
+++ b/browser/data-browser/src/chunks/TablePage/useRowSelection.ts
@@ -1,0 +1,95 @@
+import { Collection } from '@tomic/react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+export interface RowSelection {
+  /** The subjects of the currently selected rows. */
+  selected: ReadonlySet<string>;
+  selectedList: string[];
+  count: number;
+  /** Every member matching the current filter is selected. */
+  allSelected: boolean;
+  /** Some, but not all, members are selected (for an indeterminate look). */
+  someSelected: boolean;
+  isSelected: (subject: string) => boolean;
+  toggle: (subject: string) => void;
+  deselect: (subject: string) => void;
+  clear: () => void;
+  /** Select every member matching the current filter (all pages). */
+  selectAll: () => Promise<void>;
+}
+
+/**
+ * Tracks which rows (by subject) are selected for bulk actions. Selection is
+ * keyed by subject rather than grid index so it survives sorting, filtering
+ * and deletion. "Select all" pulls every member of the collection — i.e.
+ * everything matching the current filter, across all pages — not just the rows
+ * currently rendered.
+ */
+export function useRowSelection(collection: Collection): RowSelection {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+
+  // Read the latest count without making callbacks depend on it (which would
+  // re-create them, and with them the render slots, on every page load).
+  const totalMembers = collection.totalMembers;
+  const totalMembersRef = useRef(totalMembers);
+  totalMembersRef.current = totalMembers;
+
+  const isSelected = useCallback(
+    (subject: string) => selected.has(subject),
+    [selected],
+  );
+
+  const toggle = useCallback((subject: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+
+      if (next.has(subject)) {
+        next.delete(subject);
+      } else {
+        next.add(subject);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const deselect = useCallback((subject: string) => {
+    setSelected(prev => {
+      if (!prev.has(subject)) {
+        return prev;
+      }
+
+      const next = new Set(prev);
+      next.delete(subject);
+
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelected(prev => (prev.size === 0 ? prev : new Set()));
+  }, []);
+
+  const selectAll = useCallback(async () => {
+    const members = await collection.getAllMembers();
+    setSelected(new Set(members));
+  }, [collection]);
+
+  const selectedList = useMemo(() => Array.from(selected), [selected]);
+  const count = selected.size;
+  const allSelected = totalMembers > 0 && count >= totalMembers;
+  const someSelected = count > 0 && !allSelected;
+
+  return {
+    selected,
+    selectedList,
+    count,
+    allSelected,
+    someSelected,
+    isSelected,
+    toggle,
+    deselect,
+    clear,
+    selectAll,
+  };
+}

--- a/browser/e2e/tests/table-bulk-actions.spec.ts
+++ b/browser/e2e/tests/table-bulk-actions.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from '@playwright/test';
+import { before, timestamp } from './test-utils';
+
+/**
+ * Create a table via the drive's quick-create button, type `names` as rows
+ * (fast entry), then reload so the rows are collection members. Row-selection
+ * checkboxes only render on persisted members, not on this-session draft rows,
+ * so the reload is what makes them selectable.
+ */
+async function createTableWithRows(
+  page: Page,
+  tableName: string,
+  names: string[],
+) {
+  await page.getByTitle('New Table').first().click();
+  await page.getByPlaceholder('New Table').fill(tableName);
+  await page.locator('dialog[open] button:has-text("Create")').click();
+  await page.waitForURL(url => url.pathname.startsWith('/app/show'), {
+    timeout: 15000,
+  });
+  await expect(page.getByTestId('editable-title').first()).toBeVisible({
+    timeout: 15000,
+  });
+  // Leave the auto-focused title editor so keyboard entry lands in the grid.
+  await page.keyboard.press('Escape');
+
+  const firstCell = page.getByRole('gridcell').first();
+  await expect(firstCell).toBeVisible({ timeout: 15000 });
+  await firstCell.click({ force: true });
+  await page.waitForTimeout(300);
+
+  for (const name of names) {
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(100);
+    await page.keyboard.type(name, { delay: 30 });
+    await page.waitForTimeout(100);
+  }
+
+  await page.keyboard.press('Escape');
+  await page.waitForFunction(
+    () => window.store.getSyncStatus().pendingDirtyCount === 0,
+    undefined,
+    { timeout: 10000 },
+  );
+
+  await page.reload();
+  await expect(page.getByTestId('editable-title').first()).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(
+    page.getByRole('gridcell', { name: names[0], exact: true }),
+  ).toBeVisible({ timeout: 15000 });
+}
+
+/** Reveal (on hover) and click the selection checkbox of a data row. */
+async function selectRow(page: Page, rowIndex: number) {
+  const row = page.locator(`[aria-rowindex="${rowIndex}"]`);
+  // Checkbox is hidden until the index cell is hovered (or the row is checked).
+  await row.getByRole('rowheader').hover();
+  const checkbox = row.getByTestId('row-select-checkbox');
+  await expect(checkbox).toBeVisible();
+  await checkbox.click();
+  await expect(checkbox).toBeChecked();
+}
+
+test.describe('table bulk actions', () => {
+  test.beforeEach(before);
+
+  test('select individual rows and bulk delete', async ({ page }) => {
+    test.slow();
+    await createTableWithRows(page, `Bulk Delete ${timestamp()}`, [
+      'alpha',
+      'beta',
+      'gamma',
+    ]);
+
+    // Select the first two data rows individually (rowindex 2 and 3).
+    await selectRow(page, 2);
+    await selectRow(page, 3);
+
+    await expect(page.getByTestId('bulk-selected-count')).toContainText('2');
+
+    // Delete them via the bulk bar + confirmation dialog.
+    await page.getByTestId('bulk-delete-button').click();
+    const dialog = page.locator('dialog[open]').last();
+    await expect(dialog).toBeVisible();
+    // The confirm button is the last footer action (Cancel is first).
+    await dialog.locator('footer button').last().click();
+    await expect(dialog).toBeHidden();
+
+    // The two selected rows are gone; the third remains.
+    await expect(
+      page.getByRole('gridcell', { name: 'alpha', exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('gridcell', { name: 'beta', exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('gridcell', { name: 'gamma', exact: true }),
+    ).toBeVisible();
+
+    // Selection is emptied, so the bulk bar goes away.
+    await expect(page.getByTestId('table-bulk-actions')).toHaveCount(0);
+  });
+
+  test('select all and bulk set a property', async ({ page }) => {
+    test.slow();
+    await createTableWithRows(page, `Bulk Set ${timestamp()}`, [
+      'one',
+      'two',
+      'three',
+    ]);
+
+    // Select every row via the header checkbox.
+    await page.getByTestId('select-all-checkbox').click();
+    await expect(page.getByTestId('bulk-selected-count')).toContainText('3');
+
+    // Open the set-property dialog; the "name" column is the default target.
+    await page.getByTestId('bulk-set-property-button').click();
+    const dialog = page.locator('dialog[open]').last();
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('textbox').fill('Done');
+    // Apply is the last footer action.
+    await dialog.locator('footer button').last().click();
+    await expect(dialog).toBeHidden();
+
+    // All three rows now show the new value.
+    await expect(
+      page.getByRole('gridcell', { name: 'Done', exact: true }),
+    ).toHaveCount(3, { timeout: 15000 });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Adds a multi-edit mode with bulk actions to the Table view.

## What this adds

- **Per-row selection**: a checkbox to the left of the "open resource" button in each row's index cell. It shows on hover/focus and stays visible while its row is checked.
- **Select all**: a checkbox in the index-column header. It selects/deselects every row matching the **current filter** (all pages, via `collection.getAllMembers()`), and renders indeterminate when only some rows are selected.
- **Bulk actions bar** above the grid (writers only, shown once at least one row is selected):
  - **Set property** — pick one of the view's columns and a value (reusing the normal per-datatype `InputSwitcher`), then write it to every selected row.
  - **Delete** — deletes all selected rows behind a confirmation dialog.
  - **Clear** — clears the selection.

Selection is keyed by subject (not grid index) so it survives sorting, filtering, paging and deletion, and it is cleared when the query (filter/sort/view) changes. Session/new (`_new:`) rows are not selectable. Both bulk operations push undo entries onto the table history stack.

## Implementation notes

- The generic grid (`TableEditor`) stays feature-agnostic: `FancyTable` gained optional `renderRowSelector` / `headerSelector` slots, `IndexCell` renders an optional `selector`, and `TableHeader` renders an optional header selector. The index column only widens (via `useCellSizes`) when selection is enabled, so read-only/other tables are unaffected.
- New files under `chunks/TablePage/`: `useRowSelection.ts` (selection state), `RowSelectCheckbox.tsx` (per-row checkbox that resolves its own subject), `TableBulkActionsBar.tsx`, and `TableSetPropertyDialog.tsx`.
- Bulk writes mirror the existing clear-cells/delete-row helpers (`resource.set` + `save`, `resource.destroy`) and reuse `ConfirmationDialog`.

## Verification

- **New Playwright e2e** in `browser/e2e/tests/table-bulk-actions.spec.ts` (both pass locally, 2/2):
  - `select individual rows and bulk delete` — selects two rows via their checkboxes, deletes them via the bulk bar + confirmation, asserts they're gone and the untouched row remains.
  - `select all and bulk set a property` — uses the header select-all, sets the `name` property to "Done" across all rows, asserts all rows updated.
  - Interactive elements got stable `data-testid`s (`row-select-checkbox`, `select-all-checkbox`, `table-bulk-actions`, `bulk-set-property-button`, `bulk-delete-button`, `bulk-clear-button`, `bulk-set-property-select`) so the tests don't depend on i18n-wrapped label text.
- `pnpm --filter @tomic/data-browser typecheck` / `@tomic/e2e typecheck` — no new errors (only a pre-existing `pairing.test.ts` node-types error unrelated to this change).
- `lint` passes (warnings only), formatting clean.
- Manual end-to-end browser test (demo below): created a "Tasks" table with 5 rows, selected individual rows, bulk **Set property** (`name` → "Done" on 2 rows, toast "Updated 2 rows"), **Select all** from the header (5 rows selected), and bulk **Delete** with confirmation (toast "Deleted 5 rows", empty table). No errors.

[table_bulk_actions_demo.mp4](https://cursor.com/agents/bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_bulk_actions_demo.mp4)

Row selection + select-all + bulk bar (rows 1–2 already set to "Done"):

[Bulk selection and set property](https://cursor.com/agents/bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_bulk_selection_and_set_property.webp)

Bulk delete confirmation:

[Bulk delete confirmation](https://cursor.com/agents/bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_bulk_delete_confirm.webp)

Note: localization catalogs (`src/locales/*.po`) were intentionally not regenerated in this PR to avoid committing unrelated extraction churn; new English strings render via source fallback and are picked up by the project's normal `wuchale` extraction step (run during the build), which is how the demo labels above were produced. The e2e tests select by `data-testid`, so they pass regardless of extraction state.

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1a8bdd-8ba6-4155-b516-bf08ee7fdc4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

