### PR TITLE
fix(build): stop the JS build from re-triggering itself

### DIFF
--- a/server/build.rs
+++ b/server/build.rs
@@ -168,6 +168,7 @@ fn should_build(dirs: &Dirs) -> bool {
                         .to_str()
                         .map(|s| !s.starts_with(".DS_Store"))
                         .unwrap_or(false)
+                        && !is_js_build_output(entry.path())
                 })
                 .any(|entry| {
                     if let Ok(entry) = entry {
@@ -403,6 +404,36 @@ fn precompress_assets(root: &Path) -> std::io::Result<()> {
         );
     }
     Ok(())
+}
+
+/// Paths under `src/` that the JS build *writes*, so they are output, not
+/// input, even though they live among the sources (and `main.loader.js` is
+/// committed, unlike its two siblings).
+///
+/// wuchale rewrites all three on every `pnpm run build` — same bytes, new
+/// mtime. Counting them as "a source changed" makes this check
+/// self-triggering: one build guarantees the next one rebuilds too, so the
+/// ~35s data-browser build is paid every single time and the mtime comparison
+/// never gets to do its job. CI feels it hardest, where each job starts from
+/// whatever the previous one left behind.
+///
+/// A genuine wuchale change still forces a rebuild: it arrives as a
+/// `pnpm-lock.yaml` bump, which is watched.
+fn is_js_build_output(path: &Path) -> bool {
+    // Matched on the tail rather than the file name alone: `data.js` is a
+    // name plausible enough to exist as real source elsewhere under src/, and
+    // silently ignoring *that* would be the opposite bug — a source edit that
+    // never triggers a rebuild.
+    const GENERATED: &[&str] = &[
+        "src/locales/main.loader.js",
+        "src/locales/data.js",
+        "src/locales/.wuchale",
+    ];
+
+    // `.wuchale` needs no contents check: WalkDir consults filter_entry on a
+    // directory before descending, so rejecting it here prunes the subtree.
+    let path = path.to_string_lossy().replace('\\', "/");
+    GENERATED.iter().any(|suffix| path.ends_with(suffix))
 }
 
 /// Finds the modification time of the newest file in the dist directory


### PR DESCRIPTION
`should_build()` in `server/build.rs` compares source mtimes against `dist`, but three of the paths it walks are written by the JS build itself. wuchale rewrites `src/locales/main.loader.js`, `src/locales/data.js` and `src/locales/.wuchale` on every `pnpm run build`, same bytes with a new mtime. Whenever that leaves one of them newer than `dist`, the next build concludes a source changed and rebuilds the whole data-browser, which rewrites them again. The mtime check never gets to do its job.

Found from atomic-saas CI on the self-hosted runner, where each job starts from whatever the previous one left behind: every job paid the full ~36s data-browser build, and `build.rs` named `main.loader.js` as the trigger each time.

**Verified locally**, by making the loader newer than `dist` and running `cargo check -p atomic-server` with and without the change:

| loader newer than dist | result |
|---|---|
| before | `Source file modified: ".../locales/main.loader.js", rebuilding...` then a full JS build |
| after | `No changes in JS source files, skipping JS build.`, total build.rs time 0.015s |

Two notes on the implementation:

- Matched on the path tail rather than the bare file name. `data.js` is plausible enough to exist as real source elsewhere under `src/`, and silently ignoring that would be the opposite bug: an edit that never triggers a rebuild.
- No contents check for `.wuchale`, because `WalkDir` consults `filter_entry` on a directory before descending, so rejecting it prunes the subtree.

A genuine wuchale upgrade still forces a rebuild, since it arrives as a `pnpm-lock.yaml` bump, which stays watched.

Not included here: I first tried untracking `main.loader.js` as generated output, like its two gitignored siblings. That is wrong, the build needs it committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to build-script change detection only; no runtime or auth behavior, with a deliberate suffix match to avoid ignoring legitimate `data.js` sources.
> 
> **Overview**
> **Fixes a self-triggering JS rebuild loop** in `server/build.rs` where `should_build()` treated wuchale outputs under `data-browser/src/locales/` as source changes.
> 
> `should_build()` now skips `src/locales/main.loader.js`, `src/locales/data.js`, and `src/locales/.wuchale` when comparing mtimes to `dist`. Those files are rewritten on every `pnpm run build` (same content, newer mtime), which previously forced a full ~35s data-browser build on every `cargo` invocation—including CI jobs that reused a prior workspace.
> 
> Matching uses **path suffixes** (not bare filenames like `data.js`) so unrelated real sources elsewhere under `src/` still trigger rebuilds. Real wuchale upgrades remain covered via watched `pnpm-lock.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb7244b3c6a3fedd19dfad784ac3d9cad7d21e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->