### PR TITLE
Speed up auth-denied collection queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
-- Collection `/query`: the rights walk no longer full-decodes ancestors (memoize by subject + `get_resource_shallow`), and auth-denied members stop being fetched after 16 consecutive denials. Pins the remaining 0.7s invite-code listing from `planning/slow-collection-queries.md`.
+- Collection `/query`: the rights walk no longer full-decodes ancestors (memoize by subject + `get_resource_shallow`). Denied members still do not consume `page_size`, so a readable row after a private streak is returned.
 
 
 ## [v0.41.0-beta.2] - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Collection `/query`: the rights walk no longer full-decodes ancestors (memoize by subject + `get_resource_shallow`), and auth-denied members stop being fetched after 16 consecutive denials. Pins the remaining 0.7s invite-code listing from `planning/slow-collection-queries.md`.
+
+
 ## [v0.41.0-beta.2] - 2026-08-01
 
 **This is the local-first release.** Atomic Data no longer needs a server to exist.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -268,9 +268,8 @@ is only kept in step by mirroring the tests, so do that deliberately.
 |---|---|
 | Destroyed children don't inflate `parent=` `totalMembers` | `lib/src/db/test.rs` `destroy_clears_parent_index_count` |
 | In-page auth-denied members: `count` equals `subjects.len()` | `unauthorized_query_count_matches_subjects` |
-| Public child after a short private streak still fills the page | `unauthorized_query_skips_denials_to_fill_the_page` |
-| Auth-denied listing does not full-decode ancestors, and stops resolving after `AUTH_DENY_STREAK_CAP` consecutive denials | `unauthorized_collection_query_bounds_fetch_counts` (call counts, not wall clock) |
-| Denial-streak / page-full / unbounded-query contract for the fill loop | `lib/src/db/query_index.rs` `auth_fill_stops_resolving_after_a_denial_streak_when_paged` |
+| Public child after a private streak still fills the page | `unauthorized_query_skips_denials_to_fill_the_page` (20 private, then one public) |
+| Auth-denied listing does not full-decode ancestors; each member is still shallow-fetched | `unauthorized_collection_query_bounds_fetch_counts` (call counts, not wall clock) |
 
 Not covered: wall-clock on a large real store (the 21.7KB-parent form from
 `planning/slow-collection-queries.md`); per-GET rights walks on the invite-code

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -259,3 +259,19 @@ must compute the same differing set on either end of the wire. Both carry the
 same test names. A fix to one is a fix to the other; the golden-vector tests
 (`item_fingerprint_matches_golden_vector`) pin the hashing, but the *traversal*
 is only kept in step by mirroring the tests, so do that deliberately.
+
+---
+
+## Collection query authorization
+
+| Flow | Where |
+|---|---|
+| Destroyed children don't inflate `parent=` `totalMembers` | `lib/src/db/test.rs` `destroy_clears_parent_index_count` |
+| In-page auth-denied members: `count` equals `subjects.len()` | `unauthorized_query_count_matches_subjects` |
+| Public child after a short private streak still fills the page | `unauthorized_query_skips_denials_to_fill_the_page` |
+| Auth-denied listing does not full-decode ancestors, and stops resolving after `AUTH_DENY_STREAK_CAP` consecutive denials | `unauthorized_collection_query_bounds_fetch_counts` (call counts, not wall clock) |
+| Denial-streak / page-full / unbounded-query contract for the fill loop | `lib/src/db/query_index.rs` `auth_fill_stops_resolving_after_a_denial_streak_when_paged` |
+
+Not covered: wall-clock on a large real store (the 21.7KB-parent form from
+`planning/slow-collection-queries.md`); per-GET rights walks on the invite-code
+panel (memo is per-query, not per-request).

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -2143,7 +2143,6 @@ impl Db {
         let mut resources: Vec<Resource> = vec![];
         let mut total_count = 0;
         let rights_cache = std::sync::Mutex::new(RightsCache::default());
-        let mut fill = query_index::QueryAuthFill::new();
 
         let atoms = self.get_index_iterator_for_query(q);
 
@@ -2159,11 +2158,13 @@ impl Db {
                 continue;
             }
 
-            if fill.should_resolve(subjects.len(), q.limit) {
+            // Denied members do not grow `subjects`, so we keep resolving
+            // until the page is full of *authorized* hits — a private streak
+            // must not hide a later readable row.
+            if q.limit.is_none() || subjects.len() < q.limit.unwrap() {
                 // Sudo without nested bodies needs no per-member work at all.
                 if q.for_agent == ForAgent::Sudo && !q.include_nested {
                     subjects.push(atom.subject.clone());
-                    fill.on_included();
                     continue;
                 }
 
@@ -2176,7 +2177,6 @@ impl Db {
                         if let Some(resource) = body {
                             resources.push(resource);
                         }
-                        fill.on_included();
                     }
                     None => {
                         // The index has an entry for this subject but the
@@ -2185,11 +2185,9 @@ impl Db {
                         // Roll back the count bump so it doesn't outrun the
                         // returned subjects and produce a
                         // `totalMembers: N, members: []` drift. We only do
-                        // this for in-page hits; entries past the limit (or
-                        // past the denial-streak cap) stay counted blindly
-                        // (issue #286).
+                        // this for in-page hits; entries past the limit stay
+                        // counted blindly (issue #286).
                         total_count -= 1;
-                        fill.on_denied();
                     }
                 }
             }

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -29,7 +29,10 @@ mod val_prop_sub_index;
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex, RwLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, RwLock,
+    },
     vec,
 };
 
@@ -285,6 +288,21 @@ pub struct Db {
     /// blob forever, so `note_pending_blob_request` also lazily prunes
     /// anything older than `PENDING_BLOB_REQUEST_TTL`.
     pending_blob_requests: Arc<RwLock<HashMap<[u8; 32], (String, std::time::Instant)>>>,
+    /// How often the full-decode vs propvals-only fetch paths ran. Shared
+    /// across clones; used by tests to pin query-path cost to call counts
+    /// rather than wall clock (snapshots in a fresh store are too small
+    /// to show the difference). See `planning/slow-collection-queries.md`.
+    fetch_counters: Arc<FetchCounters>,
+}
+
+#[derive(Default)]
+struct FetchCounters {
+    get_resource: AtomicUsize,
+    get_resource_shallow: AtomicUsize,
+}
+
+fn default_fetch_counters() -> Arc<FetchCounters> {
+    Arc::new(FetchCounters::default())
 }
 
 /// How long an unanswered `BLOB_REQUEST` stays in `pending_blob_requests`
@@ -375,6 +393,7 @@ impl Db {
             base_domain,
             sync_policy: default_sync_policy(),
             pending_blob_requests: Arc::new(RwLock::new(HashMap::new())),
+            fetch_counters: default_fetch_counters(),
         };
 
         store.add_class_extender(crate::collections::get_collection_class_extender())?;
