### PR TITLE
CI fixes, iOS/Android signing, and two migration-data fixes

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -122,21 +122,36 @@ jobs:
 
               newest=$(ls -1t ~/atomic-server-2* 2>/dev/null | head -1)
               current=$(sha256sum ~/atomic-server 2>/dev/null | cut -d" " -f1 || echo none)
+              newest_sum=""
+              [ -n "$newest" ] && newest_sum=$(sha256sum "$newest" | cut -d" " -f1)
 
-              # A deploy can fail before it touches this host at all — the
-              # cross-compile happens in the Dagger container, so a build or
-              # rsync failure never reaches the `mv`. Rolling back then would
-              # take a perfectly healthy server BACKWARDS a version and restart
-              # it for nothing. If the installed binary still matches the newest
-              # backup, this run changed nothing: leave it alone.
+              # Whether to skip needs BOTH signals, because neither alone is
+              # enough.
               #
-              # Only valid for a deploy failure. When the health check is what
-              # failed, the deploy completed and copied its own (bad) binary, so
-              # installed matching newest is the expected state, not a sign that
-              # nothing happened.
-              if [ "$reason" = "deploy" ] && [ -n "$newest" ] &&
-                 [ "$(sha256sum "$newest" | cut -d" " -f1)" = "$current" ]; then
-                echo "Installed binary still matches the newest backup — this deploy never replaced it. Nothing to roll back."
+              # Service state alone is not: a build or rsync failure never
+              # reaches the `mv`, so the old process is still serving and a
+              # rollback would drag a healthy host BACKWARDS a version for
+              # nothing.
+              #
+              # Checksums alone are not either — and this is the trap the
+              # previous version fell into. The remote script copies its backup
+              # IMMEDIATELY after the `mv`, so "installed == newest backup" is
+              # equally true when nothing happened and when the deploy died
+              # three steps later in `export`/`start`/`status` with the service
+              # down. Skipping on that alone declined to roll back in exactly
+              # the outage this exists to end.
+              #
+              # Together they separate the three real cases:
+              #   unit dead                       -> roll back, whatever the sums say
+              #   unit up   + installed == newest -> host untouched, leave it
+              #   unit up   + installed != newest -> binary swapped but the old
+              #                                      process still serving; restore
+              #                                      it before the next restart
+              #                                      picks up the bad one
+              if [ "$reason" = "deploy" ] &&
+                 systemctl is-active --quiet atomic &&
+                 [ -n "$newest_sum" ] && [ "$newest_sum" = "$current" ]; then
+                echo "atomic is still serving and the installed binary is unchanged — this deploy never touched the host. Nothing to roll back."
                 exit 0
               fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,60 @@ jobs:
           # (required)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # The static musl binaries — the ones that run anywhere.
