### PR TITLE
ci: cache mdbook installs in dagger docsFolder

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -514,19 +514,46 @@ export class AtomicServer {
 
   @func()
   docsFolder(): Directory {
-    const mdBookContainer = dag
-      .container()
-      .from(RUST_IMAGE)
-      .withExec(['cargo', 'install', 'mdbook'])
-      .withExec(['cargo', 'install', 'mdbook-linkcheck']);
-
+    const cargoCache = dag.cacheVolume('cargo');
     const actualDocsDirectory = this.source.directory('docs');
 
-    return mdBookContainer
-      .withMountedDirectory('/docs', actualDocsDirectory)
-      .withWorkdir('/docs')
-      .withExec(['mdbook', 'build'])
-      .directory('/docs/build');
+    return (
+      dag
+        .container()
+        .from(RUST_IMAGE)
+        .withMountedCache('/usr/local/cargo/registry', cargoCache, {
+          sharing: CacheSharingMode.Locked,
+        })
+        // Same cargo-install binary cache as wasmBuild() — without it,
+        // every CI run recompiled mdbook + mdbook-linkcheck from source
+        // (~4 min). Routed through `CARGO_INSTALL_ROOT` so the cache
+        // mount can't hide the rust image's preinstalled `cargo`/`rustc`
+        // at `/usr/local/cargo/bin`. `cargo install` no-ops when the
+        // binaries are already present at the install root.
+        .withMountedCache('/opt/cargo-bin', dag.cacheVolume('cargo-bin'), {
+          sharing: CacheSharingMode.Locked,
+        })
+        .withEnvVariable('CARGO_INSTALL_ROOT', '/opt/cargo-bin')
+        .withEnvVariable(
+          'PATH',
+          '/opt/cargo-bin/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        )
+        .withMountedDirectory('/docs', actualDocsDirectory)
+        .withWorkdir('/docs')
+        // Install + build in a single exec so the install is part of the
+        // build step's own cache key. Splitting them lets dagger cache the
+        // `cargo install` step as "already ran" while the mounted
+        // `cargo-bin` cache volume can be cleared by the engine (e.g. after
+        // a restart with `Locked` sharing), leaving mdbook missing from
+        // PATH on replay. Bundling makes any cache hit imply the binaries
+        // are present too; `cargo install` no-ops when they are current.
+        .withExec([
+          'sh',
+          '-c',
+          'cargo install mdbook mdbook-linkcheck --quiet && mdbook build',
+        ])
+        .directory('/docs/build')
+    );
   }
 
   @func()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`docsFolder()` was compiling `mdbook` and `mdbook-linkcheck` from source on every CI run (~2m41s + ~1m26s). This applies the same `cargo-bin` cache pattern already used for `wasm-pack` in `wasmBuild()`.

## Changes

- Mount the shared `cargo` registry cache and `cargo-bin` install-root cache in `docsFolder()`
- Route installs through `CARGO_INSTALL_ROOT=/opt/cargo-bin` so the cache mount cannot hide the rust image's preinstalled `cargo`/`rustc`
- Bundle `cargo install mdbook mdbook-linkcheck` + `mdbook build` in a single exec so a cleared volume cannot leave binaries missing on a Dagger layer-cache hit (`cargo install` no-ops when binaries are current)

## Expected impact

Warm-cache CI runs should drop ~4 minutes from the docs publish path. Cold cache still pays the full install once, then subsequent runs reuse the volume.

## Note

`mdbook-linkcheck` is still installed here, but `docs/book.toml` has no `[output.linkcheck]` section, so the binary is unused during `mdbook build`. Left in place for this change (cache-only); dropping it is a possible follow-up.

## Related Issues

N/A — CI caching improvement

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed (N/A — Dagger CI plumbing; mirrors existing `wasmBuild()` cache pattern)
- [ ] Update docs if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f2d3e12-c1d8-469a-907c-1a1ca381e389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f2d3e12-c1d8-469a-907c-1a1ca381e389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

