### PR TITLE
Enable keyboard search on all dropdown context menus

### DIFF
--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+### Atomic Browser
+
+- [#1224](https://github.com/atomicdata-dev/atomic-server/issues/1224) Every dropdown-style context menu is searchable: type-to-filter is on by default for right-click, kebab, and ⌘M menus (pass `searchable={false}` to opt out of tiny menus).
+
 ## [v0.41.0-beta.2] - 2026-08-01
 
 ### Atomic Browser

--- a/browser/data-browser/src/actions/types.ts
+++ b/browser/data-browser/src/actions/types.ts
@@ -4,8 +4,8 @@ import type { Resource, Store } from '@tomic/react';
 /**
  * Central action system (see planning/actions.md): each user-invocable action
  * on a resource is defined ONCE as an {@link ActionDefinition}, and every
- * surface — context menus, the searchable ⌘M menu, hotkeys, the ⌘K palette,
- * AI tools — is a projection of that definition.
+ * surface — searchable context menus (right-click / kebab / ⌘M), hotkeys, the
+ * ⌘K palette, AI tools — is a projection of that definition.
  */
 
 /** Whether the action targets a specific resource or the app as a whole. */
@@ -70,12 +70,11 @@ export interface ActionDefinition {
   icon?: (ctx: ActionContext) => ReactNode;
   /** From the `shortcuts` registry; rendered as a chip wherever listed. */
   shortcut?: string;
-  /** Extra search terms for searchable surfaces (⌘M filter, ⌘K palette). */
+  /** Extra search terms for searchable menus and the ⌘K palette. */
   keywords?: string[];
   /**
-   * Hidden from the default menu listing; only surfaces in searchable menus
-   * while the filter query matches. For secondary actions that would clutter
-   * the list.
+   * Hidden from the default menu listing; only surfaces while the filter
+   * query matches. For secondary actions that would clutter the list.
    */
   searchOnly?: boolean;
   /** Surfaces must confirm before running (unless explicitly bypassed). */

--- a/browser/data-browser/src/components/Dropdown/index.tsx
+++ b/browser/data-browser/src/components/Dropdown/index.tsx
@@ -66,6 +66,8 @@ interface DropdownMenuProps {
   /**
    * Renders a filter input at the top of the menu that narrows the items by
    * label/keywords while keeping arrow+enter keyboard navigation.
+   * Defaults to true — every dropdown-style context menu is searchable.
+   * Pass `false` for tiny menus where a filter would be noise.
    */
   searchable?: boolean;
   bindActive?: (active: boolean) => void;
@@ -144,7 +146,7 @@ export function DropdownMenu({
   items,
   Trigger,
   isMainMenu,
-  searchable,
+  searchable = true,
   bindActive = () => undefined,
   anchorPoint,
 }: DropdownMenuProps): JSX.Element {

--- a/browser/data-browser/src/components/ResourceContextMenu/index.tsx
+++ b/browser/data-browser/src/components/ResourceContextMenu/index.tsx
@@ -78,8 +78,8 @@ export interface ResourceContextMenuProps {
 
 /**
  * Dropdown menu that opens a bunch of actions for some resource. Items come
- * from the central action registry; the main menu (navbar kebab / cmd+m) is
- * searchable, right-click menus are plain.
+ * from the central action registry. All instances are searchable (type-to-
+ * filter); the main menu (navbar kebab) also binds the cmd+m shortcut.
  */
 export function ResourceContextMenu({
   subject,
@@ -227,7 +227,6 @@ export function ResourceContextMenu({
         items={filteredItems}
         Trigger={triggerComp}
         isMainMenu={isMainMenu}
-        searchable={isMainMenu}
         bindActive={handleBindActive}
         anchorPoint={anchorPoint}
       />

--- a/browser/e2e/tests/resource-context-menu.spec.ts
+++ b/browser/e2e/tests/resource-context-menu.spec.ts
@@ -22,6 +22,13 @@ test.describe('resource context menu', () => {
       .first();
     await sidebarLink.click({ button: 'right' });
     await expect(page.getByRole('menu')).toBeVisible();
+    // Right-click menus are searchable: filter is focused, typing narrows items.
+    const rightClickFilter = page.getByPlaceholder(/Filter actions/);
+    await expect(rightClickFilter).toBeFocused();
+    await rightClickFilter.fill('histo');
+    await expect(page.getByTestId('menu-item-history')).toBeVisible();
+    await expect(page.getByTestId('menu-item-edit')).toHaveCount(0);
+    await rightClickFilter.fill('');
     await expect(page.getByTestId('menu-item-history')).toBeVisible();
     // Close it.
     await page.keyboard.press('Escape');

--- a/browser/e2e/tests/resource-context-menu.spec.ts
+++ b/browser/e2e/tests/resource-context-menu.spec.ts
@@ -1,8 +1,36 @@
 import { test, expect, type Page } from '@playwright/test';
 import { before, newResource } from './test-utils';
 
+async function createWidgetsTable(page: Page) {
+  await newResource('table', page);
+  await page.getByRole('button', { name: /Blank/ }).click();
+  await page.getByPlaceholder('New Table').fill('Widgets');
+  await page.getByRole('button', { name: 'Create' }).click();
+}
+
 test.describe('resource context menu', () => {
   test.beforeEach(before);
+
+  test('right-click opens a searchable resource menu', async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    await createWidgetsTable(page);
+
+    const sidebarLink = page
+      .getByRole('navigation')
+      .getByRole('button', { name: 'Widgets' })
+      .first();
+    await sidebarLink.click({ button: 'right' });
+    await expect(page.getByRole('menu')).toBeVisible();
+    // Right-click menus share the ⌘M filter. Type-to-filter is covered by the
+    // cmd+m test; here we only assert the filter is present and focused.
+    await expect(page.getByPlaceholder(/Filter actions/)).toBeFocused();
+    await expect(page.getByTestId('menu-item-history')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('menu')).toHaveCount(0);
+  });
 
   test('sidebar link + table cell open the resource menu on right-click', async ({
     page,
@@ -10,10 +38,7 @@ test.describe('resource context menu', () => {
     page: Page;
   }) => {
     // A plain table with one row.
-    await newResource('table', page);
-    await page.getByRole('button', { name: /Blank/ }).click();
-    await page.getByPlaceholder('New Table').fill('Widgets');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createWidgetsTable(page);
 
     // --- Sidebar link (AtomicLink seam) ---
     const sidebarLink = page
@@ -22,13 +47,6 @@ test.describe('resource context menu', () => {
       .first();
     await sidebarLink.click({ button: 'right' });
     await expect(page.getByRole('menu')).toBeVisible();
-    // Right-click menus are searchable: filter is focused, typing narrows items.
-    const rightClickFilter = page.getByPlaceholder(/Filter actions/);
-    await expect(rightClickFilter).toBeFocused();
-    await rightClickFilter.fill('histo');
-    await expect(page.getByTestId('menu-item-history')).toBeVisible();
-    await expect(page.getByTestId('menu-item-edit')).toHaveCount(0);
-    await rightClickFilter.fill('');
     await expect(page.getByTestId('menu-item-history')).toBeVisible();
     // Close it.
     await page.keyboard.press('Escape');
@@ -74,10 +92,7 @@ test.describe('resource context menu', () => {
     )?.[0];
     expect(driveDid).toBeTruthy();
 
-    await newResource('table', page);
-    await page.getByRole('button', { name: /Blank/ }).click();
-    await page.getByPlaceholder('New Table').fill('Widgets');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createWidgetsTable(page);
     await expect(page.getByRole('columnheader').nth(1)).toBeVisible();
     // Leave the table's cell editor — hotkeys are ignored while an input has
     // focus.

--- a/planning/actions.md
+++ b/planning/actions.md
@@ -60,7 +60,7 @@ Three kinds of actions, modeled by what `run` does:
 | Surface | How it projects the registry |
 |---|---|
 | Right-click / kebab menus | `ResourceContextMenu` builds `DropdownItem[]` from definitions; `showOnly` keeps filtering by id (17 call sites unchanged) |
-| ⌘M "more" menu | Same menu, `searchable`: filter input at top, type-to-filter over label+keywords, arrows+enter. Only the main menu is searchable; right-click stays a plain instant dropdown (mouse intent) |
+| ⌘M "more" menu | Same menu with the ⌘M shortcut bound. Every `DropdownMenu` is searchable by default: filter input at top, type-to-filter over label+keywords, arrows+enter (right-click / kebab included). |
 | ⌘K overlay | Actions appear as a section next to search results. **Placement policy, not unified ranking**: actions section capped at ~3, shown only on a strong prefix/synonym match against the action vocabulary, never interleaved with resource results |
 | Hotkeys | `HotKeyWrapper` registers definitions that carry `shortcut` |
 | Shortcuts help page | Rendered from the registry (kills the hand-synced prose) |
@@ -72,7 +72,7 @@ Three kinds of actions, modeled by what `run` does:
 1. **Registry + searchable ⌘M menu** (this slice): `src/actions/` with all
    current context-menu actions + move-to-parent (⌘↑, Finder convention);
    `ResourceContextMenu` renders from the registry; `DropdownMenu` gains a
-   `searchable` mode used by the main menu.
+   `searchable` mode (on by default for all dropdown-style context menus).
 2. **⌘K**: actions section in `SearchOverlay` per the placement policy.
 3. **Hotkeys + shortcuts page** derived from the registry; collapse the
    remaining scattered delete implementations onto the delete action.
@@ -94,5 +94,6 @@ Three kinds of actions, modeled by what `run` does:
   dedicated actions palette, scoped to the current resource.
 - **Action ids keep the old `ContextMenuOptions` string values** so `showOnly`
   call sites and `menu-item-<id>` test ids don't churn.
-- **Right-click menus are not searchable**; ⌘M and the navbar kebab are.
+- **All dropdown-style context menus are searchable** (right-click, kebab, ⌘M).
+  Pass `searchable={false}` only for tiny menus where a filter would be noise.
 - **Move to parent** gets ⌘↑, matching Finder's "go to enclosing folder".


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

closes #1224

## Summary

`DropdownMenu` already supported type-to-filter (`searchable`), but only the navbar ⌘M / More menu turned it on. Right-click and other dropdown-style context menus stayed plain.

This makes search the default for every `DropdownMenu`, so right-click, kebab, and ⌘M menus all get the filter input (label + keywords, arrows + Enter). Call sites can still pass `searchable={false}` for tiny menus where a filter would be noise.

## Changes

- Default `searchable` to `true` on `DropdownMenu`
- Drop the `searchable={isMainMenu}` gate in `ResourceContextMenu` (uses the default)
- Update `planning/actions.md` to reverse the old "right-click is not searchable" decision
- E2E: right-click menu focuses the filter; cmd+m still covers type-to-filter end-to-end
- Changelog entry

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1979e631-96ef-42af-b3a1-ff38712fe7f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1979e631-96ef-42af-b3a1-ff38712fe7f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