+  #
+  # `upload-assets` below builds for each runner's NATIVE target, so its Linux
+  # leg produces a glibc binary linked against whatever ubuntu-latest ships.
+  # That is currently glibc 2.38, which will not start on Ubuntu 22.04 (2.35,
+  # supported into 2027) or Debian 12 (2.36) — including our own staging box,
+  # where v0.41.0-beta.2 failed with `version 'GLIBC_2.38' not found`.
+  #
+  # Cross-compiling them statically is the entire reason the Dagger pipeline
+  # exists (`releaseAssets` / `TARGET_IMAGE_MAP`), but no workflow ever called
+  # it: releases up to v0.40.0 carried `x86_64-unknown-linux-musl` and
+  # `armv7-unknown-linux-musleabihf`, then v0.40.1 through v0.41.0-beta.1
+  # shipped nothing at all (the build.rs failure noted below), and when that was
+  # repaired the job had become native-only. The musl targets never came back.
+  #
+  # Separate job rather than another matrix leg: one Dagger invocation emits all
+  # three targets, and it needs no Node/Rust toolchain on the runner.
+  upload-musl-assets:
+    name: Cross-compile and upload the static musl binaries
+    # Needs the release to exist before anything can be attached to it.
+    needs: create-release
+    # Deliberately NOT CI_RUNNER, for the same reason the other release jobs
+    # avoid it: a release must not wait on one machine being switched on.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          version: "latest"
+          verb: call
+          args: release-assets export --path ./release-assets
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Attach them to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Fail loudly on an empty export. Without this the upload silently
+          # succeeds with nothing attached, which is how the musl binaries went
+          # missing for four releases without anyone noticing.
+          count=$(find ./release-assets -type f | wc -l)
+          echo "Exported ${count} binaries:"
+          ls -l ./release-assets
+
+          if [ "$count" -eq 0 ]; then
+            echo "::error::release-assets produced no binaries."
+            exit 1
+          fi
+
+          gh release upload "${GITHUB_REF_NAME}" ./release-assets/* --clobber
+
   upload-assets:
     strategy:
       matrix:

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -342,7 +342,8 @@ jobs:
   # ---------------------------------------------------------------- android --
   #
   # Secrets: ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD,
-  #          ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD
+  #          ANDROID_KEY_ALIAS
+  # (no ANDROID_KEY_PASSWORD — see the note in "Configure signing")
   # Generate them with scripts/setup-android-signing.sh, which never puts the
   # key material through a shell history or this repo.
   android:
@@ -438,7 +439,6 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           keystore="$RUNNER_TEMP/release.jks"
@@ -446,9 +446,18 @@ jobs:
 
           # Written, not committed: the plaintext-password version of this file
           # was tracked in this public repo until 2026-08-02.
+          #
+          # keyPassword is the STORE password, deliberately — not a separate
+          # ANDROID_KEY_PASSWORD secret. The keystore is PKCS12, and PKCS12 has
+          # no concept of a per-key password: keytool warns "Different store and
+          # key passwords not supported for PKCS12 KeyStores. Ignoring
+          # user-specified -keypass value" and encrypts the key under the store
+          # password anyway. Feeding Gradle a different value produced
+          # "Get Key failed: Given final block not properly padded" — the store
+          # opening fine and the key then failing to decrypt.
           cat > desktop/gen/android/keystore.properties <<PROPS
           storePassword=$ANDROID_KEYSTORE_PASSWORD
-          keyPassword=$ANDROID_KEY_PASSWORD
+          keyPassword=$ANDROID_KEYSTORE_PASSWORD
           keyAlias=$ANDROID_KEY_ALIAS
           storeFile=$keystore
           PROPS

--- a/browser/data-browser/src/helpers/managed/recovery.test.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { passkeyRpId } from './recovery';
+
+/**
+ * The RP ID a recovery passkey is created and asserted under.
+ *
+ * Getting this wrong does not fail loudly — a mismatched rpId means the
+ * authenticator simply reports no matching credential, which surfaces as "no
+ * passkey was provided" rather than as a configuration error. Hence the table.
+ */
+describe('passkeyRpId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Vitest runs in the node environment here, so there is no window to patch. */
+  function inBrowserAt(hostname: string, { tauri = false } = {}) {
+    vi.stubGlobal('window', {
+      location: {
+        hostname,
+        protocol: tauri ? 'tauri:' : 'https:',
+      },
+      ...(tauri ? { __TAURI_INTERNALS__: {} } : {}),
+    });
+  }
+
+  it('uses the parent domain on the portal', () => {
+    inBrowserAt('atomicserver.eu');
+    expect(passkeyRpId()).toBe('atomicserver.eu');
+  });
+
+  it('uses the parent domain on the app host, not the app host itself', () => {
+    inBrowserAt('app.atomicserver.eu');
+    expect(passkeyRpId()).toBe('atomicserver.eu');
+  });
+
+  // `endsWith('.atomicserver.eu')` and not `endsWith('atomicserver.eu')`: the
+  // leading dot is what stops an attacker-registered lookalike from claiming
+  // our RP. Without it this returns our RP ID on a domain we do not control.
+  it('does not treat a lookalike domain as ours', () => {
+    inBrowserAt('evilatomicserver.eu');
+    expect(passkeyRpId()).toBeUndefined();
+  });
+
+  it('defaults to the origin during local dev', () => {
+    // rp.id must be a suffix of the origin's domain, so naming a real domain
+    // on localhost throws SecurityError — undefined is the only legal answer.
+    inBrowserAt('localhost');
+    expect(passkeyRpId()).toBeUndefined();
+  });
+
+  // The Tauri webview's hostname is also literally "localhost", so this case
+  // is indistinguishable from the one above by hostname alone. It is the whole
+  // reason the Tauri check exists, and the reason it must come second.
+  it('names the RP explicitly in the Tauri app, despite the localhost host', () => {
+    inBrowserAt('localhost', { tauri: true });
+    expect(passkeyRpId()).toBe('atomicserver.eu');
+  });
+
+  it('is undefined when there is no window at all', () => {
+    vi.stubGlobal('window', undefined);
+    expect(passkeyRpId()).toBeUndefined();
+  });
+});

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1,3 +1,4 @@
+import { isRunningInTauri } from '../tauri';
 import { PRODUCT_NAME } from './product';
 import { getManagedApiBase } from './api';
 import { writeManagedAccountBinding } from './binding';
