### PR TITLE
Set up dev environment + clarify Cloud update script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,9 +235,12 @@ cd browser && pnpm run test-e2e                  # Full e2e test
 
 ## Cursor Cloud specific instructions
 
-The startup update script only runs `pnpm install` (in `browser/`). Everything below is
-already handled in the VM snapshot; these notes capture the non-obvious gotchas for
-building/running the stack again after pulling changes.
+The startup update script keeps the JS deps and Rust build prerequisites fresh: it sets
+pnpm's `script-shell` to bash, adds the `wasm32-unknown-unknown` rustup target, and runs
+`pnpm install` (in `browser/`). It does NOT build anything — the WASM bundle, the Rust
+`atomic-server` binary, and the running services are captured in the VM snapshot. These
+notes capture the non-obvious gotchas for building/running the stack again after pulling
+changes.
 
 ### Run the server on port 9885 (not the default 9883)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the full Atomic Data development environment in the Cloud VM, and updated the AGENTS.md Cloud section so the documented update script matches what's actually needed on a fresh VM.

On a clean VM, `script-shell` and the `wasm32-unknown-unknown` target were **not** already present (contrary to the previous note), which broke `build:wasm`. The startup update script now establishes both, in addition to installing JS deps.

### Update script (registered separately)
```
pnpm config set script-shell /usr/bin/bash
rustup target add wasm32-unknown-unknown
pnpm -C browser install
```
Build/run steps (WASM build, `cargo build`, starting services) are intentionally kept out of the update script and remain documented in AGENTS.md.

## Verification

Services brought up and exercised end-to-end:

| Service | Command | Result |
| --- | --- | --- |
| AtomicServer (Rust HTTP/WS on :9885) | `target/debug/atomic-server --port 9885 --initialize` | HTTP 200 on `/setup` |
| Frontend (Vite on :6747) | `cd browser && pnpm start` | HTTP 200, HMR up |
| `@tomic/lib` tests | `cd browser/lib && pnpm test` | 229 passed |
| `atomic_lib` Rust tests | `cargo test -p atomic_lib --no-default-features --features db-redb --lib` | 322 passed |
| Lint | `cd browser/lib && pnpm run lint` | oxlint clean |

Hello-world task: created a "Hello Cursor Cloud" document in a fresh dev-drive, typed body text, and confirmed it persisted after a page reload.

[atomic_data_create_document_e2e.mp4](https://cursor.com/agents/bc-de09503f-2bc7-49d9-9a07-4bae999252b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatomic_data_create_document_e2e.mp4)

[Document after reload showing persisted content](https://cursor.com/agents/bc-de09503f-2bc7-49d9-9a07-4bae999252b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocument_after_reload.webp)

## Notes / pre-existing issues (not changed here)
- `cargo test -p atomic_lib --no-default-features` (documented as 76 tests) currently fails to compile on this base branch: `hierarchy.rs`'s `legacy_internal_agent_grant_still_authorizes_its_did` `#[tokio::test]` uses `crate::db`/`test_utils::setup_test_env` which are gated behind the `db` feature but the test isn't. Running with `--features db-redb` works. Left unmodified since it's outside env-setup scope.
- `pnpm run lint` also runs `format-check`, which flags a pre-existing formatting deviation in `browser/lib/src/store.test.ts` (unrelated, untouched).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de09503f-2bc7-49d9-9a07-4bae999252b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de09503f-2bc7-49d9-9a07-4bae999252b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

