### PR TITLE
ci: stop flutterTest waiting on the Locked cargo cache

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -143,8 +143,14 @@ export class AtomicServer {
    */
   @func()
   async flutterTest(): Promise<string> {
-    const cargoCache = dag.cacheVolume('cargo');
+    // Dedicated registry volume — do NOT share the Locked `cargo` volume
+    // used by rustFmt/clippy/test/wasmBuild. Mounting that volume for the
+    // whole flutterTest container serialized pub get / analyze / dart test
+    // behind the rust pipeline (~10+ min of lock wait on the step that
+    // merely ran `flutter pub get`).
+    const flutterCargoCache = dag.cacheVolume('flutter-cargo');
     const flutterRustTarget = dag.cacheVolume('flutter-plugin-rust-target');
+    const flutterPubCache = dag.cacheVolume('flutter-pub-cache');
     const pathPrefix = 'export PATH="$HOME/.cargo/bin:$PATH"';
 
     return (
@@ -152,6 +158,11 @@ export class AtomicServer {
         .container()
         .from(FLUTTER_IMAGE)
         .withEnvVariable('CI', 'true')
+        // Persist hosted Dart packages across CI runs. Without this,
+        // every push re-downloaded the pub.dev graph into a fresh
+        // `~/.pub-cache`.
+        .withEnvVariable('PUB_CACHE', '/root/.pub-cache')
+        .withMountedCache('/root/.pub-cache', flutterPubCache)
         .withExec(['apt-get', 'update', '-qq'])
         .withExec([
           'apt-get',
@@ -173,9 +184,6 @@ export class AtomicServer {
           '-c',
           'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal',
         ])
-        .withMountedCache('/root/.cargo/registry', cargoCache, {
-          sharing: CacheSharingMode.Locked,
-        })
         .withDirectory('/workspace/lib', this.source.directory('lib'))
         .withDirectory('/workspace/flutter', this.source.directory('flutter'))
         .withMountedCache('/workspace/flutter/rust/target', flutterRustTarget, {
@@ -191,6 +199,11 @@ export class AtomicServer {
         // Dart package — analyzing the whole repo without its own pub get fails.
         .withExec(['bash', '-lc', `${pathPrefix} && flutter analyze lib test`])
         .withExec(['bash', '-lc', `${pathPrefix} && flutter test --no-pub`])
+        // Mount cargo registry only for the Rust step so Dart work above
+        // never contends for a Locked cache volume.
+        .withMountedCache('/root/.cargo/registry', flutterCargoCache, {
+          sharing: CacheSharingMode.Locked,
+        })
         // The flutter_rust_bridge crate is workspace-excluded (root Cargo.toml
         // `exclude`), so `rustTest`'s `--workspace` run never compiles it and
         // `flutter test` only runs Dart. Without this step the entire bridge —


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`flutterTest`'s `flutter pub get` step was taking ~11 minutes. The main cause was cache lock contention, not a slow pub download.

## Root cause

`flutterTest` mounted the shared Locked `cargo` registry volume (also used by `rustFmt` / `rustClippy` / `rustTest` / `wasmBuild`) **before** any Dart work. With `CacheSharingMode.Locked`, that serialized the whole Flutter container behind the rust pipeline — so wall time showed up on the `flutter pub get` step even though that step never touches cargo.

## Changes

- Mount a dedicated `flutter-cargo` registry volume, and only for the final `cargo test` step
- Add a `flutter-pub-cache` volume via `PUB_CACHE=/root/.pub-cache` so hosted Dart packages persist across runs

## Expected impact

- Dart steps (`pub get`, analyze, `flutter test`) no longer wait on the rust pipeline's cargo lock
- Warm-cache `flutter pub get` reuses the pub.dev graph instead of re-downloading it

## Related Issues

N/A — CI caching improvement

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed (N/A — Dagger CI plumbing)
- [ ] Update docs if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f2d3e12-c1d8-469a-907c-1a1ca381e389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f2d3e12-c1d8-469a-907c-1a1ca381e389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