@@ -328,6 +329,48 @@ type PrfExtensionOutputs = {
 /** How long to wait for the user's authenticator before giving up. */
 const WEBAUTHN_TIMEOUT_MS = 60_000;
 
+/**
+ * The Relying Party the recovery passkey belongs to.
+ *
+ * The parent domain, not the app host, so one credential works from both the
+ * portal (`atomicserver.eu`) and the app (`app.atomicserver.eu`) — an RP ID may
+ * be any registrable-domain suffix of the origin. It must match
+ * `webcredentials:` in the iOS entitlement and the `apple-app-site-association`
+ * served by that domain.
+ */
+const PASSKEY_RP_ID = 'atomicserver.eu';
+
+/**
+ * The `rp.id` to use here, or `undefined` to let the browser default to the
+ * origin's effective domain.
+ *
+ * This used to be omitted everywhere, on the reasoning that the default is
+ * right in both dev and production. That holds in a browser but breaks in the
+ * Tauri app: the webview serves from `tauri://localhost` (macOS/iOS) or
+ * `http://tauri.localhost` (Windows/Android), neither of which is a registrable
+ * domain, so there is no effective domain to default to and the ceremony fails.
+ * Naming the RP explicitly is what lets the Associated Domains entitlement
+ * vouch for the app.
+ *
+ * Returning `undefined` on plain localhost is deliberate rather than lazy:
+ * `rp.id` must be a suffix of the origin's domain, so naming a real domain
+ * during local dev throws SecurityError. Dev passkeys stay bound to localhost,
+ * which is correct — they are not meant to unlock production backups.
+ */
+export function passkeyRpId(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const host = window.location.hostname;
+
+  if (host === PASSKEY_RP_ID || host.endsWith(`.${PASSKEY_RP_ID}`)) {
+    return PASSKEY_RP_ID;
+  }
+
+  // Tauri's hostname is also literally "localhost", so the check above cannot
+  // tell the app apart from local dev — this has to come after it.
+  return isRunningInTauri() ? PASSKEY_RP_ID : undefined;
+}
+
 /** Thrown when this browser/authenticator can't do PRF — the caller should
  * fall back to the generated-code wrapper rather than surface an error. */
 export class PrfUnsupportedError extends Error {
@@ -405,6 +448,10 @@ async function evaluatePrf(
   const assertion = (await navigator.credentials.get({
     publicKey: {
       challenge: randomBytes(32),
+      // Must name the same RP the credential was created under, for the same
+      // reason `create` does — see {@link passkeyRpId}. An assertion whose
+      // rpId does not match the one in the credential is simply not found.
+      rpId: passkeyRpId(),
       allowCredentials: [{ type: 'public-key', id: credentialId }],
       userVerification: 'required',
       // Without this the browser's own (multi-minute) default applies, and a
@@ -501,9 +548,7 @@ async function wrapDekWithPasskey(
   const credential = (await navigator.credentials.create({
     publicKey: {
       challenge: randomBytes(32),
-      // No `rp.id`: it defaults to the current origin's effective domain,
-      // which is what we want in both dev (localhost) and production.
-      rp: { name: PRODUCT_NAME },
+      rp: { name: PRODUCT_NAME, id: passkeyRpId() },
       user: {
         // Opaque by design — we never do discoverable-credential login, so
         // this identifies nothing and leaks nothing.

--- a/browser/lib/src/legacy-drive-adoption.test.ts
+++ b/browser/lib/src/legacy-drive-adoption.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'vitest';
+import { Store } from './store.js';
+
+/**
+ * Which inherited drive subjects are safe to restore.
+ *
+ * The cases below are taken verbatim from a real migrated account's `drives`
+ * list (53 entries): 26 well-formed local drives, 11 pointing at dead dev
+ * servers, 15 with the `staging` subdomain spliced into the path by the
+ * migration, and a personal drive.
+ *
+ * The dead-dev-server ones are the dangerous class. Restoring them made an app
+ * served from `https://staging.atomicdata.dev` issue XHRs against
+ * `http://localhost:9883` — the signed-in user's own machine.
+ */
+describe('legacy drive subjects worth adopting', () => {
+  const store = () =>
+    new Store({ serverUrl: 'https://staging.atomicdata.dev' }) as unknown as {
+      isAdoptableDriveSubject(s: string): boolean;
+    };
+
+  const adoptable = (s: string) => store().isAdoptableDriveSubject(s);
+
+  it('keeps drives on this server', ({ expect }) => {
+    expect(adoptable('https://staging.atomicdata.dev/drive/xzpv34r5ibr')).toBe(
+      true,
+    );
+  });
+
+  it('keeps DIDs, which are origin-independent', ({ expect }) => {
+    expect(adoptable('did:ad:resource:abc123')).toBe(true);
+  });
+
+  it('drops drives on a dead dev server', ({ expect }) => {
+    expect(adoptable('http://localhost:9883/01j71grbnyq2w922g2ttt7w46e')).toBe(
+      false,
+    );
+    expect(
+      adoptable('http://dawdawda.localhost:9883/01j3fqv30nqa0nevd3rnjnrsse'),
+    ).toBe(false);
+  });
+
+  it('drops the migration-mangled subdomain spelling', ({ expect }) => {
+    expect(adoptable('internal:/staging:/drive/ckggjb1d3md')).toBe(false);
+    expect(
+      adoptable('https://staging.atomicdata.dev/staging:/drive/KrOMdgvZ'),
+    ).toBe(false);
+  });
+
+  it('drops any other origin, however well-formed', ({ expect }) => {
+    expect(adoptable('https://example.com/drive/abc')).toBe(false);
+  });
+
+  it('drops unparseable junk rather than throwing', ({ expect }) => {
+    expect(adoptable('not a url at all')).toBe(false);
+    expect(adoptable('')).toBe(false);
+  });
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -3684,6 +3684,43 @@ export class Store {
    * why "My drives" stayed empty while one drive was mislabelled "Private
    * drive". So provision one instead, the same way onboarding does.
    */
+  /**
+   * Whether a drive subject inherited from a pre-DID account is worth putting
+   * in front of the user on THIS server.
+   *
+   * A years-old `drives` list is a history of everywhere its owner ever had a
+   * drive, not a list of drives that exist here. A real one contained 53
+   * entries, of which only 26 were well-formed and local: 11 pointed at
+   * long-dead dev servers (`http://localhost:9883/…`,
+   * `http://dawdawda.localhost:9883/…`) and 15 carried a subdomain spliced
+   * into the path by the migration (`internal:/staging:/drive/…`).
+   *
+   * Adopting those verbatim is not merely untidy. A drive list is fetched, so
+   * a `localhost` entry makes an app served from a public origin fire requests
+   * at the machine of whoever signed in — which, if they happen to run a local
+   * server on that port, quietly returns THEIR data. The rest 404 in a loop and
+   * bury the console.
+   *
+   * So: keep DIDs (portable by construction) and subjects on this server's own
+   * origin; drop everything else. A drive that genuinely lives elsewhere is not
+   * lost — it is still on the legacy Agent, and "Open by URL" reaches it.
+   */
+  private isAdoptableDriveSubject(subject: string): boolean {
+    if (subject.startsWith('did:')) return true;
+
+    // The migration's mangled spelling. It survives serialization as a path
+    // segment containing a colon, which is not a subject this server can
+    // resolve — it is the `staging` subdomain welded onto the path.
+    if (/\/[^/]+:\//.test(subject.replace(/^https?:\/\//, ''))) return false;
+
+    try {
+      return new URL(subject).origin === new URL(this.serverUrl).origin;
+    } catch {
+      // Unparseable, and not a DID: nothing can be done with it.
+      return false;
+    }
+  }
+
   private async adoptLegacyDriveList(
     agent: Agent,
     legacy: Resource,
@@ -3695,7 +3732,7 @@ export class Store {
     const inherited = [
       ...legacy.getSubjects(server.properties.drives),
       ...didAgent.getSubjects(server.properties.drives),
-    ];
+    ].filter(subject => this.isAdoptableDriveSubject(subject));
 
     if (inherited.length === 0) return;
 

--- a/desktop/gen/android/app/src/main/java/io/ontola/atomicserver/MainActivity.kt
+++ b/desktop/gen/android/app/src/main/java/io/ontola/atomicserver/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.atomicdata.dev
+package io.ontola.atomicserver
 
 import android.os.Bundle
 import androidx.core.view.WindowCompat

--- a/desktop/gen/apple/atomic-server-tauri.xcodeproj/project.pbxproj
+++ b/desktop/gen/apple/atomic-server-tauri.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.atomicdata.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = io.ontola.atomicserver;
 				PRODUCT_NAME = "Atomic Server";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -370,7 +370,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.atomicdata.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = io.ontola.atomicserver;
 				PRODUCT_NAME = "Atomic Server";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/desktop/gen/apple/atomic-server-tauri_iOS/Info.plist
+++ b/desktop/gen/apple/atomic-server-tauri_iOS/Info.plist
@@ -20,6 +20,14 @@
 	<string>0.41.0.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_iroh.local.swarm._udp</string>
+	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Atomic Server scans pairing QR codes with the camera to connect this device to your other devices.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Atomic Server finds your other devices on this network to sync directly with them, instead of relaying your data via the internet.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/desktop/gen/apple/atomic-server-tauri_iOS/atomic-server-tauri_iOS.entitlements
+++ b/desktop/gen/apple/atomic-server-tauri_iOS/atomic-server-tauri_iOS.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:atomicserver.eu</string>
+	</array>
+</dict>
 </plist>

--- a/desktop/gen/apple/project.yml
+++ b/desktop/gen/apple/project.yml
@@ -1,6 +1,6 @@
 name: atomic-server-tauri
 options:
-  bundleIdPrefix: com.atomicdata.dev
+  bundleIdPrefix: io.ontola.atomicserver
   deploymentTarget:
     iOS: 14.0
 fileGroups: [../../src]
@@ -11,7 +11,7 @@ settingGroups:
   app:
     base:
       PRODUCT_NAME: Atomic Server
-      PRODUCT_BUNDLE_IDENTIFIER: com.atomicdata.dev
+      PRODUCT_BUNDLE_IDENTIFIER: io.ontola.atomicserver
 targetTemplates:
   app:
     type: application

--- a/desktop/gen/apple/project.yml
+++ b/desktop/gen/apple/project.yml
@@ -53,8 +53,42 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.41.0
         CFBundleVersion: "0.41.0.2"
+        # The in-app QR scanner for device pairing
+        # (tauri-plugin-barcode-scanner, see capabilities/mobile.json). The
+        # Android WebView does not grant getUserMedia to web content, so the
+        # native scanner owns the camera on both mobile platforms.
+        NSCameraUsageDescription:
+          Atomic Server scans pairing QR codes with the camera to connect this
+          device to your other devices.
+        # Iroh builds its endpoint with `.discovery_local_network()` alongside
+        # `.discovery_n0()` (lib/src/sync/peer.rs) so two devices on the same
+        # Wi-Fi dial each other directly instead of round-tripping through a
+        # relay and hoping hole-punching succeeds. iOS 14+ blocks mDNS outright
+        # without this key AND a matching NSBonjourServices entry — and it
+        # fails silently, degrading to exactly the relay path the local
+        # discovery was added to avoid.
+        NSLocalNetworkUsageDescription:
+          Atomic Server finds your other devices on this network to sync
+          directly with them, instead of relaying your data via the internet.
+        # iroh 0.35 registers the swarm under `N0_LOCAL_SWARM`
+        # ("iroh.local.swarm"), and swarm-discovery 0.3.1 formats the service
+        # name as `_{name}.{protocol}.local.` — hence this exact string.
+        NSBonjourServices:
+          - _iroh.local.swarm._udp
     entitlements:
       path: atomic-server-tauri_iOS/atomic-server-tauri_iOS.entitlements
+      properties:
+        # Passkeys. The webview serves from `tauri://localhost`, which is not a
+        # registrable domain, so WebAuthn has no effective domain to derive an
+        # RP ID from — this entitlement is what lets the app claim
+        # `atomicserver.eu` as its RP instead (see `passkeyRpId` in
+        # browser/data-browser/src/helpers/managed/recovery.ts).
+        #
+        # Requires the App ID to have the Associated Domains capability, and
+        # https://atomicserver.eu/.well-known/apple-app-site-association to
+        # serve `{"webcredentials":{"apps":["Q9WPWRTU7G.io.ontola.atomicserver"]}}`.
+        com.apple.developer.associated-domains:
+          - webcredentials:atomicserver.eu
     scheme:
       environmentVariables:
         RUST_BACKTRACE: full

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Atomic Server",
   "version": "0.41.0-beta.2",
-  "identifier": "com.atomicdata.dev",
+  "identifier": "io.ontola.atomicserver",
   "build": {
     "frontendDist": "../browser/data-browser/dist-tauri",
     "devUrl": "http://localhost:6747",

--- a/lib/src/subject.rs
+++ b/lib/src/subject.rs
@@ -123,7 +123,22 @@ impl Subject {
 
         // Some URL parsers might strip the slash for 'internal:' scheme.
         // We MUST have it for consistent internal subjects.
-        if !url.as_str().starts_with("internal:/") && url.scheme() == "internal" {
+        //
+        // Only for the subdomain-less form. A tenant subject is deliberately
+        // `internal:{sub}:/path`, which does not start with `internal:/` and so
+        // used to land here too — and the fix-up inserts its slash after the
+        // FIRST colon, turning `internal:staging:/drive/x` into
+        // `internal:/staging:/drive/x`. That is not a cosmetic difference: the
+        // subdomain then reads as part of the path, so `path()` returns
+        // `/staging:/drive/x` and `resolve()` emits the subdomain twice
+        // (`https://staging.example.com/staging:/drive/x`), while a re-parse
+        // sees a leading slash and drops the subdomain entirely. Every tenant
+        // subject ever written went through here, which is why stores are full
+        // of `internal:/{sub}:/...`.
+        if subdomain.is_none()
+            && !url.as_str().starts_with("internal:/")
+            && url.scheme() == "internal"
+        {
             let mut s = url.as_str().to_string();
             if let Some(colon_pos) = s.find(':') {
                 s.insert(colon_pos + 1, '/');
@@ -489,10 +504,46 @@ impl Subject {
         }
 
         if s.starts_with("internal:") {
+            // Repair the historical mangled tenant spelling on the way in.
+            //
+            // `new_local` used to emit `internal:/{sub}:/path` (see the note
+            // there), and stores are full of it. Read literally the subdomain
+            // is lost and the colon becomes part of the path, so the subject
+            // resolves to the wrong host — which is how a tenant's drives
+            // became unreachable. Normalising here fixes those rows as they are
+            // read, with no store rewrite.
+            //
+            // Deliberately narrow: the segment must be non-empty, contain no
+            // slash, and be followed by exactly `:/`. A genuine path segment
+            // ending in a colon before a slash would be misread, but
+            // `internal:/a:/b` is not a shape anything produces on purpose.
+            if let Some(rest) = s.strip_prefix("internal:/") {
+                if let Some(colon_pos) = rest.find(':') {
+                    let sub = &rest[..colon_pos];
+                    if !sub.is_empty() && !sub.contains('/') && rest[colon_pos..].starts_with(":/")
+                    {
+                        // Rebuild from the original string so any query or
+                        // fragment survives.
+                        if let Ok(u) = Url::parse(&format!("internal:{}", rest)) {
+                            return Subject::Internal {
+                                url: u,
+                                subdomain: Some(sub.to_string()),
+                            };
+                        }
+                    }
+                }
+            }
+
             if let Ok(u) = Url::parse(s) {
                 let opaque = u.path();
+                // `internal:{sub}:/path` — the subdomain ends at the colon, not
+                // at the first slash. Taking it to the slash kept the trailing
+                // colon (`"staging:"`), which then failed every comparison
+                // against a real subdomain.
                 let subdomain = if opaque.starts_with('/') {
                     None
+                } else if let Some(colon_pos) = opaque.find(':') {
+                    Some(opaque[..colon_pos].to_string())
                 } else if let Some(slash_pos) = opaque.find('/') {
                     Some(opaque[..slash_pos].to_string())
                 } else {
@@ -713,6 +764,79 @@ impl<'de> Deserialize<'de> for Subject {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    /// A tenant subject must survive being written down and read back.
+    ///
+    /// It did not. `new_local` emitted `internal:/{sub}:/path` — the fix-up for
+    /// parsers that strip the slash after `internal:` fired on the tenant form
+    /// too and inserted one after the first colon. The subdomain then read as
+    /// part of the path, so `resolve` emitted it twice and a re-parse dropped
+    /// it altogether, pointing the subject at the wrong host.
+    #[test]
+    fn tenant_subjects_round_trip() {
+        let base = Some("example.com");
+        let origin = "https://example.com";
+
+        let made = Subject::new_local("/drive/abc", Some("tenant"));
+        assert_eq!(made.as_str(), "internal:tenant:/drive/abc");
+        assert_eq!(made.subdomain().as_deref(), Some("tenant"));
+        assert_eq!(made.path(), "/drive/abc");
+        assert_eq!(made.resolve(origin), "https://tenant.example.com/drive/abc");
+
+        // Written down and read back: same subject, same resolution.
+        let reparsed = Subject::from_raw(made.as_str(), base);
+        assert_eq!(reparsed.as_str(), made.as_str());
+        assert_eq!(reparsed.subdomain().as_deref(), Some("tenant"));
+        assert_eq!(reparsed.resolve(origin), made.resolve(origin));
+
+        // And arriving as a URL agrees with both.
+        let from_url = Subject::from_raw("https://tenant.example.com/drive/abc", base);
+        assert_eq!(from_url.as_str(), made.as_str());
+        assert_eq!(from_url.resolve(origin), made.resolve(origin));
+    }
+
+    /// Stores already contain the mangled spelling, so it has to be readable.
+    /// Normalising on parse repairs those rows without rewriting the store.
+    #[test]
+    fn the_mangled_tenant_spelling_is_repaired_on_read() {
+        let repaired =
+            Subject::from_raw("internal:/staging:/drive/ckggjb1d3md", Some("example.com"));
+
+        assert_eq!(repaired.as_str(), "internal:staging:/drive/ckggjb1d3md");
+        assert_eq!(repaired.subdomain().as_deref(), Some("staging"));
+        assert_eq!(repaired.path(), "/drive/ckggjb1d3md");
+        assert_eq!(
+            repaired.resolve("https://example.com"),
+            "https://staging.example.com/drive/ckggjb1d3md"
+        );
+    }
+
+    /// The repair must not swallow ordinary subjects.
+    #[test]
+    fn plain_internal_subjects_are_left_alone() {
+        let base = Some("example.com");
+
+        for raw in [
+            "internal:/",
+            "internal:/drive/abc",
+            "internal:/agents/QmfpRIBn2JYEatT0MjSkMNoBJzstz19orwnT5oT2rcQ=",
+        ] {
+            let s = Subject::from_raw(raw, base);
+            assert_eq!(s.as_str(), raw, "{raw} should be unchanged");
+            assert_eq!(s.subdomain(), None, "{raw} has no subdomain");
+        }
+    }
+
+    /// A query or fragment must survive the repair.
+    #[test]
+    fn the_repair_keeps_query_and_fragment() {
+        let s = Subject::from_raw("internal:/staging:/drive/abc?page=2", Some("example.com"));
+
+        assert_eq!(
+            s.resolve("https://example.com"),
+            "https://staging.example.com/drive/abc?page=2"
+        );
+    }
 
     #[test]
     fn test_did_parsing_and_resolution() {

--- a/scripts/setup-android-signing.sh
+++ b/scripts/setup-android-signing.sh
@@ -71,18 +71,44 @@ keytool -genkeypair \
 
 chmod 600 "$KEYSTORE"
 
-echo "Uploading secrets to $repo..."
-# base64 -w0 is GNU; macOS base64 has no -w and does not wrap by default.
-if base64 --help 2>&1 | grep -q -- '-w'; then
-  b64() { base64 -w0 "$1"; }
-else
-  b64() { base64 "$1" | tr -d '\n'; }
-fi
+# From here until the secrets are stored, these passwords exist ONLY in this
+# shell's memory, and the keystore on disk cannot be opened without them. If we
+# die in between — as happened when base64 was called in a way BSD rejects — the
+# key is silently stranded. Print them instead of losing them. Cleared once the
+# uploads succeed, so a normal run never puts them on screen.
+trap 'status=$?; [ $status -eq 0 ] && exit $status; {
+  echo
+  echo "!! Aborted before the secrets were stored."
+  echo "!! The keystore below cannot be opened without these passwords, and"
+  echo "!! they are written nowhere else. Save them, or delete the keystore"
+  echo "!! and re-run this script."
+  echo "!!   keystore:      $KEYSTORE"
+  echo "!!   storePassword: $STORE_PASS"
+  echo "!!   keyPassword:   $KEY_PASS"
+} >&2' EXIT
 
-b64 "$KEYSTORE"        | gh secret set ANDROID_KEYSTORE_BASE64   --repo "$repo"
+echo "Uploading secrets to $repo..."
+# Read the file on stdin rather than as an argument. BSD/macOS base64 does not
+# accept a positional file at all (it wants -i, or stdin) — it exits with
+# "invalid argument <path>", which under `set -o pipefail` aborts this script
+# AFTER the keystore exists but BEFORE its passwords have been stored anywhere,
+# stranding a keystore nobody can open. Feeding stdin works identically on GNU
+# and BSD, so no detection is needed: GNU wraps at 76 columns and BSD does not,
+# and `tr -d '\n'` flattens both.
+b64() { base64 < "$1" | tr -d '\n'; }
+
+# Passwords BEFORE the keystore blob. All four are needed for a usable signing
+# config, so an interrupted run is broken either way — but a run that stored the
+# passwords can be finished by hand from the keystore on disk, whereas one that
+# stored only the blob has lost the passwords for good.
 printf '%s' "$STORE_PASS" | gh secret set ANDROID_KEYSTORE_PASSWORD --repo "$repo"
 printf '%s' "$KEY_PASS"   | gh secret set ANDROID_KEY_PASSWORD     --repo "$repo"
 printf '%s' "$ALIAS"      | gh secret set ANDROID_KEY_ALIAS        --repo "$repo"
+b64 "$KEYSTORE"           | gh secret set ANDROID_KEYSTORE_BASE64  --repo "$repo"
+
+# From here the secrets are safely stored, so the passwords no longer need to be
+# recoverable from this shell.
+trap - EXIT
 
 # Fingerprint is safe to print and is what the Play Console shows you, so it is
 # how you confirm a build was signed with this key rather than another.

--- a/scripts/setup-android-signing.sh
+++ b/scripts/setup-android-signing.sh
@@ -53,10 +53,19 @@ read -r -p "Generate a NEW release signing key and overwrite the GitHub secrets?
 
 # 32 bytes of entropy, base64'd. Long enough that the password is not the weak
 # part, and free of characters that need shell quoting downstream.
+#
+# ONE password, for the store and the key alike. This is not a simplification:
+# PKCS12 has no per-key password, so passing a distinct -keypass makes keytool
+# warn "Different store and key passwords not supported for PKCS12 KeyStores.
+# Ignoring user-specified -keypass value" and encrypt the key under the store
+# password regardless. Generating two and storing the second as
+# ANDROID_KEY_PASSWORD produced a keystore CI could open but not read a key
+# from — "Get Key failed: Given final block not properly padded".
 STORE_PASS=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
-KEY_PASS=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
 
 echo "Generating keystore..."
+# Output is NOT suppressed. It was, and that is precisely how the PKCS12
+# keypass warning above went unnoticed until a release build failed on it.
 keytool -genkeypair \
   -alias "$ALIAS" \
   -keyalg RSA \
@@ -65,9 +74,7 @@ keytool -genkeypair \
   -keystore "$KEYSTORE" \
   -storetype PKCS12 \
   -storepass "$STORE_PASS" \
-  -keypass "$KEY_PASS" \
-  -dname "$DNAME" \
-  >/dev/null 2>&1
+  -dname "$DNAME"
 
 chmod 600 "$KEYSTORE"
 
@@ -84,7 +91,7 @@ trap 'status=$?; [ $status -eq 0 ] && exit $status; {
   echo "!! and re-run this script."
   echo "!!   keystore:      $KEYSTORE"
   echo "!!   storePassword: $STORE_PASS"
-  echo "!!   keyPassword:   $KEY_PASS"
+  echo "!!   (the key password is the same value — PKCS12 has only one)"
 } >&2' EXIT
 
 echo "Uploading secrets to $repo..."
@@ -102,7 +109,6 @@ b64() { base64 < "$1" | tr -d '\n'; }
 # passwords can be finished by hand from the keystore on disk, whereas one that
 # stored only the blob has lost the passwords for good.
 printf '%s' "$STORE_PASS" | gh secret set ANDROID_KEYSTORE_PASSWORD --repo "$repo"
-printf '%s' "$KEY_PASS"   | gh secret set ANDROID_KEY_PASSWORD     --repo "$repo"
 printf '%s' "$ALIAS"      | gh secret set ANDROID_KEY_ALIAS        --repo "$repo"
 b64 "$KEYSTORE"           | gh secret set ANDROID_KEYSTORE_BASE64  --repo "$repo"
 
@@ -120,7 +126,12 @@ keytool -list -v -keystore "$KEYSTORE" -storepass "$STORE_PASS" -alias "$ALIAS" 
 cat <<EOF
 
 Secrets set: ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD,
-             ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD
+             ANDROID_KEY_ALIAS
+
+             There is no ANDROID_KEY_PASSWORD: PKCS12 stores the key under the
+             store password. The workflow passes ANDROID_KEYSTORE_PASSWORD for
+             both. If an old ANDROID_KEY_PASSWORD secret exists, delete it —
+             it is unused and misleading.
 
 NEXT, AND DO NOT SKIP THIS:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch deploy rollback behavior, release artifacts, WebAuthn RP ID and mobile entitlements, and core subject parsing that affects how stored drive URLs resolve—high impact if wrong, but largely corrective with new tests.
> 
> **Overview**
> **CI & releases:** Deploy rollback now skips only when **both** `atomic` is still active **and** the installed binary matches the newest backup—fixing cases where a failed deploy left the service down but checksums looked unchanged. GitHub releases gain a **Dagger `release-assets`** job that cross-compiles and uploads **musl** Linux binaries (with a hard fail on empty export). Android release signing drops `ANDROID_KEY_PASSWORD` and uses the **store password for PKCS12**; `setup-android-signing.sh` is hardened for macOS `base64` and interrupted runs.
> 
> **Migration data:** `Subject::new_local` no longer mangles tenant subjects into `internal:/{sub}:/path`; parse-time **repair** normalizes existing mangled rows. Legacy drive adoption **filters** inherited subjects to same-origin URLs, DIDs, and non-mangled paths—blocking localhost/dev URLs and migration-broken `staging:/` paths from being fetched after sign-in.
> 
> **Recovery passkeys (Tauri/iOS):** WebAuthn create/assert now set **`rp.id` via `passkeyRpId()`** (`atomicserver.eu` on production hosts and in Tauri despite `localhost` hostname). iOS gets **Associated Domains** (`webcredentials:atomicserver.eu`), camera/local-network plist entries, and bundle id **`io.ontola.atomicserver`** (aligned with Android/Tauri config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12ac28a9b1b4857b4ef33922d26b2b783e4d9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->