### PR TITLE
Chat-first new drive setup

### DIFF
--- a/browser/data-browser/src/chunks/AI/ClientOnlyTransport.ts
+++ b/browser/data-browser/src/chunks/AI/ClientOnlyTransport.ts
@@ -187,10 +187,12 @@ export const useClientOnlyTransport = (options: ClientOnlyTransportOptions) => {
   const prepareSystemPrompt = async (systemPrompt: string) => {
     let modifiedSystemPrompt = systemPrompt;
 
+    const activeDrive = store.getDrive() ?? drive;
+
     if (systemPrompt.includes('{{drive}}')) {
       modifiedSystemPrompt = modifiedSystemPrompt.replaceAll(
         '{{drive}}',
-        drive,
+        activeDrive,
       );
     }
 
@@ -203,7 +205,7 @@ export const useClientOnlyTransport = (options: ClientOnlyTransportOptions) => {
     }
 
     if (systemPrompt.includes('{{custom-classes}}')) {
-      const classSubjects = await getClassesOnDrive(drive, store);
+      const classSubjects = await getClassesOnDrive(activeDrive, store);
       const customClasses = await Promise.all(
         classSubjects.map(async cls => {
           const resource = await store.getResource(cls);

--- a/browser/data-browser/src/chunks/AI/RealAIChat.tsx
+++ b/browser/data-browser/src/chunks/AI/RealAIChat.tsx
@@ -99,6 +99,19 @@ interface RealAIChatProps {
   >;
   onDeleteMessage: (message: AtomicUIMessage) => void;
   onRegenerateMessage: (message: AtomicUIMessage) => void | Promise<void>;
+  /**
+   * Fit the chat into a parent (dialog, card) instead of the full-page /
+   * sidebar viewport. Width and height follow the parent.
+   */
+  embedded?: boolean;
+  /**
+   * Runs before the first (and every later) send. Throw to keep the message
+   * in the input and skip the request — used to create a drive before the
+   * first setup message is sent.
+   */
+  onBeforeSubmit?: (text: string) => Promise<void> | void;
+  /** Shown above the input while the conversation is still empty. */
+  starterPrompts?: string[];
 }
 
 export const RealAIChat: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
@@ -126,6 +139,9 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
   onSummaryDeleted,
   onDeleteMessage,
   onRegenerateMessage,
+  embedded = false,
+  onBeforeSubmit,
+  starterPrompts,
   children,
 }) => {
   const store = useStore();
@@ -524,6 +540,24 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
       return;
     }
 
+    if (text.trim() === '') {
+      return;
+    }
+
+    if (onBeforeSubmit) {
+      try {
+        await onBeforeSubmit(text);
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Could not send the message.';
+        setRequestError(message);
+
+        return;
+      }
+    }
+
     const context = [...externalContextItems, ...userSelectedContextItems];
     const message: AtomicUIMessage = {
       id: store.newLocalId(),
@@ -666,7 +700,11 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
   }, [selectedAgent.autoCompactThresholdPercent, modelContextLength]);
 
   return (
-    <ChatWindow fullView={fullView} empty={messages.length === 0}>
+    <ChatWindow
+      fullView={fullView}
+      empty={messages.length === 0}
+      embedded={embedded}
+    >
       {children}
       <ChatMessagesContainer
         enableAutoScroll={status === 'streaming'}
@@ -716,6 +754,17 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
         )}
         {!readonly && (
           <>
+            {isEmptyChat && starterPrompts && starterPrompts.length > 0 && (
+              <Column gap='0px'>
+                {starterPrompts.map(prompt => (
+                  <FollowUpPrompt
+                    key={prompt}
+                    text={prompt}
+                    onClick={() => handleSubmit(prompt)}
+                  />
+                ))}
+              </Column>
+            )}
             {followUpQuestions.length > 0 && (
               <Column gap='0px'>
                 {followUpQuestions.map(question => (
@@ -1007,7 +1056,11 @@ const AttachmentPreview = styled.div`
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 `;
 
-const ChatWindow = styled.div<{ fullView?: boolean; empty?: boolean }>`
+const ChatWindow = styled.div<{
+  fullView?: boolean;
+  empty?: boolean;
+  embedded?: boolean;
+}>`
   ${p => p.fullView && `background-color: ${p.theme.colors.bgBody};`}
   padding: ${p => (p.fullView ? p.theme.size() : 0)};
   padding-top: ${p => (p.fullView ? p.theme.size(2) : 0)};
@@ -1015,8 +1068,9 @@ const ChatWindow = styled.div<{ fullView?: boolean; empty?: boolean }>`
   display: grid;
   grid-template-rows: ${p =>
     p.empty && p.fullView ? 'auto 1fr auto 1fr' : 'auto 1fr auto'};
-  height: '100%';
-  width: min(100%, 70rem);
+  height: ${p => (p.embedded ? '100%' : '100%')};
+  min-height: ${p => (p.embedded ? '22rem' : undefined)};
+  width: ${p => (p.embedded ? '100%' : 'min(100%, 70rem)')};
   margin-inline: auto;
   gap: 1rem;
 
@@ -1026,7 +1080,7 @@ const ChatWindow = styled.div<{ fullView?: boolean; empty?: boolean }>`
   }
 
   @media (max-width: 1550px) {
-    height: 90vh;
+    height: ${p => (p.embedded ? '100%' : '90vh')};
   }
 `;
 

--- a/browser/data-browser/src/chunks/AI/skills/drive-setup/SKILL.md
+++ b/browser/data-browser/src/chunks/AI/skills/drive-setup/SKILL.md
@@ -1,0 +1,69 @@
+# Set up a new drive
+
+The user is creating a new drive. The drive resource already exists and is the
+current drive (`{{drive}}`). Your job is to turn that empty drive into a useful
+starter workspace — not to create another drive.
+
+## Workflow
+
+1. **Understand the purpose**
+   - If the user already said what the drive is for, do not re-ask. Ask at most
+     one short clarifying question when the purpose is genuinely ambiguous
+     (e.g. only a name, or "help me organize").
+   - Accept hints. A company website, a product name, a team, or a one-line
+     goal is enough. Do not wait for a complete spec.
+2. **Research hints**
+   - If they gave a URL, company name, or product, use `web_search_exa` (or
+     the available web-search tool) before building. Pull the official name,
+     what they do, and the obvious work objects (customers, projects, content,
+     people).
+   - If the search fails, continue from what they typed. Do not block on
+     research.
+3. **Name the drive**
+   - Rename the current drive with `edit_atomic_resource` (`name`, and a short
+     `description` when you know one). Use the real organization or project
+     name when you have it — not "New Drive".
+4. **Build a small starter workspace**
+   - Prefer `list_table_templates` + `create_table_from_template`, then adapt
+     with `add_table_columns` / `configure_view`.
+   - Create folders only when they group several things. Parent new resources
+     on the current drive (or a folder you just created).
+   - A short welcome [document-v2](https://atomicdata.dev/classes/DocumentV2)
+     is useful when the drive is for a team or company. Create the empty
+     document first, then `edit_document_resource`.
+   - Add a dashboard only when there are tables worth summarizing.
+   - Seed a few example rows so the workspace is not empty — clearly example
+     data, not invented production records.
+5. **Stop and show them around**
+   - Link the important new resources (`[Title](URL)`).
+   - Say what you set up in one short paragraph and what they can do next.
+   - Do not keep creating after the starter is in place unless they ask.
+
+## How much to build
+
+Three to six resources is usually enough. Match the purpose:
+
+| They said | Start with |
+| --- | --- |
+| Sales / CRM / customers | `crm` table, maybe a Companies folder |
+| Tasks / projects / software team | `project-tasks` and/or `issue-tracker` |
+| Time / hours / freelance | `time-tracker`, optionally `expenses` |
+| Hiring | `job-applications` |
+| Personal notes / life admin | a notes folder, `project-tasks` or `grocery-list` if it fits |
+| Company website, no other hint | CRM + tasks + a welcome doc named after the company |
+| "Just a blank drive" / skip | Rename if needed and stop. Create nothing else. |
+
+Read `/layouts` only when the purpose is a company or team workspace and you
+want a concrete folder layout. Do not invent a custom ontology unless a table
+template cannot express the data.
+
+## Gotchas
+
+- The drive is already created. Never try to create another Drive resource.
+- Write to the **current** drive. Default `parent` to the drive when the user
+  did not pick a folder.
+- Do not dump every table template onto the drive. Pick the ones that match.
+- Do not create a second ontology. Tables attach to the drive's default one.
+- Example rows must look like examples (obvious placeholder names).
+- If AI write tools fail, tell the user what you intended and stop. Do not
+  retry the same failing create in a loop.

--- a/browser/data-browser/src/chunks/AI/skills/drive-setup/references/layouts.md
+++ b/browser/data-browser/src/chunks/AI/skills/drive-setup/references/layouts.md
@@ -1,0 +1,41 @@
+# Example drive layouts
+
+Use these as starting shapes, not checklists. Drop anything that does not
+match what the user asked for. Table ids are `create_table_from_template`
+ids.
+
+## Company / team (website or "this is for Acme")
+
+- Rename the drive to the company name.
+- Welcome document: who the workspace is for, two or three links to the
+  tables you created.
+- `crm` as "Pipeline" or "Customers".
+- `project-tasks` as "Work" when they mentioned delivery, product, or a team.
+- Skip expenses, groceries, plants, workouts unless they asked.
+
+## Sales-only
+
+- `crm` only. Optionally a "Notes" document for meeting snippets.
+- No tasks table unless they also mentioned delivery.
+
+## Software / product team
+
+- `issue-tracker` as "Issues".
+- `project-tasks` as "Projects" when they want planning as well as bugs.
+- A short "How we work" document only if they described a process.
+
+## Freelance / studio
+
+- `time-tracker` as "Hours".
+- `expenses` when they mentioned money, invoices, or receipts.
+- `crm` when they mentioned clients.
+
+## Personal
+
+- One folder ("Notes") plus `project-tasks` or a single document.
+- Use lifestyle templates (`grocery-list`, `reading-list`, `plant-care`,
+  `workout-log`) only when the user named that activity.
+
+## Hiring
+
+- `job-applications` only, unless they also run a company workspace.

--- a/browser/data-browser/src/chunks/AI/skills/driveSetupSkill.ts
+++ b/browser/data-browser/src/chunks/AI/skills/driveSetupSkill.ts
@@ -1,0 +1,2 @@
+/** Bundled skill that interviews the user and templates a new drive. */
+export const DRIVE_SETUP_SKILL_NAME = 'drive-setup';

--- a/browser/data-browser/src/chunks/AI/skills/skill.ts
+++ b/browser/data-browser/src/chunks/AI/skills/skill.ts
@@ -8,6 +8,11 @@ import tablesSkillContent from './tables/SKILL.md?raw';
 import creatingTablesContent from './tables/references/creating-tables.md?raw';
 import skillCreationContent from './skill-creation/SKILL.md?raw';
 import ontologiesSkillContent from './ontologies/SKILL.md?raw';
+import driveSetupSkillContent from './drive-setup/SKILL.md?raw';
+import driveSetupLayoutsContent from './drive-setup/references/layouts.md?raw';
+import { DRIVE_SETUP_SKILL_NAME } from './driveSetupSkill';
+
+export { DRIVE_SETUP_SKILL_NAME };
 
 import { stringToSlug } from '@helpers/stringToSlug';
 
@@ -70,6 +75,21 @@ export const atomicSkills: AgentSkill[] = [
     },
     content: ontologiesSkillContent,
     references: [],
+  },
+  {
+    meta: {
+      id: 'atomic.skills.drive-setup',
+      name: DRIVE_SETUP_SKILL_NAME,
+      description:
+        'Use this when setting up a newly created drive: ask what it is for, research a company website or other hint if given, then build a small starter workspace (name, tables, folders, a welcome doc).',
+    },
+    content: driveSetupSkillContent,
+    references: [
+      {
+        path: '/layouts',
+        content: driveSetupLayoutsContent,
+      },
+    ],
   },
 ];
 

--- a/browser/data-browser/src/chunks/AI/useAtomicTools.ts
+++ b/browser/data-browser/src/chunks/AI/useAtomicTools.ts
@@ -409,6 +409,9 @@ export function useAtomicMCPTools({
   const addToOntology = useAddToOntology();
   const { drive } = useSettings();
   const runDocumentEdit = useDocumentEditAgent(editModel);
+  // Prefer the store: a setup chat can create a drive and `store.setDrive`
+  // before React has re-rendered `useSettings()`.
+  const currentDrive = () => store.getDrive() ?? drive;
 
   /** Resolves a `@class` shortname (or title) to a class subject on the
    *  current drive. Full URLs and `#refs` pass through/expand. */
@@ -419,7 +422,7 @@ export function useAtomicMCPTools({
       return nameOrSubject;
     }
 
-    const classSubjects = await getClassesOnDrive(drive, store);
+    const classSubjects = await getClassesOnDrive(currentDrive(), store);
     const wanted = nameOrSubject.toLowerCase();
     const matches: string[] = [];
 
@@ -512,7 +515,7 @@ export function useAtomicMCPTools({
             parents:
               parents && parents.length !== 0
                 ? parents.map(expandSubject)
-                : [drive],
+                : [currentDrive()],
             text_query,
           });
 
@@ -734,7 +737,7 @@ export function useAtomicMCPTools({
           'List all classes defined on the current drive. Returns each class as `<shortname>: <subject>`. Use this to discover available classes, then call `get_schema` for details on a specific class.',
         inputSchema: z.object({}),
         execute: async () => {
-          const classSubjects = await getClassesOnDrive(drive, store);
+          const classSubjects = await getClassesOnDrive(currentDrive(), store);
 
           return await Promise.all(
             classSubjects.map(async cls => {
@@ -1253,8 +1256,8 @@ NEVER omit spans of pre-existing text without using the \`<unchanged-text>\` ele
                 rows: rows ?? template.spec.rows,
               },
               {
-                parent: parent ? expandSubject(parent) : drive,
-                driveSubject: drive,
+                parent: parent ? expandSubject(parent) : currentDrive(),
+                driveSubject: currentDrive(),
                 addToOntology,
               },
             );
@@ -1294,7 +1297,7 @@ NEVER omit spans of pre-existing text without using the \`<unchanged-text>\` ele
             const result = await buildDashboardFromSpec(
               store,
               { name, blocks: blocks as DashboardBlockSpec[] },
-              { parent: parent ? expandSubject(parent) : drive },
+              { parent: parent ? expandSubject(parent) : currentDrive() },
             );
 
             return shortenRefsDeep({
@@ -1419,8 +1422,8 @@ NEVER omit spans of pre-existing text without using the \`<unchanged-text>\` ele
                 rows,
               },
               {
-                parent: parent ? expandSubject(parent) : drive,
-                driveSubject: drive,
+                parent: parent ? expandSubject(parent) : currentDrive(),
+                driveSubject: currentDrive(),
                 addToOntology,
               },
             );

--- a/browser/data-browser/src/chunks/AI/useGetDriveStructure.ts
+++ b/browser/data-browser/src/chunks/AI/useGetDriveStructure.ts
@@ -106,8 +106,9 @@ export function useGetDriveStructure() {
   };
 
   return async (): Promise<TreeNode> => {
-    const rootSubjects = await fetchChildren(store, drive);
+    const activeDrive = store.getDrive() ?? drive;
+    const rootSubjects = await fetchChildren(store, activeDrive);
 
-    return buildTree(rootSubjects, new Set([drive]));
+    return buildTree(rootSubjects, new Set([activeDrive]));
   };
 }

--- a/browser/data-browser/src/components/Drives/NewDriveSetup.tsx
+++ b/browser/data-browser/src/components/Drives/NewDriveSetup.tsx
@@ -1,0 +1,237 @@
+import React, {
+  FormEvent,
+  Suspense,
+  useCallback,
+  useId,
+  useState,
+} from 'react';
+import { flushSync } from 'react-dom';
+import { useStore, type Resource } from '@tomic/react';
+import { styled } from 'styled-components';
+import toast from 'react-hot-toast';
+import { useSettings } from '@helpers/AppSettings';
+import { constructOpenURL } from '@helpers/navigation';
+import { driveNameFromPrompt } from '@helpers/driveNameFromPrompt';
+import { useNavigateWithTransition } from '@hooks/useNavigateWithTransition';
+import { Button } from '@components/Button';
+import { Column, Row } from '@components/Row';
+import Field from '@components/forms/Field';
+import { InputStyled, InputWrapper } from '@components/forms/InputStyles';
+import { LoaderBlock } from '@components/Loader';
+import { newContextItem } from '@components/AI/AISidebarContext';
+import { DRIVE_SETUP_SKILL_NAME } from '@chunks/AI/skills/driveSetupSkill';
+import type {
+  AIMessageContext,
+  AISkillMessageContext,
+  AtomicUIMessage,
+} from '@chunks/AI/types';
+
+const RealAIChat = React.lazy(() =>
+  import('@chunks/AI/RealAIChat').then(module => ({
+    default: module.RealAIChat,
+  })),
+);
+
+const STARTER_PROMPTS = [
+  'A CRM for my sales team',
+  'Personal notes and tasks',
+  'Issues and projects for a software team',
+];
+
+export interface NewDriveSetupProps {
+  onCreated?: (resource: Resource) => void;
+  onClose?: () => void;
+  skipNavigation?: boolean;
+  createLabel?: string;
+  showCancel?: boolean;
+}
+
+export function NewDriveSetup({
+  onCreated,
+  onClose,
+  skipNavigation,
+  createLabel = 'Create',
+  showCancel = true,
+}: NewDriveSetupProps): React.JSX.Element {
+  const store = useStore();
+  const nameFieldId = useId();
+  const { setDrive } = useSettings();
+  const navigate = useNavigateWithTransition();
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<Error | undefined>();
+  const [createdDrive, setCreatedDrive] = useState<Resource | undefined>();
+  const [contextItems, setContextItems] = useState<AIMessageContext[]>(() => [
+    newContextItem<AISkillMessageContext>({
+      type: 'skill',
+      name: DRIVE_SETUP_SKILL_NAME,
+    }),
+  ]);
+
+  const goToDrive = useCallback(
+    (resource: Resource) => {
+      if (!skipNavigation) {
+        navigate(constructOpenURL(resource.subject));
+      }
+    },
+    [navigate, skipNavigation],
+  );
+
+  const createDrive = useCallback(
+    async (driveName: string) => {
+      const resource = await store.createDrive(driveName, { personal: false });
+      store.notifyResourceManuallyCreated(resource);
+      store.setDrive(resource.subject);
+      // Tools and `useAddToOntology` close over the React drive. Flush so the
+      // first setup message writes to this drive, not the previous one.
+      flushSync(() => {
+        setDrive(resource.subject);
+        setCreatedDrive(resource);
+      });
+      onCreated?.(resource);
+
+      return resource;
+    },
+    [onCreated, setDrive, store],
+  );
+
+  const handleEmptyCreate = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = name.trim();
+
+    if (!trimmed || busy || createdDrive) {
+      return;
+    }
+
+    setBusy(true);
+    setError(undefined);
+
+    try {
+      const resource = await createDrive(trimmed);
+      toast.success('Drive created');
+      goToDrive(resource);
+      onClose?.();
+    } catch (err) {
+      const asError =
+        err instanceof Error ? err : new Error('Could not create the drive.');
+      store.notifyError(asError);
+      setError(asError);
+      toast.error('Failed to create drive');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleBeforeChatSubmit = async (text: string) => {
+    if (createdDrive) {
+      return;
+    }
+
+    try {
+      await createDrive(driveNameFromPrompt(text));
+    } catch (err) {
+      const asError =
+        err instanceof Error ? err : new Error('Could not create the drive.');
+      store.notifyError(asError);
+      throw asError;
+    }
+  };
+
+  const handleDone = () => {
+    if (createdDrive) {
+      goToDrive(createdDrive);
+    }
+
+    onClose?.();
+  };
+
+  return (
+    <Column gap='1.5rem'>
+      <Intro>
+        <p>
+          What do you want to use this drive for? Describe a project, team, or
+          workflow. You can paste a company website and the assistant will
+          figure out the rest.
+        </p>
+      </Intro>
+      <ChatShell>
+        <Suspense fallback={<LoaderBlock />}>
+          <RealAIChat
+            embedded
+            externalContextItems={contextItems}
+            setExternalContextItems={setContextItems}
+            onNewMessage={noopMessage}
+            onDeleteMessage={noopMessage}
+            onRegenerateMessage={noopMessage}
+            onBeforeSubmit={handleBeforeChatSubmit}
+            starterPrompts={STARTER_PROMPTS}
+          />
+        </Suspense>
+      </ChatShell>
+      {!createdDrive && (
+        <form onSubmit={handleEmptyCreate}>
+          <Column gap='1rem'>
+            <Field
+              required
+              label='Name'
+              fieldId={nameFieldId}
+              error={error}
+              helper='Skip the chat and create an empty drive.'
+            >
+              <InputWrapper>
+                <InputStyled
+                  id={nameFieldId}
+                  placeholder='My Drive'
+                  value={name}
+                  onChange={event => setName(event.target.value)}
+                />
+              </InputWrapper>
+            </Field>
+            <Row gap='1rem' justify='flex-end'>
+              {showCancel && (
+                <Button type='button' onClick={onClose} subtle>
+                  Cancel
+                </Button>
+              )}
+              <Button
+                type='submit'
+                disabled={busy || !name.trim()}
+                loading={busy ? 'Creating…' : undefined}
+              >
+                {createLabel}
+              </Button>
+            </Row>
+          </Column>
+        </form>
+      )}
+      {createdDrive && (
+        <Row gap='1rem' justify='flex-end'>
+          <Button onClick={handleDone}>Done</Button>
+        </Row>
+      )}
+    </Column>
+  );
+}
+
+const noopMessage = (_message: AtomicUIMessage) => undefined;
+
+const Intro = styled.div`
+  color: ${p => p.theme.colors.textLight};
+  font-size: 0.95rem;
+
+  p {
+    margin: 0;
+  }
+`;
+
+const ChatShell = styled.div`
+  min-height: 22rem;
+  height: min(50vh, 32rem);
+  display: flex;
+  flex-direction: column;
+
+  & > * {
+    flex: 1;
+    min-height: 0;
+  }
+`;

--- a/browser/data-browser/src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
+++ b/browser/data-browser/src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
@@ -1,104 +1,59 @@
-import { useStore } from '@tomic/react';
-import { useState, useCallback, FormEvent, FC, useEffect, useId } from 'react';
+import { useEffect, useRef, type FC } from 'react';
 import { styled } from 'styled-components';
-import toast from 'react-hot-toast';
-import { constructOpenURL } from '../../../../../helpers/navigation';
-import { useNavigateWithTransition } from '../../../../../hooks/useNavigateWithTransition';
-import { Button } from '../../../../Button';
+import type { Resource } from '@tomic/react';
+import { NewDriveSetup } from '../../../../Drives/NewDriveSetup';
 import {
   useDialog,
   Dialog,
   DialogContent,
-  DialogActions,
   DialogTitle,
 } from '../../../../Dialog';
-import Field from '../../../Field';
-import { InputWrapper, InputStyled } from '../../../InputStyles';
 import { CustomResourceDialogProps } from '../../useNewResourceUI';
-import { useSettings } from '../../../../../helpers/AppSettings';
+import { useNavigateWithTransition } from '../../../../../hooks/useNavigateWithTransition';
+import { constructOpenURL } from '../../../../../helpers/navigation';
 
 export const NewDriveDialog: FC<CustomResourceDialogProps> = ({
   onClose,
   onCreated,
   skipNavigation,
 }) => {
-  const store = useStore();
-  const nameFieldId = useId();
-  const { setDrive } = useSettings();
-  const [name, setName] = useState('');
-
   const navigate = useNavigateWithTransition();
+  const createdRef = useRef<Resource | undefined>(undefined);
 
-  const onSuccess = useCallback(async () => {
-    if (!name.trim()) return;
+  const finish = (resource?: Resource) => {
+    const created = resource ?? createdRef.current;
 
-    try {
-      // `createDrive` owns all drive invariants (permissions, saved-drives
-      // list, default ontology); this dialog only adds UI concerns.
-      const resource = await store.createDrive(name, {
-        // An ADDITIONAL drive: linked into the switcher list, but it does not
-        // replace the agent's personal/home drive.
-        personal: false,
-      });
-
-      store.notifyResourceManuallyCreated(resource);
-
-      // Change current drive to the new drive — before navigation.
-      setDrive(resource.subject);
-
-      if (!skipNavigation) {
-        navigate(constructOpenURL(resource.subject));
-      }
-
-      toast.success('Drive created');
-      onCreated?.(resource);
-    } catch (e) {
-      store.notifyError(e);
-      toast.error('Failed to create drive');
+    if (created && !skipNavigation) {
+      navigate(constructOpenURL(created.subject));
     }
 
     onClose();
-  }, [name, navigate, onClose, setDrive, store, onCreated, skipNavigation]);
+  };
 
-  const [dialogProps, show, hide] = useDialog({ onSuccess, onCancel: onClose });
+  const [dialogProps, show, hide] = useDialog({
+    onCancel: () => finish(),
+    onSuccess: onClose,
+  });
 
   useEffect(() => {
     show();
-  }, []);
+  }, [show]);
 
   return (
-    <Dialog {...dialogProps}>
+    <Dialog {...dialogProps} width='50rem'>
       <DialogTitle>
         <H1>New Drive</H1>
       </DialogTitle>
       <DialogContent>
-        <form
-          onSubmit={(e: FormEvent) => {
-            e.preventDefault();
-            hide(true);
+        <NewDriveSetup
+          onCreated={resource => {
+            createdRef.current = resource;
+            onCreated?.(resource);
           }}
-        >
-          <Field required label='Name' fieldId={nameFieldId}>
-            <InputWrapper>
-              <InputStyled
-                id={nameFieldId}
-                placeholder='My Drive'
-                value={name}
-                autoFocus={true}
-                onChange={e => setName(e.target.value)}
-              />
-            </InputWrapper>
-          </Field>
-        </form>
+          onClose={() => hide(true)}
+          skipNavigation={skipNavigation}
+        />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={() => hide(false)} subtle>
-          Cancel
-        </Button>
-        <Button onClick={() => hide(true)} disabled={!name.trim()}>
-          Create
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/browser/data-browser/src/helpers/driveNameFromPrompt.test.ts
+++ b/browser/data-browser/src/helpers/driveNameFromPrompt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { driveNameFromPrompt } from './driveNameFromPrompt';
+
+describe('driveNameFromPrompt', () => {
+  it('uses a website host when the message includes a URL', () => {
+    expect(driveNameFromPrompt('CRM for https://www.acme.com/about')).toBe(
+      'acme.com',
+    );
+  });
+
+  it('uses the first line when there is no URL', () => {
+    expect(driveNameFromPrompt('Personal notes\nMore detail')).toBe(
+      'Personal notes',
+    );
+  });
+
+  it('truncates a long first line', () => {
+    const long = 'A'.repeat(60);
+    const name = driveNameFromPrompt(long);
+
+    expect(name.length).toBe(48);
+    expect(name.endsWith('…')).toBe(true);
+  });
+
+  it('falls back when the message is empty', () => {
+    expect(driveNameFromPrompt('   ')).toBe('New Drive');
+  });
+});

--- a/browser/data-browser/src/helpers/driveNameFromPrompt.ts
+++ b/browser/data-browser/src/helpers/driveNameFromPrompt.ts
@@ -1,0 +1,36 @@
+const DEFAULT_DRIVE_NAME = 'New Drive';
+const MAX_NAME_LENGTH = 48;
+
+/**
+ * A first-pass drive title from the user's setup message. The agent can
+ * rename the drive after it has researched a company website or similar hint.
+ */
+export function driveNameFromPrompt(text: string): string {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    return DEFAULT_DRIVE_NAME;
+  }
+
+  const urlMatch = trimmed.match(/https?:\/\/[^\s]+/i);
+
+  if (urlMatch) {
+    try {
+      const host = new URL(urlMatch[0]).hostname.replace(/^www\./, '');
+
+      if (host) {
+        return host;
+      }
+    } catch {
+      // Not a usable URL — fall through to the first line.
+    }
+  }
+
+  const firstLine = trimmed.split(/\r?\n/, 1)[0] ?? trimmed;
+
+  if (firstLine.length <= MAX_NAME_LENGTH) {
+    return firstLine;
+  }
+
+  return `${firstLine.slice(0, MAX_NAME_LENGTH - 1).trimEnd()}…`;
+}

--- a/browser/data-browser/src/routes/NewDriveRoute.tsx
+++ b/browser/data-browser/src/routes/NewDriveRoute.tsx
@@ -1,18 +1,12 @@
-import { FormEvent, useEffect, useState, type JSX } from 'react';
+import { useEffect, type JSX } from 'react';
 import { createRoute } from '@tanstack/react-router';
-import { useStore } from '@tomic/react';
-import toast from 'react-hot-toast';
 import { appRoute } from './RootRoutes';
 import { pathNames, paths } from './paths';
 import { useSettings } from '../helpers/AppSettings';
 import { useNavigateWithTransition } from '../hooks/useNavigateWithTransition';
-import { constructOpenURL } from '../helpers/navigation';
 import { Main } from '../components/Main';
-import { ContainerNarrow } from '../components/Containers';
-import { Button } from '../components/Button';
-import { Column } from '../components/Row';
-import Field from '../components/forms/Field';
-import { InputWrapper, InputStyled } from '../components/forms/InputStyles';
+import { ContainerWide } from '../components/Containers';
+import { NewDriveSetup } from '../components/Drives/NewDriveSetup';
 
 export const NewDriveRoute = createRoute({
   path: pathNames.newDrive,
@@ -28,19 +22,9 @@ export const NewDriveRoute = createRoute({
 // in Cloud Server, which was right when hosting was what every account got and
 // is wrong now: Cloud Server is the paid tier, and the default is a local-first
 // drive with encrypted backup offered from the Sync page like any other drive.
-//
-// That leftover was not a cosmetic mismatch. Enrolling needs a node with free
-// capacity, so creating a drive failed outright whenever the fleet was full —
-// a 500 reported as "Could not enable backup" — and once plan limits are
-// enforced it fails again with a 402 for anyone without a subscription. Neither
-// has anything to do with making a drive.
 function NewDrivePage(): JSX.Element {
-  const store = useStore();
-  const { agent, setDrive } = useSettings();
+  const { agent } = useSettings();
   const navigate = useNavigateWithTransition();
-  const [name, setName] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<Error | undefined>();
 
   useEffect(() => {
     if (!agent) {
@@ -48,57 +32,12 @@ function NewDrivePage(): JSX.Element {
     }
   }, [agent, navigate]);
 
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    const trimmed = name.trim();
-    const agentSubject = agent?.subject;
-
-    if (!trimmed || busy || !agentSubject) return;
-
-    setBusy(true);
-    setError(undefined);
-
-    try {
-      const resource = await store.createDrive(trimmed, { personal: false });
-      store.notifyResourceManuallyCreated(resource);
-      setDrive(resource.subject);
-
-      toast.success('Drive created');
-      navigate(constructOpenURL(resource.subject));
-    } catch (err) {
-      const asError =
-        err instanceof Error ? err : new Error('Could not create the drive.');
-      store.notifyError(asError);
-      setError(asError);
-    } finally {
-      setBusy(false);
-    }
-  }
-
   return (
     <Main>
-      <ContainerNarrow>
-        <Column gap='1.5rem'>
-          <h1>New drive</h1>
-          <form onSubmit={handleSubmit}>
-            <Column gap='1rem'>
-              <Field required label='Name' error={error}>
-                <InputWrapper>
-                  <InputStyled
-                    value={name}
-                    onChange={e => setName(e.target.value)}
-                    placeholder='My Drive'
-                    autoFocus
-                  />
-                </InputWrapper>
-              </Field>
-              <Button type='submit' disabled={busy || !name.trim()}>
-                {busy ? 'Creating…' : 'Create drive'}
-              </Button>
-            </Column>
-          </form>
-        </Column>
-      </ContainerNarrow>
+      <ContainerWide>
+        <h1>New drive</h1>
+        <NewDriveSetup showCancel={false} createLabel='Create drive' />
+      </ContainerWide>
     </Main>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
New Drive now starts as a conversation: the assistant asks what the drive is for, can take hints like a company website, and builds a small starter workspace from existing table templates.

## What changed

- Bundled **`drive-setup` skill** (`read_skill` / attached as chat context) that interviews the user, researches a URL or company name via web search, renames the drive, and creates a few matching tables/folders/docs — not every template.
- **`NewDriveSetup`** reuses `RealAIChat` (lazy-loaded) in the New Drive dialog and `/app/new-drive` page, with starter prompts and the skill pre-attached.
- The first chat message creates the drive, switches to it (`store.setDrive` + a React flush), then the agent writes into that drive.
- **Name + Create** still makes an empty drive, so `newDrive()` in e2e is unchanged.

## Tests

- Unit: `driveNameFromPrompt` (URL host, first line, truncation, empty fallback).
- Existing e2e empty-create path should keep working (same Name label and Create button).
- The live chat/skill path is not e2e-tested; it needs a configured model.

## Checklist
- [x] Add or update tests if needed
- [ ] Add changelog entry linking to issue, describe API changes
- [ ] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68303aac-1058-4c8b-b840-0399621f6a73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68303aac-1058-4c8b-b840-0399621f6a73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

