### PR TITLE
Allow editing classless resources

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -110,6 +110,7 @@ Both matter because `iroh_transport` holds the router and node identity in
 | Sync page status renders | `browser/e2e/tests/sync.spec.ts` |
 | Offline edits persist and sync on reconnect | `sync.spec.ts` |
 | Second device cold-loads a drive from the server | `second-device-load.spec.ts` |
+| Classless resource edit form (no `isA` / invalid Class) | `browser/e2e/tests/classless-edit.spec.ts` |
 
 ---
 

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+### Atomic Browser
+
+- [#1158](https://github.com/atomicdata-dev/atomic-server/issues/1158) Resources without a valid Class can be edited: the form shows their existing properties and still lets you add more, instead of hard-blocking with "is not a Class".
+
 ## [v0.41.0-beta.2] - 2026-08-01
 
 ### Atomic Browser

--- a/browser/data-browser/src/components/forms/ResourceForm.tsx
+++ b/browser/data-browser/src/components/forms/ResourceForm.tsx
@@ -89,6 +89,13 @@ export function ResourceForm({
   const [newPropErr, setNewPropErr] = useState<Error | undefined>(undefined);
   /** A list of custom properties, set by the User while editing this form */
   const [tempOtherProps, setTempOtherProps] = useState<string[]>([]);
+  // Class is optional: when missing or invalid we still edit current props
+  // (otherProps) and let the user add more via Advanced.
+  const hasValidClass =
+    !!classSubject &&
+    !klass.loading &&
+    !klass.error &&
+    klass.hasClasses(core.classes.class);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const store = useStore();
   const wasNew: boolean = resource.new;
@@ -157,17 +164,10 @@ export function ResourceForm({
     return <ErrMessage>{resource.error.message}</ErrMessage>;
   }
 
-  if (klass.loading) {
+  // Only wait on the Class when one was requested. Classless resources skip
+  // requires/recommends and render whatever properties already exist.
+  if (classSubject && klass.loading) {
     return <>Loading class...</>;
-  }
-
-  if (!klass.hasClasses(core.classes.class)) {
-    return (
-      <ErrMessage>
-        {classSubject} is not a Class. Only resources with valid classes can be
-        created or edited at this moment.
-      </ErrMessage>
-    );
   }
 
   function handleAddProp(newProp: string | undefined) {
@@ -218,31 +218,39 @@ export function ResourceForm({
                 {klass.error.message}`
               </ErrMessage>
             )}
+            {classSubject && !klass.loading && !klass.error && !hasValidClass && (
+              <ErrMessage>
+                {classSubject} is not a Class. Showing existing properties
+                instead of the usual required / recommended fields.
+              </ErrMessage>
+            )}
             {!canWrite && (
               <ErrMessage>
                 Cannot save edits: Agent does not have edit rights
               </ErrMessage>
             )}
-            {requires.map(property => {
-              return (
-                <ResourceField
-                  key={property + ' field'}
-                  propertyURL={property}
-                  resource={resource}
-                  required
-                />
-              );
-            })}
-            {recommends.map(property => {
-              return (
-                <ResourceField
-                  key={property + ' field'}
-                  disabled={!canWrite}
-                  propertyURL={property}
-                  resource={resource}
-                />
-              );
-            })}
+            {hasValidClass &&
+              requires.map(property => {
+                return (
+                  <ResourceField
+                    key={property + ' field'}
+                    propertyURL={property}
+                    resource={resource}
+                    required
+                  />
+                );
+              })}
+            {hasValidClass &&
+              recommends.map(property => {
+                return (
+                  <ResourceField
+                    key={property + ' field'}
+                    disabled={!canWrite}
+                    propertyURL={property}
+                    resource={resource}
+                  />
+                );
+              })}
             {otherProps.map(property => {
               return (
                 <ResourceField

--- a/browser/e2e/tests/classless-edit.spec.ts
+++ b/browser/e2e/tests/classless-edit.spec.ts
@@ -54,15 +54,17 @@ test.describe('classless resource edit', () => {
       page.getByText(/is not a Class\. Only resources with valid classes/),
     ).toHaveCount(0);
 
-    // Existing properties are editable (ResourceField uses shortname test ids).
-    await expect(page.getByTestId('input-name')).toBeVisible();
-    await expect(page.getByTestId('input-description')).toBeVisible();
+    // Existing properties render (name textbox + description markdown body).
+    await expect(
+      page.getByRole('textbox', { name: 'name', exact: true }),
+    ).toHaveValue('Classless Thing');
+    await expect(page.getByText('No class, still editable')).toBeVisible();
 
     // Advanced still offers adding another property.
     await page.getByRole('button', { name: /Advanced/ }).click();
     await expect(page.getByText('Add another property...')).toBeVisible();
 
-    // Save stays available (form is valid with the existing fields).
-    await expect(page.getByTestId('save')).toBeEnabled();
+    // Save stays available.
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
   });
 });

--- a/browser/e2e/tests/classless-edit.spec.ts
+++ b/browser/e2e/tests/classless-edit.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, type Page } from '@playwright/test';
+import { before, FRONTEND_URL } from './test-utils';
+
+const NAME = 'https://atomicdata.dev/properties/name';
+const DESCRIPTION = 'https://atomicdata.dev/properties/description';
+
+/**
+ * Creates a resource with no `isA` (and therefore no Class), saves it, and
+ * returns its subject. Used to exercise the classless edit form path.
+ */
+async function createClasslessResource(page: Page): Promise<string> {
+  await page.waitForFunction(
+    () =>
+      window.store.getClientDb()?.isReady === true &&
+      window.store.getSyncStatus().serverConnected === true,
+    undefined,
+    { timeout: 30_000 },
+  );
+
+  return page.evaluate(async props => {
+    const store = window.store;
+    const drive = store.getDrive();
+    const resource = await store.newResource({
+      parent: drive,
+      propVals: {
+        [props.name]: 'Classless Thing',
+        [props.description]: 'No class, still editable',
+      },
+    });
+    await resource.save();
+
+    return resource.subject;
+  }, { name: NAME, description: DESCRIPTION });
+}
+
+test.describe('classless resource edit', () => {
+  test.beforeEach(before);
+
+  test('edit form renders existing properties without a Class', async ({
+    page,
+  }) => {
+    const subject = await createClasslessResource(page);
+
+    await page.goto(
+      `${FRONTEND_URL}/app/edit?subject=${encodeURIComponent(subject)}`,
+    );
+
+    await expect(page.getByRole('heading', { name: /Edit/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The old hard gate must not appear.
+    await expect(
+      page.getByText(/is not a Class\. Only resources with valid classes/),
+    ).toHaveCount(0);
+
+    // Existing properties are editable (ResourceField uses shortname test ids).
+    await expect(page.getByTestId('input-name')).toBeVisible();
+    await expect(page.getByTestId('input-description')).toBeVisible();
+
+    // Advanced still offers adding another property.
+    await page.getByRole('button', { name: /Advanced/ }).click();
+    await expect(page.getByText('Add another property...')).toBeVisible();
+
+    // Save stays available (form is valid with the existing fields).
+    await expect(page.getByTestId('save')).toBeEnabled();
+  });
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -2133,9 +2133,11 @@ export class Store {
     // server-side state (isA, publicKey, read, etc.) was never merged into
     // the local Loro doc, so it isn't part of the outgoing snapshot, and
     // isn't written to clientDb. On reload the SPA reads the partial cache
-    // and the agent's edit form errors with "<class> is not a Class"
-    // because `isA` is missing. Forcing a fetch seeds the local resource
-    // with the full server state before we layer the new properties on top.
+    // and the agent's edit form used to hard-error with "<class> is not a
+    // Class" because `isA` was missing (the form now tolerates classless
+    // resources, but a partial agent cache is still wrong). Forcing a fetch
+    // seeds the local resource with the full server state before we layer
+    // the new properties on top.
     //
     // Use HTTP (not WS): the WS may still be authenticated as a previous
     // agent (e.g. onboarding switches from a dev-drive agent to a freshly-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

closes #1158

## Summary

`ResourceForm` hard-blocked whenever `isA` was missing or did not resolve to a Class, showing:

> … is not a Class. Only resources with valid classes can be created or edited at this moment.

Class was only needed to pick required/recommended fields. Existing properties were already collected in `otherProps`, and Advanced already supports adding new properties.

This makes Class advisory: when valid, required/recommended fields still render; otherwise the form shows current properties and lets the user add more. A soft warning appears when `isA` points at a non-Class.

## Changes

- Remove the hard gate in `ResourceForm`; only wait on Class loading when a class subject is present
- Soft warning when `isA` is set but not a Class
- E2E: create a resource with no `isA`, open `/app/edit`, assert the form renders and Save is enabled
- Changelog + `TESTING_COVERAGE.md` row
- Update related comment in `@tomic/lib` store

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1979e631-96ef-42af-b3a1-ff38712fe7f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1979e631-96ef-42af-b3a1-ff38712fe7f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

