### PR TITLE
fix(store): stop a bundled stub from shadowing the real resource

### DIFF
--- a/browser/create-template/templates/sveltekit-site/README.md
+++ b/browser/create-template/templates/sveltekit-site/README.md
@@ -46,3 +46,26 @@ To create a production version of your app:
 You can preview the production build with `<PACKAGE_MANAGER_RUN> preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Why `@swc/core` is pinned
+
+`package.json` pins `@swc/core` and `@swc/wasm` to an exact version through
+`pnpm.overrides`. Neither is a direct dependency: both arrive under
+`vite-plugin-top-level-await`, which needs them to rewrite top-level `await`
+(this project has some, via the `loro-crdt` wasm bundle).
+
+That plugin floats them on a caret range, and it parses with one and
+manipulates the AST the other produced. When SWC ships a release that changes
+the AST schema, the two disagree and every build fails with:
+
+```
+error during build:
+[vite-plugin-top-level-await] missing field `type`
+```
+
+which names neither SWC nor the plugin, and appears without you having changed
+anything — a fresh install is all it takes. Pinning is the only lever here,
+since the range belongs to a transitive dependency.
+
+Safe to raise once `vite-plugin-top-level-await` ships a release that agrees
+with a newer SWC. Verify by building this template, not by reading versions.

--- a/browser/create-template/templates/sveltekit-site/package.json
+++ b/browser/create-template/templates/sveltekit-site/package.json
@@ -41,5 +41,11 @@
 		"@tomic/svelte": "^0.41.0-beta.2",
 		"loro-crdt": "^1.12.1",
 		"svelte-markdown": "^0.4.1"
+	},
+	"pnpm": {
+		"overrides": {
+			"@swc/core": "1.15.47",
+			"@swc/wasm": "1.15.47"
+		}
 	}
 }

--- a/browser/data-browser/index.html
+++ b/browser/data-browser/index.html
@@ -57,19 +57,23 @@
 
       `as="fetch"` + `crossorigin` + `type="application/wasm"` is the
       contract that lets the worker reuse the cached response.
+
+      `__WASM_VERSION__` is substituted at build time (vite.config.ts) and must
+      stay in step with the urls the app itself requests, or these preloads
+      warm a url nothing goes on to use.
     -->
     <link
       rel="preload"
       as="fetch"
       crossorigin="anonymous"
       type="application/wasm"
-      href="/wasm/atomic_wasm_bg.wasm"
+      href="/wasm/atomic_wasm_bg.wasm?v=__WASM_VERSION__"
     />
     <link
       rel="preload"
       as="script"
       crossorigin="anonymous"
-      href="/wasm/atomic_wasm.js"
+      href="/wasm/atomic_wasm.js?v=__WASM_VERSION__"
     />
     <link
       rel="preconnect"

--- a/browser/data-browser/src/bootstrap.test.ts
+++ b/browser/data-browser/src/bootstrap.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { core, Store } from '@tomic/lib';
+import { bootstrap } from './bootstrap';
+
+const PUBLIC_AGENT = 'https://atomicdata.dev/agents/publicAgent';
+const PROPERTIES_CONTAINER = 'https://atomicdata.dev/properties';
+
+/**
+ * Which bundled entries are allowed to be marked `incomplete`. The marker
+ * makes the store refetch the subject on first read, so anything carrying
+ * content of its own must stay out of it: a client with no route to
+ * atomicdata.dev would otherwise hold a resource that never becomes ready,
+ * and every control gated on `isReady()` stays disabled.
+ */
+describe('bootstrap', () => {
+  it('marks a bare container as incomplete so it does not shadow the real one', () => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    bootstrap(store);
+
+    const container = store.resources.get(PROPERTIES_CONTAINER);
+
+    expect(container).toBeDefined();
+    expect(container?.get(core.properties.incomplete)).toBe(true);
+  });
+
+  it('leaves the public agent usable without a fetch', () => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    bootstrap(store);
+
+    const publicAgent = store.resources.get(PUBLIC_AGENT);
+
+    expect(publicAgent).toBeDefined();
+    // Bundled with a description and shortname, so it is not a bare anchor —
+    // the share page's "Public (anyone)" toggle reads this resource and stays
+    // disabled until it is ready.
+    expect(publicAgent?.get(core.properties.incomplete)).toBeUndefined();
+    expect(publicAgent?.loading).toBe(false);
+  });
+});

--- a/browser/data-browser/src/bootstrap.ts
+++ b/browser/data-browser/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { JSONADParser, type Store } from '@tomic/react';
+import { core, JSONADParser, type Resource, type Store } from '@tomic/react';
 import baseModels from '@repo-lib-defaults/default_base_models.json';
 import defaultStore from '@repo-lib-defaults/default_store.json';
 import tableDefaults from '@repo-lib-defaults/table.json';
@@ -8,6 +8,22 @@ import ontologiesDefaults from '@repo-lib-defaults/ontologies.json';
 import aiDefaults from '@repo-lib-defaults/ai.json';
 import meetingDefaults from '@repo-lib-defaults/meeting.json';
 import forksDefaults from '@repo-lib-defaults/forks.json';
+
+/**
+ * A bundled entry that holds no content of its own — no class, and no
+ * properties beyond the `parent` that places it in the tree. The real resource
+ * lives on the server; this is only here so the definitions shipped alongside
+ * it have somewhere to hang.
+ */
+function isAnchorStub(resource: Resource): boolean {
+  if (resource.get(core.properties.isA)) {
+    return false;
+  }
+
+  return Object.keys(resource.getPropVals()).every(
+    prop => prop === core.properties.parent,
+  );
+}
 
 /**
  * Injects base models and default store resources into the store.
@@ -23,6 +39,26 @@ export function bootstrap(store: Store): void {
 
     for (const r of resources) {
       r.loading = false;
+
+      // Some bundled entries are pure anchors: they exist only to hold the
+      // parent chain of the definitions shipped alongside them, and carry
+      // nothing but `parent` (`atomicdata.dev/properties`, `/classes`,
+      // `/datatypes`, `/ontology/canvas`). Mark those `incomplete` so visiting
+      // the subject still triggers a real fetch — `getResourceLoading`
+      // refetches incomplete resources. Without the marker the stub reads as
+      // fully loaded and shadows the real resource forever: no fetch, no
+      // error, an empty page.
+      //
+      // A stub carrying content of its own is NOT an anchor, even without a
+      // class. `agents/publicAgent` (description + shortname) is the one that
+      // proves the difference: marking it sends every rights UI off to
+      // atomicdata.dev before it will enable a checkbox, so the "Public"
+      // toggle on the share page stays disabled for as long as that fetch is
+      // pending — forever, on a server with no route to the internet.
+      if (isAnchorStub(r)) {
+        r.applyHydratedValues([[core.properties.incomplete, true]]);
+      }
+
       store.applyIncoming({
         subject: r.subject,
         resource: r,

--- a/browser/data-browser/src/build-info.d.ts
+++ b/browser/data-browser/src/build-info.d.ts
@@ -3,3 +3,5 @@
 declare const __APP_VERSION__: string;
 declare const __GIT_COMMIT__: string;
 declare const __BUILD_TIME__: string;
+/** Content hash of the atomic-wasm pair; see `helpers/wasmUrls.ts`. */
+declare const __WASM_VERSION__: string;

--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -10,6 +10,8 @@ import { InputStyled, InputWrapper } from './forms/InputStyles';
 import { getManagedAccount, PRODUCT_NAME } from '../helpers/managed';
 import { useSettings } from '../helpers/AppSettings';
 import { fetchManagedInfo } from '../helpers/managedServer';
+import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
+import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
 import {
   addRecoveryCodeWrapper,
   envelopeWrapperKinds,
@@ -66,7 +68,18 @@ export function AccountRecoveryCard({
       if (cancelled) return;
 
       setHasSession(!!session);
-      setPortalUrl(info?.portalUrl ?? null);
+      // Resolve the portal the same way every other surface does, rather than
+      // reading `info.portalUrl` straight off the connected node.
+      //
+      // That direct read meant only a *managed* node could produce a portal
+      // link, so this card hid "Sign in to add a recovery code" on exactly the
+      // devices that need it — a browser pointed at a self-hosted or local
+      // node, or a desktop app on its own embedded one. Worse, the hint below
+      // still told the reader to sign in, because it keys off `hasSession`
+      // alone: instructions to do something with no way to do it.
+      setPortalUrl(
+        getManagedPortalUrl(info) ?? getRememberedManagedPortalUrl(),
+      );
     })();
 
     return () => {

--- a/browser/data-browser/src/components/ChatMessagesContainer.tsx
+++ b/browser/data-browser/src/components/ChatMessagesContainer.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import { useEffect, useEffectEvent, useRef } from 'react';
-import { ScrollArea } from '@components/ScrollArea';
+import { ScrollArea, ScrollViewPort } from '@components/ScrollArea';
 import { Column } from '@components/Row';
 
 /** How close to the bottom (px) still counts as "stuck to the bottom". */
@@ -163,9 +163,13 @@ export const ChatMessagesContainer: React.FC<
 const MessagesContainer = styled(ScrollArea)<{ $fullView?: boolean }>`
   overflow: auto;
   height: 100%;
-  /* Even flush against a panel that provides its own chrome, keep a hair of
-   * inline/block room so an avatar's following/hover outline (2px + 1px offset)
-   * isn't clipped by this scroll container. Right stays 0 so message chips can
-   * still bleed into the panel's right padding. */
-  padding: ${p => (p.$fullView ? '0.25rem 0 0.25rem 0.25rem' : p.theme.size())};
+  padding: ${p => (p.$fullView ? '0.25rem 0' : p.theme.size())};
+
+  /* The viewport is what scrolls and therefore what clips, so the room for an
+   * avatar's following/hover outline (2px + 1px offset) has to live here —
+   * padding on the ScrollArea root sits outside the clip and does nothing.
+   * Start only: message chips still bleed into the panel's right padding. */
+  ${ScrollViewPort} {
+    padding-inline-start: 3px;
+  }
 `;

--- a/browser/data-browser/src/components/NavBar.tsx
+++ b/browser/data-browser/src/components/NavBar.tsx
@@ -232,18 +232,26 @@ export function NavBar({ resource: resourceProp }: NavBarProps): JSX.Element {
   const { drive, sideBarLocked, setSideBarLocked } = useSettings();
   const driveResource = useResource(drive);
 
-  const resource =
+  /**
+   * The resource the user is actually looking at, if any. App routes
+   * (/app/settings, /app/sync, …) are pages of the app itself, not of a
+   * resource, so they have no subject.
+   */
+  const contextResource =
     resourceProp &&
     resourceProp.subject &&
     resourceProp.subject !== 'unknown-subject'
       ? resourceProp
-      : driveResource;
+      : undefined;
+
+  /** Falls back to the drive so the breadcrumb still names where you are. */
+  const resource = contextResource ?? driveResource;
 
   const [parent] = useString(resource, core.properties.parent);
   const { changes, revertResource, acceptChanges } = useAIChanges();
   const { enableAI } = useAISettings();
   const { isOpen: aiOpen, setIsOpen } = useAISidebar();
-  const hasAiChanges = changes.includes(resource.subject);
+  const hasAiChanges = !!contextResource && changes.includes(resource.subject);
 
   const handleAcceptChanges = async () => {
     acceptChanges(resource);
@@ -371,44 +379,52 @@ export function NavBar({ resource: resourceProp }: NavBarProps): JSX.Element {
       <ButtonArea $iconOnly={iconOnly}>
         <FollowStatus />
         <MeetingBanner />
-        <ResourcePresenceRow subject={resource.subject} />
-        {hasAiChanges && (
-          <Row gap='0.5rem' center>
-            <SmallButton clean onClick={() => revertResource(resource.subject)}>
-              Revert
-            </SmallButton>
-            <SmallButton onClick={handleAcceptChanges}>
-              Accept Changes
-            </SmallButton>
-          </Row>
-        )}
-
         <ContentLanguageSelect />
-        <CommentsButton subject={resource.subject} />
-        {enableAI && (
-          <LabelButton
-            $active={aiOpen}
-            onClick={() => setIsOpen(prev => !prev)}
-          >
-            <AIIcon />
-            <span>AI</span>
-          </LabelButton>
+        {/* Everything below acts on the resource you're looking at, so it only
+         * makes sense when there is one. */}
+        {contextResource && (
+          <>
+            <ResourcePresenceRow subject={contextResource.subject} />
+            {hasAiChanges && (
+              <Row gap='0.5rem' center>
+                <SmallButton
+                  clean
+                  onClick={() => revertResource(contextResource.subject)}
+                >
+                  Revert
+                </SmallButton>
+                <SmallButton onClick={handleAcceptChanges}>
+                  Accept Changes
+                </SmallButton>
+              </Row>
+            )}
+            <CommentsButton subject={contextResource.subject} />
+            {enableAI && (
+              <LabelButton
+                $active={aiOpen}
+                onClick={() => setIsOpen(prev => !prev)}
+              >
+                <AIIcon />
+                <span>AI</span>
+              </LabelButton>
+            )}
+            <TagSelectPopoverWrapper resource={contextResource} />
+            <ShareDialog
+              subject={contextResource.subject}
+              trigger={
+                <LabelButton as='button'>
+                  <FaShare />
+                  <span>Share</span>
+                </LabelButton>
+              }
+            />
+            <ResourceContextMenu
+              isMainMenu
+              subject={contextResource.subject}
+              trigger={ParentContextMenuTrigger}
+            />
+          </>
         )}
-        <TagSelectPopoverWrapper resource={resource} />
-        <ShareDialog
-          subject={resource.subject}
-          trigger={
-            <LabelButton as='button'>
-              <FaShare />
-              <span>Share</span>
-            </LabelButton>
-          }
-        />
-        <ResourceContextMenu
-          isMainMenu
-          subject={resource.subject}
-          trigger={ParentContextMenuTrigger}
-        />
       </ButtonArea>
     </NavBarWrapper>
   );

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -640,7 +640,7 @@ function SecretStep({
             Are you sure you&apos;ve stored this secret somewhere safe? You
             cannot recover it if you lose it.
           </p>
-          <Row key='confirm-row' gap='1rem'>
+          <Row key='confirm-row' gap='1rem' wrapItems>
             <Button onClick={onConfirm}>
               {verifySecret
                 ? "Yes, I've stored it — sign me out to verify"
@@ -743,7 +743,7 @@ function ProfileStep({
               />
             </InputWrapper>
           </Field>
-          <Row key='submit' gap='1rem'>
+          <Row key='submit' gap='1rem' wrapItems>
             <ContinueButton type='submit' disabled={loading || !name.trim()}>
               {loading ? 'Creating drive…' : 'Save & continue'}
             </ContinueButton>
@@ -801,7 +801,7 @@ function RecoveryBackupStep({
           reset it for you, and losing it means losing your account and
           everything in it. Fine if you&apos;ll genuinely keep it safe.
         </SkipWarning>
-        <Row key='actions' gap='1rem'>
+        <Row key='actions' gap='1rem' wrapItems>
           <ContinueButton
             type='button'
             onClick={() => setConfirmingSkip(false)}
@@ -830,7 +830,7 @@ function RecoveryBackupStep({
           email to use it, so it&apos;s safe to keep on paper.
         </p>
         {error && <ErrorText key='error'>{error}</ErrorText>}
-        <Row key='actions' gap='1rem'>
+        <Row key='actions' gap='1rem' wrapItems>
           <ContinueButton
             type='button'
             onClick={onAddCodeToPasskey}
@@ -873,7 +873,7 @@ function RecoveryBackupStep({
               Are you sure you&apos;ve stored this code somewhere safe? You
               cannot recover your account without it.
             </p>
-            <Row key='confirm-row' gap='1rem'>
+            <Row key='confirm-row' gap='1rem' wrapItems>
               <ContinueButton onClick={onContinue}>
                 Yes, I&apos;ve stored it safely
               </ContinueButton>
@@ -911,7 +911,7 @@ function RecoveryBackupStep({
           safe to keep in a password manager or on paper.
         </p>
         {error && <ErrorText key='error'>{error}</ErrorText>}
-        <Row key='actions' gap='1rem'>
+        <Row key='actions' gap='1rem' wrapItems>
           <ContinueButton type='button' onClick={onGenerate} disabled={loading}>
             {loading ? 'Generating…' : 'Generate my recovery code'}
           </ContinueButton>
@@ -938,7 +938,7 @@ function RecoveryBackupStep({
         too.
       </p>
       {error && <ErrorText key='error'>{error}</ErrorText>}
-      <Row key='actions' gap='1rem'>
+      <Row key='actions' gap='1rem' wrapItems>
         <ContinueButton type='button' onClick={onUsePasskey} disabled={loading}>
           {loading ? 'Waiting for your passkey…' : 'Use a passkey'}
         </ContinueButton>

--- a/browser/data-browser/src/components/Presence/AgentAvatar.tsx
+++ b/browser/data-browser/src/components/Presence/AgentAvatar.tsx
@@ -2,8 +2,11 @@ import { styled } from 'styled-components';
 import {
   useResource,
   useString,
+  useSubject,
   useTitle,
+  useFileObjectUrl,
   dataBrowser,
+  server,
   Image,
 } from '@tomic/react';
 /** Same palette as the collaborative editor's cursors, but picked
@@ -30,10 +33,14 @@ interface AgentAvatarProps {
 }
 
 /**
- * Round avatar for an agent: their profile image if they set one (the
- * `image` File property, or an external `imageUrl`), otherwise their
- * initial on a per-agent deterministic color. Pass `online` to overlay a
+ * Round avatar for an agent: their profile picture if they set one, otherwise
+ * their initial on a per-agent deterministic color. Pass `online` to overlay a
  * green presence dot.
+ *
+ * The picture is the `icon` File — the same property the profile editor writes
+ * and every other surface reads through `ResourceGlyph`, so one upload shows up
+ * everywhere. `image`/`imageUrl` are the older properties, still honoured for
+ * agents that carry them.
  */
 export function AgentAvatar({
   agentSubject,
@@ -42,12 +49,29 @@ export function AgentAvatar({
 }: AgentAvatarProps): React.JSX.Element {
   const agentResource = useResource(agentSubject);
   const [name] = useTitle(agentResource);
+  const [iconFile] = useSubject(agentResource, dataBrowser.properties.icon);
   const [imageFile] = useString(agentResource, dataBrowser.properties.image);
   const [imageUrl] = useString(agentResource, dataBrowser.properties.imageUrl);
 
+  // The icon File resolves to a local blob when the bytes are already here
+  // (fresh upload, offline) and to the server download URL otherwise.
+  const iconResource = useResource(iconFile);
+  const [iconDownloadUrl] = useString(
+    iconResource,
+    server.properties.downloadUrl,
+  );
+  const localIconUrl = useFileObjectUrl(iconResource);
+  const iconSrc = iconFile ? (localIconUrl ?? iconDownloadUrl) : undefined;
+
   let circle: React.JSX.Element;
 
-  if (imageFile) {
+  if (iconSrc) {
+    circle = (
+      <ImageCircle $size={size} title={name}>
+        <img src={iconSrc} alt={name} />
+      </ImageCircle>
+    );
+  } else if (imageFile) {
     circle = (
       <ImageCircle $size={size} title={name}>
         <Image subject={imageFile} alt={name} sizeIndication='2rem' />

--- a/browser/data-browser/src/components/Vault/VaultPanel.tsx
+++ b/browser/data-browser/src/components/Vault/VaultPanel.tsx
@@ -28,10 +28,17 @@ import type { UseVaultBackup } from '../../helpers/managed/useVaultBackup';
 export function VaultPanel({
   vault,
   onRestored,
+  embedded = false,
 }: {
   vault: UseVaultBackup;
   /** Called after a successful restore, so the host can refresh its view. */
   onRestored?: () => void;
+  /**
+   * Render as a row inside a surface the host already drew, rather than as a
+   * card of its own. Nesting a card in a card reads as two things when this is
+   * one service listed under an account.
+   */
+  embedded?: boolean;
 }) {
   const { status, busy, error, restoreProgress } = vault;
 
@@ -50,12 +57,16 @@ export function VaultPanel({
   // and leave the decision to the reader.
   if (status.state === 'unavailable') {
     return (
-      <Panel data-testid='vault-panel' data-vault-state='unavailable'>
+      <Panel
+        data-testid='vault-panel'
+        data-vault-state='unavailable'
+        $embedded={embedded}
+      >
         <Icon>
           <FaLock />
         </Icon>
         <Body>
-          <Title>Encrypted backup</Title>
+          <Title>Cloud Vault</Title>
           <Sub data-testid='vault-unavailable-reason'>{status.reason}</Sub>
         </Body>
       </Panel>
@@ -70,12 +81,16 @@ export function VaultPanel({
 
   if (status.state === 'off') {
     return (
-      <Panel data-testid='vault-panel' data-vault-state='off'>
+      <Panel
+        data-testid='vault-panel'
+        data-vault-state='off'
+        $embedded={embedded}
+      >
         <Icon $accent>
           <FaLock />
         </Icon>
         <Body>
-          <Title>Encrypted backup</Title>
+          <Title>Cloud Vault</Title>
           <Sub>
             Keep an encrypted copy of this workspace in {PRODUCT_NAME}. It is
             sealed on this device, so we store it without being able to read it.
@@ -87,7 +102,7 @@ export function VaultPanel({
               onClick={vault.enable}
               disabled={busy}
             >
-              {busy ? 'Setting up…' : 'Turn on encrypted backup'}
+              {busy ? 'Setting up…' : 'Turn on Cloud Vault'}
             </Button>
           </Actions>
         </Body>
@@ -102,13 +117,14 @@ export function VaultPanel({
     <Panel
       data-testid='vault-panel'
       data-vault-state={suspended ? 'suspended' : 'on'}
-      $accent
+      $accent={!embedded}
+      $embedded={embedded}
     >
       <Icon $accent>
         <FaLock />
       </Icon>
       <Body>
-        <Title>Encrypted backup is on</Title>
+        <Title>Cloud Vault is on</Title>
         {/* The object count is an attribute as well as prose: a test asserting
             that a second backup actually stored something should read the
             number, not parse a sentence that is free to be reworded. */}
@@ -211,10 +227,21 @@ function formatWhen(unixSeconds: number): string {
 // from `theme.size(2)` (8px) while the cards around it used 0.9rem (14.4px),
 // and left its body text at the inherited 1rem against their 0.82rem — close
 // enough to look like a mistake rather than a distinction.
-const Panel = styled.div<{ $accent?: boolean }>`
+const Panel = styled.div<{ $accent?: boolean; $embedded?: boolean }>`
   ${cardSurface}
   border-color: ${p => (p.$accent ? p.theme.colors.main : undefined)};
   background: ${p => (p.$accent ? `${p.theme.colors.main}0a` : undefined)};
+
+  /* Inside the provider card the surrounding card already supplies the
+     surface and the accent, so drawing them again would box one service
+     inside another box. */
+  ${p =>
+    p.$embedded &&
+    `
+      border: none;
+      background: none;
+      padding: 0;
+    `}
 `;
 
 /**

--- a/browser/data-browser/src/components/Vault/VaultPanel.tsx
+++ b/browser/data-browser/src/components/Vault/VaultPanel.tsx
@@ -2,10 +2,9 @@ import { styled } from 'styled-components';
 import { FaLock, FaRotateLeft, FaCloudArrowUp } from 'react-icons/fa6';
 import {
   cardSurface,
+  CardIcon,
   CARD_ACTIONS_GAP,
   CARD_BODY_GAP,
-  CARD_ICON_FONT,
-  CARD_ICON_SIZE,
   CARD_SUB_FONT,
   CARD_TITLE_FONT,
 } from '../cardSurface';
@@ -29,6 +28,8 @@ export function VaultPanel({
   vault,
   onRestored,
   embedded = false,
+  offerUrl,
+  onOfferClick,
 }: {
   vault: UseVaultBackup;
   /** Called after a successful restore, so the host can refresh its view. */