@@ -409,6 +428,7 @@ impl Db {
             base_domain,
             sync_policy: default_sync_policy(),
             pending_blob_requests: Arc::new(RwLock::new(HashMap::new())),
+            fetch_counters: default_fetch_counters(),
         };
 
         store.add_class_extender(crate::collections::get_collection_class_extender())?;
@@ -441,6 +461,7 @@ impl Db {
             base_domain,
             sync_policy: default_sync_policy(),
             pending_blob_requests: Arc::new(RwLock::new(HashMap::new())),
+            fetch_counters: default_fetch_counters(),
         };
 
         store.add_class_extender(crate::collections::get_collection_class_extender())?;
@@ -534,6 +555,7 @@ impl Db {
             base_domain,
             sync_policy: default_sync_policy(),
             pending_blob_requests: Arc::new(RwLock::new(HashMap::new())),
+            fetch_counters: default_fetch_counters(),
         };
 
         store.add_class_extender(crate::collections::get_collection_class_extender())?;
@@ -683,6 +705,7 @@ impl Db {
             base_domain,
             sync_policy: default_sync_policy(),
             pending_blob_requests: Arc::new(RwLock::new(HashMap::new())),
+            fetch_counters: default_fetch_counters(),
         };
 
         store.add_class_extender(crate::collections::get_collection_class_extender())?;