@@ -39,13 +40,41 @@ export function VaultPanel({
    * one service listed under an account.
    */
   embedded?: boolean;
+  /**
+   * Where to read what this tier costs. Shown only while the vault is off:
+   * once it is on, the price is a question for the account page, not for a
+   * panel whose job is the state of one drive's backup.
+   */
+  offerUrl?: string | null;
+  /**
+   * Opening the link is the host's business. A plain anchor is wrong in the
+   * desktop app, where Tauri intercepts a new window natively and the shell
+   * refuses it; the host already knows how to open one properly.
+   */
+  onOfferClick?: (url: string) => void;
 }) {
   const { status, busy, error, restoreProgress } = vault;
 
-  // Still settling. Genuinely brief — the hook gives up on `loading` rather
-  // than sitting in it, so this is a flicker and not a resting state.
+  // Still settling. Bounded — the hook gives up on `loading` rather than
+  // sitting in it — but the bound is seconds, not a frame, so rendering
+  // nothing meant the row appeared out of nowhere and shoved the rest of the
+  // account card down with it. Hold the space and say what is happening.
   if (status.state === 'loading') {
-    return null;
+    return (
+      <Panel
+        data-testid='vault-panel'
+        data-vault-state='loading'
+        $embedded={embedded}
+      >
+        <CardIcon>
+          <FaLock />
+        </CardIcon>
+        <Body>
+          <Title>Cloud Vault</Title>
+          <Sub>Checking this workspace’s backup…</Sub>
+        </Body>
+      </Panel>
+    );
   }
 
   // "Cannot say" is not "off": offering an enable button when we could not
@@ -62,9 +91,9 @@ export function VaultPanel({
         data-vault-state='unavailable'
         $embedded={embedded}
       >
-        <Icon>
+        <CardIcon>
           <FaLock />
-        </Icon>
+        </CardIcon>
         <Body>
           <Title>Cloud Vault</Title>
           <Sub data-testid='vault-unavailable-reason'>{status.reason}</Sub>
@@ -86,9 +115,9 @@ export function VaultPanel({
         data-vault-state='off'
         $embedded={embedded}
       >
-        <Icon $accent>
+        <CardIcon $tone='provider'>
           <FaLock />
-        </Icon>
+        </CardIcon>
         <Body>
           <Title>Cloud Vault</Title>
           <Sub>
@@ -104,6 +133,21 @@ export function VaultPanel({
             >
               {busy ? 'Setting up…' : 'Turn on Cloud Vault'}
             </Button>
+            {offerUrl && (
+              <OfferLink
+                data-testid='vault-offer'
+                href={offerUrl}
+                rel='noreferrer'
+                onClick={e => {
+                  if (!onOfferClick) return;
+
+                  e.preventDefault();
+                  onOfferClick(offerUrl);
+                }}
+              >
+                See plans
+              </OfferLink>
+            )}
           </Actions>
         </Body>
       </Panel>
@@ -120,9 +164,9 @@ export function VaultPanel({
       $accent={!embedded}
       $embedded={embedded}
     >
-      <Icon $accent>
+      <CardIcon $tone='provider'>
         <FaLock />
-      </Icon>
+      </CardIcon>
       <Body>
         <Title>Cloud Vault is on</Title>
         {/* The object count is an attribute as well as prose: a test asserting
@@ -244,30 +288,6 @@ const Panel = styled.div<{ $accent?: boolean; $embedded?: boolean }>`
     `}
 `;
 
-/**
- * Blue marks a surface as account-backed, the same accent an active
- * connection card wears, so the Sync page reads in two tones: what is yours
- * and local, and what involves the provider.
- *
- * Split from the card's own accent on purpose. The glyph turns blue as soon as
- * this is recognisably a provider feature — including while it is still only
- * an offer — but the card only tints once the feature is actually on. If the
- * offer looked identical to the live thing, the page would answer "is my data
- * backed up?" with a colour that means nothing.
- */
-const Icon = styled.div<{ $accent?: boolean }>`
-  display: grid;
-  place-items: center;
-  width: ${CARD_ICON_SIZE};
-  height: ${CARD_ICON_SIZE};
-  font-size: ${CARD_ICON_FONT};
-  flex-shrink: 0;
-  border-radius: 50%;
-  background-color: ${p =>
-    p.$accent ? p.theme.colors.main : p.theme.colors.bg2};
-  color: ${p => (p.$accent ? 'white' : p.theme.colors.textLight)};
-`;
-
 const Body = styled.div`
   display: flex;
   flex-direction: column;
@@ -291,6 +311,18 @@ const ErrorText = styled.p`
   margin: 0;
   color: ${p => p.theme.colors.alert};
   font-size: ${CARD_SUB_FONT};
+`;
+
+const OfferLink = styled.a`
+  align-self: center;
+  color: ${p => p.theme.colors.main};
+  font-size: ${CARD_SUB_FONT};
+  text-decoration: underline;
+
+  &:hover,
+  &:focus-visible {
+    color: ${p => p.theme.colors.mainDark};
+  }
 `;
 
 const Actions = styled.div`

--- a/browser/data-browser/src/components/Vault/VaultPanel.tsx
+++ b/browser/data-browser/src/components/Vault/VaultPanel.tsx
@@ -71,7 +71,7 @@ export function VaultPanel({
   if (status.state === 'off') {
     return (
       <Panel data-testid='vault-panel' data-vault-state='off'>
-        <Icon>
+        <Icon $accent>
           <FaLock />
         </Icon>
         <Body>
@@ -102,8 +102,9 @@ export function VaultPanel({
     <Panel
       data-testid='vault-panel'
       data-vault-state={suspended ? 'suspended' : 'on'}
+      $accent
     >
-      <Icon>
+      <Icon $accent>
         <FaLock />
       </Icon>
       <Body>
@@ -210,11 +211,24 @@ function formatWhen(unixSeconds: number): string {
 // from `theme.size(2)` (8px) while the cards around it used 0.9rem (14.4px),
 // and left its body text at the inherited 1rem against their 0.82rem — close
 // enough to look like a mistake rather than a distinction.
-const Panel = styled.div`
+const Panel = styled.div<{ $accent?: boolean }>`
   ${cardSurface}
+  border-color: ${p => (p.$accent ? p.theme.colors.main : undefined)};
+  background: ${p => (p.$accent ? `${p.theme.colors.main}0a` : undefined)};
 `;
 
-const Icon = styled.div`
+/**
+ * Blue marks a surface as account-backed, the same accent an active
+ * connection card wears, so the Sync page reads in two tones: what is yours
+ * and local, and what involves the provider.
+ *
+ * Split from the card's own accent on purpose. The glyph turns blue as soon as
+ * this is recognisably a provider feature — including while it is still only
+ * an offer — but the card only tints once the feature is actually on. If the
+ * offer looked identical to the live thing, the page would answer "is my data
+ * backed up?" with a colour that means nothing.
+ */
+const Icon = styled.div<{ $accent?: boolean }>`
   display: grid;
   place-items: center;
   width: ${CARD_ICON_SIZE};
@@ -222,8 +236,9 @@ const Icon = styled.div`
   font-size: ${CARD_ICON_FONT};
   flex-shrink: 0;
   border-radius: 50%;
-  background-color: ${p => p.theme.colors.bg2};
-  color: ${p => p.theme.colors.textLight};
+  background-color: ${p =>
+    p.$accent ? p.theme.colors.main : p.theme.colors.bg2};
+  color: ${p => (p.$accent ? 'white' : p.theme.colors.textLight)};
 `;
 
 const Body = styled.div`

--- a/browser/data-browser/src/components/cardSurface.ts
+++ b/browser/data-browser/src/components/cardSurface.ts
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css, styled } from 'styled-components';
 
 /**
  * The one card surface the Sync page and its panels share.
@@ -38,3 +38,29 @@ export const CARD_SUB_FONT = '0.82rem';
 /** Between title and subtitle: they read as one block. */
 export const CARD_BODY_GAP = '0.15rem';
 export const CARD_ACTIONS_GAP = '0.5rem';
+
+/**
+ * The round glyph chip on a {@link cardSurface}.
+ *
+ * One component with exactly two tones, because there were three separate
+ * implementations of this circle — one per card family — and they had drifted:
+ * a device chip was light grey with a dark glyph while a server chip was dark
+ * grey with a white one, so two things in the same category looked like two
+ * categories. Anything that reads as a distinction here should be a real one.
+ *
+ * The only real one left is whose service it is. Blue means the provider owns
+ * it; everything else is neutral, including a self-hosted node, which is
+ * somebody else's box however live it happens to be.
+ */
+export const CardIcon = styled.div<{ $tone?: 'neutral' | 'provider' }>`
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: ${CARD_ICON_SIZE};
+  height: ${CARD_ICON_SIZE};
+  border-radius: 50%;
+  font-size: ${CARD_ICON_FONT};
+  color: ${p => (p.$tone === 'provider' ? 'white' : p.theme.colors.text)};
+  background: ${p =>
+    p.$tone === 'provider' ? p.theme.colors.main : p.theme.colors.bg2};
+`;

--- a/browser/data-browser/src/helpers/initClientDb.ts
+++ b/browser/data-browser/src/helpers/initClientDb.ts
@@ -9,6 +9,7 @@ import {
   getSessionDbKey,
   hasWrappedDbKey,
 } from './localDbKey';
+import { wasmJsUrl } from './wasmUrls';
 
 // Track the current worker so we can terminate it on HMR reload and on
 // agent switches.
@@ -141,8 +142,7 @@ async function startForIdentity(
     dbKey = await resolveDbKey(agentSubject);
   }
 
-  const origin = window.location.origin;
-  const wasmUrl = `${origin}/wasm/atomic_wasm.js`;
+  const wasmUrl = wasmJsUrl();
 
   const clientDb = new ClientDbWorker(wasmUrl, clientDbWorkerUrl, {
     dbName,

--- a/browser/data-browser/src/helpers/managed/deviceLink.test.ts
+++ b/browser/data-browser/src/helpers/managed/deviceLink.test.ts
@@ -90,7 +90,9 @@ describe('requestDeviceLink', () => {
     await expect(requestDeviceLink(PORTAL)).rejects.toThrow(/Too many/);
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}, 500));
-    await expect(requestDeviceLink(PORTAL)).rejects.toThrow(/Check the address/);
+    await expect(requestDeviceLink(PORTAL)).rejects.toThrow(
+      /Check the address/,
+    );
   });
 });
 
@@ -124,7 +126,9 @@ describe('awaitDeviceLink', () => {
   it('keeps the session once approved', async () => {
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(jsonResponse({ state: 'pending' }))
-      .mockResolvedValueOnce(jsonResponse({ state: 'approved', token: 'sess' }));
+      .mockResolvedValueOnce(
+        jsonResponse({ state: 'approved', token: 'sess' }),
+      );
 
     expect(await awaitDeviceLink(PORTAL, request)).toBe('linked');
     expect(getManagedDeviceToken()).toBe('sess');

--- a/browser/data-browser/src/helpers/managed/devices.ts
+++ b/browser/data-browser/src/helpers/managed/devices.ts
@@ -13,7 +13,7 @@
 //
 // Canonical design: planning/device-pairing.md (§ SaaS-assisted pairing).
 
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 import { getManagedAccount } from './session';
 import { getLocalServerOrigin, isRunningInTauri } from '../tauri';
 import { pairAndSync } from '../pairing';

--- a/browser/data-browser/src/helpers/managed/enrollment.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.ts
@@ -1,5 +1,5 @@
 import { PRODUCT_NAME } from './product';
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 import { writeManagedAccountBinding } from './binding';
 import { getManagedAccount } from './session';
 
@@ -34,7 +34,9 @@ async function enrollmentError(response: Response): Promise<Error> {
   } | null;
 
   if (response.status === 401) {
-    return new Error(`Your ${PRODUCT_NAME} session expired. Sign in and retry.`);
+    return new Error(
+      `Your ${PRODUCT_NAME} session expired. Sign in and retry.`,
+    );
   }
 
   // The server's own words when it has them: it knows why far better than a

--- a/browser/data-browser/src/helpers/managed/enrollmentApi.ts
+++ b/browser/data-browser/src/helpers/managed/enrollmentApi.ts
@@ -6,7 +6,7 @@
 //        drive_name, resource_count, blob_bytes, loro_bytes, quota_bytes)
 // against the control-plane `GET /api/sync-enrollments` route.
 
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 
 export type ManagedEnrollmentStatus = 'Active' | 'Disabled' | string;
 

--- a/browser/data-browser/src/helpers/managed/nodeVault.test.ts
+++ b/browser/data-browser/src/helpers/managed/nodeVault.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const invoke = vi.fn();
-vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...a: unknown[]) => invoke(...a),
+}));
 
 const { nodeVault } = await import('./nodeVault');
 
@@ -29,9 +31,19 @@ describe('nodeVault', () => {
       tombstones: 1,
     });
 
-    const result = await nodeVault.vaultExport('did:ad:drive', key, 2, 'pseudo', 'dev', 1);
+    const result = await nodeVault.vaultExport(
+      'did:ad:drive',
+      key,
+      2,
+      'pseudo',
+      'dev',
+      1,
+    );
 
-    const [command, args] = invoke.mock.calls[0] as [string, Record<string, unknown>];
+    const [command, args] = invoke.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
     expect(command).toBe('vault_export');
     expect(typeof args.key).toBe('string');
     expect(args.keyEpoch).toBe(2);
@@ -45,7 +57,9 @@ describe('nodeVault', () => {
   /** Nothing to back up is an answer, not a failure. */
   it('passes through the "unchanged since last segment" null', async () => {
     invoke.mockResolvedValue(null);
-    expect(await nodeVault.vaultExport('did:ad:drive', key, 1, 'p', 'd', 4)).toBeNull();
+    expect(
+      await nodeVault.vaultExport('did:ad:drive', key, 1, 'p', 'd', 4),
+    ).toBeNull();
   });
 
   it('encodes objects for import and preserves their order', async () => {

--- a/browser/data-browser/src/helpers/managed/nodeVault.ts
+++ b/browser/data-browser/src/helpers/managed/nodeVault.ts
@@ -65,7 +65,12 @@ export const nodeVault: VaultCapableDb = {
     };
   },
 
-  async vaultImport(key, keyEpoch, drivePseudonym, objects): Promise<RestoreOutcome> {
+  async vaultImport(
+    key,
+    keyEpoch,
+    drivePseudonym,
+    objects,
+  ): Promise<RestoreOutcome> {
     return invoke<RestoreOutcome>('vault_import', {
       key: encodeB64(key),
       keyEpoch,

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1,4 +1,5 @@
 import { isRunningInTauri } from '../tauri';
+import { wasmBinaryUrl, wasmJsUrl } from '../wasmUrls';
 import { PRODUCT_NAME } from './product';
 import { getManagedApiBase, managedFetch } from './api';
 import { writeManagedAccountBinding } from './binding';
@@ -256,7 +257,7 @@ export async function decryptRecoverySecret(
 // --- Envelope v2 (DEK + recovery-code wrapper via Argon2id) ---
 
 type Argon2WasmModule = {
-  default: () => Promise<unknown>;
+  default: (init?: { module_or_path: string }) => Promise<unknown>;
   argon2idDeriveKey: (
     secret: string,
     salt: Uint8Array,
@@ -266,23 +267,47 @@ type Argon2WasmModule = {
   ) => Uint8Array;
 };
 
+/** What the dynamic import actually gives us: an older build of the glue has
+ * `default` but not the KDF, which is the case {@link loadArgon2Wasm} checks. */
+type LoadedWasmModule = Partial<Argon2WasmModule> &
+  Pick<Argon2WasmModule, 'default'>;
+
 let argon2ModulePromise: Promise<Argon2WasmModule> | null = null;
 
 /**
  * Lazily loads the atomic_wasm bundle on the main thread, independent of the
  * ClientDb worker (initClientDb.ts) — this is a stateless KDF call, not a
  * database, so it doesn't need OPFS or worker/leader-election machinery.
+ *
+ * The export is verified rather than assumed. A page that spans a deploy can
+ * hold a module from an older build (see `helpers/wasmUrls.ts`), where calling
+ * the missing KDF surfaces as a bare "is not a function" TypeError halfway
+ * through generating a recovery code. Failing here instead says what to do.
  */
 async function loadArgon2Wasm(): Promise<Argon2WasmModule> {
   if (!argon2ModulePromise) {
     argon2ModulePromise = (async () => {
-      const url = `${window.location.origin}/wasm/atomic_wasm.js`;
-      const wasmModule = (await import(
-        /* @vite-ignore */ url
-      )) as Argon2WasmModule;
-      await wasmModule.default();
+      try {
+        const url = wasmJsUrl();
+        const loaded = (await import(
+          /* @vite-ignore */ url
+        )) as LoadedWasmModule;
+        await loaded.default({ module_or_path: wasmBinaryUrl() });
 
-      return wasmModule;
+        if (typeof loaded.argon2idDeriveKey !== 'function') {
+          throw new Error(
+            'This page is running an outdated version of Atomic. Reload the page and try again.',
+          );
+        }
+
+        return loaded as Argon2WasmModule;
+      } catch (e) {
+        // Never memoize a failure: after the reload this asks for, and for an
+        // offline blip on the way to a 6MB binary, a retry must be able to
+        // load it rather than replay the rejection for the tab's lifetime.
+        argon2ModulePromise = null;
+        throw e;
+      }
     })();
   }
 

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1,7 +1,7 @@
 import { isRunningInTauri } from '../tauri';
 import { wasmBinaryUrl, wasmJsUrl } from '../wasmUrls';
 import { PRODUCT_NAME } from './product';
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 import { writeManagedAccountBinding } from './binding';
 
 export type RecoveryWrapperInput = {

--- a/browser/data-browser/src/helpers/managed/session.ts
+++ b/browser/data-browser/src/helpers/managed/session.ts
@@ -4,7 +4,7 @@
 // route. Mirrors the captured `getManagedUser()` in helpers/managedUsage.ts.
 
 import { PRODUCT_NAME } from './product';
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 
 export type ManagedAccount = {
   email: string;

--- a/browser/data-browser/src/helpers/managed/useVaultBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/useVaultBackup.test.ts
@@ -36,9 +36,9 @@ describe('describeMissingVaultInputs', () => {
 
   /** What staging showed: a local drive, but the page never resolved one. */
   it('names a drive that never resolved', () => {
-    expect(describeMissingVaultInputs({ ...ready, driveSubject: null })).toEqual(
-      ['no drive is open'],
-    );
+    expect(
+      describeMissingVaultInputs({ ...ready, driveSubject: null }),
+    ).toEqual(['no drive is open']);
   });
 
   /**

--- a/browser/data-browser/src/helpers/managed/useVaultBackup.ts
+++ b/browser/data-browser/src/helpers/managed/useVaultBackup.ts
@@ -168,7 +168,7 @@ export function useVaultBackup({
     const timer = setTimeout(() => {
       setStatus({
         state: 'unavailable',
-        reason: `Encrypted backup is not available here: ${missing.join(', ')}.`,
+        reason: `Cloud Vault is not available here: ${missing.join(', ')}.`,
       });
     }, READINESS_GRACE_MS);
 

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -1,5 +1,5 @@
 import { decodeB64 } from '@tomic/lib';
-import { getManagedApiBase, managedFetch } from './api';
+import { managedFetch } from './api';
 
 /**
  * Cloud Vault client: encrypted, blind backup of a drive.

--- a/browser/data-browser/src/helpers/managedServer.ts
+++ b/browser/data-browser/src/helpers/managedServer.ts
@@ -179,9 +179,7 @@ export function managedPortalOverride(): string | null {
 export function isHostedDistribution(): boolean {
   const flag =
     typeof import.meta !== 'undefined'
-      ? (import.meta.env?.VITE_ATOMIC_HOSTED_DISTRIBUTION as
-          | string
-          | undefined)
+      ? (import.meta.env?.VITE_ATOMIC_HOSTED_DISTRIBUTION as string | undefined)
       : undefined;
 
   return flag === '1' || flag === 'true';

--- a/browser/data-browser/src/helpers/tauri.test.ts
+++ b/browser/data-browser/src/helpers/tauri.test.ts
@@ -44,8 +44,9 @@ describe('isRunningInTauri', () => {
 
   it('trusts the injected global whatever the origin', () => {
     windowAt('http://localhost:6747/app/sync');
-    (globalThis.window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ =
-      {};
+    (
+      globalThis.window as unknown as Record<string, unknown>
+    ).__TAURI_INTERNALS__ = {};
     expect(isRunningInTauri()).toBe(true);
   });
 });

--- a/browser/data-browser/src/helpers/wasmUrls.ts
+++ b/browser/data-browser/src/helpers/wasmUrls.ts
@@ -1,0 +1,30 @@
+/**
+ * Where the app loads atomic-wasm from.
+ *
+ * The glue and its binary are served from `/wasm/` on the app's own origin
+ * (in Tauri that's the bundled `tauri://localhost`), a path that stays the
+ * same across builds because those files are copied into `public/` rather
+ * than run through Rollup. Everything else the app loads is content-hashed by
+ * Vite, so this pair was the one place where a cache — the service worker's
+ * precache in particular — could hand a page an older build's file under a url
+ * the new build still asks for. `__WASM_VERSION__` (the pair's content hash,
+ * computed in vite.config.ts) closes that gap.
+ */
+export function wasmJsUrl(origin: string = window.location.origin): string {
+  return `${origin}/wasm/atomic_wasm.js?v=${__WASM_VERSION__}`;
+}
+
+/**
+ * The binary belonging to {@link wasmJsUrl}, on the same version.
+ *
+ * Pass this to the glue's `default({ module_or_path })` rather than letting
+ * wasm-bindgen default to `new URL('atomic_wasm_bg.wasm', import.meta.url)`:
+ * that relative resolve drops the `?v=` and can pair this build's glue with a
+ * cached binary from another one, which fails deep inside instantiation
+ * instead of at a call site. (The ClientDb worker does the same thing via its
+ * own copy of this, in `@tomic/lib`'s `wasm-url.ts` — it cannot import from
+ * here, or from anywhere, without breaking its single-file packaging.)
+ */
+export function wasmBinaryUrl(origin: string = window.location.origin): string {
+  return `${origin}/wasm/atomic_wasm_bg.wasm?v=${__WASM_VERSION__}`;
+}

--- a/browser/data-browser/src/helpers/withDeadline.test.ts
+++ b/browser/data-browser/src/helpers/withDeadline.test.ts
@@ -16,7 +16,11 @@ describe('withDeadline', () => {
   it('gives up on a promise that never settles', async () => {
     vi.useFakeTimers();
 
-    const result = withDeadline(new Promise<string>(() => {}), 5000, 'fallback');
+    const result = withDeadline(
+      new Promise<string>(() => {}),
+      5000,
+      'fallback',
+    );
 
     await vi.advanceTimersByTimeAsync(5000);
     expect(await result).toBe('fallback');

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -144,7 +144,6 @@ msgstr ""
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewOntologyDialog.tsx
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/routes/History/HistoryMobileView.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/NewClassButton.tsx
 #: src/views/OntologyPage/NewPropertyButton.tsx
 #: src/views/Plugin/AssignRights.tsx
@@ -284,6 +283,7 @@ msgstr ""
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
+#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Remove"
 msgstr ""
@@ -831,9 +831,6 @@ msgstr ""
 #: src/routes/Search/SearchRoute.tsx
 msgid "With Tags:"
 msgstr ""
-
-#~ msgid "The easiest way to create, share and model linked data."
-#~ msgstr ""
 
 #: src/routes/AboutRoute.tsx
 msgid "Features"
@@ -4284,9 +4281,6 @@ msgstr ""
 msgid "Atomic Data Browser"
 msgstr ""
 
-#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
-#~ msgstr ""
-
 #. 0: ' '; 1: ' '
 #: src/routes/PruneTestsRoute.tsx
 msgid "This removes drives created for automated tests or local dev: names containing <0/> (E2E), or descriptions containing{0} <1/> (from{1} <2/>)."
@@ -4828,7 +4822,6 @@ msgstr ""
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
 msgstr ""
@@ -4909,9 +4902,6 @@ msgstr ""
 msgid "Server-only · no local cache"
 msgstr ""
 
-#~ msgid "Cloud Sync"
-#~ msgstr ""
-
 #. 0: usagePct
 #: src/routes/SyncRoute.tsx
 msgid "{0}% of storage used"
@@ -4936,6 +4926,7 @@ msgstr ""
 msgid "Embedded (this device)"
 msgstr ""
 
+#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
 msgstr ""
@@ -5112,15 +5103,6 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Setting up…"
 msgstr ""
-
-#~ msgid "Back up to {0}"
-#~ msgstr ""
-
-#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
-#~ msgstr ""
-
-#~ msgid "Timed out connecting to the Cloud Sync node."
-#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sign-in wasn’t completed — nothing was backed up."
@@ -6600,9 +6582,6 @@ msgstr ""
 msgid "The one workspace for everything, owned by you."
 msgstr ""
 
-#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
-#~ msgstr ""
-
 #: src/routes/AboutRoute.tsx
 msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device, and can run with no server at all. It adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
 msgstr ""
@@ -6621,48 +6600,34 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Devices"
-msgstr ""
+#~ msgid "Devices"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "An always-on device has an address. One you carry has a code — scan it below instead."
-msgstr ""
+#~ msgid "An always-on device has an address. One you carry has a code — scan it below instead."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "How to run your own server"
-msgstr ""
+#~ msgid "How to run your own server"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "<0/> Connect a device"
-msgstr ""
+#~ msgid "<0/> Connect a device"
+#~ msgstr ""
 
 #: src/helpers/managed/cloudSync.ts
 msgid "Timed out connecting to the Cloud Server node."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup"
-msgstr ""
+#~ msgid "Encrypted backup"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
 msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Turn on encrypted backup"
-msgstr ""
-
-#~ msgid "Nothing has been backed up yet."
-#~ msgstr ""
-
-#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgid "Turn on encrypted backup"
 #~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
@@ -6677,9 +6642,8 @@ msgstr ""
 msgid "Backups are paused. You can still restore what is already stored."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup is on"
-msgstr ""
+#~ msgid "Encrypted backup is on"
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "<0/> Restore"
@@ -6778,9 +6742,8 @@ msgstr ""
 msgid "…or bring it from another device instead"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Learn more"
-msgstr ""
+#~ msgid "Learn more"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6827,4 +6790,216 @@ msgstr ""
 
 #: src/helpers/managed/enrollment.test.ts
 msgid "Internal Server Error"
+msgstr ""
+
+#~ msgid "The easiest way to create, share and model linked data."
+#~ msgstr ""
+
+#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
+#~ msgstr ""
+
+#~ msgid "Cloud Sync"
+#~ msgstr ""
+
+#~ msgid "Back up to {0}"
+#~ msgstr ""
+
+#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
+#~ msgstr ""
+
+#~ msgid "Timed out connecting to the Cloud Sync node."
+#~ msgstr ""
+
+#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
+#~ msgstr ""
+
+#~ msgid "Nothing has been backed up yet."
+#~ msgstr ""
+
+#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgstr ""
+
+#~ msgid "Encrypted backup is not available here: {0}."
+#~ msgstr ""
+
+#~ msgid "Signed in to {0}"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage account →"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Turn on Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault is on"
+msgstr ""
+
+#~ msgid "Hosted services for this workspace"
+#~ msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+msgstr ""
+
+#. 0: missing.join(', ')
+#: src/helpers/managed/useVaultBackup.ts
+msgid "Cloud Vault is not available here: {0}."
+msgstr ""
+
+#~ msgid "See plans"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Disconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Reconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Not connected"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Switch"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Your cloud services"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud services for this workspace"
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "Signed in as {0}."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — we hold your key sealed, so this email gets you back in on a new device."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — no recovery backup stored. Lose every device and this workspace is gone."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Email recovery"
+msgstr ""
+
+#~ msgid "ProbeBetaNested {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeAlphaTop {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeOne {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeTwo{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeThree{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFour{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFive {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeSix {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeGuard"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardTwo"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardThree"
+#~ msgstr ""
+
+#. 0: nodeUsage.resourceCount.toLocaleString()
+#: src/routes/SyncRoute.tsx
+msgid "{0} resources"
+msgstr ""
+
+#. 0: formatBytes(usedBytes); 1: formatBytes(quotaBytes)
+#: src/routes/SyncRoute.tsx
+msgid "{0} of {1}"
+msgstr ""
+
+#~ msgid "ProbeFallbackA"
+#~ msgstr ""
+
+#~ msgid "ProbeLiteralB"
+#~ msgstr ""
+
+#~ msgid "ProbeGammaC {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeDeltaD {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeEpsilonE {0}"
+#~ msgstr ""
+
+#. 0: syncedAgo
+#: src/routes/SyncRoute.tsx
+msgid "Synced {0}"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Synced just now"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Open a workspace to see whether it can be hosted."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "Already set up for this workspace. This app is reading from {0} instead."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This server"
+msgstr ""
+
+#. 0: serverHostname ?? 'This server'
+#: src/routes/SyncRoute.tsx
+msgid "{0} doesn’t offer hosting, so it can’t be switched on from here."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking whether this workspace is hosted…"
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Checking this workspace’s backup…"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -144,7 +144,6 @@ msgstr "<0/> Create New Agent"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewOntologyDialog.tsx
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/routes/History/HistoryMobileView.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/NewClassButton.tsx
 #: src/views/OntologyPage/NewPropertyButton.tsx
 #: src/views/Plugin/AssignRights.tsx
@@ -284,6 +283,7 @@ msgstr "Automatically compact the conversation when input tokens exceed this per
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
+#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Remove"
 msgstr "Remove"
@@ -831,9 +831,6 @@ msgstr "Result"
 #: src/routes/Search/SearchRoute.tsx
 msgid "With Tags:"
 msgstr "With Tags:"
-
-#~ msgid "The easiest way to create, share and model linked data."
-#~ msgstr "The easiest way to create, share and model linked data."
 
 #: src/routes/AboutRoute.tsx
 msgid "Features"
@@ -4287,9 +4284,6 @@ msgstr ""
 msgid "Atomic Data Browser"
 msgstr "Atomic Data Browser"
 
-#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
-#~ msgstr "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
-
 #. 0: ' '; 1: ' '
 #: src/routes/PruneTestsRoute.tsx
 msgid "This removes drives created for automated tests or local dev: names containing <0/> (E2E), or descriptions containing{0} <1/> (from{1} <2/>)."
@@ -4862,7 +4856,6 @@ msgstr "Could not copy — select and copy the code manually."
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
 msgstr "Connect"
@@ -4943,9 +4936,6 @@ msgstr "Cached locally · works offline"
 msgid "Server-only · no local cache"
 msgstr "Server-only · no local cache"
 
-#~ msgid "Cloud Sync"
-#~ msgstr "Cloud Sync"
-
 #. 0: usagePct
 #: src/routes/SyncRoute.tsx
 msgid "{0}% of storage used"
@@ -4970,6 +4960,7 @@ msgstr "Sync now"
 msgid "Embedded (this device)"
 msgstr "Embedded (this device)"
 
+#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
 msgstr "Node ID"
@@ -5146,15 +5137,6 @@ msgstr "Backing up this workspace to {0}…"
 #: src/routes/SyncRoute.tsx
 msgid "Setting up…"
 msgstr "Setting up…"
-
-#~ msgid "Back up to {0}"
-#~ msgstr "Back up to {0}"
-
-#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
-#~ msgstr "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
-
-#~ msgid "Timed out connecting to the Cloud Sync node."
-#~ msgstr "Timed out connecting to the Cloud Sync node."
 
 #: src/routes/SyncRoute.tsx
 msgid "Sign-in wasn’t completed — nothing was backed up."
@@ -6634,9 +6616,6 @@ msgstr "{0} presets \"{1}\", which is not a column"
 msgid "The one workspace for everything, owned by you."
 msgstr "The one workspace for everything, owned by you."
 
-#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
-#~ msgstr "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
-
 #: src/routes/AboutRoute.tsx
 msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device, and can run with no server at all. It adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
 msgstr "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device, and can run with no server at all. It adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
@@ -6655,49 +6634,35 @@ msgstr "Set up Cloud Server"
 msgid "Cloud Server"
 msgstr "Cloud Server"
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
-msgstr "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
+#~ msgstr "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
 
-#: src/routes/SyncRoute.tsx
-msgid "Devices"
-msgstr "Devices"
+#~ msgid "Devices"
+#~ msgstr "Devices"
 
-#: src/routes/SyncRoute.tsx
-msgid "An always-on device has an address. One you carry has a code — scan it below instead."
-msgstr "An always-on device has an address. One you carry has a code — scan it below instead."
+#~ msgid "An always-on device has an address. One you carry has a code — scan it below instead."
+#~ msgstr "An always-on device has an address. One you carry has a code — scan it below instead."
 
-#: src/routes/SyncRoute.tsx
-msgid "How to run your own server"
-msgstr "How to run your own server"
+#~ msgid "How to run your own server"
+#~ msgstr "How to run your own server"
 
-#: src/routes/SyncRoute.tsx
-msgid "<0/> Connect a device"
-msgstr "<0/> Connect a device"
+#~ msgid "<0/> Connect a device"
+#~ msgstr "<0/> Connect a device"
 
 #: src/helpers/managed/cloudSync.ts
 msgid "Timed out connecting to the Cloud Server node."
 msgstr "Timed out connecting to the Cloud Server node."
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup"
-msgstr "Encrypted backup"
+#~ msgid "Encrypted backup"
+#~ msgstr "Encrypted backup"
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
 msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 msgstr "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Turn on encrypted backup"
-msgstr "Turn on encrypted backup"
-
-#~ msgid "Nothing has been backed up yet."
-#~ msgstr "Nothing has been backed up yet."
-
-#~ msgid "{0} encrypted object{1} · {2} stored."
-#~ msgstr "{0} encrypted object{1} · {2} stored."
+#~ msgid "Turn on encrypted backup"
+#~ msgstr "Turn on encrypted backup"
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Working…"
@@ -6711,9 +6676,8 @@ msgstr "Back up now"
 msgid "Backups are paused. You can still restore what is already stored."
 msgstr "Backups are paused. You can still restore what is already stored."
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup is on"
-msgstr "Encrypted backup is on"
+#~ msgid "Encrypted backup is on"
+#~ msgstr "Encrypted backup is on"
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "<0/> Restore"
@@ -6812,9 +6776,8 @@ msgstr "Restore my workspace"
 msgid "…or bring it from another device instead"
 msgstr "…or bring it from another device instead"
 
-#: src/routes/SyncRoute.tsx
-msgid "Learn more"
-msgstr "Learn more"
+#~ msgid "Learn more"
+#~ msgstr "Learn more"
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6862,3 +6825,215 @@ msgstr "No session"
 #: src/helpers/managed/enrollment.test.ts
 msgid "Internal Server Error"
 msgstr "Internal Server Error"
+
+#~ msgid "The easiest way to create, share and model linked data."
+#~ msgstr "The easiest way to create, share and model linked data."
+
+#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
+#~ msgstr "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
+
+#~ msgid "Cloud Sync"
+#~ msgstr "Cloud Sync"
+
+#~ msgid "Back up to {0}"
+#~ msgstr "Back up to {0}"
+
+#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
+#~ msgstr "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
+
+#~ msgid "Timed out connecting to the Cloud Sync node."
+#~ msgstr "Timed out connecting to the Cloud Sync node."
+
+#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
+#~ msgstr "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
+
+#~ msgid "Nothing has been backed up yet."
+#~ msgstr "Nothing has been backed up yet."
+
+#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgstr "{0} encrypted object{1} · {2} stored."
+
+#~ msgid "Encrypted backup is not available here: {0}."
+#~ msgstr "Encrypted backup is not available here: {0}."
+
+#~ msgid "Signed in to {0}"
+#~ msgstr "Signed in to {0}"
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage account →"
+msgstr "Manage account →"
+
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault"
+msgstr "Cloud Vault"
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Turn on Cloud Vault"
+msgstr "Turn on Cloud Vault"
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault is on"
+msgstr "Cloud Vault is on"
+
+#~ msgid "Hosted services for this workspace"
+#~ msgstr "Hosted services for this workspace"
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+msgstr "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+
+#. 0: missing.join(', ')
+#: src/helpers/managed/useVaultBackup.ts
+msgid "Cloud Vault is not available here: {0}."
+msgstr "Cloud Vault is not available here: {0}."
+
+#~ msgid "See plans"
+#~ msgstr "See plans"
+
+#: src/routes/SyncRoute.tsx
+msgid "Disconnect"
+msgstr "Disconnect"
+
+#: src/routes/SyncRoute.tsx
+msgid "Reconnect"
+msgstr "Reconnect"
+
+#: src/routes/SyncRoute.tsx
+msgid "Not connected"
+msgstr "Not connected"
+
+#: src/routes/SyncRoute.tsx
+msgid "Switch"
+msgstr "Switch"
+
+#: src/routes/SyncRoute.tsx
+msgid "Your cloud services"
+msgstr "Your cloud services"
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud services for this workspace"
+msgstr "Cloud services for this workspace"
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "Signed in as {0}."
+msgstr "Signed in as {0}."
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — we hold your key sealed, so this email gets you back in on a new device."
+msgstr "{0} — we hold your key sealed, so this email gets you back in on a new device."
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — no recovery backup stored. Lose every device and this workspace is gone."
+msgstr "{0} — no recovery backup stored. Lose every device and this workspace is gone."
+
+#: src/routes/SyncRoute.tsx
+msgid "Email recovery"
+msgstr "Email recovery"
+
+#~ msgid "ProbeBetaNested {0} tail"
+#~ msgstr "ProbeBetaNested {0} tail"
+
+#~ msgid "ProbeAlphaTop {0} tail"
+#~ msgstr "ProbeAlphaTop {0} tail"
+
+#~ msgid "ProbeOne {0} tail"
+#~ msgstr "ProbeOne {0} tail"
+
+#~ msgid "ProbeTwo{0} {1}"
+#~ msgstr "ProbeTwo{0} {1}"
+
+#~ msgid "ProbeThree{0} {1}"
+#~ msgstr "ProbeThree{0} {1}"
+
+#~ msgid "ProbeFour{0} {1}"
+#~ msgstr "ProbeFour{0} {1}"
+
+#~ msgid "ProbeFive {0}"
+#~ msgstr "ProbeFive {0}"
+
+#~ msgid "ProbeSix {0}"
+#~ msgstr "ProbeSix {0}"
+
+#~ msgid "ProbeGuard"
+#~ msgstr "ProbeGuard"
+
+#~ msgid "ProbeGuardTwo"
+#~ msgstr "ProbeGuardTwo"
+
+#~ msgid "ProbeGuardThree"
+#~ msgstr "ProbeGuardThree"
+
+#. 0: nodeUsage.resourceCount.toLocaleString()
+#: src/routes/SyncRoute.tsx
+msgid "{0} resources"
+msgstr "{0} resources"
+
+#. 0: formatBytes(usedBytes); 1: formatBytes(quotaBytes)
+#: src/routes/SyncRoute.tsx
+msgid "{0} of {1}"
+msgstr "{0} of {1}"
+
+#~ msgid "ProbeFallbackA"
+#~ msgstr "ProbeFallbackA"
+
+#~ msgid "ProbeLiteralB"
+#~ msgstr "ProbeLiteralB"
+
+#~ msgid "ProbeGammaC {0}"
+#~ msgstr "ProbeGammaC {0}"
+
+#~ msgid "ProbeDeltaD {0}"
+#~ msgstr "ProbeDeltaD {0}"
+
+#~ msgid "ProbeEpsilonE {0}"
+#~ msgstr "ProbeEpsilonE {0}"
+
+#. 0: syncedAgo
+#: src/routes/SyncRoute.tsx
+msgid "Synced {0}"
+msgstr "Synced {0}"
+
+#: src/routes/SyncRoute.tsx
+msgid "Synced just now"
+msgstr "Synced just now"
+
+#: src/routes/SyncRoute.tsx
+msgid "Open a workspace to see whether it can be hosted."
+msgstr "Open a workspace to see whether it can be hosted."
+
+#: src/routes/SyncRoute.tsx
+msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
+msgstr "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "Already set up for this workspace. This app is reading from {0} instead."
+msgstr "Already set up for this workspace. This app is reading from {0} instead."
+
+#: src/routes/SyncRoute.tsx
+msgid "This server"
+msgstr "This server"
+
+#. 0: serverHostname ?? 'This server'
+#: src/routes/SyncRoute.tsx
+msgid "{0} doesn’t offer hosting, so it can’t be switched on from here."
+msgstr "{0} doesn’t offer hosting, so it can’t be switched on from here."
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking whether this workspace is hosted…"
+msgstr "Checking whether this workspace is hosted…"
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+msgstr "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Checking this workspace’s backup…"
+msgstr "Checking this workspace’s backup…"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -144,7 +144,6 @@ msgstr "<0/> Crear Nuevo Agente"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewOntologyDialog.tsx
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/routes/History/HistoryMobileView.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/NewClassButton.tsx
 #: src/views/OntologyPage/NewPropertyButton.tsx
 #: src/views/Plugin/AssignRights.tsx
@@ -284,6 +283,7 @@ msgstr "Compacta automáticamente la conversación cuando los tokens de entrada 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
+#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Remove"
 msgstr "Eliminar"
@@ -831,9 +831,6 @@ msgstr "Resultado"
 #: src/routes/Search/SearchRoute.tsx
 msgid "With Tags:"
 msgstr "Con etiquetas:"
-
-#~ msgid "The easiest way to create, share and model linked data."
-#~ msgstr "La forma más fácil de crear, compartir y modelar datos enlazados."
 
 #: src/routes/AboutRoute.tsx
 msgid "Features"
@@ -4284,9 +4281,6 @@ msgstr "Creado a través de `/app/dev-drive` para desarrollo local y E2E. Puedes
 msgid "Atomic Data Browser"
 msgstr "Navegador de datos atómicos"
 
-#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
-#~ msgstr "Atomic Data combina la facilidad de uso de JSON, la conectividad de los datos enlazados y la fiabilidad de la seguridad de tipos — un protocolo abierto para grafos de conocimiento, aplicaciones colaborativas y conjuntos de datos compartibles."
-
 #. 0: ' '; 1: ' '
 #: src/routes/PruneTestsRoute.tsx
 msgid "This removes drives created for automated tests or local dev: names containing <0/> (E2E), or descriptions containing{0} <1/> (from{1} <2/>)."
@@ -4828,7 +4822,6 @@ msgstr ""
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
 msgstr ""
@@ -4909,9 +4902,6 @@ msgstr ""
 msgid "Server-only · no local cache"
 msgstr ""
 
-#~ msgid "Cloud Sync"
-#~ msgstr ""
-
 #. 0: usagePct
 #: src/routes/SyncRoute.tsx
 msgid "{0}% of storage used"
@@ -4936,6 +4926,7 @@ msgstr ""
 msgid "Embedded (this device)"
 msgstr ""
 
+#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
 msgstr ""
@@ -5112,15 +5103,6 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Setting up…"
 msgstr ""
-
-#~ msgid "Back up to {0}"
-#~ msgstr ""
-
-#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
-#~ msgstr ""
-
-#~ msgid "Timed out connecting to the Cloud Sync node."
-#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sign-in wasn’t completed — nothing was backed up."
@@ -6600,9 +6582,6 @@ msgstr ""
 msgid "The one workspace for everything, owned by you."
 msgstr ""
 
-#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
-#~ msgstr ""
-
 #: src/routes/AboutRoute.tsx
 msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device, and can run with no server at all. It adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
 msgstr ""
@@ -6621,48 +6600,34 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Devices"
-msgstr ""
+#~ msgid "Devices"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "An always-on device has an address. One you carry has a code — scan it below instead."
-msgstr ""
+#~ msgid "An always-on device has an address. One you carry has a code — scan it below instead."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "How to run your own server"
-msgstr ""
+#~ msgid "How to run your own server"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "<0/> Connect a device"
-msgstr ""
+#~ msgid "<0/> Connect a device"
+#~ msgstr ""
 
 #: src/helpers/managed/cloudSync.ts
 msgid "Timed out connecting to the Cloud Server node."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup"
-msgstr ""
+#~ msgid "Encrypted backup"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
 msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Turn on encrypted backup"
-msgstr ""
-
-#~ msgid "Nothing has been backed up yet."
-#~ msgstr ""
-
-#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgid "Turn on encrypted backup"
 #~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
@@ -6677,9 +6642,8 @@ msgstr ""
 msgid "Backups are paused. You can still restore what is already stored."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup is on"
-msgstr ""
+#~ msgid "Encrypted backup is on"
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "<0/> Restore"
@@ -6778,9 +6742,8 @@ msgstr ""
 msgid "…or bring it from another device instead"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Learn more"
-msgstr ""
+#~ msgid "Learn more"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6827,4 +6790,216 @@ msgstr ""
 
 #: src/helpers/managed/enrollment.test.ts
 msgid "Internal Server Error"
+msgstr ""
+
+#~ msgid "The easiest way to create, share and model linked data."
+#~ msgstr "La forma más fácil de crear, compartir y modelar datos enlazados."
+
+#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
+#~ msgstr "Atomic Data combina la facilidad de uso de JSON, la conectividad de los datos enlazados y la fiabilidad de la seguridad de tipos — un protocolo abierto para grafos de conocimiento, aplicaciones colaborativas y conjuntos de datos compartibles."
+
+#~ msgid "Cloud Sync"
+#~ msgstr ""
+
+#~ msgid "Back up to {0}"
+#~ msgstr ""
+
+#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
+#~ msgstr ""
+
+#~ msgid "Timed out connecting to the Cloud Sync node."
+#~ msgstr ""
+
+#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
+#~ msgstr ""
+
+#~ msgid "Nothing has been backed up yet."
+#~ msgstr ""
+
+#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgstr ""
+
+#~ msgid "Encrypted backup is not available here: {0}."
+#~ msgstr ""
+
+#~ msgid "Signed in to {0}"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage account →"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Turn on Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault is on"
+msgstr ""
+
+#~ msgid "Hosted services for this workspace"
+#~ msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+msgstr ""
+
+#. 0: missing.join(', ')
+#: src/helpers/managed/useVaultBackup.ts
+msgid "Cloud Vault is not available here: {0}."
+msgstr ""
+
+#~ msgid "See plans"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Disconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Reconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Not connected"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Switch"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Your cloud services"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud services for this workspace"
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "Signed in as {0}."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — we hold your key sealed, so this email gets you back in on a new device."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — no recovery backup stored. Lose every device and this workspace is gone."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Email recovery"
+msgstr ""
+
+#~ msgid "ProbeBetaNested {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeAlphaTop {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeOne {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeTwo{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeThree{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFour{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFive {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeSix {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeGuard"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardTwo"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardThree"
+#~ msgstr ""
+
+#. 0: nodeUsage.resourceCount.toLocaleString()
+#: src/routes/SyncRoute.tsx
+msgid "{0} resources"
+msgstr ""
+
+#. 0: formatBytes(usedBytes); 1: formatBytes(quotaBytes)
+#: src/routes/SyncRoute.tsx
+msgid "{0} of {1}"
+msgstr ""
+
+#~ msgid "ProbeFallbackA"
+#~ msgstr ""
+
+#~ msgid "ProbeLiteralB"
+#~ msgstr ""
+
+#~ msgid "ProbeGammaC {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeDeltaD {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeEpsilonE {0}"
+#~ msgstr ""
+
+#. 0: syncedAgo
+#: src/routes/SyncRoute.tsx
+msgid "Synced {0}"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Synced just now"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Open a workspace to see whether it can be hosted."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "Already set up for this workspace. This app is reading from {0} instead."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This server"
+msgstr ""
+
+#. 0: serverHostname ?? 'This server'
+#: src/routes/SyncRoute.tsx
+msgid "{0} doesn’t offer hosting, so it can’t be switched on from here."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking whether this workspace is hosted…"
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Checking this workspace’s backup…"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -144,7 +144,6 @@ msgstr "<0/> Créer un nouvel agent"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewOntologyDialog.tsx
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/routes/History/HistoryMobileView.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/NewClassButton.tsx
 #: src/views/OntologyPage/NewPropertyButton.tsx
 #: src/views/Plugin/AssignRights.tsx
@@ -284,6 +283,7 @@ msgstr "Compacte automatiquement la conversation lorsque les jetons d'entrée d�
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
+#: src/routes/SyncRoute.tsx
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Remove"
 msgstr "Supprimer"
@@ -831,9 +831,6 @@ msgstr "Résultat"
 #: src/routes/Search/SearchRoute.tsx
 msgid "With Tags:"
 msgstr "Avec les étiquettes :"
-
-#~ msgid "The easiest way to create, share and model linked data."
-#~ msgstr "Le moyen le plus simple de créer, partager et modéliser des données liées."
 
 #: src/routes/AboutRoute.tsx
 msgid "Features"
@@ -4284,9 +4281,6 @@ msgstr "Créé via `/app/dev-drive` pour le développement local et E2E. Vous po
 msgid "Atomic Data Browser"
 msgstr "Navigateur de données atomiques"
 
-#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
-#~ msgstr "Atomic Data combine la facilité d'utilisation de JSON, la connectivité des données liées et la fiabilité de la sécurité des types — un protocole ouvert pour les graphes de connaissances, les applications collaboratives et les jeux de données partageables."
-
 #. 0: ' '; 1: ' '
 #: src/routes/PruneTestsRoute.tsx
 msgid "This removes drives created for automated tests or local dev: names containing <0/> (E2E), or descriptions containing{0} <1/> (from{1} <2/>)."
@@ -4828,7 +4822,6 @@ msgstr ""
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
-#: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
 msgstr ""
@@ -4909,9 +4902,6 @@ msgstr ""
 msgid "Server-only · no local cache"
 msgstr ""
 
-#~ msgid "Cloud Sync"
-#~ msgstr ""
-
 #. 0: usagePct
 #: src/routes/SyncRoute.tsx
 msgid "{0}% of storage used"
@@ -4936,6 +4926,7 @@ msgstr ""
 msgid "Embedded (this device)"
 msgstr ""
 
+#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
 msgstr ""
@@ -5112,15 +5103,6 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Setting up…"
 msgstr ""
-
-#~ msgid "Back up to {0}"
-#~ msgstr ""
-
-#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
-#~ msgstr ""
-
-#~ msgid "Timed out connecting to the Cloud Sync node."
-#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sign-in wasn’t completed — nothing was backed up."
@@ -6600,9 +6582,6 @@ msgstr ""
 msgid "The one workspace for everything, owned by you."
 msgstr ""
 
-#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
-#~ msgstr ""
-
 #: src/routes/AboutRoute.tsx
 msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device, and can run with no server at all. It adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
 msgstr ""
@@ -6621,48 +6600,34 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike encrypted backup, our servers process what you put here."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Devices"
-msgstr ""
+#~ msgid "Devices"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "An always-on device has an address. One you carry has a code — scan it below instead."
-msgstr ""
+#~ msgid "An always-on device has an address. One you carry has a code — scan it below instead."
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "How to run your own server"
-msgstr ""
+#~ msgid "How to run your own server"
+#~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "<0/> Connect a device"
-msgstr ""
+#~ msgid "<0/> Connect a device"
+#~ msgstr ""
 
 #: src/helpers/managed/cloudSync.ts
 msgid "Timed out connecting to the Cloud Server node."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup"
-msgstr ""
+#~ msgid "Encrypted backup"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
 msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Turn on encrypted backup"
-msgstr ""
-
-#~ msgid "Nothing has been backed up yet."
-#~ msgstr ""
-
-#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgid "Turn on encrypted backup"
 #~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
@@ -6677,9 +6642,8 @@ msgstr ""
 msgid "Backups are paused. You can still restore what is already stored."
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Encrypted backup is on"
-msgstr ""
+#~ msgid "Encrypted backup is on"
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "<0/> Restore"
@@ -6778,9 +6742,8 @@ msgstr ""
 msgid "…or bring it from another device instead"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Learn more"
-msgstr ""
+#~ msgid "Learn more"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6827,4 +6790,216 @@ msgstr ""
 
 #: src/helpers/managed/enrollment.test.ts
 msgid "Internal Server Error"
+msgstr ""
+
+#~ msgid "The easiest way to create, share and model linked data."
+#~ msgstr "Le moyen le plus simple de créer, partager et modéliser des données liées."
+
+#~ msgid "Atomic Data combines the ease of use of JSON, the connectivity of linked data and the reliability of type-safety — one open protocol for knowledge graphs, collaborative apps and shareable datasets."
+#~ msgstr "Atomic Data combine la facilité d'utilisation de JSON, la connectivité des données liées et la fiabilité de la sécurité des types — un protocole ouvert pour les graphes de connaissances, les applications collaboratives et les jeux de données partageables."
+
+#~ msgid "Cloud Sync"
+#~ msgstr ""
+
+#~ msgid "Back up to {0}"
+#~ msgstr ""
+
+#~ msgid "This workspace lives only on this device. Turn on {0}{1} to back it up and reach it from your other devices and the web."
+#~ msgstr ""
+
+#~ msgid "Timed out connecting to the Cloud Sync node."
+#~ msgstr ""
+
+#~ msgid "Documents, tables, files, chat and custom apps in one place. AtomicServer starts on your device — it can run with no server at all — and adds backup, sharing and always-on availability when you want them. Everything you make is Atomic Data: typed, linked and portable, so it stays readable by other apps and by you."
+#~ msgstr ""
+
+#~ msgid "Nothing has been backed up yet."
+#~ msgstr ""
+
+#~ msgid "{0} encrypted object{1} · {2} stored."
+#~ msgstr ""
+
+#~ msgid "Encrypted backup is not available here: {0}."
+#~ msgstr ""
+
+#~ msgid "Signed in to {0}"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage account →"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Turn on Cloud Vault"
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Cloud Vault is on"
+msgstr ""
+
+#~ msgid "Hosted services for this workspace"
+#~ msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+msgstr ""
+
+#. 0: missing.join(', ')
+#: src/helpers/managed/useVaultBackup.ts
+msgid "Cloud Vault is not available here: {0}."
+msgstr ""
+
+#~ msgid "See plans"
+#~ msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Disconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Reconnect"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Not connected"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Switch"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Your cloud services"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud services for this workspace"
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "Signed in as {0}."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — we hold your key sealed, so this email gets you back in on a new device."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0} — no recovery backup stored. Lose every device and this workspace is gone."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Email recovery"
+msgstr ""
+
+#~ msgid "ProbeBetaNested {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeAlphaTop {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeOne {0} tail"
+#~ msgstr ""
+
+#~ msgid "ProbeTwo{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeThree{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFour{0} {1}"
+#~ msgstr ""
+
+#~ msgid "ProbeFive {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeSix {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeGuard"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardTwo"
+#~ msgstr ""
+
+#~ msgid "ProbeGuardThree"
+#~ msgstr ""
+
+#. 0: nodeUsage.resourceCount.toLocaleString()
+#: src/routes/SyncRoute.tsx
+msgid "{0} resources"
+msgstr ""
+
+#. 0: formatBytes(usedBytes); 1: formatBytes(quotaBytes)
+#: src/routes/SyncRoute.tsx
+msgid "{0} of {1}"
+msgstr ""
+
+#~ msgid "ProbeFallbackA"
+#~ msgstr ""
+
+#~ msgid "ProbeLiteralB"
+#~ msgstr ""
+
+#~ msgid "ProbeGammaC {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeDeltaD {0}"
+#~ msgstr ""
+
+#~ msgid "ProbeEpsilonE {0}"
+#~ msgstr ""
+
+#. 0: syncedAgo
+#: src/routes/SyncRoute.tsx
+msgid "Synced {0}"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Synced just now"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Open a workspace to see whether it can be hosted."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "Already set up for this workspace. This app is reading from {0} instead."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This server"
+msgstr ""
+
+#. 0: serverHostname ?? 'This server'
+#: src/routes/SyncRoute.tsx
+msgid "{0} doesn’t offer hosting, so it can’t be switched on from here."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking whether this workspace is hosted…"
+msgstr ""
+
+#. 0: serverHostname ?? 'another server'
+#: src/routes/SyncRoute.tsx
+msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+msgstr ""
+
+#: src/components/Vault/VaultPanel.tsx
+msgid "Checking this workspace’s backup…"
 msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -11,7 +11,13 @@ import {
   Datatype,
 } from '@tomic/react';
 import { styled, keyframes, css, type DefaultTheme } from 'styled-components';
-import { cardSurface, CARD_SUB_FONT } from '../components/cardSurface';
+import {
+  cardSurface,
+  CARD_ICON_FONT,
+  CARD_ICON_SIZE,
+  CARD_SUB_FONT,
+  CARD_TITLE_FONT,
+} from '../components/cardSurface';
 import { openExternal } from '../helpers/openExternal';
 import {
   FaLaptop,
@@ -29,7 +35,11 @@ import { Button } from '../components/Button';
 import { VaultPanel } from '../components/Vault/VaultPanel';
 import { LinkProviderPanel } from '../components/Vault/LinkProviderPanel';
 import { isDeviceLinked } from '../helpers/managed/deviceLink';
-import { getManagedAccount } from '../helpers/managed/session';
+import {
+  getManagedAccount,
+  type ManagedAccount,
+} from '../helpers/managed/session';
+import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
 import { useDriveVault } from '../helpers/managed/useDriveVault';
 import { ContainerNarrow } from '../components/Containers';
 import { Main } from '../components/Main';
@@ -267,25 +277,39 @@ function SyncPage() {
    */
   const [needsProviderLink, setNeedsProviderLink] = useState(false);
 
+  /**
+   * The provider account this client is signed in to, if any.
+   *
+   * Kept rather than reduced to a boolean because the account is what earns a
+   * link back to the portal, and that relationship exists independently of any
+   * managed node: Cloud Vault is blind backup and needs no hosting, so a user
+   * can be signed in with nothing managed in sight.
+   */
+  const [managedAccount, setManagedAccount] = useState<ManagedAccount | null>(
+    null,
+  );
+
   useEffect(() => {
     let cancelled = false;
 
     void (async () => {
-      if (isDeviceLinked()) {
-        if (!cancelled) setNeedsProviderLink(false);
-
-        return;
-      }
+      // Asked even when this device is already linked. The link only settles
+      // *how* this client authenticates; it says nothing about who, and the
+      // portal link needs the account itself.
+      const linked = isDeviceLinked();
 
       try {
         const account = await getManagedAccount();
 
-        if (!cancelled) setNeedsProviderLink(account === null);
+        if (cancelled) return;
+
+        setManagedAccount(account);
+        setNeedsProviderLink(!linked && account === null);
       } catch {
         // Unreachable control plane. Offering to link is the useful answer —
         // the alternative is a Sync page that silently omits backup with no
         // way to ask for it.
-        if (!cancelled) setNeedsProviderLink(true);
+        if (!cancelled) setNeedsProviderLink(!linked);
       }
     })();
 
@@ -578,6 +602,18 @@ function SyncPage() {
     }.`;
   }
 
+  /**
+   * Where to send someone who holds an account.
+   *
+   * Same sources as the Cloud Server CTA, then the control plane a managed
+   * node named earlier in this install's life. That fallback is what makes the
+   * link work on a device whose active node is unmanaged — a desktop app on
+   * its own embedded node, say — without inventing a URL for a node that has
+   * never heard of a portal.
+   */
+  const accountPortalUrl =
+    getManagedPortalUrl(managedInfo) ?? getRememberedManagedPortalUrl();
+
   async function promoteDrive() {
     if (!status.drive || promoting) return;
     setPromoting(true);
@@ -789,6 +825,44 @@ function SyncPage() {
       <ContainerNarrow>
         <h1>Sync</h1>
         <Lead>{summaryLine()}</Lead>
+
+        {/* Signed in to a provider, so say so and offer the way back.
+
+            Gated on holding an account rather than on the active node being
+            managed, which is what the only other link to the portal on this
+            page uses. That condition is wrong for an account: encrypted backup
+            is blind storage that needs no managed node, so someone can be
+            signed in, backing up daily, and never meet a managed node at all —
+            which is exactly the state that had no way back to the portal.
+
+            The URL still comes from configuration (a managed node's
+            `portalUrl`, a build-time override, or the control plane one pointed
+            us at before), never from anything hardcoded. A self-hosted node
+            that has never seen a portal yields null and renders nothing, which
+            is the FOSS boundary this page keeps elsewhere. */}
+        {managedAccount && accountPortalUrl && (
+          <AccountBar data-testid='managed-account-bar'>
+            <AccountIcon>
+              <FaCloud />
+            </AccountIcon>
+            <AccountBody>
+              <AccountLabel>Signed in to {PRODUCT_NAME}</AccountLabel>
+              <AccountEmail title={managedAccount.email}>
+                {managedAccount.email}
+              </AccountEmail>
+            </AccountBody>
+            <ManagedLink
+              // The dashboard, not the portal root: a signed-in visitor gets
+              // the marketing page at `/`, so the link would land on a sales
+              // pitch rather than the account it promises to manage.
+              href={`${accountPortalUrl}/dashboard`}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {'Manage account →'}
+            </ManagedLink>
+          </AccountBar>
+        )}
 
         {/* Signed in, but this device holds none of the account's data — it's
             still on whatever device created it. Pairing is the way across, so
@@ -1609,6 +1683,56 @@ function formatValue(value: unknown): string {
 const Lead = styled.p`
   color: ${p => p.theme.colors.textLight};
   margin-bottom: 2rem;
+`;
+
+/**
+ * The account strip under the lead line.
+ *
+ * Wears the same accent as an active connection card rather than a style of
+ * its own: everything on this page that is backed by the provider account
+ * reads blue, so a glance separates "this is yours and local" from "this
+ * involves your account".
+ */
+const AccountBar = styled.div`
+  ${cardSurface}
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+  border-color: ${p => p.theme.colors.main};
+  background: ${p => `${p.theme.colors.main}0a`};
+`;
+
+const AccountIcon = styled.div`
+  flex-shrink: 0;
+  width: ${CARD_ICON_SIZE};
+  height: ${CARD_ICON_SIZE};
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: ${CARD_ICON_FONT};
+  color: white;
+  background: ${p => p.theme.colors.main};
+`;
+
+const AccountBody = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+`;
+
+const AccountLabel = styled.span`
+  font-size: ${CARD_TITLE_FONT};
+  font-weight: 600;
+`;
+
+const AccountEmail = styled.span`
+  color: ${p => p.theme.colors.textLight};
+  font-size: ${CARD_SUB_FONT};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const Section = styled.section`

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -826,42 +826,113 @@ function SyncPage() {
         <h1>Sync</h1>
         <Lead>{summaryLine()}</Lead>
 
-        {/* Signed in to a provider, so say so and offer the way back.
+        {/* Everything our paid services own, in one card.
 
-            Gated on holding an account rather than on the active node being
-            managed, which is what the only other link to the portal on this
-            page uses. That condition is wrong for an account: encrypted backup
-            is blind storage that needs no managed node, so someone can be
-            signed in, backing up daily, and never meet a managed node at all —
-            which is exactly the state that had no way back to the portal.
+            These used to be loose entries in the Devices list, on the reasoning
+            that a person does not think of "this device", "the backup" and "the
+            hosted workspace" as different kinds of thing — they are all places
+            the same data lives. True as far as it goes, but it left no answer to
+            a different question the page is also asked: which of this is a
+            product I am paying for, and where do I go to manage it. Grouping
+            under the account answers that without returning to the old stack of
+            free-floating offer cards, because this is one card, not three.
 
-            The URL still comes from configuration (a managed node's
-            `portalUrl`, a build-time override, or the control plane one pointed
-            us at before), never from anything hardcoded. A self-hosted node
-            that has never seen a portal yields null and renders nothing, which
-            is the FOSS boundary this page keeps elsewhere. */}
-        {managedAccount && accountPortalUrl && (
-          <AccountBar data-testid='managed-account-bar'>
-            <AccountIcon>
-              <FaCloud />
-            </AccountIcon>
-            <AccountBody>
-              <AccountLabel>Signed in to {PRODUCT_NAME}</AccountLabel>
-              <AccountEmail title={managedAccount.email}>
-                {managedAccount.email}
-              </AccountEmail>
-            </AccountBody>
-            <ManagedLink
-              // The dashboard, not the portal root: a signed-in visitor gets
-              // the marketing page at `/`, so the link would land on a sales
-              // pitch rather than the account it promises to manage.
-              href={`${accountPortalUrl}/dashboard`}
-              target='_blank'
-              rel='noopener noreferrer'
-            >
-              {'Manage account →'}
-            </ManagedLink>
-          </AccountBar>
+            Gated on a portal being known at all, so a self-hosted node with no
+            control plane renders none of it. That URL comes from a managed
+            node, a build-time override, or one a node named earlier — never
+            from anything hardcoded here. */}
+        {accountPortalUrl && (
+          <ProviderCard data-testid='provider-card'>
+            <ProviderHeader>
+              <AccountIcon>
+                <FaCloud />
+              </AccountIcon>
+              <AccountBody>
+                <AccountLabel>{PRODUCT_NAME}</AccountLabel>
+                <AccountEmail
+                  title={managedAccount?.email ?? undefined}
+                  data-testid='provider-account'
+                >
+                  {managedAccount
+                    ? managedAccount.email
+                    : 'Hosted services for this workspace'}
+                </AccountEmail>
+              </AccountBody>
+              {managedAccount && (
+                <ManagedLink
+                  // The dashboard, not the portal root: a signed-in visitor
+                  // gets the marketing page at `/`, so the link would land on
+                  // a sales pitch rather than the account it promises to
+                  // manage.
+                  href={`${accountPortalUrl}/dashboard`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {'Manage account →'}
+                </ManagedLink>
+              )}
+            </ProviderHeader>
+
+            {/* The wrapper is conditional, not just the panel. `VaultPanel`
+                renders nothing while its prerequisites are still resolving,
+                and an unconditional row left a bordered empty strip under the
+                account header. */}
+            {vault.status.state !== 'loading' && (
+              <ProviderService>
+                <VaultPanel
+                  vault={vault}
+                  embedded
+                  onRestored={() => window.location.reload()}
+                />
+              </ProviderService>
+            )}
+
+            {showCloudBackup && (
+              <ProviderService>
+                <ConnIcon $tone='cloud'>
+                  <FaCloud />
+                </ConnIcon>
+                <ConnBody>
+                  <ConnTitle>Cloud Server</ConnTitle>
+                  <ConnSub>
+                    A hosted workspace on {PRODUCT_NAME}: shareable links,
+                    search across everything, API access, and no waiting on
+                    another device to be awake. Unlike Cloud Vault, our servers
+                    process what you put here.
+                  </ConnSub>
+                  <ConnActions>
+                    <Button onClick={backupToCloud} disabled={cloudBusy}>
+                      {cloudBusy ? 'Setting up…' : 'Set up Cloud Server'}
+                    </Button>
+                    {/* This tier costs money and reads our copy of your data,
+                        so "what am I agreeing to" deserves an answer that
+                        isn't a paragraph on this card. The sales page already
+                        explains the tiers side by side. */}
+                    {cloudPortalUrl && (
+                      <LearnMore
+                        href={`${cloudPortalUrl}/#pricing`}
+                        // No `_blank` in the app: Tauri intercepts a
+                        // new-window request natively, before the click
+                        // handler can cancel it, and hands it to `shell.open`
+                        // — which is denied and then fails on Android
+                        // regardless. The href stays real either way, so this
+                        // is still a link to assistive tech and to "copy link
+                        // address".
+                        target={isNode ? undefined : '_blank'}
+                        rel='noreferrer'
+                        onClick={e => {
+                          e.preventDefault();
+                          void openExternal(`${cloudPortalUrl}/#pricing`);
+                        }}
+                      >
+                        Learn more
+                      </LearnMore>
+                    )}
+                  </ConnActions>
+                </ConnBody>
+              </ProviderService>
+            )}
+          </ProviderCard>
         )}
 
         {/* Signed in, but this device holds none of the account's data — it's
@@ -932,12 +1003,12 @@ function SyncPage() {
         <Section>
           <SectionTitle>Devices</SectionTitle>
 
-          {/* One list, because a person does not think of these as
-              different kinds of thing. This device, the encrypted
-              backup and the hosted workspace are all places the same
-              data lives; splitting them into a stack of cards above an
-              empty "Devices" heading made the page read as a pile of
-              offers rather than an inventory. */}
+          {/* Devices only. The hosted services moved up into the provider
+              card, which is a narrower split than the one this list was
+              built to avoid: that earlier layout scattered them as separate
+              offer cards, where they are now one card under the account that
+              pays for them. What is left here is an inventory of places this
+              workspace physically lives. */}
           {/* This device — always the source of truth for local-first data. */}
           <DeviceCard>
             <ConnIcon $tone='device'>
@@ -987,66 +1058,6 @@ function SyncPage() {
             />
           )}
 
-          <VaultSlot>
-            <VaultPanel
-              vault={vault}
-              onRestored={() => window.location.reload()}
-            />
-          </VaultSlot>
-
-          {/* Cloud Server, the hosted tier, offered below the vault rather than
-              above it.
-
-              Deliberately not called "back up" any more. Backup is Cloud Vault's
-              job, and having two things on one page both offering to "back up
-              your workspace" made the only distinction that matters — whether we
-              can read it — the one thing the screen did not say. The copy leads
-              with what hosting buys and states plainly that this side is
-              readable, matching the tier described on the sales page. */}
-          {showCloudBackup && (
-            <LocalDriveNotice>
-              <ConnIcon $tone='cloud'>
-                <FaCloud />
-              </ConnIcon>
-              <ConnBody>
-                <ConnTitle>Cloud Server</ConnTitle>
-                <ConnSub>
-                  A hosted workspace on {PRODUCT_NAME}: shareable links, search
-                  across everything, API access, and no waiting on another
-                  device to be awake. Unlike encrypted backup, our servers
-                  process what you put here.
-                </ConnSub>
-                <ConnActions>
-                  <Button onClick={backupToCloud} disabled={cloudBusy}>
-                    {cloudBusy ? 'Setting up…' : 'Set up Cloud Server'}
-                  </Button>
-                  {/* This tier costs money and reads our copy of your data, so
-                      "what am I agreeing to" deserves an answer that isn't a
-                      paragraph on this card. The sales page already explains
-                      the tiers side by side. */}
-                  {cloudPortalUrl && (
-                    <LearnMore
-                      href={`${cloudPortalUrl}/#pricing`}
-                      // No `_blank` in the app: Tauri intercepts a new-window
-                      // request natively, before the click handler can cancel
-                      // it, and hands it to `shell.open` — which is denied and
-                      // then fails on Android regardless. The href stays real
-                      // either way, so this is still a link to assistive tech
-                      // and to "copy link address".
-                      target={isNode ? undefined : '_blank'}
-                      rel='noreferrer'
-                      onClick={e => {
-                        e.preventDefault();
-                        void openExternal(`${cloudPortalUrl}/#pricing`);
-                      }}
-                    >
-                      Learn more
-                    </LearnMore>
-                  )}
-                </ConnActions>
-              </ConnBody>
-            </LocalDriveNotice>
-          )}
           {localOnlyDrive && connectionCount > 0 && (
             <ConnNote>
               These sync your other drives — not this workspace.
@@ -1693,13 +1704,38 @@ const Lead = styled.p`
  * reads blue, so a glance separates "this is yours and local" from "this
  * involves your account".
  */
-const AccountBar = styled.div`
+const ProviderCard = styled.div`
   ${cardSurface}
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
   margin-bottom: 2rem;
   border-color: ${p => p.theme.colors.main};
   background: ${p => `${p.theme.colors.main}0a`};
+`;
+
+const ProviderHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+`;
+
+/**
+ * One service under the account header.
+ *
+ * Separated by a rule rather than by gaps between cards: these belong to the
+ * account above them, and whitespace alone made them read as neighbours of it
+ * instead of contents.
+ */
+const ProviderService = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 0.9rem 1rem;
+  border-top: 1px solid ${p => `${p.theme.colors.main}33`};
+  min-width: 0;
 `;
 
 const AccountIcon = styled.div`
@@ -1872,20 +1908,6 @@ const ConnCard = styled.div<{ $active?: boolean }>`
  *  inside it is the affordance; a second accent surface was just noise. */
 const LocalDriveNotice = styled.div`
   ${cardBase}
-  margin-bottom: 1.5rem;
-`;
-
-/**
- * Vertical rhythm for the vault panel.
- *
- * This page spaces blocks with their own `margin-bottom` rather than a
- * container `gap`, and `VaultPanel` is a standalone component that sets no
- * outer margin — deliberately, so it can be dropped elsewhere without bringing
- * one page's spacing with it. Without this wrapper it sits flush against
- * whatever follows, which put the "Devices" heading directly on the card's
- * bottom border. The host owns the rhythm; the component stays layout-agnostic.
- */
-const VaultSlot = styled.div`
   margin-bottom: 1.5rem;
 `;
 

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -13,8 +13,7 @@ import {
 import { styled, keyframes, css, type DefaultTheme } from 'styled-components';
 import {
   cardSurface,
-  CARD_ICON_FONT,
-  CARD_ICON_SIZE,
+  CardIcon,
   CARD_SUB_FONT,
   CARD_TITLE_FONT,
 } from '../components/cardSurface';
@@ -30,6 +29,7 @@ import {
   FaPlus,
   FaMobileScreenButton,
   FaCloudArrowUp,
+  FaKey,
 } from 'react-icons/fa6';
 import { Button } from '../components/Button';
 import { VaultPanel } from '../components/Vault/VaultPanel';
@@ -40,6 +40,7 @@ import {
   type ManagedAccount,
 } from '../helpers/managed/session';
 import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
+import { getRecoverySecret } from '../helpers/managed/recovery';
 import { useDriveVault } from '../helpers/managed/useDriveVault';
 import { ContainerNarrow } from '../components/Containers';
 import { Main } from '../components/Main';
@@ -194,6 +195,235 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(value < 10 ? 1 : 0)} ${units[unit]}`;
 }
 
+type ServerCardProps = {
+  server: string;
+  status: StoreSyncStatus;
+  managedInfo: ManagedInfo;
+  /** Sync status of the server actually in use. */
+  serverStatus: NodeStatus;
+  hasWorkingLocalStore: boolean;
+  nodeUsage: NodeDriveUsage | null;
+  quotaBytes: number | null;
+  serverNodeId: string | null;
+  onSwitch: (server: string) => void;
+  onRemove: (server: string) => void;
+};
+
+/**
+ * One server, as a card.
+ *
+ * Rendered in two places, which is why it is a component: a managed node is no
+ * longer listed among the devices, because it is one of the provider's
+ * services and belongs inside the account card. Both places want the same
+ * content — status, usage, node id, the way to disconnect — and one renderer
+ * is what stops the two copies drifting.
+ *
+ * At module scope with every input passed in, even though all of them are to
+ * hand in `SyncPage`. A component declared inside another component is a fresh
+ * type on every parent render, so React remounts the subtree rather than
+ * updating it — which for this card means throwing away a live connection's
+ * DOM on every keystroke elsewhere on the page.
+ */
+function ServerCard({
+  server,
+  status,
+  managedInfo,
+  serverStatus,
+  hasWorkingLocalStore,
+  nodeUsage,
+  quotaBytes,
+  serverNodeId,
+  onSwitch,
+  onRemove,
+}: ServerCardProps) {
+  const store = useStore();
+  const isActive = sameOrigin(server, status.serverUrl);
+  const isCloud = isActive && managedInfo.managed;
+  const serverHostname = status.serverUrl
+    ? new URL(status.serverUrl).hostname
+    : undefined;
+  const usagePct =
+    nodeUsage && quotaBytes
+      ? Math.min(
+          100,
+          Math.round(
+            ((nodeUsage.blobBytes + nodeUsage.loroBytes) / quotaBytes) * 100,
+          ),
+        )
+      : null;
+
+  const syncedAgo = status.lastDriveSync
+    ? formatTimeAgo(new Date(status.lastDriveSync.timestamp))
+    : null;
+  const usedBytes = nodeUsage
+    ? nodeUsage.blobBytes + nodeUsage.loroBytes
+    : null;
+  /**
+   * What is true of the server in use, as whole phrases joined by a dot.
+   *
+   * Assembled here rather than written inline in the JSX for two reasons.
+   * Interpolated text placed directly inside a `&&` guard extracts wrong —
+   * wuchale keeps the leading literal and drops the arguments, so at runtime
+   * the lookup wants more placeholders than the catalogue entry has and the
+   * line renders as `[i18n-404:…]`. And a translator given a whole phrase can
+   * reorder it, which is the whole point; given `resources ·` and ` of ` they
+   * cannot.
+   *
+   * Each phrase has to start with a capital or a placeholder: wuchale's
+   * default heuristic drops script-scope strings with a lower-case beginning,
+   * on the reasoning that those are usually identifiers rather than prose. A
+   * dropped string is not an error, it is simply never translated — which is
+   * the quiet failure, so it is worth knowing about.
+   */
+  const facts: string[] = [];
+
+  if (nodeUsage && usedBytes !== null) {
+    facts.push(`${nodeUsage.resourceCount.toLocaleString()} resources`);
+    facts.push(
+      quotaBytes
+        ? `${formatBytes(usedBytes)} of ${formatBytes(quotaBytes)}`
+        : formatBytes(usedBytes),
+    );
+  }
+
+  if (status.lastDriveSync) {
+    facts.push(syncedAgo ? `Synced ${syncedAgo}` : 'Synced just now');
+  }
+
+  return (
+    <ConnCard $active={isActive} $provider={isCloud}>
+      <CardIcon $tone={isCloud ? 'provider' : 'neutral'}>
+        {isCloud ? <FaCloud /> : <FaServer />}
+      </CardIcon>
+      <ConnBody>
+        <ConnTopRow>
+          <ConnTitle>
+            {isCloud ? 'Cloud Server' : serverLabel(server)}
+          </ConnTitle>
+          <ConnTopRight>
+            {isActive ? (
+              <>
+                <StatusPill $status={serverStatus}>
+                  <StatusIcon status={serverStatus} />
+                  {statusLabel(serverStatus)}
+                </StatusPill>
+                {status.serverConnected ? (
+                  // Without a working local store (embedded node or
+                  // ready OPFS cache), the server is the only data
+                  // source — disconnecting would leave the app with
+                  // no data at all.
+                  <NodeAction
+                    onClick={() => store.disconnect()}
+                    disabled={!hasWorkingLocalStore}
+                    title={
+                      hasWorkingLocalStore
+                        ? undefined
+                        : 'Local storage is off, so this server is the only data source. Enable local storage below to work disconnected.'
+                    }
+                  >
+                    Disconnect
+                  </NodeAction>
+                ) : (
+                  <NodeAction
+                    onClick={() =>
+                      store.reconnect().catch(e => store.notifyError(e))
+                    }
+                  >
+                    Reconnect
+                  </NodeAction>
+                )}
+              </>
+            ) : (
+              <>
+                <StatusPill $status='unknown'>Not connected</StatusPill>
+                <NodeAction onClick={() => onSwitch(server)}>Switch</NodeAction>
+              </>
+            )}
+          </ConnTopRight>
+        </ConnTopRow>
+
+        <ConnSub>
+          {isActive
+            ? isCloud
+              ? serverHostname
+              : 'Always-on · in use'
+            : 'Always-on device'}
+        </ConnSub>
+
+        {/* Status details belong to the server actually in use. */}
+        {isActive &&
+          !status.serverConnected &&
+          status.serverConnectionError && (
+            <ConnError role='alert'>
+              <FaCircleExclamation aria-hidden />
+              <span>{status.serverConnectionError}</span>
+            </ConnError>
+          )}
+
+        {isActive && usagePct !== null && (
+          <UsageBar
+            aria-label={`${usagePct}% of storage used`}
+            title={`${usagePct}% used`}
+          >
+            <UsageFill style={{ width: `${usagePct}%` }} />
+          </UsageBar>
+        )}
+
+        {isActive && facts.length > 0 && (
+          <ConnMeta>{facts.join(' · ')}</ConnMeta>
+        )}
+
+        {/* A node id identifies this server's node, so it belongs on
+                    the server — not buried in Developer. */}
+        {isActive && serverNodeId && (
+          <NodeIdRow>
+            <NodeIdLabel>Node ID</NodeIdLabel>
+            <NodeIdValue
+              title={`Copy ${rawToNodeDid(serverNodeId)}`}
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(
+                    rawToNodeDid(serverNodeId),
+                  );
+                  toast.success('Node ID copied');
+                } catch (e) {
+                  store.notifyError(e as Error);
+                }
+              }}
+            >
+              {rawToNodeDid(serverNodeId)}
+            </NodeIdValue>
+          </NodeIdRow>
+        )}
+
+        {isCloud && managedInfo.portalUrl && (
+          <ConnActions>
+            <ManagedLink
+              // The dashboard, not the portal root: signed-in
+              // visitors get the marketing page at `/`, so the
+              // link landed on a sales pitch rather than the
+              // account it promises to manage.
+              href={`${managedInfo.portalUrl}/dashboard`}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {'Manage account & plan →'}
+            </ManagedLink>
+          </ConnActions>
+        )}
+        {/* Removing the server you're using would strand the app. */}
+        {!isActive && (
+          <ConnActions>
+            <NodeActionSubtle onClick={() => onRemove(server)}>
+              Remove
+            </NodeActionSubtle>
+          </ConnActions>
+        )}
+      </ConnBody>
+    </ConnCard>
+  );
+}
+
 function SyncPage() {
   const store = useStore();
   const [status, setStatus] = useState<StoreSyncStatus>(() =>
@@ -288,6 +518,37 @@ function SyncPage() {
   const [managedAccount, setManagedAccount] = useState<ManagedAccount | null>(
     null,
   );
+
+  /**
+   * Whether the account holds an encrypted recovery backup.
+   *
+   * `null` until asked, and on failure — "we could not check" is not "you have
+   * none", and telling someone their recovery is missing when the control
+   * plane was merely unreachable is the one wrong answer this row can give.
+   */
+  const [hasRecoveryBackup, setHasRecoveryBackup] = useState<boolean | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!managedAccount) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const secret = await getRecoverySecret();
+
+        if (!cancelled) setHasRecoveryBackup(secret !== null);
+      } catch {
+        if (!cancelled) setHasRecoveryBackup(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [managedAccount]);
 
   useEffect(() => {
     let cancelled = false;
@@ -570,19 +831,50 @@ function SyncPage() {
     cloudEnrolled === false &&
     deviceLocalDrive &&
     !driveMissing;
-  /** Where "Learn more" goes. Null on a build with no provider, which is also
-   *  the case where there is no tier to explain. */
-  const cloudPortalUrl = getManagedPortalUrl(managedInfo);
 
-  const usagePct =
-    nodeUsage && quotaBytes
-      ? Math.min(
-          100,
-          Math.round(
-            ((nodeUsage.blobBytes + nodeUsage.loroBytes) / quotaBytes) * 100,
-          ),
-        )
-      : null;
+  /**
+   * Why Cloud Server can't be switched on from here, or null when it can.
+   *
+   * The row itself is unconditional once an account is known: a service that
+   * vanishes when it is off cannot be discovered, and "is this on?" is exactly
+   * the question this card exists to answer. But most of the reasons it can't
+   * be enabled right now are about *this device* rather than about the
+   * product, and saying which one is the difference between a page that reads
+   * as broken and one that reads as informative.
+   *
+   * The order matters: each line assumes the ones above it are false. `null`
+   * here is the same condition as `showCloudBackup`, by construction.
+   */
+  function cloudServerBlocker(): string | null {
+    if (!status.drive) {
+      return 'Open a workspace to see whether it can be hosted.';
+    }
+
+    if (driveMissing) {
+      return 'This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here.';
+    }
+
+    if (cloudEnrolled === true) {
+      return `Already set up for this workspace. This app is reading from ${serverHostname ?? 'another server'} instead.`;
+    }
+
+    if (!isCloudSyncAvailable(managedInfo)) {
+      return `${serverHostname ?? 'This server'} doesn’t offer hosting, so it can’t be switched on from here.`;
+    }
+
+    if (cloudEnrolled === null) {
+      return 'Checking whether this workspace is hosted…';
+    }
+
+    if (!deviceLocalDrive) {
+      return `This workspace already lives on ${serverHostname ?? 'another server'}. Moving it here is a migration, not a backup.`;
+    }
+
+    return null;
+  }
+
+  /** Evaluated once: three JSX call sites want the same answer. */
+  const cloudServerBlocked = cloudServerBlocker();
 
   function summaryLine(): string {
     if (localOnlyDrive) {
@@ -600,6 +892,41 @@ function SyncPage() {
     return `Your data lives on this device and syncs with ${connectionCount} other ${
       connectionCount === 1 ? 'device' : 'devices'
     }.`;
+  }
+
+  /** The provider's own node, when this drive is on one. */
+  const managedServer =
+    connectionServers.find(server => isManagedServer(server)) ?? null;
+
+  /** Is this one of ours? Mirrors `isCloud` inside the card renderer. */
+  function isManagedServer(server: string): boolean {
+    return sameOrigin(server, status.serverUrl) && managedInfo.managed;
+  }
+
+  /**
+   * A sales-page link for one tier, carrying what it would apply to.
+   *
+   * The portal only lists prices today, but buying a tier is per drive (that is
+   * how Cloud Server placement and Cloud Vault storage are both costed), so a
+   * checkout will need to know which drive and which agent it is selling to.
+   * Both identifiers are already on this page and both are public DIDs — the
+   * agent's *secret* never leaves the device — so passing them costs nothing
+   * now and saves the round trip later. Unknown values are omitted rather than
+   * sent empty.
+   */
+  function tierOfferUrl(portalUrl: string, tier: 'vault' | 'server'): string {
+    const url = new URL(portalUrl);
+    url.searchParams.set('tier', tier);
+
+    if (status.drive) url.searchParams.set('drive', status.drive);
+
+    const agentSubject = store.getAgent()?.subject;
+
+    if (agentSubject) url.searchParams.set('agent', agentSubject);
+
+    url.hash = 'pricing';
+
+    return url.toString();
   }
 
   /**
@@ -844,18 +1171,15 @@ function SyncPage() {
         {accountPortalUrl && (
           <ProviderCard data-testid='provider-card'>
             <ProviderHeader>
-              <AccountIcon>
+              <CardIcon $tone='provider'>
                 <FaCloud />
-              </AccountIcon>
+              </CardIcon>
               <AccountBody>
                 <AccountLabel>{PRODUCT_NAME}</AccountLabel>
-                <AccountEmail
-                  title={managedAccount?.email ?? undefined}
-                  data-testid='provider-account'
-                >
+                <AccountEmail data-testid='provider-account'>
                   {managedAccount
-                    ? managedAccount.email
-                    : 'Hosted services for this workspace'}
+                    ? 'Your cloud services'
+                    : 'Cloud services for this workspace'}
                 </AccountEmail>
               </AccountBody>
               {managedAccount && (
@@ -873,25 +1197,68 @@ function SyncPage() {
               )}
             </ProviderHeader>
 
-            {/* The wrapper is conditional, not just the panel. `VaultPanel`
-                renders nothing while its prerequisites are still resolving,
-                and an unconditional row left a bordered empty strip under the
-                account header. */}
-            {vault.status.state !== 'loading' && (
-              <ProviderService>
-                <VaultPanel
-                  vault={vault}
-                  embedded
-                  onRestored={() => window.location.reload()}
-                />
+            {/* Email recovery. Blue when it is actually set up, which is the
+                rule for every row here: colour answers "is this on", not "does
+                this exist". Left neutral while unknown too — a failed check
+                must not be drawn as a missing backup. */}
+            {managedAccount && (
+              <ProviderService data-testid='recovery-row'>
+                <CardIcon $tone={hasRecoveryBackup ? 'provider' : 'neutral'}>
+                  <FaKey />
+                </CardIcon>
+                <ConnBody>
+                  <ConnTitle>Email recovery</ConnTitle>
+                  <ConnSub>
+                    {hasRecoveryBackup === null
+                      ? `Signed in as ${managedAccount.email}.`
+                      : hasRecoveryBackup
+                        ? `${managedAccount.email} — we hold your key sealed, so this email gets you back in on a new device.`
+                        : `${managedAccount.email} — no recovery backup stored. Lose every device and this workspace is gone.`}
+                  </ConnSub>
+                </ConnBody>
               </ProviderService>
             )}
 
-            {showCloudBackup && (
-              <ProviderService>
-                <ConnIcon $tone='cloud'>
+            {/* Unconditional, like the other two: a service that disappears
+                when it is off cannot be found, and the question this card
+                answers is "is this on". `VaultPanel` renders every state
+                itself, including the seconds it spends deciding. */}
+            <ProviderService>
+              <VaultPanel
+                vault={vault}
+                embedded
+                offerUrl={tierOfferUrl(accountPortalUrl, 'vault')}
+                onOfferClick={url => void openExternal(url)}
+                onRestored={() => window.location.reload()}
+              />
+            </ProviderService>
+
+            {/* On: the managed node itself, rendered by the same function the
+                Devices list uses, so the two cannot drift. Off: the offer,
+                which stays on the page in every other state — with the reason
+                in place of the button when there is nothing to press. */}
+            {managedServer ? (
+              <ProviderService data-testid='cloud-server-row'>
+                <ServerCard
+                  server={managedServer}
+                  status={status}
+                  managedInfo={managedInfo}
+                  serverStatus={nodes.server}
+                  hasWorkingLocalStore={hasWorkingLocalStore}
+                  nodeUsage={nodeUsage}
+                  quotaBytes={quotaBytes}
+                  serverNodeId={serverNodeId}
+                  onSwitch={switchToServer}
+                  onRemove={removeServer}
+                />
+              </ProviderService>
+            ) : (
+              <ProviderService data-testid='cloud-server-row'>
+                {/* Glyph blue, card neutral: an offer should be findable as
+                    one of ours without being mistaken for a live service. */}
+                <CardIcon $tone='provider'>
                   <FaCloud />
-                </ConnIcon>
+                </CardIcon>
                 <ConnBody>
                   <ConnTitle>Cloud Server</ConnTitle>
                   <ConnSub>
@@ -900,34 +1267,43 @@ function SyncPage() {
                     another device to be awake. Unlike Cloud Vault, our servers
                     process what you put here.
                   </ConnSub>
+                  {cloudServerBlocked && (
+                    <ConnMeta>{cloudServerBlocked}</ConnMeta>
+                  )}
                   <ConnActions>
-                    <Button onClick={backupToCloud} disabled={cloudBusy}>
-                      {cloudBusy ? 'Setting up…' : 'Set up Cloud Server'}
-                    </Button>
+                    {!cloudServerBlocked && (
+                      <Button onClick={backupToCloud} disabled={cloudBusy}>
+                        {cloudBusy ? 'Setting up…' : 'Set up Cloud Server'}
+                      </Button>
+                    )}
                     {/* This tier costs money and reads our copy of your data,
                         so "what am I agreeing to" deserves an answer that
                         isn't a paragraph on this card. The sales page already
-                        explains the tiers side by side. */}
-                    {cloudPortalUrl && (
-                      <LearnMore
-                        href={`${cloudPortalUrl}/#pricing`}
-                        // No `_blank` in the app: Tauri intercepts a
-                        // new-window request natively, before the click
-                        // handler can cancel it, and hands it to `shell.open`
-                        // — which is denied and then fails on Android
-                        // regardless. The href stays real either way, so this
-                        // is still a link to assistive tech and to "copy link
-                        // address".
-                        target={isNode ? undefined : '_blank'}
-                        rel='noreferrer'
-                        onClick={e => {
-                          e.preventDefault();
-                          void openExternal(`${cloudPortalUrl}/#pricing`);
-                        }}
-                      >
-                        Learn more
-                      </LearnMore>
-                    )}
+                        explains the tiers side by side.
+
+                        Linked off the *account's* portal, not the connected
+                        node's: the states that most need a price are the ones
+                        where this device is talking to a node that has never
+                        heard of a portal. */}
+                    <LearnMore
+                      href={tierOfferUrl(accountPortalUrl, 'server')}
+                      // No `_blank` in the app: Tauri intercepts a new-window
+                      // request natively, before the click handler can cancel
+                      // it, and hands it to `shell.open` — which is denied and
+                      // then fails on Android regardless. The href stays real
+                      // either way, so this is still a link to assistive tech
+                      // and to "copy link address".
+                      target={isNode ? undefined : '_blank'}
+                      rel='noreferrer'
+                      onClick={e => {
+                        e.preventDefault();
+                        void openExternal(
+                          tierOfferUrl(accountPortalUrl, 'server'),
+                        );
+                      }}
+                    >
+                      See plans
+                    </LearnMore>
                   </ConnActions>
                 </ConnBody>
               </ProviderService>
@@ -941,9 +1317,9 @@ function SyncPage() {
             there is nothing here to promote. */}
         {driveMissing && (
           <LocalDriveNotice>
-            <ConnIcon $tone='device'>
+            <CardIcon>
               <FaMobileScreenButton />
-            </ConnIcon>
+            </CardIcon>
             <ConnBody>
               <ConnTitle>Your data is on another device</ConnTitle>
               <ConnSub>
@@ -976,9 +1352,9 @@ function SyncPage() {
             server — the same reconcile a regular drive uses, no special path. */}
         {localOnlyDrive && !driveMissing && !showCloudBackup && (
           <LocalDriveNotice>
-            <ConnIcon $tone='cloud'>
+            <CardIcon $tone='provider'>
               <FaCloudArrowUp />
-            </ConnIcon>
+            </CardIcon>
             <ConnBody>
               <ConnTitle>Only on this device</ConnTitle>
               <ConnSub>
@@ -1011,9 +1387,9 @@ function SyncPage() {
               workspace physically lives. */}
           {/* This device — always the source of truth for local-first data. */}
           <DeviceCard>
-            <ConnIcon $tone='device'>
+            <CardIcon>
               <FaLaptop />
-            </ConnIcon>
+            </CardIcon>
             <ConnBody>
               <ConnTitle>This device</ConnTitle>
               <ConnSub>
@@ -1078,175 +1454,35 @@ function SyncPage() {
             </EmptyConnections>
           )}
 
-          {/* Servers — one stable list; the active one is marked, not moved. */}
-          {connectionServers.map(server => {
-            const isActive = sameOrigin(server, status.serverUrl);
-            const isCloud = isActive && managedInfo.managed;
-
-            return (
-              <ConnCard key={server} $active={isActive}>
-                <ConnIcon
-                  $tone={isCloud ? 'cloud' : 'server'}
-                  $active={isActive}
-                >
-                  {isCloud ? <FaCloud /> : <FaServer />}
-                </ConnIcon>
-                <ConnBody>
-                  <ConnTopRow>
-                    <ConnTitle>
-                      {isCloud ? 'Cloud Server' : serverLabel(server)}
-                    </ConnTitle>
-                    <ConnTopRight>
-                      {isActive ? (
-                        <>
-                          <StatusPill $status={nodes.server}>
-                            <StatusIcon status={nodes.server} />
-                            {statusLabel(nodes.server)}
-                          </StatusPill>
-                          {status.serverConnected ? (
-                            // Without a working local store (embedded node or
-                            // ready OPFS cache), the server is the only data
-                            // source — disconnecting would leave the app with
-                            // no data at all.
-                            <NodeAction
-                              onClick={() => store.disconnect()}
-                              disabled={!hasWorkingLocalStore}
-                              title={
-                                hasWorkingLocalStore
-                                  ? undefined
-                                  : 'Local storage is off, so this server is the only data source. Enable local storage below to work disconnected.'
-                              }
-                            >
-                              Disconnect
-                            </NodeAction>
-                          ) : (
-                            <NodeAction
-                              onClick={() =>
-                                store
-                                  .reconnect()
-                                  .catch(e => store.notifyError(e))
-                              }
-                            >
-                              Reconnect
-                            </NodeAction>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <StatusPill $status='unknown'>
-                            Not connected
-                          </StatusPill>
-                          <NodeAction onClick={() => switchToServer(server)}>
-                            Switch
-                          </NodeAction>
-                        </>
-                      )}
-                    </ConnTopRight>
-                  </ConnTopRow>
-
-                  <ConnSub>
-                    {isActive
-                      ? isCloud
-                        ? serverHostname
-                        : 'Always-on · in use'
-                      : 'Always-on device'}
-                  </ConnSub>
-
-                  {/* Status details belong to the server actually in use. */}
-                  {isActive &&
-                    !status.serverConnected &&
-                    status.serverConnectionError && (
-                      <ConnError role='alert'>
-                        <FaCircleExclamation aria-hidden />
-                        <span>{status.serverConnectionError}</span>
-                      </ConnError>
-                    )}
-
-                  {isActive && usagePct !== null && (
-                    <UsageBar
-                      aria-label={`${usagePct}% of storage used`}
-                      title={`${usagePct}% used`}
-                    >
-                      <UsageFill style={{ width: `${usagePct}%` }} />
-                    </UsageBar>
-                  )}
-
-                  {isActive && nodeUsage && (
-                    <ConnMeta>
-                      {nodeUsage.resourceCount.toLocaleString()} resources ·{' '}
-                      {formatBytes(nodeUsage.blobBytes + nodeUsage.loroBytes)}
-                      {quotaBytes ? ` of ${formatBytes(quotaBytes)}` : ''}
-                      {status.lastDriveSync
-                        ? ` · synced ${formatTimeAgo(new Date(status.lastDriveSync.timestamp)) ?? 'just now'}`
-                        : ''}
-                    </ConnMeta>
-                  )}
-                  {isActive && !nodeUsage && status.lastDriveSync && (
-                    <ConnMeta>
-                      Last synced{' '}
-                      {formatTimeAgo(
-                        new Date(status.lastDriveSync.timestamp),
-                      ) ?? 'just now'}
-                    </ConnMeta>
-                  )}
-
-                  {/* A node id identifies this server's node, so it belongs on
-                      the server — not buried in Developer. */}
-                  {isActive && serverNodeId && (
-                    <NodeIdRow>
-                      <NodeIdLabel>Node ID</NodeIdLabel>
-                      <NodeIdValue
-                        title={`Copy ${rawToNodeDid(serverNodeId)}`}
-                        onClick={async () => {
-                          try {
-                            await navigator.clipboard.writeText(
-                              rawToNodeDid(serverNodeId),
-                            );
-                            toast.success('Node ID copied');
-                          } catch (e) {
-                            store.notifyError(e as Error);
-                          }
-                        }}
-                      >
-                        {rawToNodeDid(serverNodeId)}
-                      </NodeIdValue>
-                    </NodeIdRow>
-                  )}
-
-                  {isCloud && managedInfo.portalUrl && (
-                    <ConnActions>
-                      <ManagedLink
-                        // The dashboard, not the portal root: signed-in
-                        // visitors get the marketing page at `/`, so the
-                        // link landed on a sales pitch rather than the
-                        // account it promises to manage.
-                        href={`${managedInfo.portalUrl}/dashboard`}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                      >
-                        {'Manage account & plan →'}
-                      </ManagedLink>
-                    </ConnActions>
-                  )}
-                  {/* Removing the server you're using would strand the app. */}
-                  {!isActive && (
-                    <ConnActions>
-                      <NodeActionSubtle onClick={() => removeServer(server)}>
-                        Remove
-                      </NodeActionSubtle>
-                    </ConnActions>
-                  )}
-                </ConnBody>
-              </ConnCard>
-            );
-          })}
+          {/* Servers we do not own — one stable list; the active one is marked,
+              not moved. A managed node is deliberately absent: it moved up into
+              the account card, because "what am I paying for" and "where does
+              this drive live" are different questions and it was answering the
+              second while looking like the first. */}
+          {connectionServers
+            .filter(server => !isManagedServer(server))
+            .map(server => (
+              <ServerCard
+                key={server}
+                server={server}
+                status={status}
+                managedInfo={managedInfo}
+                serverStatus={nodes.server}
+                hasWorkingLocalStore={hasWorkingLocalStore}
+                nodeUsage={nodeUsage}
+                quotaBytes={quotaBytes}
+                serverNodeId={serverNodeId}
+                onSwitch={switchToServer}
+                onRemove={removeServer}
+              />
+            ))}
 
           {/* Paired devices (Iroh peers) */}
           {pairedPeers.map(peer => (
             <ConnCard key={peer.nodeId}>
-              <ConnIcon $tone='device'>
+              <CardIcon>
                 <FaMobileScreenButton />
-              </ConnIcon>
+              </CardIcon>
               <ConnBody>
                 <ConnTopRow>
                   <ConnTitle title={peer.nodeId}>{peer.label}</ConnTitle>
@@ -1285,9 +1521,9 @@ function SyncPage() {
 
             return (
               <ConnCard key={peer.nodeId}>
-                <ConnIcon $tone='device'>
+                <CardIcon>
                   <FaMobileScreenButton />
-                </ConnIcon>
+                </CardIcon>
                 <ConnBody>
                   <ConnTopRow>
                     <ConnTitle title={peer.nodeId}>{name}</ConnTitle>
@@ -1736,18 +1972,16 @@ const ProviderService = styled.div`
   padding: 0.9rem 1rem;
   border-top: 1px solid ${p => `${p.theme.colors.main}33`};
   min-width: 0;
-`;
 
-const AccountIcon = styled.div`
-  flex-shrink: 0;
-  width: ${CARD_ICON_SIZE};
-  height: ${CARD_ICON_SIZE};
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  font-size: ${CARD_ICON_FONT};
-  color: white;
-  background: ${p => p.theme.colors.main};
+  /* A connection row is one ellipsised line because a server origin has no
+     useful second line. These rows explain a service, so their text wraps —
+     otherwise the recovery row trails off mid-sentence. */
+  p,
+  span {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
 `;
 
 const AccountBody = styled.div`
@@ -1897,11 +2131,25 @@ const NodeIdValue = styled.button`
 /** `$active` marks the server actually in use. The list order is stable across
  *  switches, so this accent is the only thing that changes — which is the point:
  *  a reshuffling list is far harder to follow than a highlighted row. */
-const ConnCard = styled.div<{ $active?: boolean }>`
+/**
+ * Blue means "one of the provider's services", not "the one in use".
+ *
+ * These used to be the same thing, because the accent keyed off `$active`. A
+ * self-hosted node someone runs on their own hardware is not a hosted product
+ * no matter how live it is, and painting it the same blue as the account card
+ * said it was. Being in use is still worth showing, so it keeps a neutral
+ * emphasis, and the "In sync" badge next to the title carries the state.
+ */
+const ConnCard = styled.div<{ $active?: boolean; $provider?: boolean }>`
   ${cardBase}
   margin-bottom: 0.6rem;
-  border-color: ${p => (p.$active ? p.theme.colors.main : undefined)};
-  background: ${p => (p.$active ? `${p.theme.colors.main}0a` : undefined)};
+  border-color: ${p =>
+    p.$provider
+      ? p.theme.colors.main
+      : p.$active
+        ? p.theme.colors.textLight
+        : undefined};
+  background: ${p => (p.$provider ? `${p.theme.colors.main}0a` : undefined)};
 `;
 
 /** A call to action, but still one of the cards in this list. The button
@@ -1965,31 +2213,6 @@ const PairLabel = styled.span`
   font-size: 0.82rem;
   font-weight: 600;
   color: ${p => p.theme.colors.textLight};
-`;
-
-const ConnIcon = styled.div<{
-  $tone: 'device' | 'cloud' | 'server';
-  /** The server in use — accented, so which one is live reads at a glance. */
-  $active?: boolean;
-}>`
-  flex-shrink: 0;
-  width: 2.4rem;
-  height: 2.4rem;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1rem;
-  color: ${p =>
-    p.$tone === 'device' && !p.$active ? p.theme.colors.text : 'white'};
-  background: ${p =>
-    p.$active
-      ? p.theme.colors.main
-      : p.$tone === 'device'
-        ? p.theme.colors.bg2
-        : p.$tone === 'cloud'
-          ? p.theme.colors.main
-          : p.theme.colors.textLight};
 `;
 
 const ConnBody = styled.div`

--- a/browser/data-browser/src/views/ChatRoom/ChatRoomView.tsx
+++ b/browser/data-browser/src/views/ChatRoom/ChatRoomView.tsx
@@ -402,7 +402,8 @@ function MessageMeta({
     <MessageMetaRow>
       {createdBy && (
         <MessageAuthor>
-          <ResourceInline subject={createdBy} />
+          {/* No glyph: the message already leads with the author's avatar. */}
+          <ResourceInline subject={createdBy} hideGlyph />
         </MessageAuthor>
       )}
       {createdAt && (

--- a/browser/data-browser/src/views/ResourceInline/ResourceInline.tsx
+++ b/browser/data-browser/src/views/ResourceInline/ResourceInline.tsx
@@ -21,6 +21,9 @@ import type { JSX } from 'react';
 
 export type ResourceInlineInstanceProps = {
   subject: string;
+  /** Render the title only. For places that already show the resource's
+   *  picture next to this link, like a chat message's avatar. */
+  hideGlyph?: boolean;
 };
 
 type ResourceInlineProps = {
@@ -34,6 +37,7 @@ export function ResourceInline({
   subject,
   untabbable,
   basic,
+  hideGlyph,
   className,
 }: ResourceInlineProps): JSX.Element {
   const resource = useResource(subject, { allowIncomplete: true });
@@ -65,23 +69,25 @@ export function ResourceInline({
 
   return (
     <AtomicLink subject={subject} untabbable={untabbable} className={className}>
-      <Comp subject={subject} />
+      <Comp subject={subject} hideGlyph={hideGlyph} />
     </AtomicLink>
   );
 }
 
-function DefaultInline({ subject }: ResourceInlineInstanceProps): JSX.Element {
+function DefaultInline({
+  subject,
+  hideGlyph,
+}: ResourceInlineInstanceProps): JSX.Element {
   const resource = useResource(subject);
   const [description] = useString(resource, core.properties.description);
   const [emoji] = useString(resource, dataBrowser.properties.emoji);
   const [iconImage] = useSubject(resource, dataBrowser.properties.icon);
+  const showGlyph = !hideGlyph && (emoji || iconImage);
 
   return (
     <InlineText title={description ? description : ''}>
-      {(emoji || iconImage) && (
-        <ResourceGlyph resource={resource} requireCustom />
-      )}
-      {emoji && !iconImage ? ' ' : ''}
+      {showGlyph && <ResourceGlyph resource={resource} requireCustom />}
+      {showGlyph && emoji && !iconImage ? ' ' : ''}
       {resource.title}
     </InlineText>
   );

--- a/browser/data-browser/vite.config.ts
+++ b/browser/data-browser/vite.config.ts
@@ -8,6 +8,7 @@ import wasm from 'vite-plugin-wasm';
 import { wuchale } from 'wuchale/vite';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 
 // TAURI=1 produces a Tauri-compatible bundle: no CSP nonces (Tauri serves
@@ -52,11 +53,45 @@ try {
 
 const buildTime = new Date().toISOString();
 
+// A content hash of the atomic-wasm pair, appended to their URLs as `?v=`.
+//
+// These two files are the only ones the app loads from a STABLE url: they're
+// copied into `public/wasm/` by `build:wasm` instead of going through Rollup,
+// so unlike every hashed chunk their url stays identical across builds. That is
+// what let a page span a service-worker update in 2026-08 and run the NEW app
+// chunks against the PREVIOUS generation's precached glue, whose namespace has
+// no `argon2idDeriveKey` — recovery-code generation died on a stale module the
+// server had already replaced. Hashing the content into the url means the two
+// generations no longer collide, so a mixed-generation page misses and refetches
+// instead of silently resolving to the old body.
+function wasmVersion(): string {
+  const dir = path.resolve(__dirname, 'public/wasm');
+  const hash = crypto.createHash('sha256');
+  let hashedAny = false;
+
+  for (const file of ['atomic_wasm.js', 'atomic_wasm_bg.wasm']) {
+    const full = path.join(dir, file);
+
+    if (!fs.existsSync(full)) continue;
+
+    hash.update(fs.readFileSync(full));
+    hashedAny = true;
+  }
+
+  // Absent under SKIP_WASM_BUILD=1 (and before the first `build:wasm`). A
+  // constant beats a hash of nothing, which would read as a real version.
+  return hashedAny ? hash.digest('hex').slice(0, 12) : 'dev';
+}
+
+// Computed once: hashing the pair reads ~6MB off disk.
+const wasmVersionHash = wasmVersion();
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
     __GIT_COMMIT__: JSON.stringify(gitCommit),
     __BUILD_TIME__: JSON.stringify(buildTime),
+    __WASM_VERSION__: JSON.stringify(wasmVersionHash),
   },
   resolve: {
     // `loro-prosemirror` is excluded from dep-optimization (see
@@ -97,6 +132,14 @@ export default defineConfig({
   },
   plugins: [
     wasm(),
+    {
+      // index.html preloads the wasm pair to warm the worker's fetch, so those
+      // hrefs have to carry the same `?v=` the app requests — a preload for a
+      // url nobody asks for is a wasted download plus a console warning.
+      name: 'atomic-wasm-version-html',
+      transformIndexHtml: (html: string) =>
+        html.replaceAll('__WASM_VERSION__', wasmVersionHash),
+    },
     !isVitest && webfontDownload(),
     !isVitest && wuchale(),
     // OXC handles the bulk JSX/TS transform via @vitejs/plugin-react v6.
@@ -216,7 +259,13 @@ export default defineConfig({
           // CSP nonces dynamically. Instead we use runtime caching with NetworkFirst
           // so the SW caches whatever HTML the server serves (with nonce), and falls
           // back to it offline.
-          globIgnores: ['**/index.html'],
+          // `/wasm/` is excluded because the app now requests those files with
+          // a `?v=<hash>` query (see `wasmVersion` above), which no precache
+          // entry keyed on the bare path can serve — precaching them would
+          // just park ~6MB per generation that nothing ever reads. The
+          // runtimeCaching rule below still caches them (keyed by the full
+          // versioned url), so offline use is unaffected after first load.
+          globIgnores: ['**/index.html', '**/wasm/**'],
           // Purge precache entries from prior builds on SW activation, so a
           // stale worker/wasm can never linger after the hashed names change.
           cleanupOutdatedCaches: true,

--- a/browser/e2e/scripts/record-features.mjs
+++ b/browser/e2e/scripts/record-features.mjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+/**
+ * Records a short FEATURE COLLAGE for the website: one clip per feature
+ * (document, kanban board, canvas, table, chat), cut out of a single
+ * continuous run of the scripted demo (`/app/demo`) and concatenated.
+ *
+ * Why one recording + cuts rather than one recording per feature: the demo
+ * drive lives in OPFS, so a fresh browser context means rebuilding the whole
+ * workspace. Instead we let the demo's own follow-mode tour act as the camera
+ * (Mara walks the user from board → moodboard → team table, working live in
+ * each), poll `main[about]` to learn WHICH resource is on screen WHEN, and
+ * cut the good stretch out of each.
+ *
+ * The clips are deliberately stripped down (see `--help` notes):
+ *  - sidebar collapsed, so each resource renders full-page;
+ *  - meeting chat panel closed (we still join + say hi, because the director
+ *    gates its tour on that — see record-demo.mjs — we just don't film it).
+ *
+ * Anything that would look like UI-fiddling on camera (collapsing the
+ * sidebar, joining, typing in chat, navigating via the sidebar) is wrapped in
+ * an "exclusion window" and never appears in a clip.
+ *
+ * Usage:
+ *   node scripts/record-features.mjs [--headed] [--out <dir>]
+ *
+ * Requires the data-browser dev server at FRONTEND_URL (default :6747).
+ * No atomic-server backend needed — the demo drive is local-only.
+ */
+import { chromium } from '@playwright/test';
+import { mkdirSync, writeFileSync, rmSync, renameSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:6747';
+const headed = process.argv.includes('--headed');
+const outArgIndex = process.argv.indexOf('--out');
+const outDir =
+  outArgIndex !== -1
+    ? path.resolve(process.argv[outArgIndex + 1])
+    : path.resolve(__dirname, '../recordings');
+
+mkdirSync(outDir, { recursive: true });
+
+// Matches record-demo.mjs: >=1728 crosses the app's own responsiveWidth
+// breakpoint (useResizable.ts), which is also why panels aren't cramped.
+const VIEWPORT = { width: 1728, height: 1080 };
+
+/**
+ * The collage, in narrative order (NOT the order the tour visits them).
+ * `path` indexes into the demo manifest (chunks/Demo/demoWorkspace.ts).
+ */
+const FEATURES = [
+  { label: 'Documents', path: 'welcomeDoc', seconds: 7 },
+  { label: 'Kanban board', path: 'checklist.table', seconds: 8 },
+  { label: 'Canvas', path: 'moodboard', seconds: 8 },
+  { label: 'Tables', path: 'team.table', seconds: 7 },
+  { label: 'Chat', path: 'teamChat', seconds: 6 },
+];
+
+/** Skip this much of a segment's head — navigation/render settling. */
+const SETTLE_SECONDS = 1.2;
+
+function pick(obj, dottedPath) {
+  return dottedPath.split('.').reduce((acc, key) => acc?.[key], obj);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: { dir: outDir, size: VIEWPORT },
+    locale: 'en-GB',
+    timezoneId: 'Europe/Amsterdam',
+  });
+  const page = await context.newPage();
+  // Frame zero of the .webm — every timestamp below is relative to this.
+  const t0 = Date.now();
+  const now = () => (Date.now() - t0) / 1000;
+
+  /** [{subject, start, end}] — which resource filled the screen, when. */
+  const segments = [];
+  /** [{start, end}] — ranges containing us driving the UI; never filmed. */
+  const exclusions = [];
+  let polling = true;
+
+  /** Wrap on-camera UI fiddling so it can't land in a clip. */
+  async function offCamera(fn) {
+    const start = now();
+
+    try {
+      return await fn();
+    } finally {
+      // Pad the tail: React transitions/animations outlive the last click.
+      exclusions.push({ start: start - 0.3, end: now() + 0.7 });
+    }
+  }
+
+  const poll = (async () => {
+    while (polling) {
+      try {
+        const subject = await page.evaluate(
+          () =>
+            document.querySelector('main[about]')?.getAttribute('about') ??
+            null,
+        );
+        const at = now();
+        const last = segments[segments.length - 1];
+
+        if (subject && last?.subject === subject) {
+          last.end = at;
+        } else if (subject) {
+          segments.push({ subject, start: at, end: at });
+        }
+      } catch {
+        // Navigation tore down the execution context mid-evaluate; ignore.
+      }
+
+      await new Promise(r => setTimeout(r, 200));
+    }
+  })();
+
+  console.log(`Loading ${FRONTEND_URL}/app/demo …`);
+  await page.goto(`${FRONTEND_URL}/app/demo`);
+  await page.waitForURL(/\/app\/show/, { timeout: 30_000 });
+
+  const manifest = await page.evaluate(() => {
+    const raw = localStorage.getItem('atomic.demoWorkspace');
+
+    return raw ? JSON.parse(raw) : undefined;
+  });
+
+  if (!manifest) throw new Error('No demo manifest in localStorage.');
+
+  // Collapse the sidebar so every resource renders full-page. The sidebar
+  // ALSO reveals on hover near the left edge (SideBar/index.tsx:
+  // `sideBarLocked || hoveringOverSideBar`), so park the pointer centre-screen
+  // afterwards or it slides back out over the footage.
+  await offCamera(async () => {
+    await page.click('[data-test="sidebar-toggle"]');
+    await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+    await page.waitForTimeout(600);
+  });
+
+  // ── Clip 1 is free: Mara is already typing into the welcome doc ──
+  console.log('Filming the welcome doc while Mara types …');
+  await page.waitForTimeout(9_000);
+
+  // ── Chat: the tour never visits it, so go there ourselves (off camera) ──
+  console.log('Filming the team chat …');
+  await offCamera(async () => {
+    await page.click('[data-test="sidebar-toggle"]');
+    await page.getByTestId('sidebar').getByText('Team chat').first().click();
+    await page.waitForTimeout(500);
+    await page.click('[data-test="sidebar-toggle"]');
+    await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+    await page.waitForTimeout(600);
+  });
+  await page.waitForTimeout(7_000);
+
+  // ── Join the meeting: the director gates its whole tour on this ──
+  // We film the RESULT (Mara touring us through each feature), never the
+  // meeting chat itself — the panel goes straight back shut.
+  const joinBanner = page.getByTitle(/led by/);
+  console.log('Waiting for the tour meeting …');
+  await joinBanner.waitFor({ state: 'visible', timeout: 60_000 });
+
+  await offCamera(async () => {
+    await joinBanner.click();
+
+    // Say hi immediately: `waitForUserChat` otherwise idles up to 4 minutes
+    // before the tour winds down (see record-demo.mjs).
+    const chatInput = page.getByLabel('Chat input');
+    await chatInput.waitFor({ state: 'visible', timeout: 15_000 });
+    await chatInput.fill('Hi team! 👋');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await page.waitForTimeout(800);
+
+    // Clicking the banner again toggles the panel shut WITHOUT unfollowing
+    // (MeetingBanner.handleClick) — so the tour still drives our camera.
+    await joinBanner.click();
+    await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+    await page.waitForTimeout(600);
+  });
+
+  // ── Ride the tour: board → moodboard → team table ──
+  console.log('Following the tour …');
+  const teamTable = pick(manifest, 'team.table');
+  const deadline = Date.now() + 3 * 60_000;
+
+  while (Date.now() < deadline) {
+    const onTeamTable = segments.some(
+      s =>
+        s.subject === teamTable &&
+        s.end - s.start > FEATURES[3].seconds + SETTLE_SECONDS,
+    );
+
+    if (onTeamTable) break;
+    await page.waitForTimeout(1_000);
+  }
+
+  console.log('Captured the tour — stopping.');
+  polling = false;
+  await poll;
+
+  const rawVideoPath = await page.video()?.path();
+  await context.close();
+  await browser.close();
+
+  if (!rawVideoPath) throw new Error('No video was recorded.');
+
+  const webmPath = path.join(outDir, 'features-raw.webm');
+  renameSync(rawVideoPath, webmPath);
+
+  // ── Cut ──────────────────────────────────────────────────────────
+  const clipPaths = [];
+
+  for (const [index, feature] of FEATURES.entries()) {
+    const subject = pick(manifest, feature.path);
+
+    if (!subject) {
+      console.log(`! ${feature.label}: not in the manifest — skipped.`);
+      continue;
+    }
+
+    const window = bestWindow(segments, exclusions, subject, feature.seconds);
+
+    if (!window) {
+      console.log(`! ${feature.label}: no clean stretch on camera — skipped.`);
+      continue;
+    }
+
+    const clipPath = path.join(
+      outDir,
+      `clip-${index}-${slug(feature.label)}.mp4`,
+    );
+    const args = [
+      '-y',
+      '-ss',
+      window.start.toFixed(2),
+      '-t',
+      window.duration.toFixed(2),
+      '-i',
+      webmPath,
+      '-c:v',
+      'libx264',
+      '-crf',
+      '21',
+      '-preset',
+      'slow',
+      '-pix_fmt',
+      'yuv420p',
+      // Uniform timebase + keyframe at the head, so the concat below can
+      // stream-copy the clips instead of re-encoding them a second time.
+      '-video_track_timescale',
+      '90000',
+      '-an',
+      clipPath,
+    ];
+    const result = spawnSync('ffmpeg', args, { stdio: 'ignore' });
+
+    if (result.error || result.status !== 0) {
+      console.log(`! ${feature.label}: ffmpeg failed — skipped.`);
+      continue;
+    }
+
+    clipPaths.push(clipPath);
+    console.log(
+      `✓ ${feature.label}: ${window.duration.toFixed(1)}s @ ${window.start.toFixed(1)}s`,
+    );
+  }
+
+  if (clipPaths.length === 0) throw new Error('No clips were produced.');
+
+  const listPath = path.join(outDir, 'concat.txt');
+  writeFileSync(listPath, clipPaths.map(p => `file '${p}'`).join('\n'));
+
+  const collagePath = path.join(outDir, 'features.mp4');
+  const concat = spawnSync(
+    'ffmpeg',
+    [
+      '-y',
+      '-f',
+      'concat',
+      '-safe',
+      '0',
+      '-i',
+      listPath,
+      '-c',
+      'copy',
+      '-movflags',
+      '+faststart',
+      collagePath,
+    ],
+    { stdio: 'ignore' },
+  );
+
+  if (concat.error || concat.status !== 0) {
+    console.log(
+      'Could not concatenate; the individual clips are still in',
+      outDir,
+    );
+
+    return;
+  }
+
+  rmSync(listPath, { force: true });
+  for (const clip of clipPaths) rmSync(clip, { force: true });
+  rmSync(webmPath, { force: true });
+
+  console.log(`\nFeature collage: ${collagePath}`);
+}
+
+/**
+ * The longest stretch where `subject` was on screen and we weren't touching
+ * the UI, trimmed to `seconds`. Returns undefined if nothing usable is left.
+ */
+function bestWindow(segments, exclusions, subject, seconds) {
+  const candidates = [];
+
+  for (const segment of segments.filter(s => s.subject === subject)) {
+    // Subtract every exclusion from this segment, leaving clean sub-ranges.
+    let ranges = [{ start: segment.start + SETTLE_SECONDS, end: segment.end }];
+
+    for (const excluded of exclusions) {
+      const next = [];
+
+      for (const range of ranges) {
+        if (excluded.end <= range.start || excluded.start >= range.end) {
+          next.push(range);
+          continue;
+        }
+
+        if (excluded.start > range.start)
+          next.push({ start: range.start, end: excluded.start });
+        if (excluded.end < range.end)
+          next.push({ start: excluded.end, end: range.end });
+      }
+
+      ranges = next;
+    }
+
+    candidates.push(...ranges);
+  }
+
+  const best = candidates.sort(
+    (a, b) => b.end - b.start - (a.end - a.start),
+  )[0];
+
+  if (!best) return undefined;
+
+  const available = best.end - best.start;
+
+  // A sliver isn't worth a cut; anything shorter reads as a glitch.
+  if (available < 2) return undefined;
+
+  return { start: best.start, duration: Math.min(seconds, available) };
+}
+
+function slug(label) {
+  return label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/browser/e2e/tests/ai.spec.ts
+++ b/browser/e2e/tests/ai.spec.ts
@@ -211,5 +211,22 @@ async function sendChatMessage(
   // Wait for Send to be enabled — this naturally waits out server indexing.
   const sendButton = sidebar.getByTitle('Send');
   await expect(sendButton).toBeEnabled({ timeout });
+
+  // Then wait for any toast to clear. Toasts stack in the bottom-right corner,
+  // which is exactly where this sidebar's Send button is: the container is
+  // `pointer-events: none` but each toast bar sets `auto` (it has Clear and
+  // Copy buttons), so a leftover setup toast — "Signed in!", "Dev agent
+  // created" — swallows the click for as long as it is on screen. Observed as
+  // a 10s retry loop reporting `<div data-rht-toaster> subtree intercepts
+  // pointer events`.
+  //
+  // Waiting rather than `{ force: true }` on purpose. Forcing would dispatch
+  // the click regardless of what is on top, so this same helper would keep
+  // passing if a dialog or an overlay ever genuinely covered Send — which is a
+  // real bug and one this suite should be able to catch.
+  await expect(page.locator('[data-rht-toaster] > div')).toHaveCount(0, {
+    timeout: 15_000,
+  });
+
   await sendButton.click();
 }

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -773,7 +773,11 @@ test.describe('data-browser', async () => {
       page.getByText('First Title', { exact: true }).first(),
     ).toBeVisible();
 
-    await page.click('text=Restore this version');
+    // Enabled only once the selected version differs from the current one, so
+    // wait for that rather than racing the selection above.
+    const restore = page.getByRole('button', { name: 'Restore this version' });
+    await expect(restore).toBeEnabled({ timeout: 15_000 });
+    await restore.click();
 
     await expect(page.locator('text=Resource version updated')).toBeVisible();
     // After restore the page navigates back to the resource. EditableTitle

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -512,13 +512,6 @@ test.describe('data-browser', async () => {
     await expect(page.locator('text=Resource Saved')).toBeVisible();
   });
 
-  // FLAKY (dagger CI): the `Resource deleted` toast and/or the sidebar
-  // un-listing of `folder` aren't visible within 5 s after the delete
-  // confirmation. The toast fires from the store's
-  // `notifyResourceManuallyCreated` / removal handler — the surrounding
-  // commit-flush + sidebar refetch path is what's slow. Investigate:
-  // assert on `store.resources.has(subject) === false` via
-  // `waitForFunction` instead of toast text.
   test('delete resource', async ({ page }) => {
     await newResource('folder', page);
     const parentResource = await getCurrentSubject(page);
@@ -537,7 +530,34 @@ test.describe('data-browser', async () => {
     // some renders before it unmounts, leading to flaky no-ops.
     await page.locator('dialog[open] button:has-text("Delete")').click();
 
-    await expect(page.locator('text=Resource deleted')).toBeVisible();
+    // Wait for the destroy to actually land before reloading. The reload is
+    // what makes this a barrier and not a nicety: it abandons whatever the
+    // page still had in flight, so returning too early cancels the destroy and
+    // the resource is simply still there afterwards.
+    //
+    // This used to wait on the "Resource deleted" toast alone, which is why
+    // the test was marked flaky. A success toast expires after about two
+    // seconds, so under suite load it can be raised and gone before the first
+    // poll — the delete having worked perfectly — and the assertion then waits
+    // out its timeout on an element that will never come back.
+    //
+    // So accept either signal: the toast if we catch it, or the sidebar having
+    // dropped the folder, which is the same fact in a form that does not
+    // expire. Whichever arrives first, the destroy has been applied.
+    await expect
+      .poll(
+        async () => {
+          const toast = await page.locator('text=Resource deleted').count();
+          const listed = await page
+            .getByTestId('sidebar')
+            .getByText('Folder')
+            .count();
+
+          return toast > 0 || listed === 0;
+        },
+        { timeout: 15000, message: 'Destroy never landed' },
+      )
+      .toBe(true);
 
     await page.reload();
     await openSubject(page, nestedResource);

--- a/browser/e2e/tests/filePicker.spec.ts
+++ b/browser/e2e/tests/filePicker.spec.ts
@@ -9,7 +9,7 @@ import {
   inDialog,
   newDrive,
   newResource,
-  sidebarNewResourceButton,
+  openNewResourcePage,
   signIn,
   testFilePath,
   waitForSearchIndex,
@@ -18,8 +18,7 @@ import {
 const ONTOLOGY_NAME = 'filepicker-test';
 
 const uploadFile = async (page: Page, fileName: string) => {
-  await sidebarNewResourceButton(page).click();
-  await expect(page).toHaveURL(/\/app\/new(\?|$)/);
+  await openNewResourcePage(page);
 
   const fileChooserPromise = page.waitForEvent('filechooser');
 

--- a/browser/e2e/tests/search.spec.ts
+++ b/browser/e2e/tests/search.spec.ts
@@ -3,7 +3,6 @@ import {
   before,
   editTitle,
   setTitle,
-  sidebarNewResourceButton,
   contextMenuClick,
   timestamp,
   newResource,
@@ -108,8 +107,7 @@ test.describe('search', async () => {
     const driveSubject = await getCurrentSubject(page);
     const unique = Date.now().toString(36);
     const targetName = `Searchable-Folder-${unique}`;
-    await sidebarNewResourceButton(page).click();
-    await page.locator('button:has-text("folder")').click();
+    await newResource('folder', page);
     await setTitle(page, targetName);
     const folderSubject = await getCurrentSubject(page);
 
@@ -143,8 +141,7 @@ test.describe('search', async () => {
 
     // Create folder called 'Cake folder' at root
     await openSubject(page, driveSubject);
-    await sidebarNewResourceButton(page).click();
-    await page.locator('button:has-text("folder")').click();
+    await newResource('folder', page);
     await setTitle(page, 'Cake Folder');
     await expect(
       page.getByRole('heading', { name: 'Cake Folder' }),
@@ -216,8 +213,7 @@ test.describe('search', async () => {
 
   test('add tags and search for them', async ({ page }) => {
     const folderName = `TagTestFolder-${timestamp()}`;
-    await sidebarNewResourceButton(page).click();
-    await page.locator('button:has-text("folder")').click();
+    await newResource('folder', page);
     await setTitle(page, folderName);
     const driveSubject = await page.evaluate(() => window.store.getDrive());
     const folderSubject = await getCurrentSubject(page);
@@ -295,8 +291,7 @@ test.describe('search', async () => {
 
     // Create a folder with a distinctive name while online.
     const unique = `OfflineFindable-${timestamp()}`;
-    await sidebarNewResourceButton(page).click();
-    await page.locator('button:has-text("folder")').click();
+    await newResource('folder', page);
     await setTitle(page, unique);
 
     // It must be in the store (and therefore the local search index) before

--- a/browser/e2e/tests/second-device-load.spec.ts
+++ b/browser/e2e/tests/second-device-load.spec.ts
@@ -37,7 +37,19 @@ test('a fresh-OPFS second device loads an existing drive’s contents', async ({
     return d;
   });
   const secret = await getDevDriveSecret(p1);
-  await p1.waitForTimeout(2000);
+
+  // Device 1 is about to be closed, so the folder has to have reached the
+  // server before that — device 2 has an empty OPFS and can only load it from
+  // there. This was a flat 2s sleep, which is a guess at how long a commit
+  // takes and was simply wrong on a loaded CI runner: the context closed with
+  // the commit still queued, and the failure landed on device 2 as "the drive
+  // is missing its contents", pointing at the cold-load path this test exists
+  // to check rather than at the setup that never completed.
+  await p1.waitForFunction(
+    () => window.store?.getSyncStatus().pendingDirtyCount === 0,
+    undefined,
+    { timeout: 30_000 },
+  );
   await ctx1.close();
 
   const ctx2 = await browser.newContext(); // brand-new context ⇒ empty OPFS

--- a/browser/e2e/tests/table-refresh.spec.ts
+++ b/browser/e2e/tests/table-refresh.spec.ts
@@ -99,7 +99,13 @@ test.describe('table refresh', () => {
           const start = Date.now();
 
           const tick = () => {
-            const db = window.store.getClientDb();
+            // `window.store` is published when the app bundle runs, and the
+            // navigation above only waits for `domcontentloaded` — so on a
+            // slower machine this polls before there is a store at all. It
+            // used to read straight through and throw a TypeError out of the
+            // promise, failing the test with "Cannot read properties of
+            // undefined" instead of waiting the extra tick it needed.
+            const db = window.store?.getClientDb?.();
 
             if (db?.isReady) {
               resolve('ready');
@@ -114,7 +120,9 @@ test.describe('table refresh', () => {
             }
 
             if (Date.now() - start > 20000) {
-              resolve(`timeout: db=${!!db} isReady=${db?.isReady}`);
+              resolve(
+                `timeout: store=${!!window.store} db=${!!db} isReady=${db?.isReady}`,
+              );
 
               return;
             }

--- a/browser/e2e/tests/table-templates.spec.ts
+++ b/browser/e2e/tests/table-templates.spec.ts
@@ -144,6 +144,15 @@ test.describe('table templates', () => {
 
     // The sum under Amount was configured by the template — nobody opened a
     // menu to ask for it.
+    //
+    // When this fails on CI it reads "1ΣΣΣSum—ΣΣ": the label is there and the
+    // value is an em-dash. Traced 2026-08-14 — the two `setCell` calls above
+    // are two separate commits, and the aggregate read that follows the FIRST
+    // correctly reports the row as a member with no value to sum. Only a read
+    // that observes the second commit settles the total, so an em-dash here
+    // means the last read predates the value, not that the total is wrong.
+    // Don't widen the budget to cover it; the read is queued behind the
+    // post-save write storm (see `useTableAggregates`' max-wait note).
     const footer = page.getByTestId('table-totals');
     await expect(footer).toContainText('Sum', { timeout: 15_000 });
     await expect(footer).toContainText('4.5', { timeout: 15_000 });

--- a/browser/e2e/tests/table-views-filters.spec.ts
+++ b/browser/e2e/tests/table-views-filters.spec.ts
@@ -143,6 +143,41 @@ const filterChip = (page: Page, prefix: string) =>
     .locator('[role="toolbar"][aria-label="Table filters"]')
     .getByRole('button', { name: new RegExp(`^${prefix}`) });
 
+/**
+ * How the chip spells each operator. Mirrors `OPERATOR_LABELS` in
+ * `chunks/TablePage/tableFiltering.ts`; used to tell whether a chosen operator
+ * has actually reached the chip.
+ */
+const OPERATOR_LABEL: Record<string, string> = {
+  eq: 'is',
+  gt: 'greater than',
+  gte: 'at least',
+  lt: 'less than',
+  lte: 'at most',
+  starts_with: 'starts with',
+  contains: 'contains',
+};
+
+/**
+ * Dismiss the filter popover once the chip reflects what was chosen.
+ *
+ * Pressing Escape straight after `selectOption` races the change: the popover
+ * unmounts and the edit can go with it, leaving the previous operator in force
+ * and the grid still showing rows the new one excludes. That surfaced as "the
+ * filter does not work", ten seconds of waiting for a row to disappear that was
+ * never filtered out in the first place.
+ */
+async function closeFilterEditor(
+  page: Page,
+  columnShortname: string,
+  operator: string,
+) {
+  await expect(filterChip(page, columnShortname)).toContainText(
+    OPERATOR_LABEL[operator],
+  );
+  await page.keyboard.press('Escape');
+}
+
 /** Adds a filter for `columnShortname` via the view-row Filter button and sets
  * its operator + value in the auto-opened chip popover. */
 async function addFilter(
@@ -161,8 +196,7 @@ async function addFilter(
     .locator('select[aria-label="Filter operator"]')
     .selectOption(operator);
   await page.getByPlaceholder('Value…').fill(value);
-  // Close the popover so it doesn't overlay the grid.
-  await page.keyboard.press('Escape');
+  await closeFilterEditor(page, columnShortname, operator);
 }
 
 test.describe('table filtering + views', () => {
@@ -216,7 +250,7 @@ test.describe('table filtering + views', () => {
     await page
       .locator('select[aria-label="Filter operator"]')
       .selectOption('gt');
-    await page.keyboard.press('Escape');
+    await closeFilterEditor(page, 'birthday', 'gt');
     await expect(page.getByRole('gridcell', { name: 'Bob' })).toBeVisible();
     await expect(
       page.getByRole('gridcell', { name: 'Alice' }),

--- a/browser/e2e/tests/table-views-filters.spec.ts
+++ b/browser/e2e/tests/table-views-filters.spec.ts
@@ -115,6 +115,14 @@ async function createPeopleTable(page: Page): Promise<PeopleTable> {
     { timeout: 30000 },
   );
 
+  // A drained outbox means the commits are ACKED, not that the local index can
+  // answer for them: the ClientDb writes (and the index rebuild inside each)
+  // sit on a flush tick, and a filter query issued before they land silently
+  // returns a short row set — the grid then shows Alice without Charlie. The
+  // worker processes its messages in order, so a flush resolves only once
+  // everything queued ahead of it has been written and indexed.
+  await page.evaluate(() => window.store?.getClientDb()?.flush?.());
+
   await page.goto(
     `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(created.table)}`,
   );

--- a/browser/e2e/tests/template.spec.ts
+++ b/browser/e2e/tests/template.spec.ts
@@ -6,7 +6,7 @@ import {
   newDrive,
   nodeReachableServerUrl,
   signIn,
-  sidebarNewResourceButton,
+  openNewResourcePage,
 } from './test-utils';
 import fs from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -279,8 +279,7 @@ test.describe('Test create-template package', () => {
     await makeDrivePublic(page);
 
     // Apply the template in data browser
-    await sidebarNewResourceButton(page).click();
-    await expect(page).toHaveURL(/\/app\/new(\?|$)/);
+    await openNewResourcePage(page);
 
     await page.getByTestId('template-button').click();
 
@@ -333,8 +332,7 @@ test.describe('Test create-template package', () => {
     await makeDrivePublic(page);
 
     // Apply the template in data browser
-    await sidebarNewResourceButton(page).click();
-    await expect(page).toHaveURL(/\/app\/new(\?|$)/);
+    await openNewResourcePage(page);
 
     const button = page.getByTestId('template-button');
     await button.click();

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -836,19 +836,32 @@ export const SEARCHBOX_PROPERTY_PLACEHOLDER = /Search for a .+ or enter a URL/;
 
 /** Create a new Resource in the current Drive.
  * Class can be an Class URL or a shortname available in the new page. */
-export async function newResource(klass: string, page: Page) {
-  // Sidebar "New" navigates to /app/new?parentSubject=<parent> to preserve
-  // the container context (see QuickCreateRow). Match pathname only.
-  //
-  // Retry the click AND the navigation as a unit: the button can be clicked
-  // before its handler is attached, and the click is then simply swallowed —
-  // the app stays where it was, and no amount of waiting on a navigation that
-  // was never started will produce one. Seen in CI as this assertion timing
-  // out with the URL still on `/app/show`.
+/**
+ * Click the sidebar's "New" and land on `/app/new`.
+ *
+ * Sidebar "New" navigates to /app/new?parentSubject=<parent> to preserve the
+ * container context (see QuickCreateRow). Match pathname only.
+ *
+ * Retry the click AND the navigation as a unit: the button can be clicked
+ * before its handler is attached, and the click is then simply swallowed — the
+ * app stays where it was, and no amount of waiting on a navigation that was
+ * never started will produce one. Seen in CI as an assertion timing out with
+ * the URL still on `/app/show`, or as the next click waiting out its budget on
+ * a class button that was never going to render.
+ *
+ * Exported because every caller needs the retry, not just `newResource`.
+ * Clicking and then asserting the URL separately looks equivalent and is not:
+ * it waits for a navigation that the swallowed click never began.
+ */
+export async function openNewResourcePage(page: Page) {
   await expect(async () => {
     await sidebarNewResourceButton(page).click();
     await expect(page).toHaveURL(/\/app\/new(\?|$)/, { timeout: 3_000 });
   }).toPass({ timeout: 20_000 });
+}
+
+export async function newResource(klass: string, page: Page) {
+  await openNewResourcePage(page);
 
   const waitForResourceForm = async () => {
     await Promise.any([
@@ -1424,13 +1437,33 @@ export async function selectHistoryVersionShowing(
 
   for (let i = 0; i < count; i++) {
     await buttons.nth(i).click();
-    const visible = await page
+
+    // Judge the version by its *resource*, not by whatever text the page
+    // happens to contain.
+    //
+    // The default tab is the diff, and a diff names both sides of the change:
+    // the version that introduced "First Title" and the one that replaced it
+    // with "Second Title" both render "First Title". Scanning the page for
+    // that string therefore matched two different versions, and which one the
+    // loop settled on came down to how quickly a preview rendered. Landing on
+    // the newest version leaves "Restore this version" correctly disabled,
+    // because it is already the current one — a failure that looks like a
+    // broken button and is really a test picking the wrong row.
+    //
+    // The Resource tab shows only the selected version, so it can only match
+    // the version actually meant. Radix unmounts the inactive panel, so this
+    // has to be selected rather than read through.
+    await page.getByRole('tab', { name: 'Resource' }).click();
+
+    const shown = await page
+      .getByRole('tabpanel')
       .getByText(text, { exact: true })
       .first()
-      .isVisible()
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
       .catch(() => false);
 
-    if (visible) {
+    if (shown) {
       return;
     }
   }

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1044,6 +1044,14 @@ export async function waitForRowsMaterialized(page: Page, timeoutMs = 15_000) {
     undefined,
     { timeout: timeoutMs },
   );
+
+  // Acked is not queryable. The ClientDb writes each row — and rebuilds the
+  // index inside that write — on a flush tick, so a query issued in between
+  // answers from an index that is missing rows the grid already shows. The
+  // worker handles its messages in order, so awaiting a flush means everything
+  // queued ahead of it has landed. Without this a filter drops a matching row,
+  // and a total reads an em-dash because the value it sums is not there yet.
+  await page.evaluate(() => window.store?.getClientDb()?.flush?.());
 }
 
 /**
@@ -1055,15 +1063,10 @@ export async function waitForRowsMaterialized(page: Page, timeoutMs = 15_000) {
  * reload then drops it. {@link waitForRowsMaterialized} covers both halves.
  */
 export async function reloadGrid(page: Page) {
+  // Includes the OPFS flush: those writes commit with `Durability::None`, so
+  // reloading inside the worker's 1s tick rolls them back and the local db
+  // answers post-reload queries with the pre-edit copy.
   await waitForRowsMaterialized(page);
-  // `pendingDirtyCount === 0` means the rows reached the SERVER — not that
-  // their post-ack re-persist reached OPFS durably. Those writes commit with
-  // `Durability::None` and only survive a reload after the worker's 1s flush
-  // tick; reloading inside that window rolls them back, and the local db then
-  // answers post-reload queries with the pre-edit copy (the CI-only em-dash
-  // totals: member indexed, its newest value missing). Ask for the flush —
-  // the durability signal — instead of racing the tick.
-  await page.evaluate(() => window.store?.getClientDb()?.flush?.());
   await page.reload();
   await expect(page.getByRole('grid')).toBeVisible();
   // The grid binds its cell handlers after the first render.

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -31,7 +31,8 @@ import {
   timestamp,
 } from './test-utils';
 
-const PORTAL_URL = process.env.ATOMIC_VAULT_PORTAL_URL ?? 'http://localhost:3030';
+const PORTAL_URL =
+  process.env.ATOMIC_VAULT_PORTAL_URL ?? 'http://localhost:3030';
 
 /**
  * A fresh account per test.
@@ -138,13 +139,14 @@ async function completeOnboarding(
   // The confirm button stays disabled until the code has been copied — the
   // flow's own guard against a user skipping past the one thing they must keep.
   await page.getByRole('button', { name: 'Copy to clipboard' }).click();
-  await page.getByRole('button', { name: "Yes, I've stored it safely" }).click();
+  await page
+    .getByRole('button', { name: "Yes, I've stored it safely" })
+    .click();
 
   await expect(page).toHaveURL(/\/app\/show\?subject=/, { timeout: 30_000 });
 
   return { recoveryCode: code.trim(), driveUrl: page.url() };
 }
-
 
 /**
  * Rename the open resource and wait for it to stick locally.
@@ -393,9 +395,13 @@ test.describe('Cloud Vault backup and restore', () => {
       // And the vault agrees it is on for this drive, from a device that had
       // to learn that from the control plane rather than from local state.
       await openSync(fresh);
-      await expect(vaultPanel(fresh)).toHaveAttribute('data-vault-state', 'on', {
-        timeout: 60_000,
-      });
+      await expect(vaultPanel(fresh)).toHaveAttribute(
+        'data-vault-state',
+        'on',
+        {
+          timeout: 60_000,
+        },
+      );
       await expect(fresh.getByTestId('vault-error')).toBeHidden();
     } finally {
       await wiped.close();

--- a/browser/lib/src/client-db.worker.ts
+++ b/browser/lib/src/client-db.worker.ts
@@ -343,6 +343,7 @@ async function handleMessage(msg: WorkerRequest): Promise<unknown> {
       // A restore is one bulk write, so the amortisation the tick exists for
       // does not apply. Flush now; we are already inside the work queue, so
       // this cannot race an in-flight mutation.
+
       try {
         db!.flush();
       } catch (e) {

--- a/browser/lib/src/client-db.worker.ts
+++ b/browser/lib/src/client-db.worker.ts
@@ -6,6 +6,7 @@
  */
 
 import { openClientDb, isStorageBlockedDbError } from './client-db-open.js';
+import { wasmBinaryUrl } from './wasm-url.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type WasmModule = any;
@@ -403,8 +404,11 @@ async function doInit(
   const t0 = performance.now();
   const wasm = await import(/* webpackIgnore: true */ wasmUrl);
   const t1 = performance.now();
-  // Compile + instantiate the WASM module.
-  await wasm.default();
+  // Compile + instantiate the WASM module. The binary is named explicitly
+  // instead of left to wasm-bindgen's `import.meta.url` default, which would
+  // drop any version query on `wasmUrl` and pair this glue with a binary from
+  // a different build — see `wasmBinaryUrl`.
+  await wasm.default({ module_or_path: wasmBinaryUrl(wasmUrl) });
   const t2 = performance.now();
 
   // One-time migration of the legacy shared DB file into the per-agent

--- a/browser/lib/src/parse.test.ts
+++ b/browser/lib/src/parse.test.ts
@@ -56,6 +56,67 @@ describe('parse.ts', () => {
     expect(resources).toHaveLength(3);
   });
 
+  /**
+   * Regression: legacy servers (and `include_nested` responses) inline
+   * member resources as full objects. Leaving those objects in the propval
+   * hands consumers an object where they expect a subject string —
+   * `normalizeSubject` crashed rendering such a collection. The parser must
+   * extract each nested resource and keep only its `@id` as the reference.
+   */
+  it('extracts nested resources with an @id, keeping only the reference', ({
+    expect,
+  }) => {
+    const jsonObject = {
+      '@id': EXAMPLE_SUBJECT,
+      [NESTED_RESOURCE_PROPERTY]: [
+        {
+          '@id': EXAMPLE_SUBJECT2,
+          [STRING_PROPERTY]: 'First member',
+        },
+        // Plain refs mixed in stay untouched.
+        EXAMPLE_SUBJECT3,
+      ],
+    };
+
+    const parser = new JSONADParser();
+    const resources = parser.parse(jsonObject, EXAMPLE_SUBJECT);
+
+    expect(resources).toHaveLength(2);
+
+    // The requested resource stays last — `fetchResourceHTTP` falls back to
+    // "last parsed resource" when no subject matches exactly.
+    const main = resources.at(-1)!;
+    expect(main.subject).toBe(EXAMPLE_SUBJECT);
+    expect(main.get(NESTED_RESOURCE_PROPERTY)).toEqual([
+      EXAMPLE_SUBJECT2,
+      EXAMPLE_SUBJECT3,
+    ]);
+
+    const member = resources.find(r => r.subject === EXAMPLE_SUBJECT2);
+    expect(member?.get(STRING_PROPERTY)).toBe('First member');
+  });
+
+  it('passes objects without an @id through as plain JSON values', ({
+    expect,
+  }) => {
+    const columnWidths = { col1: 120, col2: 80 };
+    const jsonObject = {
+      '@id': EXAMPLE_SUBJECT,
+      [NESTED_RESOURCE_PROPERTY]: columnWidths,
+    };
+
+    const parser = new JSONADParser();
+    const resources = parser.parse(jsonObject, EXAMPLE_SUBJECT);
+
+    // No extraction: the object is a value, not a resource. (The resource
+    // layer stores object values JSON-stringified; equality after parsing is
+    // what matters here.)
+    expect(resources).toHaveLength(1);
+    const value = resources[0].get(NESTED_RESOURCE_PROPERTY);
+    const roundTripped = typeof value === 'string' ? JSON.parse(value) : value;
+    expect(roundTripped).toEqual(columnWidths);
+  });
+
   it('Handles resources without an ID', ({ expect }) => {
     const jsonObject = {
       [STRING_PROPERTY]: 'Hoi',

--- a/browser/lib/src/parse.ts
+++ b/browser/lib/src/parse.ts
@@ -9,23 +9,34 @@ import { decodeB64 } from './base64.js';
  * Parses a JSON-AD object or array into resources. Create a new instance each time you need to parse a json-ad string.
  */
 export class JSONADParser {
+  /** Resources found nested inside other resources' property values (e.g.
+   *  collection `members` served with `include_nested`). Collected during
+   *  `parseObject`; the referencing property keeps only the `@id` string. */
+  private nestedResources: Resource[] = [];
+
   public parse(json: unknown, subject: string = unknownSubject): Resource[] {
     if (Array.isArray(json)) {
       // Array responses contain multiple resources (e.g. search with include=true).
       // Each item has its own @id. Parse without enforcing a subject match — the
       // caller (fetchResourceHTTP) will find the right one by subject.
-      return json.flatMap(item =>
+      const mains = json.flatMap(item =>
         typeof item === 'object' && item !== null && !Array.isArray(item)
           ? [this.parseObject(item as JSONObject)]
           : [],
       );
+
+      return [...this.nestedResources, ...mains];
     }
 
     if (typeof json !== 'object' || json === null) {
       throw new Error('JSON-AD must be an object or array');
     }
 
-    return [this.parseObject(json as JSONObject, subject)];
+    const main = this.parseObject(json as JSONObject, subject);
+
+    // Nested first: `fetchResourceHTTP` falls back to "the last resource is
+    // the requested one" when no subject matches exactly.
+    return [...this.nestedResources, main];
   }
 
   private parseObject(json: JSONObject, subject?: string): Resource {
@@ -63,6 +74,37 @@ export class JSONADParser {
           typeof value.data === 'string'
         ) {
           hydratedValues.push([key, decodeB64(value.data)]);
+          continue;
+        }
+
+        // A nested resource (an object with an `@id`, e.g. collection members
+        // served with `include_nested`) is a resource of its own: parse it
+        // separately and keep only the reference. Leaving the raw object in
+        // the propval hands consumers an object where they expect a subject
+        // string (`normalizeSubject` crashes on it). Objects WITHOUT an `@id`
+        // are plain JSON-datatype values and pass through untouched.
+        if (isJSONObject(value) && typeof value['@id'] === 'string') {
+          this.nestedResources.push(this.parseObject(value));
+          hydratedValues.push([key, value['@id']]);
+          continue;
+        }
+
+        if (
+          Array.isArray(value) &&
+          value.some(v => isJSONObject(v) && typeof v['@id'] === 'string')
+        ) {
+          hydratedValues.push([
+            key,
+            value.map(v => {
+              if (isJSONObject(v) && typeof v['@id'] === 'string') {
+                this.nestedResources.push(this.parseObject(v));
+
+                return v['@id'];
+              }
+
+              return v;
+            }),
+          ]);
           continue;
         }
 

--- a/browser/lib/src/parse.ts
+++ b/browser/lib/src/parse.ts
@@ -15,6 +15,8 @@ export class JSONADParser {
   private nestedResources: Resource[] = [];
 
   public parse(json: unknown, subject: string = unknownSubject): Resource[] {
+    this.nestedResources = [];
+
     if (Array.isArray(json)) {
       // Array responses contain multiple resources (e.g. search with include=true).
       // Each item has its own @id. Parse without enforcing a subject match — the

--- a/browser/lib/src/resource.test.ts
+++ b/browser/lib/src/resource.test.ts
@@ -525,6 +525,56 @@ describe('Resource.merge Loro options', () => {
 
     expect(local.get(name)).toBe('baseline');
   });
+
+  /**
+   * Regression: bootstrapped stubs carry an `incomplete` marker so visiting
+   * the subject triggers a real fetch. The marker lives in the stub's local
+   * Loro ops, and a CRDT merge UNIONS docs — so merging the fetched full
+   * copy left the marker in place, and `getResourceLoading` kept refetching
+   * forever. Merging a full copy must resolve the staleness.
+   */
+  it('drops the incomplete marker when merging in a full copy', async ({
+    expect,
+  }) => {
+    const subject = 'https://example.com/merge-incomplete';
+    const name = 'https://atomicdata.dev/properties/name';
+
+    const stub = new Resource(subject);
+    stub.applyHydratedValues([
+      [core.properties.parent, 'https://example.com'],
+      [core.properties.incomplete, true],
+    ]);
+    // Seed the stub's Loro doc so the merge goes down the CRDT-union path.
+    stub.getLoroDoc();
+
+    const full = new Resource(subject);
+    await full.set(name, 'The real resource', false);
+    full.loading = false;
+
+    stub.merge(full);
+
+    expect(stub.get(core.properties.incomplete)).toBeUndefined();
+    expect(stub.get(name)).toBe('The real resource');
+    expect(stub.loading).toBe(false);
+  });
+
+  it('keeps the incomplete marker when the incoming copy is itself incomplete', async ({
+    expect,
+  }) => {
+    const subject = 'https://example.com/merge-still-incomplete';
+
+    const stub = new Resource(subject);
+    stub.applyHydratedValues([[core.properties.incomplete, true]]);
+    stub.getLoroDoc();
+
+    const alsoPartial = new Resource(subject);
+    alsoPartial.applyHydratedValues([[core.properties.incomplete, true]]);
+    alsoPartial.getLoroDoc();
+
+    stub.merge(alsoPartial);
+
+    expect(stub.get(core.properties.incomplete)).toBe(true);
+  });
 });
 
 describe('getLoroHistory', () => {

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -1516,6 +1516,22 @@ export class Resource<C extends OptionalClass = any> {
       this.setCreatedAtValue(remoteCreatedAt);
     }
 
+    // A bootstrapped stub carries an `incomplete` marker so that visiting its
+    // subject triggers a real fetch. That marker lives in the stub's own Loro
+    // ops, and a CRDT merge UNIONS the two docs — so merging in the fetched
+    // full copy left the marker standing and `getResourceLoading` refetched
+    // the subject forever. The incoming copy is what decides: if it is not
+    // itself marked incomplete, the staleness the marker recorded is resolved.
+    //
+    // `removeUnsafe`, not `remove`: this is reconciliation, not an edit, and
+    // must not leave a pending change for the drain to commit.
+    if (
+      resourceB.get(core.properties.incomplete) === undefined &&
+      this.get(core.properties.incomplete) !== undefined
+    ) {
+      this.removeUnsafe(core.properties.incomplete);
+    }
+
     // We set this last because it will trigger a loading change event.
     this.loading = resourceB.loading;
   }

--- a/browser/lib/src/wasm-url.ts
+++ b/browser/lib/src/wasm-url.ts
@@ -1,0 +1,37 @@
+/**
+ * Deliberately NOT exported from `index.ts`, and worth keeping that way: its
+ * only consumer is `client-db.worker.ts`, which apps load as a standalone file
+ * (`import '@tomic/lib/client-db.worker.js?url'` copies that one file and
+ * nothing else). A second importer would make tsup hoist this into a shared
+ * chunk, and the worker's `import './chunk-XXXX.js'` would then 404 at runtime
+ * and take the whole ClientDb down with it. Callers outside the worker build
+ * their own url; see `data-browser/src/helpers/wasmUrls.ts`.
+ *
+ * The atomic-wasm glue and its binary are served from a stable `/wasm/` path
+ * (they are copied into the app's `public/` dir by `build:wasm` rather than
+ * going through Rollup), so their URL does not change when their content does.
+ * Callers therefore append a build hash — `?v=<hash>` — to keep the pair in
+ * step with the app chunks that call into them.
+ */
+
+/**
+ * The binary URL belonging to a glue-JS URL, carrying the same query.
+ *
+ * wasm-bindgen's own default is `new URL('atomic_wasm_bg.wasm',
+ * import.meta.url)`, and resolving a relative path that way drops the glue
+ * URL's query string. A versioned glue would then be paired with whatever
+ * binary sits under the bare path, which is a worse failure than the stale
+ * glue this versioning exists to prevent: mismatched glue and binary fail
+ * inside `WebAssembly.instantiate` on a missing import rather than at a
+ * legible call site. Deriving it here keeps both halves on one version.
+ */
+export function wasmBinaryUrl(
+  jsUrl: string,
+  binaryName = 'atomic_wasm_bg.wasm',
+): string {
+  const base = typeof location === 'undefined' ? undefined : location.href;
+  const url = new URL(jsUrl, base);
+  url.pathname = url.pathname.replace(/[^/]*$/, binaryName);
+
+  return url.toString();
+}

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -248,9 +248,7 @@ mod vault_ipc {
     Ok(DriveVaultKey::from_bytes(bytes, epoch))
   }
 
-  pub fn store_of(
-    node: &std::sync::Arc<super::EmbeddedNode>,
-  ) -> Result<atomic_lib::Db, String> {
+  pub fn store_of(node: &std::sync::Arc<super::EmbeddedNode>) -> Result<atomic_lib::Db, String> {
     node
       .store
       .get()
@@ -389,9 +387,12 @@ async fn vault_import(
     let staging = vault_ipc::MemoryVaultStore::new();
 
     for object in &objects {
-      let sealed = STANDARD
-        .decode(&object.sealed)
-        .map_err(|e| format!("Vault object {} is not valid base64: {e}", object.object_key))?;
+      let sealed = STANDARD.decode(&object.sealed).map_err(|e| {
+        format!(
+          "Vault object {} is not valid base64: {e}",
+          object.object_key
+        )
+      })?;
       staging
         .put(&object.object_key, &sealed)
         .map_err(|e| format!("Could not stage vault object {}: {e}", object.object_key))?;

--- a/lib/src/vault/sync.rs
+++ b/lib/src/vault/sync.rs
@@ -853,7 +853,9 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let target = Db::init_temp("vault_history_roundtrip_target").await.unwrap();
+        let target = Db::init_temp("vault_history_roundtrip_target")
+            .await
+            .unwrap();
         import_vault_batch(&target, &key, &vault, &drive_prefix(PSEUDONYM))
             .await
             .unwrap();
@@ -941,7 +943,9 @@ mod tests {
         assert_eq!(keys.len(), 2, "the fixture needs two segments");
         let newest = keys.iter().max().unwrap().clone();
         let latest_only = MemoryVaultStore::new();
-        latest_only.put(&newest, &vault.get(&newest).unwrap()).unwrap();
+        latest_only
+            .put(&newest, &vault.get(&newest).unwrap())
+            .unwrap();
 
         let target = Db::init_temp("vault_latest_segment_target").await.unwrap();
         import_vault_batch(&target, &key, &latest_only, &drive_prefix(PSEUDONYM))
@@ -964,5 +968,4 @@ mod tests {
             "a resource deleted before this segment must stay deleted — recovering it is what an OLDER segment would be kept for"
         );
     }
-
 }

--- a/scripts/setup-apple-signing.sh
+++ b/scripts/setup-apple-signing.sh
@@ -26,18 +26,28 @@
 # re-downloaded with its private key, and a team is limited to five of them —
 # so losing one is not a free do-over. The .p12 is the only complete copy.
 #
-# Usage:  scripts/setup-apple-signing.sh [--macos-only|--ios-only] [workdir]
+# Usage:  scripts/setup-apple-signing.sh [--macos-only|--ios-only] [--macos-p12 FILE] [workdir]
 
 set -euo pipefail
 
 WORKDIR=""
 DO_MACOS=true
 DO_IOS=true
+MACOS_P12=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --macos-only) DO_IOS=false ;;
     --ios-only)   DO_MACOS=false ;;
+    # Reuse a Developer ID certificate you already hold, instead of issuing a
+    # new one. Prefer this whenever `security find-identity -v -p codesigning`
+    # already lists "Developer ID Application: <your team>": a team may hold
+    # only FIVE of them, and revoking one invalidates nothing already signed
+    # but does burn a slot you cannot get back cheaply. Export it first via
+    # Keychain Access -> My Certificates -> right-click -> Export as .p12,
+    # making sure you export the certificate WITH its private key (the
+    # disclosure triangle should show a key underneath it).
+    --macos-p12) shift; MACOS_P12="${1:-}"; [ -n "$MACOS_P12" ] || { echo "--macos-p12 needs a path" >&2; exit 1; } ;;
     -*) echo "unknown flag: $1" >&2; exit 1 ;;
     *)  WORKDIR="$1" ;;
   esac
@@ -154,7 +164,37 @@ EOF
 }
 
 if [ "$DO_MACOS" = true ]; then
-  request_cert "developer-id" "Developer ID Application" "Developer ID Application"
+  if [ -n "$MACOS_P12" ]; then
+    [ -e "$MACOS_P12" ] || die "$MACOS_P12 not found."
+    echo
+    echo "──── Developer ID Application (existing certificate) ────"
+    read -r -s -p "Password for $MACOS_P12: " PASS; echo
+    [ -n "$PASS" ] || die "a password is required — an unprotected .p12 cannot be imported by CI."
+
+    # Verify before uploading. A .p12 exported from Keychain Access WITHOUT the
+    # private key is the classic mistake here: it looks fine, uploads fine, and
+    # then fails deep inside a release build with an error about no identity
+    # being found rather than about the file.
+    openssl pkcs12 -in "$MACOS_P12" -nokeys "${P12_LEGACY[@]}" \
+      -passin "pass:$PASS" -out "$WORKDIR/developer-id.pem" 2>/dev/null \
+      || die "could not read $MACOS_P12 — wrong password, or OpenSSL cannot parse it."
+    # Grep the extracted key rather than relying on an exit code: `pkcs12
+    # -nocerts -noout` exits 0 on a certificate-only .p12, so it detects
+    # nothing. Verified both ways against a with-key and a no-key file.
+    openssl pkcs12 -in "$MACOS_P12" -nocerts -nodes "${P12_LEGACY[@]}" \
+      -passin "pass:$PASS" 2>/dev/null | grep -q 'PRIVATE KEY' \
+      || die "$MACOS_P12 contains no private key. In Keychain Access, expand the certificate's disclosure triangle and export the certificate itself (which carries the key underneath), not the bare certificate."
+
+    IDENTITY=$(openssl x509 -in "$WORKDIR/developer-id.pem" -noout -subject -nameopt multiline \
+      | sed -n 's/ *commonName *= //p')
+    [ -n "$IDENTITY" ] || die "could not read the certificate common name."
+    echo "Identity: $IDENTITY"
+
+    cp "$MACOS_P12" "$WORKDIR/developer-id.p12"
+    chmod 600 "$WORKDIR/developer-id.p12"
+  else
+    request_cert "developer-id" "Developer ID Application" "Developer ID Application"
+  fi
 
   set_secret_file APPLE_CERTIFICATE "developer-id.p12"
   set_secret APPLE_CERTIFICATE_PASSWORD "$PASS"

--- a/wasm/tests/vault.rs
+++ b/wasm/tests/vault.rs
@@ -171,7 +171,10 @@ async fn a_real_export_hands_js_binary_not_a_number_array() {
         .await
         .expect("export should succeed");
 
-    assert!(!out.is_null(), "a drive with a resource has something to back up");
+    assert!(
+        !out.is_null(),
+        "a drive with a resource has something to back up"
+    );
 
     let sealed = js_sys::Reflect::get(&out, &wasm_bindgen::JsValue::from_str("sealed"))
         .expect("the export result carries the sealed bytes");
@@ -186,5 +189,8 @@ async fn a_real_export_hands_js_binary_not_a_number_array() {
     // The envelope's own header, which is what a restore reads first. Asserting
     // it here means a future change to the boundary fails on the byte that
     // actually matters rather than on a type name.
-    assert_eq!(bytes[0], 1, "first byte is the envelope version, not '1' (49)");
+    assert_eq!(
+        bytes[0], 1,
+        "first byte is the envelope version, not '1' (49)"
+    );
 }


### PR DESCRIPTION
Chases down why a resource could open as a blank page, and picks up the
fixes that fell out of the same trail.

## The empty resource

Three separate ways a subject ended up permanently blank:

- A bundled entry that only anchors a parent chain read as fully loaded, so
  visiting its subject never fetched anything — no request, no error, an empty
  page. Those are now marked `incomplete` so the store refetches on first read.
  Only the bare anchors: an entry carrying content of its own is usable as-is,
  and marking it would send the UI off to atomicdata.dev before enabling
  anything gated on `isReady()` — which never returns on a server with no route
  out. `agents/publicAgent` is exactly that case, and it gates the share page's
  "Public (anyone)" toggle. `bootstrap.test.ts` pins both halves.
- Merging a fetched copy over such a stub left the `incomplete` marker standing,
  because a CRDT merge unions the two docs, so the subject refetched forever.
- A nested resource served inside another's property value (collection members
  with `include_nested`) stayed a raw object where consumers expect a subject
  string, and `normalizeSubject` threw on it.

## Also in here

- **wasm**: the atomic-wasm glue and binary are the only files on a stable url,
  so a page spanning a service-worker update ran new app chunks against the
  previous generation's precached glue — recovery-code generation died on a
  namespace with no `argon2idDeriveKey`. Their contents are now hashed into a
  `?v=` on every url that asks for them.
- **navbar**: Comments/AI/Tags/Share/context-menu stayed lit on `/app/settings`
  and `/app/sync` and quietly acted on the drive. They render only when there is
  a resource in context; the breadcrumb still names the drive.
- **chat**: `AgentAvatar` read the older `image` property, so a picture uploaded
  through the profile editor (which writes the `icon` File) showed as an initial.
- Onboarding button rows wrap instead of overflowing; brand/About alignment;
  a feature-collage recording script; Developer ID cert reuse; dagger bump.

## Verification

Local, against a fresh e2e store on an isolated stack: **e2e 167 passed / 5
skipped / 0 failed**, unit 757 (lib 229, data-browser 525, svelte 3), lint clean,
typecheck clean apart from two pre-existing `pairing.test.ts` node-types errors.

The `bootstrap` predicate was the gate: with it too wide, 6 specs failed on the
share page's disabled Public toggle (canvas-live-update, documents ×2,
drive-deeplink ×2, template next-js).

Note: the branch is ~70 commits behind `develop`, and merging it conflicts in
generated files only (the four `locales/*.po` and `desktop/gen/schemas/acl-manifests.json`).
Happy to merge develop in and regenerate before this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline bootstrap semantics and wasm/recovery loading paths that affect first paint and account recovery, plus a large Sync/managed UX refactor, though behavior is covered by new bootstrap tests and described e2e verification.
> 
> **Overview**
> Fixes **blank pages** caused by bundled **anchor-only** store entries looking fully loaded: those stubs are now marked `incomplete` so the first visit refetches the real resource, while content-bearing bundles like `publicAgent` stay offline-ready (with tests locking that split).
> 
> **atomic-wasm** is loaded through shared **`?v=__WASM_VERSION__`** URLs (build-time hash, HTML preloads, ClientDb worker, recovery Argon2) so service-worker/cache cannot pair new JS with an old wasm module; Argon2 load failures are surfaced with a clear reload message instead of a stuck promise.
> 
> **Sync** reorganizes paid offerings into one **provider account card** (email recovery, **Cloud Vault**, **Cloud Server** offer or live `ServerCard`), keeps self-hosted servers under **Devices**, and renames copy to **Cloud Vault**. **NavBar** resource actions only show when a real resource is in context (not on `/app/settings` etc.). **AgentAvatar** prefers profile **`icon`**; account recovery resolves the managed portal like other surfaces; smaller chat/onboarding/layout and E2E stability fixes; SvelteKit template pins `@swc/core` for top-level-await builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bbc064d6d61686959ef5c8a463f34ee60127dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->