@@ -1687,6 +1710,9 @@ impl Db {
     /// CRDT-authoritative state matters. Subject normalization (incl. the DID
     /// drive hint) matches `get_resource`, so ids/subjects stay consistent.
     pub fn get_resource_shallow(&self, subject: &Subject) -> AtomicResult<Resource> {
+        self.fetch_counters
+            .get_resource_shallow
+            .fetch_add(1, Ordering::Relaxed);
         let normalized = self.normalize_subject(subject);
         let subject_str = normalized.pure_id();
         let propvals = self.get_propvals(&subject_str)?;
@@ -1704,6 +1730,27 @@ impl Db {
         }
 
         Ok(Resource::from_propvals(propvals, res_subject))
+    }
+
+    /// Zero the fetch counters. Tests call this after fixture setup so the
+    /// subsequent query's counts aren't mixed with bootstrap / save traffic.
+    pub fn reset_fetch_counters(&self) {
+        self.fetch_counters.get_resource.store(0, Ordering::Relaxed);
+        self.fetch_counters
+            .get_resource_shallow
+            .store(0, Ordering::Relaxed);
+    }
+
+    /// Full-decode [`Storelike::get_resource`] calls since the last reset.
+    pub fn get_resource_call_count(&self) -> usize {
+        self.fetch_counters.get_resource.load(Ordering::Relaxed)
+    }
+
+    /// Propvals-only [`Db::get_resource_shallow`] calls since the last reset.
+    pub fn get_resource_shallow_call_count(&self) -> usize {
+        self.fetch_counters
+            .get_resource_shallow
+            .load(Ordering::Relaxed)
     }
 
     /// Removes all values from the indexes.
@@ -2096,6 +2143,7 @@ impl Db {
         let mut resources: Vec<Resource> = vec![];
         let mut total_count = 0;
         let rights_cache = std::sync::Mutex::new(RightsCache::default());
+        let mut fill = query_index::QueryAuthFill::new();
 
         let atoms = self.get_index_iterator_for_query(q);
 
@@ -2111,10 +2159,11 @@ impl Db {
                 continue;
             }
 
-            if q.limit.is_none() || subjects.len() < q.limit.unwrap() {
+            if fill.should_resolve(subjects.len(), q.limit) {
                 // Sudo without nested bodies needs no per-member work at all.
                 if q.for_agent == ForAgent::Sudo && !q.include_nested {
                     subjects.push(atom.subject.clone());
+                    fill.on_included();
                     continue;
                 }
 
@@ -2127,6 +2176,7 @@ impl Db {
                         if let Some(resource) = body {
                             resources.push(resource);
                         }
+                        fill.on_included();
                     }
                     None => {
                         // The index has an entry for this subject but the
@@ -2135,9 +2185,11 @@ impl Db {
                         // Roll back the count bump so it doesn't outrun the
                         // returned subjects and produce a
                         // `totalMembers: N, members: []` drift. We only do
-                        // this for in-page hits; entries past the limit stay
-                        // counted blindly (issue #286).
+                        // this for in-page hits; entries past the limit (or
+                        // past the denial-streak cap) stay counted blindly
+                        // (issue #286).
                         total_count -= 1;
+                        fill.on_denied();
                     }
                 }
             }
@@ -3032,6 +3084,9 @@ impl Storelike for Db {
 
     #[instrument(skip_all)]
     async fn get_resource(&self, subject: &Subject) -> AtomicResult<Resource> {
+        self.fetch_counters
+            .get_resource
+            .fetch_add(1, Ordering::Relaxed);
         let normalized = self.normalize_subject(subject);
         let subject_str = normalized.pure_id();
         if let Ok(propvals) = self.get_propvals(&subject_str) {
@@ -3061,9 +3116,7 @@ impl Storelike for Db {
                     // We already hold the exact bytes `doc` was just imported
                     // from — reuse them instead of having `apply_state_doc`
                     // re-export an equivalent snapshot. This is the hot path
-                    // for every resource read (including once per member of
-                    // a collection query), so the saved export is per-read,
-                    // not one-off.
+                    // for every CRDT-authoritative resource read.
                     let _ = resource.apply_state_doc_with_snapshot(doc, snapshot);
                 }
             }
@@ -3189,6 +3242,10 @@ impl Storelike for Db {
                 .await
             }
         }
+    }
+
+    async fn get_resource_shallow(&self, subject: &Subject) -> AtomicResult<Resource> {
+        Db::get_resource_shallow(self, subject)
     }
 
     fn has_stored_resource(&self, subject: &Subject) -> bool {

--- a/lib/src/db/query_index.rs
+++ b/lib/src/db/query_index.rs
@@ -10,6 +10,48 @@ use std::sync::Arc;
 
 use super::trees::{self, Operation, Transaction, Tree};
 
+/// After this many consecutive auth-denied (or unresolvable) members while
+/// filling a page, stop calling [`Db::resolve_query_member`] and only count
+/// remaining index hits. Denied members never grow `subjects`, so without
+/// this cap a fully-private collection of size N costs N fetches even for
+/// `page_size=1`. Unbounded queries (`limit = None`) keep resolving — they
+/// have to, to return a complete set. See
+/// `planning/slow-collection-queries.md`.
+pub(crate) const AUTH_DENY_STREAK_CAP: usize = 16;
+
+/// Tracks whether the query loop is still trying to fill the page, or has
+/// given up on further `resolve_query_member` calls (page full, or a long
+/// denial streak).
+pub(crate) struct QueryAuthFill {
+    consecutive_denials: usize,
+}
+
+impl QueryAuthFill {
+    pub(crate) fn new() -> Self {
+        Self {
+            consecutive_denials: 0,
+        }
+    }
+
+    /// Whether the next in-window index hit should be fetched and
+    /// permission-checked.
+    pub(crate) fn should_resolve(&self, subjects_len: usize, limit: Option<usize>) -> bool {
+        match limit {
+            Some(l) if subjects_len >= l => false,
+            Some(_) => self.consecutive_denials < AUTH_DENY_STREAK_CAP,
+            None => true,
+        }
+    }
+
+    pub(crate) fn on_included(&mut self) {
+        self.consecutive_denials = 0;
+    }
+
+    pub(crate) fn on_denied(&mut self) {
+        self.consecutive_denials += 1;
+    }
+}
+
 /// Returned by functions that iterate over [IndexAtom]s
 pub type IndexIterator = Box<dyn Iterator<Item = AtomicResult<IndexAtom>> + Send>;
 
@@ -264,15 +306,14 @@ pub async fn query_sorted_indexed(
 
     let base_domain = store.get_base_domain();
     let rights_cache = std::sync::Mutex::new(crate::hierarchy::RightsCache::default());
-
-    let limit = q.limit.unwrap_or(usize::MAX);
+    let mut fill = QueryAuthFill::new();
 
     for (i, kv) in iter.enumerate() {
         let kv = kv?;
         // The user's maximum amount of results has not yet been reached
         // and
         // The users minimum starting distance (offset) has been reached
-        let in_selection = subjects.len() < limit && i >= q.offset;
+        let in_selection = i >= q.offset && fill.should_resolve(subjects.len(), q.limit);
         // Tracks whether this iter step should bump the visible count.
         // Defaults to true so entries past the page limit still count
         // (preserving the cheap-pagination behavior). Flipped to false
@@ -296,15 +337,18 @@ pub async fn query_sorted_indexed(
                         if let Some(resource) = body {
                             resources.push(resource);
                         }
+                        fill.on_included();
                     }
                     None => {
                         // Index hit that doesn't resolve for this agent
                         // (auth-filtered or destroyed-with-stale-index).
                         should_count = false;
+                        fill.on_denied();
                     }
                 }
             } else {
                 subjects.push(subject);
+                fill.on_included();
             }
         }
 
@@ -654,6 +698,30 @@ pub fn drive_prefix_from_subject(subject: &Subject) -> Subject {
 pub mod test {
     use super::*;
     use crate::{urls, values::SubResource};
+
+    #[test]
+    fn auth_fill_stops_resolving_after_a_denial_streak_when_paged() {
+        let mut fill = QueryAuthFill::new();
+        assert!(fill.should_resolve(0, Some(10)));
+        for _ in 0..AUTH_DENY_STREAK_CAP {
+            fill.on_denied();
+        }
+        assert!(
+            !fill.should_resolve(0, Some(10)),
+            "a full denial streak must stop filling a paged query"
+        );
+        assert!(
+            fill.should_resolve(0, None),
+            "unbounded queries keep resolving so they can return a complete set"
+        );
+        fill.on_included();
+        assert!(
+            fill.should_resolve(0, Some(10)),
+            "an included member resets the streak"
+        );
+        // Page already full.
+        assert!(!fill.should_resolve(10, Some(10)));
+    }
 
     /// Regression: real-world folder-table filters (where value is a DID
     /// Subject and property+sort_by are atomicdata.dev URLs) must round-trip

--- a/lib/src/db/query_index.rs
+++ b/lib/src/db/query_index.rs
@@ -10,48 +10,6 @@ use std::sync::Arc;
 
 use super::trees::{self, Operation, Transaction, Tree};
 
-/// After this many consecutive auth-denied (or unresolvable) members while
-/// filling a page, stop calling [`Db::resolve_query_member`] and only count
-/// remaining index hits. Denied members never grow `subjects`, so without
-/// this cap a fully-private collection of size N costs N fetches even for
-/// `page_size=1`. Unbounded queries (`limit = None`) keep resolving — they
-/// have to, to return a complete set. See
-/// `planning/slow-collection-queries.md`.
-pub(crate) const AUTH_DENY_STREAK_CAP: usize = 16;
-
-/// Tracks whether the query loop is still trying to fill the page, or has
-/// given up on further `resolve_query_member` calls (page full, or a long
-/// denial streak).
-pub(crate) struct QueryAuthFill {
-    consecutive_denials: usize,
-}
-
-impl QueryAuthFill {
-    pub(crate) fn new() -> Self {
-        Self {
-            consecutive_denials: 0,
-        }
-    }
-
-    /// Whether the next in-window index hit should be fetched and
-    /// permission-checked.
-    pub(crate) fn should_resolve(&self, subjects_len: usize, limit: Option<usize>) -> bool {
-        match limit {
-            Some(l) if subjects_len >= l => false,
-            Some(_) => self.consecutive_denials < AUTH_DENY_STREAK_CAP,
-            None => true,
-        }
-    }
-
-    pub(crate) fn on_included(&mut self) {
-        self.consecutive_denials = 0;
-    }
-
-    pub(crate) fn on_denied(&mut self) {
-        self.consecutive_denials += 1;
-    }
-}
-
 /// Returned by functions that iterate over [IndexAtom]s
 pub type IndexIterator = Box<dyn Iterator<Item = AtomicResult<IndexAtom>> + Send>;
 
@@ -306,14 +264,18 @@ pub async fn query_sorted_indexed(
 
     let base_domain = store.get_base_domain();
     let rights_cache = std::sync::Mutex::new(crate::hierarchy::RightsCache::default());
-    let mut fill = QueryAuthFill::new();
+
+    let limit = q.limit.unwrap_or(usize::MAX);
 
     for (i, kv) in iter.enumerate() {
         let kv = kv?;
         // The user's maximum amount of results has not yet been reached
         // and
-        // The users minimum starting distance (offset) has been reached
-        let in_selection = i >= q.offset && fill.should_resolve(subjects.len(), q.limit);
+        // The users minimum starting distance (offset) has been reached.
+        // Denied members do not grow `subjects`, so we keep resolving until
+        // the page is full of *authorized* hits — a private streak must not
+        // hide a later readable row.
+        let in_selection = subjects.len() < limit && i >= q.offset;
         // Tracks whether this iter step should bump the visible count.
         // Defaults to true so entries past the page limit still count
         // (preserving the cheap-pagination behavior). Flipped to false
@@ -337,18 +299,15 @@ pub async fn query_sorted_indexed(
                         if let Some(resource) = body {
                             resources.push(resource);
                         }
-                        fill.on_included();
                     }
                     None => {
                         // Index hit that doesn't resolve for this agent
                         // (auth-filtered or destroyed-with-stale-index).
                         should_count = false;
-                        fill.on_denied();
                     }
                 }
             } else {
                 subjects.push(subject);
-                fill.on_included();
             }
         }
 
@@ -698,30 +657,6 @@ pub fn drive_prefix_from_subject(subject: &Subject) -> Subject {
 pub mod test {
     use super::*;
     use crate::{urls, values::SubResource};
-
-    #[test]
-    fn auth_fill_stops_resolving_after_a_denial_streak_when_paged() {
-        let mut fill = QueryAuthFill::new();
-        assert!(fill.should_resolve(0, Some(10)));
-        for _ in 0..AUTH_DENY_STREAK_CAP {
-            fill.on_denied();
-        }
-        assert!(
-            !fill.should_resolve(0, Some(10)),
-            "a full denial streak must stop filling a paged query"
-        );
-        assert!(
-            fill.should_resolve(0, None),
-            "unbounded queries keep resolving so they can return a complete set"
-        );
-        fill.on_included();
-        assert!(
-            fill.should_resolve(0, Some(10)),
-            "an included member resets the streak"
-        );
-        // Page already full.
-        assert!(!fill.should_resolve(10, Some(10)));
-    }
 
     /// Regression: real-world folder-table filters (where value is a DID
     /// Subject and property+sort_by are atomicdata.dev URLs) must round-trip

--- a/lib/src/db/test.rs
+++ b/lib/src/db/test.rs
@@ -415,14 +415,13 @@ fn parent_query(parent: &Subject, limit: Option<usize>, for_agent: ForAgent) -> 
 
 /// Synthetic repro from `planning/slow-collection-queries.md`: drive → folder
 /// → form → many private children, queried `parent=form` as a non-authorized
-/// agent. Pins the two remaining costs to *call counts* (a fresh store's
-/// snapshots are too small to show wall-clock):
+/// agent. Pins remaining cost to *call counts* (a fresh store's snapshots are
+/// too small to show wall-clock):
 ///
-/// 1. The rights walk must not full-decode ancestors (`get_resource` stays 0)
-///    and must not re-fetch a parent whose verdict is already cached.
-/// 2. After [`query_index::AUTH_DENY_STREAK_CAP`] consecutive denials, the
-///    loop must stop calling `resolve_query_member` — otherwise page_size
-///    makes no difference and every match is fetched.
+/// The rights walk must not full-decode ancestors (`get_resource` stays 0)
+/// and must not re-fetch a parent whose verdict is already cached. Each
+/// member is still shallow-fetched — a later readable sibling after a
+/// private streak must not be skipped.
 #[tokio::test]
 async fn unauthorized_collection_query_bounds_fetch_counts() {
     let store = Db::init_temp("unauthorized_collection_query_bounds_fetch_counts")
@@ -462,21 +461,24 @@ async fn unauthorized_collection_query_bounds_fetch_counts() {
 
     let full_decodes = store.get_resource_call_count();
     let shallow = store.get_resource_shallow_call_count();
-    let cap = super::query_index::AUTH_DENY_STREAK_CAP;
     assert_eq!(
         full_decodes, 0,
         "rights walk must not Loro-decode ancestors; get_resource was called {full_decodes} times"
     );
     assert!(
-        shallow <= cap + 8,
-        "expected at most {cap} member fetches plus a handful of ancestors, got {shallow} shallow fetches — \
-         either the parent memo is not skipping refetches or the denial-streak cap is not stopping the loop"
+        shallow >= CHILDREN,
+        "every member must still be shallow-fetched (a readable row after a private streak would otherwise be skipped); got {shallow}"
+    );
+    assert!(
+        shallow <= CHILDREN + 8,
+        "expected one shallow fetch per member plus a handful of ancestors, got {shallow} — \
+         the parent memo is not skipping refetches"
     );
 }
 
-/// Denied members must not consume the page: a public child after a short
-/// private streak is still returned. (A streak at the cap is a different
-/// contract — see AUTH_DENY_STREAK_CAP.)
+/// Denied members must not consume the page: a public child after a long
+/// private streak is still returned. Each member can carry its own grant,
+/// so a run of private siblings must not stop the scan.
 #[tokio::test]
 async fn unauthorized_query_skips_denials_to_fill_the_page() {
     let store = Db::init_temp("unauthorized_query_skips_denials_to_fill_the_page")
@@ -487,7 +489,7 @@ async fn unauthorized_query_skips_denials_to_fill_the_page() {
     let drive = crate::test_utils::create_test_drive(&store).await.unwrap();
     let form = genesis_child(&store, &drive).await;
 
-    for _ in 0..5 {
+    for _ in 0..20 {
         genesis_child(&store, &form).await;
     }
 
@@ -520,7 +522,7 @@ async fn unauthorized_query_skips_denials_to_fill_the_page() {
     assert_eq!(
         res.subjects,
         vec![public_subject],
-        "a public child after a few private siblings must still fill page_size=1"
+        "a public child after many private siblings must still fill page_size=1"
     );
 }
 

--- a/lib/src/db/test.rs
+++ b/lib/src/db/test.rs
@@ -379,6 +379,151 @@ async fn unauthorized_query_count_matches_subjects() {
     );
 }
 
+async fn genesis_child(store: &Db, parent: &Subject) -> Subject {
+    let mut res = Resource::new("did:ad:placeholder".into());
+    res.set(urls::PARENT.into(), Value::AtomicUrl(parent.clone()), store)
+        .await
+        .unwrap();
+    res.save_as_genesis(store)
+        .await
+        .unwrap()
+        .resource_new
+        .unwrap()
+        .get_subject()
+        .clone()
+}
+
+fn parent_query(parent: &Subject, limit: Option<usize>, for_agent: ForAgent) -> Query {
+    Query {
+        property: Some(urls::PARENT.into()),
+        value: Some(Value::AtomicUrl(parent.clone())),
+        filters: Vec::new(),
+        limit,
+        start_val: None,
+        end_val: None,
+        offset: 0,
+        sort_by: None,
+        sort_desc: false,
+        include_external: true,
+        include_nested: false,
+        for_agent,
+        drive: None,
+        aggregation: None,
+        expression_filters: Vec::new(),
+    }
+}
+
+/// Synthetic repro from `planning/slow-collection-queries.md`: drive → folder
+/// → form → many private children, queried `parent=form` as a non-authorized
+/// agent. Pins the two remaining costs to *call counts* (a fresh store's
+/// snapshots are too small to show wall-clock):
+///
+/// 1. The rights walk must not full-decode ancestors (`get_resource` stays 0)
+///    and must not re-fetch a parent whose verdict is already cached.
+/// 2. After [`query_index::AUTH_DENY_STREAK_CAP`] consecutive denials, the
+///    loop must stop calling `resolve_query_member` — otherwise page_size
+///    makes no difference and every match is fetched.
+#[tokio::test]
+async fn unauthorized_collection_query_bounds_fetch_counts() {
+    let store = Db::init_temp("unauthorized_collection_query_bounds_fetch_counts")
+        .await
+        .unwrap();
+    crate::test_utils::setup_test_env(&store).await.unwrap();
+
+    let drive = crate::test_utils::create_test_drive(&store).await.unwrap();
+    let folder = genesis_child(&store, &drive).await;
+    let form = genesis_child(&store, &folder).await;
+
+    const CHILDREN: usize = 100;
+    for _ in 0..CHILDREN {
+        genesis_child(&store, &form).await;
+    }
+
+    let sudo = store
+        .query(&parent_query(&form, Some(500), ForAgent::Sudo))
+        .await
+        .unwrap();
+    assert_eq!(
+        sudo.subjects.len(),
+        CHILDREN,
+        "sanity: the form has {CHILDREN} children visible to sudo"
+    );
+
+    store.reset_fetch_counters();
+
+    let denied = store
+        .query(&parent_query(&form, Some(1), urls::PUBLIC_AGENT.into()))
+        .await
+        .unwrap();
+    assert!(
+        denied.subjects.is_empty(),
+        "the public agent must not see private invite-code children"
+    );
+
+    let full_decodes = store.get_resource_call_count();
+    let shallow = store.get_resource_shallow_call_count();
+    let cap = super::query_index::AUTH_DENY_STREAK_CAP;
+    assert_eq!(
+        full_decodes, 0,
+        "rights walk must not Loro-decode ancestors; get_resource was called {full_decodes} times"
+    );
+    assert!(
+        shallow <= cap + 8,
+        "expected at most {cap} member fetches plus a handful of ancestors, got {shallow} shallow fetches — \
+         either the parent memo is not skipping refetches or the denial-streak cap is not stopping the loop"
+    );
+}
+
+/// Denied members must not consume the page: a public child after a short
+/// private streak is still returned. (A streak at the cap is a different
+/// contract — see AUTH_DENY_STREAK_CAP.)
+#[tokio::test]
+async fn unauthorized_query_skips_denials_to_fill_the_page() {
+    let store = Db::init_temp("unauthorized_query_skips_denials_to_fill_the_page")
+        .await
+        .unwrap();
+    crate::test_utils::setup_test_env(&store).await.unwrap();
+
+    let drive = crate::test_utils::create_test_drive(&store).await.unwrap();
+    let form = genesis_child(&store, &drive).await;
+
+    for _ in 0..5 {
+        genesis_child(&store, &form).await;
+    }
+
+    let mut public_child = Resource::new("did:ad:placeholder".into());
+    public_child
+        .set(urls::PARENT.into(), Value::AtomicUrl(form.clone()), &store)
+        .await
+        .unwrap();
+    public_child
+        .set(
+            urls::READ.into(),
+            Value::ResourceArray(vec![urls::PUBLIC_AGENT.into()]),
+            &store,
+        )
+        .await
+        .unwrap();
+    let public_subject = public_child
+        .save_as_genesis(&store)
+        .await
+        .unwrap()
+        .resource_new
+        .unwrap()
+        .get_subject()
+        .clone();
+
+    let res = store
+        .query(&parent_query(&form, Some(1), urls::PUBLIC_AGENT.into()))
+        .await
+        .unwrap();
+    assert_eq!(
+        res.subjects,
+        vec![public_subject],
+        "a public child after a few private siblings must still fill page_size=1"
+    );
+}
+
 #[tokio::test]
 async fn get_extended_resource_pagination() {
     let store = Db::init_temp("get_extended_resource_pagination")

--- a/lib/src/hierarchy.rs
+++ b/lib/src/hierarchy.rs
@@ -118,9 +118,20 @@ pub fn check_read<'a>(
 ///
 /// Must not outlive a request (rights can change between requests) and must
 /// not be shared across agents — it does not key on the agent.
+///
+/// Lookups are by subject (not `&Resource`) so a cached verdict can skip
+/// fetching the ancestor entirely — see [`cached_outcome`].
 #[derive(Default)]
 pub struct RightsCache {
     outcomes: std::collections::HashMap<(u8, String), bool>,
+}
+
+impl RightsCache {
+    fn get(&self, right: Right, subject: &crate::Subject) -> Option<bool> {
+        self.outcomes
+            .get(&(right_discriminant(right), subject.pure_id()))
+            .copied()
+    }
 }
 
 fn right_discriminant(right: Right) -> u8 {
@@ -129,6 +140,40 @@ fn right_discriminant(right: Right) -> u8 {
         Right::Write => 1,
         Right::Append => 2,
     }
+}
+
+/// Cached `(right, subject)` verdict, if any. `None` when there is no cache
+/// or that pair has not been resolved yet.
+fn cached_outcome(
+    cache: Option<&std::sync::Mutex<RightsCache>>,
+    right: Right,
+    subject: &crate::Subject,
+) -> Option<bool> {
+    cache.and_then(|c| c.lock().ok().and_then(|g| g.get(right, subject)))
+}
+
+/// Load a resource for the rights walk: propvals-only when the store
+/// supports it, falling back to a full [`Storelike::get_resource`] so an
+/// un-materialized external parent can still be fetched.
+async fn fetch_for_rights<S: Storelike>(
+    store: &S,
+    subject: &crate::Subject,
+) -> AtomicResult<Resource> {
+    match store.get_resource_shallow(subject).await {
+        Ok(resource) => Ok(resource),
+        Err(_) => store.get_resource(subject).await,
+    }
+}
+
+fn cached_allow_msg() -> String {
+    "Allowed (cached for this request)".into()
+}
+
+fn cached_deny_err(right: Right, for_agent_enum: &ForAgent) -> crate::errors::AtomicError {
+    crate::errors::AtomicError::unauthorized(format!(
+        "No {} right found for {} (cached for this request)",
+        right, for_agent_enum
+    ))
 }
 
 /// [`check_rights`] with an optional per-request [`RightsCache`]. The cache is
@@ -143,29 +188,20 @@ pub fn check_rights_cached<'a, S: Storelike>(
     cache: Option<&'a std::sync::Mutex<RightsCache>>,
 ) -> AsyncResult<'a, AtomicResult<String>> {
     Box::pin(async move {
-        let key = (right_discriminant(right), resource.get_subject().pure_id());
-        if let Some(cache) = cache {
-            let hit = cache
-                .lock()
-                .ok()
-                .and_then(|guard| guard.outcomes.get(&key).copied());
-            match hit {
-                Some(true) => return Ok("Allowed (cached for this request)".into()),
-                Some(false) => {
-                    return Err(crate::errors::AtomicError::unauthorized(format!(
-                        "No {} right found for {} (cached for this request)",
-                        right, for_agent_enum
-                    )))
-                }
-                None => {}
-            }
+        match cached_outcome(cache, right, resource.get_subject()) {
+            Some(true) => return Ok(cached_allow_msg()),
+            Some(false) => return Err(cached_deny_err(right, for_agent_enum)),
+            None => {}
         }
 
         let result = check_rights_impl(store, resource, for_agent_enum, right, cache).await;
 
         if let Some(cache) = cache {
             if let Ok(mut guard) = cache.lock() {
-                guard.outcomes.insert(key, result.is_ok());
+                guard.outcomes.insert(
+                    (right_discriminant(right), resource.get_subject().pure_id()),
+                    result.is_ok(),
+                );
             }
         }
         result
@@ -256,9 +292,9 @@ fn check_rights_impl<'a, S: Storelike>(
             return match right {
                 Right::Read => {
                     // Commits can be read when their subject / target is readable.
-                    let target = store
-                        .get_resource(&commit_subject.to_string().as_str().into())
-                        .await?;
+                    let target =
+                        fetch_for_rights(store, &commit_subject.to_string().as_str().into())
+                            .await?;
                     check_rights_cached(store, &target, for_agent_enum, right, cache).await
                 }
                 Right::Write => Err("Commits cannot be edited.".into()),
@@ -318,37 +354,77 @@ fn check_rights_impl<'a, S: Storelike>(
         if let Ok(drive_val) = resource.get(urls::DRIVE_PROP) {
             let drive_subject = crate::Subject::from(drive_val.to_string());
             if &drive_subject != resource.get_subject() {
-                // A cached deny short-circuits the drive fetch entirely.
-                let cached_deny = cache.and_then(|c| {
-                    let key = (right_discriminant(right), drive_subject.pure_id());
-                    c.lock().ok().and_then(|g| g.outcomes.get(&key).copied())
-                }) == Some(false);
-                if !cached_deny {
-                    if let Ok(drive_res) = store.get_resource(&drive_subject).await {
-                        if let Ok(reason) =
-                            check_rights_cached(store, &drive_res, for_agent_enum, right, cache)
-                                .await
-                        {
-                            return Ok(reason);
+                // Consult the memo by subject *before* fetching: a cached allow
+                // is a hit, a cached deny skips the drive fetch and falls
+                // through to the parent walk (intermediate parents can still
+                // grant). Same idea as the parent path below.
+                match cached_outcome(cache, right, &drive_subject) {
+                    Some(true) => return Ok(cached_allow_msg()),
+                    Some(false) => {}
+                    None => {
+                        if let Ok(drive_res) = fetch_for_rights(store, &drive_subject).await {
+                            if let Ok(reason) =
+                                check_rights_cached(store, &drive_res, for_agent_enum, right, cache)
+                                    .await
+                            {
+                                return Ok(reason);
+                            }
                         }
                     }
                 }
             }
         }
 
-        // Try the parents recursively
+        // Try the parents recursively. The parent *subject* is known from
+        // propvals, so a cached verdict skips the fetch entirely — without
+        // this, every member of a listing pays a full `get_resource` of the
+        // same parent even though the memo already has the answer.
         tracing::debug!(
             subject = %resource.get_subject(),
             "rights walk: no explicit grant here, ascending to parent"
         );
-        match resource.get_parent(store).await {
-            Ok(parent) => {
-                tracing::debug!(
-                    subject = %resource.get_subject(),
-                    parent = %parent.get_subject(),
-                    "rights walk: ascending"
-                );
-                return check_rights_cached(store, &parent, for_agent_enum, right, cache).await;
+        match resource.get(urls::PARENT) {
+            Ok(parent_val) => {
+                let parent_subject = crate::Subject::from(parent_val.to_string());
+                if resource.get_subject() == &parent_subject {
+                    tracing::warn!(
+                        subject = %resource.get_subject(),
+                        "rights walk TERMINATED: circular parent (parent = same resource)"
+                    );
+                } else {
+                    match cached_outcome(cache, right, &parent_subject) {
+                        Some(true) => return Ok(cached_allow_msg()),
+                        Some(false) => {
+                            return Err(cached_deny_err(right, for_agent_enum));
+                        }
+                        None => match fetch_for_rights(store, &parent_subject).await {
+                            Ok(parent) => {
+                                tracing::debug!(
+                                    subject = %resource.get_subject(),
+                                    parent = %parent.get_subject(),
+                                    "rights walk: ascending"
+                                );
+                                return check_rights_cached(
+                                    store,
+                                    &parent,
+                                    for_agent_enum,
+                                    right,
+                                    cache,
+                                )
+                                .await;
+                            }
+                            Err(parent_err) => {
+                                tracing::warn!(
+                                    subject = %resource.get_subject(),
+                                    agent = %for_agent,
+                                    ?right,
+                                    parent_err = %parent_err,
+                                    "rights walk TERMINATED: parent fetch failed (this is where the 401 originates)"
+                                );
+                            }
+                        },
+                    }
+                }
             }
             Err(parent_err) => {
                 tracing::warn!(
@@ -356,7 +432,7 @@ fn check_rights_impl<'a, S: Storelike>(
                     agent = %for_agent,
                     ?right,
                     parent_err = %parent_err,
-                    "rights walk TERMINATED: get_parent failed (this is where the 401 originates)"
+                    "rights walk TERMINATED: no parent (this is where the 401 originates)"
                 );
             }
         }

--- a/lib/src/storelike.rs
+++ b/lib/src/storelike.rs
@@ -437,6 +437,16 @@ pub trait Storelike: Sized + Send + Sync {
     /// If you're not sure what to use, use `get_resource_extended`.
     async fn get_resource(&self, subject: &Subject) -> AtomicResult<Resource>;
 
+    /// Resource built from materialized propvals only — no Loro snapshot decode.
+    ///
+    /// [`check_rights`](crate::hierarchy::check_rights) reads only propvals
+    /// (`parent`, `drive`, ACL arrays), so the rights walk uses this instead of
+    /// [`get_resource`]. Stores with a row cache (`Db`) override; the default
+    /// is [`get_resource`] itself.
+    async fn get_resource_shallow(&self, subject: &Subject) -> AtomicResult<Resource> {
+        self.get_resource(subject).await
+    }
+
     /// Returns true when the resource is present in the local backing store.
     ///
     /// This must not fetch, synthesize dynamic resources, call endpoints, or

--- a/planning/index-performance.md
+++ b/planning/index-performance.md
@@ -75,7 +75,7 @@ a derived, rebuildable projection:
 | Batched KV reads (one read txn per query) | not built (`KvStore` trait change; per-`get` redb txns remain) |
 | Zones index (walk-free auth) | see [`zones.md`](./zones.md) |
 | Memoized ancestor *fetch* in the rights walk (consult the memo by subject before `get_parent`; ancestors loaded via `get_resource_shallow`) | **built** — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
-| Cap on the auth-denied member cascade (stop `resolve_query_member` after `AUTH_DENY_STREAK_CAP` consecutive denials while filling a page) | **built** — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
+| Cap on the auth-denied member cascade (stop resolving after N consecutive denials) | **declined** — would hide later readable members after a private streak; the ancestor-fetch memo is the speedup that stays correct |
 
 ## Benchmark context
 

--- a/planning/index-performance.md
+++ b/planning/index-performance.md
@@ -74,8 +74,8 @@ a derived, rebuildable projection:
 | Cursor pagination / `hasMore` instead of exact counts | not built (wire + client change) |
 | Batched KV reads (one read txn per query) | not built (`KvStore` trait change; per-`get` redb txns remain) |
 | Zones index (walk-free auth) | see [`zones.md`](./zones.md) |
-| Memoized ancestor *fetch* in the rights walk (the memo caches verdicts, but `get_parent` still full-decodes the parent per member) | not built — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
-| Cap on the auth-denied member cascade (denied members don't fill the page, so the loop resolves every match) | not built — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
+| Memoized ancestor *fetch* in the rights walk (consult the memo by subject before `get_parent`; ancestors loaded via `get_resource_shallow`) | **built** — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
+| Cap on the auth-denied member cascade (stop `resolve_query_member` after `AUTH_DENY_STREAK_CAP` consecutive denials while filling a page) | **built** — see [`slow-collection-queries.md`](./slow-collection-queries.md) |
 
 ## Benchmark context
 

--- a/planning/slow-collection-queries.md
+++ b/planning/slow-collection-queries.md
@@ -1,9 +1,11 @@
 # Slow collection queries (`/query`)
 
-**Status:** two of three causes fixed by the index/query rework
-(`3578d080`, see [`index-performance.md`](./index-performance.md)); **two
-items still open**, re-measured 2026-08-10 against the same real store.
-Original diagnosis 2026-07-16.
+**Status:** all three causes addressed. Index/query rework (`3578d080`,
+see [`index-performance.md`](./index-performance.md)) fixed the per-member
+Loro decode and added a per-query rights *verdict* memo; the two remaining
+items below landed 2026-08-14 (ancestor *fetch* memo + denial-streak cap).
+Original diagnosis 2026-07-16; last re-measure of the production store
+2026-08-10.
 
 ## Where it stands
 
@@ -19,57 +21,54 @@ build, anonymous agent) on a binary built after the rebase:
 | same, `page_size=100` | 3.4s | **0.69s** |
 | same, `page_size=1&offset=1000` (skips all per-member work) | — | **11ms** |
 
-~90% faster, but a 105-member auth-denied query still costs 0.7s, and page
-size still makes no difference.
+~90% faster after the index rework, but a 105-member auth-denied query still
+cost 0.7s, and page size still made no difference — that was the two open
+items. They were not re-measured on the production store; the regression
+test pins them to `get_resource` / `get_resource_shallow` call counts
+instead (`unauthorized_collection_query_bounds_fetch_counts`).
 
-### Cause 1 — no memoization in the rights walk → **fixed (partially)**
+### Cause 1 — no memoization in the rights walk → **fixed**
 
 `hierarchy::RightsCache` + `check_rights_cached` memoize
 `(right, subject) → verdict` for one query; `query_basic` and
 `query_sorted_indexed` each build one and thread it through
-`resolve_query_member`. The drive fast path also got an explicit
-`cached_deny` short-circuit that skips the drive fetch entirely.
+`resolve_query_member`.
 
-**But the parent walk did not get the same treatment** — see open item 1.
+The walk now consults that memo by *subject* **before** fetching an
+ancestor (drive or parent). A cached allow returns immediately; a cached
+deny on the drive still falls through to the parent walk (intermediate
+parents can grant); a cached deny on the parent is final. Ancestors are
+loaded with `Storelike::get_resource_shallow` (propvals only — `check_rights`
+never needs the CRDT), falling back to `get_resource` only if the row is
+missing (external / not yet materialized).
 
 ### Cause 2 — `get_resource` parses the full Loro snapshot on every read → **fixed for the query path**
 
 `Db::get_resource_shallow` (row-only, no CRDT decode) is now what queries
 read; nested bodies get the raw snapshot bytes attached verbatim as
 `loroUpdate` instead of a decode+re-export. `Storelike::get_resource`
-(`lib/src/db.rs:3034`) still decodes — deliberately; it's the
-CRDT-authoritative path. That's fine except where the rights walk calls it
-(open item 1).
+(`lib/src/db.rs`) still decodes — deliberately; it's the
+CRDT-authoritative path. The rights walk no longer calls it for local
+ancestors (cause 1).
 
-### Cause 3 — auth-failed members don't fill the page → **still open**
+### Cause 3 — auth-failed members don't fill the page → **fixed (capped)**
 
-Unchanged in `query_sorted_indexed` (`lib/src/db/query_index.rs:273`) and
-`query_basic` (`lib/src/db.rs:2110`): `in_selection = subjects.len() < limit
-&& i >= q.offset`. A denied member never grows `subjects`, so every
-subsequent entry is still fetched and rights-walked. Measured cost of exactly
-this: the same query at `offset=1000` (where `i >= q.offset` is false, so the
-loop only counts) is **11ms vs 700ms** — a 64× gap that is entirely
-per-member work the client never sees.
+Unchanged contract for mixed ACLs: denied members do not consume
+`page_size`, so a public child after a short private streak still fills
+the page (`unauthorized_query_skips_denials_to_fill_the_page`).
+
+What changed: `QueryAuthFill` in `query_basic` and `query_sorted_indexed`
+stops calling `resolve_query_member` after
+`query_index::AUTH_DENY_STREAK_CAP` (16) consecutive denials *while filling
+a page*, and only counts the remaining index hits (same cheap-pagination
+behavior as entries past `limit`, issue #286). Unbounded queries
+(`limit = None`) keep resolving so aggregations / complete listings stay
+correct.
 
 ## Open items
 
-- [ ] **Memoize the parent *fetch*, not just the verdict.**
-      `check_rights_impl` (`lib/src/hierarchy.rs:339`) calls
-      `resource.get_parent(store)`, which does a full
-      `store.get_resource(parent)` — Loro snapshot decode and all — *before*
-      `check_rights_cached` can consult the memo, because the memo takes a
-      `&Resource`. So each member pays one full decode of the form's 21.7KB
-      snapshot even though the verdict for that parent is already cached.
-      Confirmed by the cost scaling with parent snapshot size: ~6.7ms/member
-      when the parent is the 21.7KB form, ~2.3ms/member when it's the 2.9KB
-      drive.
-      Fix: consult the memo by *subject* before fetching (the drive fast path
-      at `hierarchy.rs:321` already does exactly this with `cached_deny` —
-      generalize it), and/or fetch ancestors with `get_resource_shallow`, since
-      `check_rights` only reads propvals.
-- [ ] **Cap the auth-failed fetch cascade** (original cause 3, unchanged):
-      once the page is full — or after N consecutive denials — stop calling
-      `resolve_query_member` and only count the remaining entries.
+- [x] **Memoize the parent *fetch*, not just the verdict.**
+- [x] **Cap the auth-failed fetch cascade.**
 
 Either fix alone should take the repro well under 100ms; both should land it
 near the 12ms fixed overhead.
@@ -85,10 +84,11 @@ curl -s -o /dev/null -w "%{time_total}s\n" -H "Accept: application/ad+json" \
 # add &offset=1000 to see the same query with the per-member loop skipped
 ```
 
-Synthetic repro for a regression test: drive → folder → form → ~100
-`FormInviteCode` children, query `parent=form` as a *non-authorized* agent,
-assert `get_resource` call counts (not wall clock — a fresh store's snapshots
-are too small to show it).
+Synthetic repro (now a regression test): drive → folder → form → ~100
+children, query `parent=form` as a *non-authorized* agent, assert
+`get_resource` / `get_resource_shallow` call counts — not wall clock.
+See `unauthorized_collection_query_bounds_fetch_counts` in
+`lib/src/db/test.rs`.
 
 Profiling: `atomic-server --trace chrome` writes `./trace-<ts>.json`;
 `check_rights` spans carry `subject` in args.
@@ -105,12 +105,14 @@ Profiling: `atomic-server --trace chrome` writes `./trace-<ts>.json`;
   are unreachable garbage rather than bad reads) — but they never get dropped,
   and the next key-format change has no working version gate on redb.
 - Watched queries are still emptied on every server startup by design
-  (`Db::clear_watched_queries`, `lib/src/db.rs:1729`), so the first sorted /
+  (`Db::clear_watched_queries`), so the first sorted /
   multi-filter query after a restart still pays an index rebuild.
 - `createInviteCodes` (`browser/data-browser/src/chunks/FormBuilder/FormAccessSection.tsx:54`)
   still saves codes in a sequential `for` loop (~9.3s for 100).
 - The invite-code panel still renders all rows via `mapAll`
   (`FormAccessSection.tsx:275`), each row's `useMemberFromCollection` fetching
   its own resource. Those per-row GETs go through `get_resource_extended` →
-  `check_rights` with **no** memo (the memo is per-query, not per-request), so
-  open item 1 hits them too.
+  `check_rights` with **no** memo (the memo is per-query, not per-request).
+  Cause 1 still helps each GET (ancestors are shallow-fetched), but there is
+  still one rights walk per row rather than one per listing.
+

--- a/planning/slow-collection-queries.md
+++ b/planning/slow-collection-queries.md
@@ -1,11 +1,9 @@
 # Slow collection queries (`/query`)
 
-**Status:** all three causes addressed. Index/query rework (`3578d080`,
-see [`index-performance.md`](./index-performance.md)) fixed the per-member
-Loro decode and added a per-query rights *verdict* memo; the two remaining
-items below landed 2026-08-14 (ancestor *fetch* memo + denial-streak cap).
-Original diagnosis 2026-07-16; last re-measure of the production store
-2026-08-10.
+**Status:** ancestor-fetch memo landed 2026-08-14. A consecutive-denial
+cap was tried and **reverted**: each member can carry its own grant, so a
+private streak must not stop the scan. Original diagnosis 2026-07-16;
+last re-measure of the production store 2026-08-10.
 
 ## Where it stands
 
@@ -22,10 +20,10 @@ build, anonymous agent) on a binary built after the rebase:
 | same, `page_size=1&offset=1000` (skips all per-member work) | — | **11ms** |
 
 ~90% faster after the index rework, but a 105-member auth-denied query still
-cost 0.7s, and page size still made no difference — that was the two open
-items. They were not re-measured on the production store; the regression
-test pins them to `get_resource` / `get_resource_shallow` call counts
-instead (`unauthorized_collection_query_bounds_fetch_counts`).
+cost 0.7s because each member full-decoded the parent. The ancestor-fetch
+memo (not re-measured on the production store) pins that to call counts in
+`unauthorized_collection_query_bounds_fetch_counts`. A denial-streak cap
+was not taken: it would hide later readable rows.
 
 ### Cause 1 — no memoization in the rights walk → **fixed**
 
@@ -51,27 +49,28 @@ read; nested bodies get the raw snapshot bytes attached verbatim as
 CRDT-authoritative path. The rights walk no longer calls it for local
 ancestors (cause 1).
 
-### Cause 3 — auth-failed members don't fill the page → **fixed (capped)**
+### Cause 3 — auth-failed members don't fill the page → **left as-is**
 
-Unchanged contract for mixed ACLs: denied members do not consume
-`page_size`, so a public child after a short private streak still fills
-the page (`unauthorized_query_skips_denials_to_fill_the_page`).
+Denied members do not consume `page_size`, so the loop keeps
+`resolve_query_member` until it has `limit` *authorized* hits (or the
+index is exhausted). That is required: a resource can have its own
+`read` grant even when every previous sibling was private
+(`unauthorized_query_skips_denials_to_fill_the_page` — 20 private, then
+one public, `page_size=1`).
 
-What changed: `QueryAuthFill` in `query_basic` and `query_sorted_indexed`
-stops calling `resolve_query_member` after
-`query_index::AUTH_DENY_STREAK_CAP` (16) consecutive denials *while filling
-a page*, and only counts the remaining index hits (same cheap-pagination
-behavior as entries past `limit`, issue #286). Unbounded queries
-(`limit = None`) keep resolving so aggregations / complete listings stay
-correct.
+A consecutive-denial cap would make the all-denied invite-code listing
+cheaper, but would hide later readable rows after a private streak. The
+ancestor-fetch memo (cause 1) is the speedup that stays correct: each
+member is still a cheap shallow row read + a cache hit on the parent,
+not a Loro decode of the form.
 
 ## Open items
 
 - [x] **Memoize the parent *fetch*, not just the verdict.**
-- [x] **Cap the auth-failed fetch cascade.**
-
-Either fix alone should take the repro well under 100ms; both should land it
-near the 12ms fixed overhead.
+- [x] **Cap the auth-failed fetch cascade** — *declined.* Stopping after N
+      consecutive denials would skip later members the agent *can* read.
+      Keep scanning until the page is full of authorized hits; the parent
+      memo makes that cheap.
 
 ## Repro
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The rights walk was full-decoding the shared parent on every member of a collection query, even after the verdict was cached. That is fixed. A consecutive-denial cap was **not** taken: each member can carry its own grant, so a private streak must not hide later readable rows.

## Changes

**Memoize the parent fetch, not just the verdict.** `check_rights` looks up `(right, subject)` in the per-query `RightsCache` *before* loading an ancestor. Local ancestors are read with `get_resource_shallow` (propvals only), falling back to `get_resource` only if the row is missing.

Denied members still do not consume `page_size`. The loop keeps resolving until it has `limit` authorized hits (or the index is exhausted). A table of 20 private rows followed by readable ones still returns those readable rows.

## Tests

Call counts, not wall clock:

- `unauthorized_collection_query_bounds_fetch_counts` — 100 private children, `page_size=1` as the public agent. `get_resource` stays 0; each member is still shallow-fetched once; the parent is not re-fetched.
- `unauthorized_query_skips_denials_to_fill_the_page` — 20 private siblings, then one public; `page_size=1` returns the public child.

`cargo test -p atomic_lib --features db-redb --lib -- db:: hierarchy::` — 67 passed (plus the tightened mixed-ACL case).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-246f8fe6-69f2-4eb3-b49c-a45fc4503487?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-246f8fe6-69f2-4eb3-b49c-a45fc4503487&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

