### PR TITLE
Form branching: hide/show questions from other answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 ## UNRELEASED
 
 - Collection `/query`: the rights walk no longer full-decodes ancestors (memoize by subject + `get_resource_shallow`). Denied members still do not consume `page_size`, so a readable row after a private streak is returned.
+- Forms: branching — hide/show pages and questions from earlier answers (`FormCondition` resources). Submit validation skips hidden fields (required-on-hidden is not an error; submitted values for them are dropped). [#875](https://github.com/ontola/atomic-server/issues/875)
 
 
 ## [v0.41.0-beta.2] - 2026-08-01

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -277,6 +277,30 @@ panel (memo is per-query, not per-request).
 
 ---
 
+## Commit delivery and the Loro save cursor
+
+The client exports each commit as a delta starting at its save cursor
+(`_loroVersionAtLastSave`). If the cursor ever sits past ops the server never
+received, every later delta is un-importable server-side — and Loro parks such
+ops as *pending* (VV unchanged, empty diff), which without a guard is
+indistinguishable from an idempotent replay. This lost a real user's
+`form-pages` write in 2026-08.
+
+| Flow | Where |
+|---|---|
+| Server rejects a delta whose deps it never received (pending import), and accepts the full-range re-send | `lib/src/commit.rs::commit_with_pending_loro_deps_is_rejected` |
+| Idempotent replay of an already-applied commit is still accepted | `lib/src/commit.rs::idempotent_commit_replay_is_accepted` |
+| Drain reacts to the pending-deps rejection by clearing the cursor and re-sending a self-contained snapshot | `browser/lib/src/store.test.ts` ("recovers from a server pending-deps rejection…") |
+| `clone()` / `merge(replaceLoroDocs)` carries the cursor VALUE, not the current doc version | `browser/lib/src/resource.test.ts` ("clone preserves the save cursor value…") |
+| Imports/echoes don't advance the cursor past unsigned local edits | `browser/lib/src/resource.test.ts` ("importLoroUpdate does not advance…") |
+
+Not covered: the OPFS-suppression window (edits live only in memory between
+`markDirty` and a successful drain — an app kill in that window still loses
+them, `store.ts` `addResource`'s `!hasPendingCommits` gate); WS `COMMIT_OK`
+acks carrying no server-side apply confirmation beyond the echoed commit.
+
+---
+
 ## Forms
 
 | Flow | Where |
@@ -286,4 +310,4 @@ panel (memo is per-query, not per-request).
 | Form ontology populate (incl. FormCondition) | `lib/src/store.rs::populate_forms_ontology` |
 | Publish → anonymous submit of a branching follow-up | `browser/e2e/tests/forms-submission.spec.ts` ("branching hides a follow-up unless its condition matches") |
 
-Not covered: builder UI for adding/removing conditions (the e2e walks it once as setup, not as its own assertion); page-level (not field-level) branching in e2e (unit fixtures cover it).
+Not covered: builder UI for adding/removing conditions (the e2e walks it once as setup, not as its own assertion); page-level (not field-level) branching in e2e (unit fixtures cover it); add/delete-page write ordering in `PageTabBar` (both now `await` the form's `form-pages` save — add before selecting, delete before destroying — but no test pins that ordering).

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -274,3 +274,16 @@ is only kept in step by mirroring the tests, so do that deliberately.
 Not covered: wall-clock on a large real store (the 21.7KB-parent form from
 `planning/slow-collection-queries.md`); per-GET rights walks on the invite-code
 panel (memo is per-query, not per-request).
+
+---
+
+## Forms
+
+| Flow | Where |
+|---|---|
+| FormCondition evaluator (visibility + hidden-field validation skip) | Shared fixtures `testdata/form-conditions.json` loaded by `server/src/forms.rs::condition_fixtures_match_ts` **and** `browser/form-renderer/src/conditions.test.ts`. A fix to one is a fix to the other. |
+| Definition serializer inlines FormCondition resources as `{field, operator, value}` | `server/src/forms.rs::definition_inlines_field_conditions` |
+| Form ontology populate (incl. FormCondition) | `lib/src/store.rs::populate_forms_ontology` |
+| Publish → anonymous submit of a branching follow-up | `browser/e2e/tests/forms-submission.spec.ts` ("branching hides a follow-up unless its condition matches") |
+
+Not covered: builder UI for adding/removing conditions (the e2e walks it once as setup, not as its own assertion); page-level (not field-level) branching in e2e (unit fixtures cover it).

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Forms: branching — a "Show when" editor on questions and pages hides follow-ups unless earlier answers match. Published forms skip hidden pages in Next/Back/progress/Submit. [#875](https://github.com/ontola/atomic-server/issues/875)
+
 ## [v0.41.0-beta.2] - 2026-08-01
 
 ### Atomic Browser

--- a/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
@@ -1,5 +1,3 @@
-'use no memo';
-
 import {
   forms,
   useArray,
@@ -119,7 +117,8 @@ export function ConditionsEditor({
           onClick={addCondition}
         >
           <Row gap='.5rem' center>
-            <FaPlus /> Add condition
+            <FaPlus />
+            <span>Add condition</span>
           </Row>
         </AddButton>
       </Column>

--- a/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import {
   forms,
   useArray,

--- a/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
@@ -1,0 +1,345 @@
+import {
+  forms,
+  useArray,
+  useResource,
+  useStore,
+  useString,
+  useSubject,
+  useValue,
+  type JSONValue,
+  type Resource,
+} from '@tomic/react';
+import type { JSX } from 'react';
+import { styled } from 'styled-components';
+import { FaPlus, FaTrash } from 'react-icons/fa6';
+import Field from '@components/forms/Field';
+import { BasicSelect } from '@components/forms/BasicSelect';
+import { InputStyled, InputWrapper } from '@components/forms/InputStyles';
+import { Button } from '@components/Button';
+import { Column, Row } from '@components/Row';
+import {
+  IconButton,
+  IconButtonVariant,
+} from '@components/IconButton/IconButton';
+import {
+  previousQuestions,
+  useFormQuestions,
+  type FormQuestionRef,
+} from './useFormQuestions';
+
+const OPERATORS: Array<{ value: string; label: string }> = [
+  { value: 'equals', label: 'equals' },
+  { value: 'not-equals', label: 'does not equal' },
+  { value: 'contains', label: 'contains' },
+  { value: 'greater-than', label: 'greater than' },
+  { value: 'less-than', label: 'less than' },
+];
+
+interface ConditionsEditorProps {
+  /** The page, field, or layout block that owns the conditions. */
+  resource: Resource;
+  form: Resource;
+  /** When editing a field, only earlier questions are offered. */
+  beforeField?: string;
+  /** When editing a page, only questions on earlier pages are offered. */
+  beforePage?: string;
+}
+
+export function ConditionsEditor({
+  resource,
+  form,
+  beforeField,
+  beforePage,
+}: ConditionsEditorProps): JSX.Element {
+  const store = useStore();
+  const [pages] = useArray(form, forms.properties.formPages);
+  const questions = useFormQuestions(form);
+  const available = previousQuestions(questions, pages, {
+    beforeField,
+    beforePage,
+  });
+  const [conditionSubjects, setConditionSubjects] = useArray(
+    resource,
+    forms.properties.formConditions,
+    { commit: true },
+  );
+
+  const addCondition = async () => {
+    const first = available[0];
+
+    if (!first) return;
+
+    const cond = await store.newResource({
+      parent: resource.subject,
+      isA: forms.classes.formCondition,
+      propVals: {
+        [forms.properties.formConditionField]: first.subject,
+        [forms.properties.formConditionOperator]: 'equals',
+        [forms.properties.formConditionValue]: defaultValueFor(first),
+      },
+    });
+    await cond.save();
+    setConditionSubjects([...conditionSubjects, cond.subject]);
+  };
+
+  const removeCondition = async (subject: string) => {
+    setConditionSubjects(conditionSubjects.filter(s => s !== subject));
+    const cond = await store.getResource(subject);
+    await cond.destroy();
+  };
+
+  return (
+    <Field
+      label='Show when'
+      helper='All of these must match. Leave empty to always show.'
+    >
+      <Column gap='0.4rem'>
+        {conditionSubjects.map((subject, index) => (
+          <div key={subject}>
+            {index > 0 && <AndLabel>and</AndLabel>}
+            <ConditionRow
+              subject={subject}
+              available={available}
+              onRemove={() => removeCondition(subject)}
+            />
+          </div>
+        ))}
+        <AddButton
+          type='button'
+          subtle
+          data-testid='add-condition'
+          disabled={available.length === 0}
+          title={
+            available.length === 0
+              ? 'Add a question before this one first'
+              : undefined
+          }
+          onClick={addCondition}
+        >
+          <Row gap='.5rem' center>
+            <FaPlus /> Add condition
+          </Row>
+        </AddButton>
+      </Column>
+    </Field>
+  );
+}
+
+interface ConditionRowProps {
+  subject: string;
+  available: FormQuestionRef[];
+  onRemove: () => void;
+}
+
+function ConditionRow({
+  subject,
+  available,
+  onRemove,
+}: ConditionRowProps): JSX.Element {
+  const resource = useResource(subject);
+  const [fieldSubject, setFieldSubject] = useSubject(
+    resource,
+    forms.properties.formConditionField,
+    { commit: true },
+  );
+  const [operator, setOperator] = useString(
+    resource,
+    forms.properties.formConditionOperator,
+    { commit: true },
+  );
+  const [value, setValue] = useValue(
+    resource,
+    forms.properties.formConditionValue,
+    { commit: true, validate: false },
+  );
+
+  const selected =
+    available.find(q => q.subject === fieldSubject) ?? available[0];
+
+  const onFieldChange = (nextSubject: string) => {
+    const next = available.find(q => q.subject === nextSubject);
+
+    if (!next) return;
+
+    setFieldSubject(next.subject);
+    setValue(defaultValueFor(next));
+  };
+
+  return (
+    <Row gap='0.4rem' center>
+      <BasicSelect
+        data-testid='condition-field'
+        value={fieldSubject ?? ''}
+        onChange={e => onFieldChange(e.target.value)}
+      >
+        {available.map(q => (
+          <option key={q.subject} value={q.subject}>
+            {q.label}
+          </option>
+        ))}
+      </BasicSelect>
+      <BasicSelect
+        data-testid='condition-operator'
+        value={operator ?? 'equals'}
+        onChange={e => setOperator(e.target.value)}
+      >
+        {OPERATORS.map(op => (
+          <option key={op.value} value={op.value}>
+            {op.label}
+          </option>
+        ))}
+      </BasicSelect>
+      <ValueInput
+        question={selected}
+        value={parseConditionValue(value)}
+        onChange={setValue}
+      />
+      <IconButton
+        variant={IconButtonVariant.Simple}
+        size='0.8rem'
+        color='textLight'
+        title='Remove condition'
+        type='button'
+        data-testid='remove-condition'
+        onClick={onRemove}
+      >
+        <FaTrash />
+      </IconButton>
+    </Row>
+  );
+}
+
+function ValueInput({
+  question,
+  value,
+  onChange,
+}: {
+  question: FormQuestionRef | undefined;
+  value: JSONValue;
+  onChange: (value: JSONValue) => void;
+}): JSX.Element {
+  if (!question) {
+    return (
+      <InputWrapper>
+        <InputStyled data-testid='condition-value' disabled />
+      </InputWrapper>
+    );
+  }
+
+  if (question.type === 'checkbox') {
+    const boolVal = value === true;
+
+    return (
+      <BasicSelect
+        data-testid='condition-value'
+        value={boolVal ? 'true' : 'false'}
+        onChange={e => onChange(e.target.value === 'true')}
+      >
+        <option value='true'>checked</option>
+        <option value='false'>unchecked</option>
+      </BasicSelect>
+    );
+  }
+
+  if (
+    (question.type === 'radio' || question.type === 'multi-select') &&
+    question.choiceOptions &&
+    question.choiceOptions.length > 0
+  ) {
+    const current = typeof value === 'string' ? value : '';
+
+    return (
+      <BasicSelect
+        data-testid='condition-value'
+        value={current}
+        onChange={e => onChange(e.target.value)}
+      >
+        {question.choiceOptions.map(opt => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </BasicSelect>
+    );
+  }
+
+  if (question.type === 'number') {
+    return (
+      <InputWrapper>
+        <InputStyled
+          data-testid='condition-value'
+          type='number'
+          value={typeof value === 'number' ? value : ''}
+          onChange={e =>
+            onChange(e.target.value === '' ? '' : Number(e.target.value))
+          }
+        />
+      </InputWrapper>
+    );
+  }
+
+  if (question.type === 'date') {
+    return (
+      <InputWrapper>
+        <InputStyled
+          data-testid='condition-value'
+          type='date'
+          value={typeof value === 'string' ? value : ''}
+          onChange={e => onChange(e.target.value)}
+        />
+      </InputWrapper>
+    );
+  }
+
+  return (
+    <InputWrapper>
+      <InputStyled
+        data-testid='condition-value'
+        value={
+          typeof value === 'string' || typeof value === 'number' ? value : ''
+        }
+        onChange={e => onChange(e.target.value)}
+      />
+    </InputWrapper>
+  );
+}
+
+function defaultValueFor(question: FormQuestionRef): JSONValue {
+  if (question.type === 'checkbox') return true;
+
+  if (question.type === 'number') return 0;
+
+  if (question.choiceOptions && question.choiceOptions.length > 0) {
+    return question.choiceOptions[0];
+  }
+
+  return '';
+}
+
+/** Tolerates a raw JSON string (property unresolvable → no json tag). */
+function parseConditionValue(raw: JSONValue | undefined): JSONValue {
+  if (raw === undefined || raw === null) return '';
+
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as JSONValue;
+    } catch {
+      return raw;
+    }
+  }
+
+  return raw;
+}
+
+const AndLabel = styled.p`
+  margin: 0.15rem 0;
+  font-size: 0.8rem;
+  color: ${p => p.theme.colors.textLight};
+`;
+
+const AddButton = styled(Button)`
+  align-self: flex-start;
+  box-shadow: none;
+  border: 1px dashed ${p => p.theme.colors.bg2};
+  background: none;
+`;

--- a/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/ConditionsEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@tomic/react';
 import type { JSX } from 'react';
 import { styled } from 'styled-components';
-import { FaPlus, FaTrash } from 'react-icons/fa6';
+import { FaCodeBranch, FaPlus, FaTrash } from 'react-icons/fa6';
 import Field from '@components/forms/Field';
 import { BasicSelect } from '@components/forms/BasicSelect';
 import { InputStyled, InputWrapper } from '@components/forms/InputStyles';
@@ -21,6 +21,7 @@ import {
   IconButton,
   IconButtonVariant,
 } from '@components/IconButton/IconButton';
+import { Dialog, useDialog } from '@components/Dialog';
 import {
   previousQuestions,
   useFormQuestions,
@@ -46,6 +47,70 @@ interface ConditionsEditorProps {
 }
 
 export function ConditionsEditor({
+  resource,
+  form,
+  beforeField,
+  beforePage,
+}: ConditionsEditorProps): JSX.Element {
+  const [dialogProps, show, close, isOpen] = useDialog();
+  const [conditionSubjects] = useArray(
+    resource,
+    forms.properties.formConditions,
+  );
+  const title = beforePage ? 'Show Page When' : 'Show Field When';
+
+  return (
+    <>
+      <Field label={title}>
+        <OpenButton
+          type="button"
+          subtle
+          data-testid="edit-conditions"
+          onClick={show}
+        >
+          <Row gap=".5rem" center>
+            <FaCodeBranch />
+            <ConditionsSummary count={conditionSubjects.length} />
+          </Row>
+        </OpenButton>
+      </Field>
+      <Dialog {...dialogProps} width="40rem">
+        {isOpen && (
+          <>
+            <Dialog.Title>
+              <h1>{title}</h1>
+            </Dialog.Title>
+            <Dialog.Content>
+              <ConditionsList
+                resource={resource}
+                form={form}
+                beforeField={beforeField}
+                beforePage={beforePage}
+              />
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onClick={() => close(true)}>Done</Button>
+            </Dialog.Actions>
+          </>
+        )}
+      </Dialog>
+    </>
+  );
+}
+
+function ConditionsSummary({ count }: { count: number }): JSX.Element {
+  if (count === 0) {
+    return <span>Always shown</span>;
+  }
+
+  if (count === 1) {
+    return <span>1 condition</span>;
+  }
+
+  return <span>{count} conditions</span>;
+}
+
+function ConditionsList({
   resource,
   form,
   beforeField,
@@ -89,11 +154,9 @@ export function ConditionsEditor({
   };
 
   return (
-    <Field
-      label='Show when'
-      helper='All of these must match. Leave empty to always show.'
-    >
-      <Column gap='0.4rem'>
+    <Column gap="0.75rem">
+      <Helper>All of these must match. Leave empty to always show.</Helper>
+      <Column gap="0.4rem">
         {conditionSubjects.map((subject, index) => (
           <div key={subject}>
             {index > 0 && <AndLabel>and</AndLabel>}
@@ -105,9 +168,9 @@ export function ConditionsEditor({
           </div>
         ))}
         <AddButton
-          type='button'
+          type="button"
           subtle
-          data-testid='add-condition'
+          data-testid="add-condition"
           disabled={available.length === 0}
           title={
             available.length === 0
@@ -116,13 +179,13 @@ export function ConditionsEditor({
           }
           onClick={addCondition}
         >
-          <Row gap='.5rem' center>
+          <Row gap=".5rem" center>
             <FaPlus />
             <span>Add condition</span>
           </Row>
         </AddButton>
       </Column>
-    </Field>
+    </Column>
   );
 }
 
@@ -167,9 +230,9 @@ function ConditionRow({
   };
 
   return (
-    <Row gap='0.4rem' center>
-      <BasicSelect
-        data-testid='condition-field'
+    <ConditionGrid>
+      <ShrinkSelect
+        data-testid="condition-field"
         value={fieldSubject ?? ''}
         onChange={e => onFieldChange(e.target.value)}
       >
@@ -178,9 +241,9 @@ function ConditionRow({
             {q.label}
           </option>
         ))}
-      </BasicSelect>
-      <BasicSelect
-        data-testid='condition-operator'
+      </ShrinkSelect>
+      <ShrinkSelect
+        data-testid="condition-operator"
         value={operator ?? 'equals'}
         onChange={e => setOperator(e.target.value)}
       >
@@ -189,7 +252,7 @@ function ConditionRow({
             {op.label}
           </option>
         ))}
-      </BasicSelect>
+      </ShrinkSelect>
       <ValueInput
         question={selected}
         value={parseConditionValue(value)}
@@ -197,16 +260,16 @@ function ConditionRow({
       />
       <IconButton
         variant={IconButtonVariant.Simple}
-        size='0.8rem'
-        color='textLight'
-        title='Remove condition'
-        type='button'
-        data-testid='remove-condition'
+        size="0.8rem"
+        color="textLight"
+        title="Remove condition"
+        type="button"
+        data-testid="remove-condition"
         onClick={onRemove}
       >
         <FaTrash />
       </IconButton>
-    </Row>
+    </ConditionGrid>
   );
 }
 
@@ -222,7 +285,7 @@ function ValueInput({
   if (!question) {
     return (
       <InputWrapper>
-        <InputStyled data-testid='condition-value' disabled />
+        <InputStyled data-testid="condition-value" disabled />
       </InputWrapper>
     );
   }
@@ -231,14 +294,14 @@ function ValueInput({
     const boolVal = value === true;
 
     return (
-      <BasicSelect
-        data-testid='condition-value'
+      <ShrinkSelect
+        data-testid="condition-value"
         value={boolVal ? 'true' : 'false'}
         onChange={e => onChange(e.target.value === 'true')}
       >
-        <option value='true'>checked</option>
-        <option value='false'>unchecked</option>
-      </BasicSelect>
+        <option value="true">checked</option>
+        <option value="false">unchecked</option>
+      </ShrinkSelect>
     );
   }
 
@@ -250,8 +313,8 @@ function ValueInput({
     const current = typeof value === 'string' ? value : '';
 
     return (
-      <BasicSelect
-        data-testid='condition-value'
+      <ShrinkSelect
+        data-testid="condition-value"
         value={current}
         onChange={e => onChange(e.target.value)}
       >
@@ -260,7 +323,7 @@ function ValueInput({
             {opt}
           </option>
         ))}
-      </BasicSelect>
+      </ShrinkSelect>
     );
   }
 
@@ -268,8 +331,8 @@ function ValueInput({
     return (
       <InputWrapper>
         <InputStyled
-          data-testid='condition-value'
-          type='number'
+          data-testid="condition-value"
+          type="number"
           value={typeof value === 'number' ? value : ''}
           onChange={e =>
             onChange(e.target.value === '' ? '' : Number(e.target.value))
@@ -283,8 +346,8 @@ function ValueInput({
     return (
       <InputWrapper>
         <InputStyled
-          data-testid='condition-value'
-          type='date'
+          data-testid="condition-value"
+          type="date"
           value={typeof value === 'string' ? value : ''}
           onChange={e => onChange(e.target.value)}
         />
@@ -295,7 +358,7 @@ function ValueInput({
   return (
     <InputWrapper>
       <InputStyled
-        data-testid='condition-value'
+        data-testid="condition-value"
         value={
           typeof value === 'string' || typeof value === 'number' ? value : ''
         }
@@ -332,6 +395,17 @@ function parseConditionValue(raw: JSONValue | undefined): JSONValue {
   return raw;
 }
 
+const OpenButton = styled(Button)`
+  width: 100%;
+  justify-content: flex-start;
+`;
+
+const Helper = styled.p`
+  margin: 0;
+  font-size: 0.9rem;
+  color: ${p => p.theme.colors.textLight};
+`;
+
 const AndLabel = styled.p`
   margin: 0.15rem 0;
   font-size: 0.8rem;
@@ -343,4 +417,19 @@ const AddButton = styled(Button)`
   box-shadow: none;
   border: 1px dashed ${p => p.theme.colors.bg2};
   background: none;
+`;
+
+const ConditionGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1.4fr) auto;
+  gap: 0.4rem;
+  align-items: center;
+
+  & > * {
+    min-width: 0;
+  }
+`;
+
+const ShrinkSelect = styled(BasicSelect)`
+  min-width: 0;
 `;

--- a/browser/data-browser/src/chunks/FormBuilder/FieldRow.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/FieldRow.tsx
@@ -1,7 +1,14 @@
-import { core, forms, useResource, useString, useTitle } from '@tomic/react';
+import {
+  core,
+  forms,
+  useArray,
+  useResource,
+  useString,
+  useTitle,
+} from '@tomic/react';
 import type { JSX } from 'react';
 import { styled } from 'styled-components';
-import { FaTrash } from 'react-icons/fa6';
+import { FaCodeBranch, FaTrash } from 'react-icons/fa6';
 import { Column, Row } from '@components/Row';
 import {
   IconButton,
@@ -26,6 +33,7 @@ export function FieldRow({
   const [name] = useTitle(resource);
   const [fieldType] = useString(resource, forms.properties.formFieldType);
   const [description] = useString(resource, core.properties.description);
+  const [conditions] = useArray(resource, forms.properties.formConditions);
   const isHeading = resource.hasClasses(forms.classes.formHeading);
   const isParagraph = resource.hasClasses(forms.classes.formParagraph);
 
@@ -43,7 +51,7 @@ export function FieldRow({
   return (
     <RowWrapper $selected={selected}>
       <SelectButton
-        type="button"
+        type='button'
         // While the resource is loading, `type` is just the fallback — don't
         // claim a concrete testid yet, or every hydrating row briefly reads
         // as `field-row-short-text` (breaks e2e strict-mode selectors).
@@ -53,19 +61,25 @@ export function FieldRow({
         onClick={onSelect}
       >
         <Column fullWidth>
-          <FieldTypeRow gap="0.5rem" center>
+          <FieldTypeRow gap='0.5rem' center>
             <Icon />
             <Label light>{meta.label}</Label>
           </FieldTypeRow>
           {label ? <Label>{label}</Label> : null}
+          {conditions.length > 0 && (
+            <FieldTypeRow gap='0.35rem' center>
+              <FaCodeBranch />
+              <Label light>Conditional</Label>
+            </FieldTypeRow>
+          )}
         </Column>
       </SelectButton>
       <IconButton
         variant={IconButtonVariant.Simple}
-        size="0.8rem"
-        color="textLight"
-        title="Delete field"
-        type="button"
+        size='0.8rem'
+        color='textLight'
+        title='Delete field'
+        type='button'
         onClick={onDelete}
       >
         <FaTrash />

--- a/browser/data-browser/src/chunks/FormBuilder/FieldSettingsPanel.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/FieldSettingsPanel.tsx
@@ -18,15 +18,18 @@ import { NumberOptions } from './FieldOptions/NumberOptions';
 import { ChoiceOptions } from './FieldOptions/ChoiceOptions';
 import type { FormFieldType } from './fieldTypes';
 import { useFormFieldPropertySync } from './useFormFieldPropertySync';
+import { ConditionsEditor } from './ConditionsEditor';
 
 interface FieldSettingsPanelProps {
   fieldSubject: string;
   dataClassSubject: string;
+  form: Resource;
 }
 
 export function FieldSettingsPanel({
   fieldSubject,
   dataClassSubject,
+  form,
 }: FieldSettingsPanelProps): JSX.Element {
   const field = useResource(fieldSubject);
   const descriptionProp = useProperty(core.properties.description);
@@ -43,6 +46,11 @@ export function FieldSettingsPanel({
         <Field label='Heading text' required>
           <FieldLabelInput field={field} renameField={renameField} />
         </Field>
+        <ConditionsEditor
+          resource={field}
+          form={form}
+          beforeField={fieldSubject}
+        />
       </Panel>
     );
   }
@@ -58,6 +66,11 @@ export function FieldSettingsPanel({
             required
           />
         </Field>
+        <ConditionsEditor
+          resource={field}
+          form={form}
+          beforeField={fieldSubject}
+        />
       </Panel>
     );
   }
@@ -73,7 +86,15 @@ export function FieldSettingsPanel({
       <Field label='Required'>
         <InputSwitcher commit resource={field} property={requiredProp} />
       </Field>
-      <TypeOptions field={field} type={fieldType as FormFieldType | undefined} />
+      <TypeOptions
+        field={field}
+        type={fieldType as FormFieldType | undefined}
+      />
+      <ConditionsEditor
+        resource={field}
+        form={form}
+        beforeField={fieldSubject}
+      />
     </Panel>
   );
 }

--- a/browser/data-browser/src/chunks/FormBuilder/FormBuilderPage.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/FormBuilderPage.tsx
@@ -13,6 +13,7 @@ import type { ResourcePageProps } from '@views/ResourcePage';
 import { PageTabBar } from './PageTabBar';
 import { FieldList } from './FieldList';
 import { FieldSettingsPanel } from './FieldSettingsPanel';
+import { PageSettingsPanel } from './PageSettingsPanel';
 import { PublishToggle } from './PublishToggle';
 import { FormPreviewButton } from './FormPreviewDialog';
 import { ResultsTab } from './ResultsTab';
@@ -106,11 +107,16 @@ export function FormBuilderPage({ resource }: ResourcePageProps): JSX.Element {
             )}
           </MainSlot>
           <SettingsSlot>
-            {selectedField && dataClassSubject && (
+            {selectedField && dataClassSubject ? (
               <FieldSettingsPanel
                 fieldSubject={selectedField}
                 dataClassSubject={dataClassSubject}
+                form={resource}
               />
+            ) : (
+              activePage && (
+                <PageSettingsPanel pageSubject={activePage} form={resource} />
+              )
             )}
           </SettingsSlot>
           <PageBarSlot>

--- a/browser/data-browser/src/chunks/FormBuilder/PageSettingsPanel.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/PageSettingsPanel.tsx
@@ -1,0 +1,29 @@
+import { useResource, type Resource } from '@tomic/react';
+import type { JSX } from 'react';
+import { styled } from 'styled-components';
+import { Column } from '@components/Row';
+import { ConditionsEditor } from './ConditionsEditor';
+
+interface PageSettingsPanelProps {
+  pageSubject: string;
+  form: Resource;
+}
+
+/** Shown in the builder's right pane when a page is selected but no field is.
+ * Page title is edited in-place on the tab; this pane is for visibility. */
+export function PageSettingsPanel({
+  pageSubject,
+  form,
+}: PageSettingsPanelProps): JSX.Element {
+  const page = useResource(pageSubject);
+
+  return (
+    <Panel>
+      <ConditionsEditor resource={page} form={form} beforePage={pageSubject} />
+    </Panel>
+  );
+}
+
+const Panel = styled(Column)`
+  gap: 0.75rem;
+`;

--- a/browser/data-browser/src/chunks/FormBuilder/PageTabBar.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/PageTabBar.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tomic/react';
 import { useState, type JSX } from 'react';
 import { styled } from 'styled-components';
-import { FaPlus, FaTrash } from 'react-icons/fa6';
+import { FaCodeBranch, FaPlus, FaTrash } from 'react-icons/fa6';
 import { Row } from '@components/Row';
 import { Button } from '@components/Button';
 import { InputStyled } from '@components/forms/InputStyles';
@@ -45,7 +45,15 @@ export function PageTabBar({
       },
     });
     await page.save();
-    setPages([...pages, page.subject]);
+    // Write the form's page list explicitly and await durability — the
+    // debounced `setPages` commit is fire-and-forget, and if it never lands
+    // the page just saved above is orphaned (exists, but no form points at
+    // it).
+    await formResource.set(forms.properties.formPages, [
+      ...pages,
+      page.subject,
+    ]);
+    await formResource.save();
     onSelectPage(page.subject);
   };
 
@@ -53,6 +61,14 @@ export function PageTabBar({
     if (pages.length <= 1) {
       return;
     }
+
+    const remaining = pages.filter(p => p !== subject);
+
+    // Point the form away from the page BEFORE destroying anything, and
+    // await durability — the reverse order leaves the form referencing a
+    // destroyed page if the debounced commit never lands.
+    await formResource.set(forms.properties.formPages, remaining);
+    await formResource.save();
 
     const page = await store.getResource(subject);
     const conditions =
@@ -63,22 +79,20 @@ export function PageTabBar({
       await cond.destroy();
     }
 
-    setPages(pages.filter(p => p !== subject));
     await page.destroy();
 
     if (activePage === subject) {
-      const remaining = pages.filter(p => p !== subject);
       onSelectPage(remaining[0]);
     }
   };
 
   return (
-    <TabBarRow gap='0.5rem' center>
+    <TabBarRow gap="0.5rem" center>
       <ScrollArea>
         <ReorderableList
           subjects={pages}
           onReorder={setPages}
-          orientation='horizontal'
+          orientation="horizontal"
           renderItem={subject => (
             <PageTab
               subject={subject}
@@ -90,8 +104,8 @@ export function PageTabBar({
           )}
         />
       </ScrollArea>
-      <AddButton type='button' subtle onClick={addPage}>
-        <Row gap='.5rem' center>
+      <AddButton type="button" subtle onClick={addPage}>
+        <Row gap=".5rem" center>
           <FaPlus /> Add page
         </Row>
       </AddButton>
@@ -116,6 +130,7 @@ function PageTab({
 }: PageTabProps): JSX.Element {
   const resource = useResource(subject);
   const [name, setName] = useTitle(resource, Infinity, { commit: true });
+  const [conditions] = useArray(resource, forms.properties.formConditions);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(name);
 
@@ -149,23 +164,25 @@ function PageTab({
   return (
     <TabRow $active={active}>
       <TabButton
-        type='button'
+        type="button"
         $active={active}
+        title={conditions.length > 0 ? 'Conditional' : undefined}
         onClick={onSelect}
         onDoubleClick={() => {
           setDraft(name);
           setEditing(true);
         }}
       >
+        {conditions.length > 0 && <BranchIcon aria-hidden />}
         {name || 'Untitled page'}
       </TabButton>
       {canDelete && (
         <IconButton
           variant={IconButtonVariant.Simple}
-          size='0.8rem'
-          color='textLight'
-          title='Delete page'
-          type='button'
+          size="0.8rem"
+          color="textLight"
+          title="Delete page"
+          type="button"
           onClick={onDelete}
         >
           <FaTrash />
@@ -195,6 +212,9 @@ const TabRow = styled(Row)<{ $active: boolean }>`
 `;
 
 const TabButton = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   text-align: left;
   padding: 0.35rem 0.6rem;
   border: none;
@@ -208,6 +228,12 @@ const TabButton = styled.button<{ $active: boolean }>`
   &:hover {
     background-color: ${p => p.theme.colors.bg1};
   }
+`;
+
+const BranchIcon = styled(FaCodeBranch)`
+  flex-shrink: 0;
+  font-size: 0.75em;
+  color: ${p => p.theme.colors.textLight};
 `;
 
 const AddButton = styled(Button)`

--- a/browser/data-browser/src/chunks/FormBuilder/PageTabBar.tsx
+++ b/browser/data-browser/src/chunks/FormBuilder/PageTabBar.tsx
@@ -13,7 +13,10 @@ import { FaPlus, FaTrash } from 'react-icons/fa6';
 import { Row } from '@components/Row';
 import { Button } from '@components/Button';
 import { InputStyled } from '@components/forms/InputStyles';
-import { IconButton, IconButtonVariant } from '@components/IconButton/IconButton';
+import {
+  IconButton,
+  IconButtonVariant,
+} from '@components/IconButton/IconButton';
 import { ReorderableList } from './ReorderableList';
 
 interface PageTabBarProps {
@@ -52,6 +55,14 @@ export function PageTabBar({
     }
 
     const page = await store.getResource(subject);
+    const conditions =
+      (page.get(forms.properties.formConditions) as string[] | undefined) ?? [];
+
+    for (const condSubject of conditions) {
+      const cond = await store.getResource(condSubject);
+      await cond.destroy();
+    }
+
     setPages(pages.filter(p => p !== subject));
     await page.destroy();
 

--- a/browser/data-browser/src/chunks/FormBuilder/buildFormDefinition.ts
+++ b/browser/data-browser/src/chunks/FormBuilder/buildFormDefinition.ts
@@ -3,6 +3,7 @@ import type {
   FieldOptions,
   FieldType,
   FormBlock,
+  FormCondition,
   FormDefinition,
   FormPageDefinition,
   FormStyling,
@@ -108,19 +109,82 @@ async function buildPageDefinition(
 
   for (const fieldSubject of fieldSubjects) {
     const field = await store.getResource(fieldSubject);
-    blocks.push(buildBlock(field));
+    blocks.push(await buildBlock(store, field));
   }
 
-  return { name, coverImage, imagePosition, blocks };
+  const conditions = await buildConditions(store, page);
+
+  return {
+    name,
+    coverImage,
+    imagePosition,
+    ...(conditions.length > 0 ? { conditions } : {}),
+    blocks,
+  };
 }
 
-function buildBlock(
+async function buildConditions(
+  store: Store,
+  resource: Awaited<ReturnType<Store['getResource']>>,
+): Promise<FormCondition[]> {
+  const subjects =
+    (resource.get(forms.properties.formConditions) as string[] | undefined) ??
+    [];
+  const out: FormCondition[] = [];
+
+  for (const subject of subjects) {
+    const cond = await store.getResource(subject);
+    const fieldSubject = cond.get(forms.properties.formConditionField) as
+      | string
+      | undefined;
+    let mapsTo = '';
+
+    if (fieldSubject) {
+      const field = await store.getResource(fieldSubject);
+      mapsTo =
+        (field.get(forms.properties.formMapsTo) as string | undefined) ?? '';
+    }
+
+    out.push({
+      field: mapsTo,
+      operator:
+        (cond.get(forms.properties.formConditionOperator) as
+          | string
+          | undefined) ?? 'equals',
+      value: parseConditionValue(
+        cond.get(forms.properties.formConditionValue) as JSONValue | undefined,
+      ),
+    });
+  }
+
+  return out;
+}
+
+function parseConditionValue(raw: JSONValue | undefined): unknown {
+  if (raw === undefined || raw === null) return null;
+
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+
+  return raw;
+}
+
+async function buildBlock(
+  store: Store,
   field: Awaited<ReturnType<Store['getResource']>>,
-): FormBlock {
+): Promise<FormBlock> {
+  const conditions = await buildConditions(store, field);
+
   if (field.hasClasses(forms.classes.formHeading)) {
     return {
       kind: 'heading',
       text: (field.get(core.properties.name) as string) ?? '',
+      ...(conditions.length > 0 ? { conditions } : {}),
     };
   }
 
@@ -128,6 +192,7 @@ function buildBlock(
     return {
       kind: 'paragraph',
       text: (field.get(core.properties.description) as string) ?? '',
+      ...(conditions.length > 0 ? { conditions } : {}),
     };
   }
 
@@ -146,5 +211,6 @@ function buildBlock(
       'short-text',
     required: Boolean(field.get(forms.properties.required)),
     options,
+    ...(conditions.length > 0 ? { conditions } : {}),
   };
 }

--- a/browser/data-browser/src/chunks/FormBuilder/useFormFieldPropertySync.ts
+++ b/browser/data-browser/src/chunks/FormBuilder/useFormFieldPropertySync.ts
@@ -42,14 +42,10 @@ export function useFormFieldPropertySync(dataClassSubject: string) {
         });
         await field.save();
       } else {
-        const propertySubject = await createPropertyOnClass(
-          store,
-          dataClass,
-          {
-            name: opts.label,
-            datatype: FIELD_TYPE_TO_DATATYPE[opts.type],
-          },
-        );
+        const propertySubject = await createPropertyOnClass(store, dataClass, {
+          name: opts.label,
+          datatype: FIELD_TYPE_TO_DATATYPE[opts.type],
+        });
 
         field = await store.newResource({
           parent: page.subject,
@@ -110,12 +106,21 @@ export function useFormFieldPropertySync(dataClassSubject: string) {
       );
       await page.save();
 
+      const conditions =
+        (field.get(forms.properties.formConditions) as string[] | undefined) ??
+        [];
+
+      for (const subject of conditions) {
+        const cond = await store.getResource(subject);
+        await cond.destroy();
+      }
+
       // The mapped Property (and any submissions already written to it) is
       // deliberately left in place — only the FormField / form-maps-to link
       // is removed.
       await field.destroy();
     },
-    [],
+    [store],
   );
 
   return { createField, renameField, deleteField };

--- a/browser/data-browser/src/chunks/FormBuilder/useFormQuestions.ts
+++ b/browser/data-browser/src/chunks/FormBuilder/useFormQuestions.ts
@@ -1,0 +1,134 @@
+import {
+  core,
+  forms,
+  useArray,
+  useResources,
+  type Resource,
+} from '@tomic/react';
+import { useMemo } from 'react';
+import type { FormFieldType } from './fieldTypes';
+
+export interface FormQuestionRef {
+  subject: string;
+  pageSubject: string;
+  label: string;
+  mapsTo: string;
+  type: FormFieldType | string;
+  choiceOptions?: string[];
+}
+
+/**
+ * Every input FormField in the form, in page then field order. Layout
+ * blocks are skipped — they have no `form-maps-to` to condition on.
+ */
+export function useFormQuestions(form: Resource): FormQuestionRef[] {
+  const [pages] = useArray(form, forms.properties.formPages);
+  const pageResources = useResources(pages);
+
+  const fieldSubjects = useMemo(() => {
+    const subjects: string[] = [];
+
+    for (const pageSubject of pages) {
+      const page = pageResources.get(pageSubject);
+      const fields =
+        (page?.get(forms.properties.formFields) as string[] | undefined) ?? [];
+      subjects.push(...fields);
+    }
+
+    return subjects;
+  }, [pages, pageResources]);
+
+  const fieldResources = useResources(fieldSubjects);
+
+  return useMemo(() => {
+    const questions: FormQuestionRef[] = [];
+
+    for (const pageSubject of pages) {
+      const page = pageResources.get(pageSubject);
+      const fields =
+        (page?.get(forms.properties.formFields) as string[] | undefined) ?? [];
+
+      for (const fieldSubject of fields) {
+        const field = fieldResources.get(fieldSubject);
+
+        if (
+          !field ||
+          field.loading ||
+          !field.hasClasses(forms.classes.formField)
+        ) {
+          continue;
+        }
+
+        questions.push({
+          subject: fieldSubject,
+          pageSubject,
+          label:
+            (field.get(core.properties.name) as string | undefined) ??
+            'Untitled',
+          mapsTo:
+            (field.get(forms.properties.formMapsTo) as string | undefined) ??
+            '',
+          type:
+            (field.get(forms.properties.formFieldType) as string | undefined) ??
+            'short-text',
+          choiceOptions: choiceOptionsFrom(
+            field.get(forms.properties.formFieldOptions),
+          ),
+        });
+      }
+    }
+
+    return questions;
+  }, [pages, pageResources, fieldResources]);
+}
+
+/** Questions the current field/page is allowed to condition on: earlier
+ * in document order. Page conditions only see earlier pages, so a page
+ * can't hide itself based on a question it contains. */
+export function previousQuestions(
+  questions: FormQuestionRef[],
+  pages: string[],
+  opts: { beforeField?: string; beforePage?: string },
+): FormQuestionRef[] {
+  if (opts.beforePage) {
+    const idx = pages.indexOf(opts.beforePage);
+
+    if (idx <= 0) return [];
+
+    const allowed = new Set(pages.slice(0, idx));
+
+    return questions.filter(q => allowed.has(q.pageSubject));
+  }
+
+  if (opts.beforeField) {
+    const out: FormQuestionRef[] = [];
+
+    for (const q of questions) {
+      if (q.subject === opts.beforeField) break;
+
+      out.push(q);
+    }
+
+    return out;
+  }
+
+  return questions;
+}
+
+function choiceOptionsFrom(raw: unknown): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+
+  let parsed: { options?: string[] } | undefined;
+
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw) as { options?: string[] };
+    } catch {
+      return undefined;
+    }
+  } else if (typeof raw === 'object') {
+    parsed = raw as { options?: string[] };
+  }
+
+  return parsed?.options;
+}

--- a/browser/data-browser/src/chunks/TablePage/ColumnLanguageChip.tsx
+++ b/browser/data-browser/src/chunks/TablePage/ColumnLanguageChip.tsx
@@ -102,7 +102,7 @@ const buildChipTrigger = (label: string): DropdownTriggerComponent => {
     </ChipButton>
   );
 
-  Comp.DisplayName = 'LanguageChipTrigger';
+  Comp.DisplayName = /* @wc-ignore */ 'LanguageChipTrigger';
 
   return Comp;
 };

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -376,7 +376,7 @@ export function passkeyRpId(): string | undefined {
 export class PrfUnsupportedError extends Error {
   constructor(message = 'This device cannot protect a backup with a passkey.') {
     super(message);
-    this.name = 'PrfUnsupportedError';
+    this.name = /* @wc-ignore */ 'PrfUnsupportedError';
   }
 }
 

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -1939,6 +1939,7 @@ msgstr "Bitte warten Sie, während wir Ihr OpenRouter-Konto verknüpfen..."
 msgid "Set a title"
 msgstr ""
 
+#: src/chunks/FormBuilder/useFormQuestions.ts
 #: src/components/EditableTitle.tsx
 #: src/components/NavBar.tsx
 msgid "Untitled"
@@ -6963,3 +6964,39 @@ msgstr "Jede Antwort ist ein"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewFormDialog.tsx
 msgid "Names the class of a single submission — e.g. every response of a Job Application form is an Application."
 msgstr "Benennt die Klasse einer einzelnen Übermittlung – z. B. ist jede Antwort eines Bewerbungsformulars eine Bewerbung."
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add a question before this one first"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "and"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "<0/> Add condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show when"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "All of these must match. Leave empty to always show."
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Remove condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "checked"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "unchecked"
+msgstr ""
+
+#: src/chunks/FormBuilder/FieldRow.tsx
+msgid "Conditional"
+msgstr ""

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -871,7 +871,7 @@ msgstr "erstellt am {0}"
 
 #: src/chunks/AI/AIChatMessageParts/SearchToolMessageContent.tsx
 msgid "No matching results."
-msgstr ""
+msgstr "Keine passenden Ergebnisse."
 
 #: src/components/ImageViewer.tsx
 msgid "Click to enlarge"
@@ -1145,19 +1145,19 @@ msgstr "Tag entfernen"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Loading messages..."
-msgstr ""
+msgstr "Nachrichten werden geladen..."
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "No messages yet"
-msgstr ""
+msgstr "Noch keine Nachrichten"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Be the first to say something"
-msgstr ""
+msgstr "Sei der Erste, der etwas sagt"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Chat input"
-msgstr ""
+msgstr "Chat-Eingabe"
 
 #: src/chunks/RTE/AIChatInput/AsyncAIChatInput.tsx
 #: src/views/ChatRoom/ChatRoomView.tsx
@@ -1166,31 +1166,31 @@ msgstr "Senden"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Send message [enter]"
-msgstr ""
+msgstr "Nachricht senden [Eingabetaste]"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Copied message URL to clipboard"
-msgstr ""
+msgstr "Nachrichten-URL in die Zwischenablage kopiert"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Copied message text to clipboard"
-msgstr ""
+msgstr "Nachrichtentext in die Zwischenablage kopiert"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Edit message"
-msgstr ""
+msgstr "Nachricht bearbeiten"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Reply to this message"
-msgstr ""
+msgstr "Auf diese Nachricht antworten"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Copy link to this message"
-msgstr ""
+msgstr "Link zu dieser Nachricht kopieren"
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "Copy message text"
-msgstr ""
+msgstr "Nachrichtentext kopieren"
 
 #: src/chunks/TablePage/PropertyForm/NumberPropertyForm.tsx
 #: src/views/BookmarkPage/BookmarkPreview.tsx
@@ -1200,7 +1200,7 @@ msgstr "wird geladen..."
 
 #: src/views/ChatRoom/ChatRoomView.tsx
 msgid "to"
-msgstr ""
+msgstr "an"
 
 #: src/views/ImporterPage.tsx
 msgid "Imported!"
@@ -1343,70 +1343,70 @@ msgstr "Ressource wird geladen…"
 #: src/components/OverlayContainer.tsx
 #: src/routes/Search/SearchOverlay.tsx
 msgid "Search for resources..."
-msgstr ""
+msgstr "Ressourcen suchen..."
 
 #: src/components/OverlayContainer.tsx
 #: src/components/OverlayContainer.tsx
 #: src/routes/Search/SearchOverlay.tsx
 msgid "esc"
-msgstr ""
+msgstr "esc"
 
 #. 0: query
 #: src/components/OverlayContainer.tsx
 msgid "Start AI Chat with \"{0}\""
-msgstr ""
+msgstr "KI-Chat mit \"{0}\" starten"
 
 #: src/components/OverlayContainer.tsx
 #: src/routes/Search/SearchOverlay.tsx
 msgid "<0/> <1/> navigate"
-msgstr ""
+msgstr "<0/> <1/> navigieren"
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> open / chat"
-msgstr ""
+msgstr "<0/> öffnen / chatten"
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> chat"
-msgstr ""
+msgstr "<0/> chatten"
 
 #: src/components/OverlayContainer.tsx
 #: src/routes/Search/SearchOverlay.tsx
 msgid "<0>esc</0> close"
-msgstr ""
+msgstr "<0>esc</0> schließen"
 
 #: src/components/OverlayContainer.tsx
 msgid "Open search"
-msgstr ""
+msgstr "Suche öffnen"
 
 #: src/components/OverlayContainer.tsx
 msgid "Show keyboard shortcuts"
-msgstr ""
+msgstr "Tastaturkürzel anzeigen"
 
 #: src/components/OverlayContainer.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
 msgid "Edit resource"
-msgstr ""
+msgstr "Ressource bearbeiten"
 
 #: src/components/OverlayContainer.tsx
 msgid "Show data view"
-msgstr ""
+msgstr "Datenansicht anzeigen"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 #: src/components/OverlayContainer.tsx
 msgid "New resource"
-msgstr ""
+msgstr "Neue Ressource"
 
 #: src/components/OverlayContainer.tsx
 msgid "Open menu"
-msgstr ""
+msgstr "Menü öffnen"
 
 #: src/components/OverlayContainer.tsx
 msgid "User settings"
-msgstr ""
+msgstr "Benutzereinstellungen"
 
 #: src/components/OverlayContainer.tsx
 msgid "Theme settings"
-msgstr ""
+msgstr "Design-Einstellungen"
 
 #: src/components/OverlayContainer.tsx
 #: src/routes/ShortcutsRoute.tsx
@@ -1493,43 +1493,43 @@ msgstr "Wird synchronisiert..."
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Left"
-msgstr ""
+msgstr "Links"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Inline"
-msgstr ""
+msgstr "Inline"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Right"
-msgstr ""
+msgstr "Rechts"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Failed to load image."
-msgstr ""
+msgstr "Bild konnte nicht geladen werden."
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Enter a URL..."
-msgstr ""
+msgstr "Geben Sie eine URL ein..."
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Choose an image <0/>"
-msgstr ""
+msgstr "Wählen Sie ein Bild aus <0/>"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Or"
-msgstr ""
+msgstr "Oder"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Add a caption..."
-msgstr ""
+msgstr "Bildunterschrift hinzufügen..."
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Alt text"
-msgstr ""
+msgstr "Alternativtext"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Textual Description <0/>"
-msgstr ""
+msgstr "Textliche Beschreibung <0/>"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/RTE/ImagePicker.tsx
@@ -1705,7 +1705,7 @@ msgstr "Turtle / N-Tripel / N3"
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Create account"
-msgstr ""
+msgstr "Konto erstellen"
 
 #: src/routes/SettingsAgent.tsx
 msgid "Warning:"
@@ -1794,12 +1794,12 @@ msgstr "Konto & Tarif verwalten →"
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 #: src/components/PairingCode.tsx
 #: src/components/Toaster.tsx
 msgid "Copy"
-msgstr ""
+msgstr "Kopieren"
 
 #: src/components/forms/SearchBox/SearchBox.tsx
 #: src/routes/LinkOpenRouter.tsx
@@ -1937,25 +1937,25 @@ msgstr "Bitte warten Sie, während wir Ihr OpenRouter-Konto verknüpfen..."
 
 #: src/components/EditableTitle.tsx
 msgid "Set a title"
-msgstr ""
+msgstr "Titel festlegen"
 
 #: src/chunks/FormBuilder/useFormQuestions.ts
 #: src/components/EditableTitle.tsx
 #: src/components/NavBar.tsx
 msgid "Untitled"
-msgstr ""
+msgstr "Unbenannt"
 
 #: src/chunks/TablePage/Kanban/KanbanCard.tsx
 #: src/components/EditableTitle.tsx
 msgid "Click to edit title"
-msgstr ""
+msgstr "Klicken Sie, um den Titel zu bearbeiten"
 
 #. 0: displayFileSize(fileSize ?? 0)
 #. 0: displayFileSize(fileSize ?? 0)
 #: src/views/File/DownloadButton.tsx
 #: src/views/File/DownloadButton.tsx
 msgid "Download file ({0})"
-msgstr ""
+msgstr "Datei herunterladen ({0})"
 
 #: src/chunks/TablePage/TableExportDialog.tsx
 #: src/views/File/DownloadButton.tsx
@@ -1964,22 +1964,22 @@ msgstr "<0/> Herunterladen"
 
 #: src/views/File/FilePreview.tsx
 msgid "Sorry, your browser doesn't support embedded videos."
-msgstr ""
+msgstr "Entschuldigung, Ihr Browser unterstützt keine eingebetteten Videos."
 
 #: src/views/File/FilePreview.tsx
 #: src/views/File/FilePreviewThumbnail.tsx
 msgid "No preview available"
-msgstr ""
+msgstr "Keine Vorschau verfügbar"
 
 #. 0: ' '; 1: displayFileSize(fileSizeLimit)
 #: src/views/File/FilePreview.tsx
 msgid "Preview hidden because the file is larger than{0} {1}."
-msgstr ""
+msgstr "Vorschau ausgeblendet, da die Datei größer als{0} {1} ist."
 
 #. 0: displayFileSize(bytes)
 #: src/views/File/FilePreview.tsx
 msgid "Load anyway ({0})"
-msgstr ""
+msgstr "Trotzdem laden ({0})"
 
 #: src/chunks/RTE/CollaborativeEditor.tsx
 #: src/components/forms/NewForm/NewFormTitle.tsx
@@ -2002,23 +2002,23 @@ msgstr "Wird hochgeladen…"
 
 #: src/components/forms/FileDropzone/FileDropzone.tsx
 msgid "<0/> Drop files here to upload."
-msgstr ""
+msgstr "<0/> Dateien hier ablegen zum Hochladen."
 
 #: src/views/FolderPage/DisplayStyleButton.tsx
 msgid "List View"
-msgstr ""
+msgstr "Listenansicht"
 
 #: src/views/FolderPage/DisplayStyleButton.tsx
 msgid "Grid View"
-msgstr ""
+msgstr "Rasteransicht"
 
 #: src/views/FolderPage/GridView.tsx
 msgid "Create new resource"
-msgstr ""
+msgstr "Neue Ressource erstellen"
 
 #: src/views/FolderPage/GridView.tsx
 msgid "New Resource"
-msgstr ""
+msgstr "Neue Ressource"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewArticleDialog.tsx
@@ -2028,40 +2028,40 @@ msgstr "Titel"
 
 #: src/views/FolderPage/ListView.tsx
 msgid "Class"
-msgstr ""
+msgstr "Klasse"
 
 #: src/views/FolderPage/ListView.tsx
 msgid "Last Modified"
-msgstr ""
+msgstr "Zuletzt geändert"
 
 #: src/views/Article/ArticlePage.tsx
 msgid "Children"
-msgstr ""
+msgstr "Kinder"
 
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "Classes"
-msgstr ""
+msgstr "Klassen"
 
 #: src/components/ClassSelectorDialog.tsx
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "No classes"
-msgstr ""
+msgstr "Keine Klassen"
 
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "Properties"
-msgstr ""
+msgstr "Eigenschaften"
 
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "No properties"
-msgstr ""
+msgstr "Keine Eigenschaften"
 
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "Instances"
-msgstr ""
+msgstr "Instanzen"
 
 #: src/views/OntologyPage/OntologyPage.tsx
 msgid "No instances"
-msgstr ""
+msgstr "Keine Instanzen"
 
 #: src/chunks/RTE/AIChatInput/mcpSuggestions.ts
 #: src/components/MetaSetter.tsx
@@ -2070,44 +2070,44 @@ msgstr "Atomare Daten"
 
 #: src/components/MetaSetter.tsx
 msgid "The easiest way to create and share linked data."
-msgstr ""
+msgstr "Der einfachste Weg, verknüpfte Daten zu erstellen und zu teilen."
 
 #: src/components/SkipNav.tsx
 msgid "Skip Navigation?"
-msgstr ""
+msgstr "Navigation überspringen?"
 
 #: src/components/NetworkIndicator.tsx
 msgid "Running in offline mode. Reconnect in the sync menu."
-msgstr ""
+msgstr "Läuft im Offline-Modus. Verbinden Sie sich im Synchronisationsmenü neu."
 
 #. 0: host
 #: src/components/NetworkIndicator.tsx
 msgid "Connected to {0}"
-msgstr ""
+msgstr "Verbunden mit {0}"
 
 #: src/components/NetworkIndicator.tsx
 msgid "Working offline — your changes are saved locally"
-msgstr ""
+msgstr "Arbeiten im Offline-Modus – Ihre Änderungen werden lokal gespeichert."
 
 #: src/components/NetworkIndicator.tsx
 msgid "No internet — your changes are saved locally"
-msgstr ""
+msgstr "Kein Internet – Ihre Änderungen werden lokal gespeichert."
 
 #: src/views/CrashPage.tsx
 msgid "Clear error"
-msgstr ""
+msgstr "Fehler löschen"
 
 #: src/views/CrashPage.tsx
 msgid "Try Again"
-msgstr ""
+msgstr "Erneut versuchen"
 
 #: src/components/Toaster.tsx
 msgid "Nothing to copy."
-msgstr ""
+msgstr "Nichts zu kopieren."
 
 #: src/components/Toaster.tsx
 msgid "Copied error to clipboard"
-msgstr ""
+msgstr "Fehler in die Zwischenablage kopiert."
 
 #: src/chunks/TablePage/EditorCells/AtomicURLCell.tsx
 #: src/components/Toaster.tsx
@@ -2117,23 +2117,23 @@ msgstr "Löschen"
 #: src/actions/resourceActions.tsx
 #: src/hooks/useAfterResourceDelete.ts
 msgid "Resource deleted!"
-msgstr ""
+msgstr "Ressource gelöscht!"
 
 #: src/actions/resourceActions.tsx
 msgid "Normal View"
-msgstr ""
+msgstr "Normale Ansicht"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the regular, default View."
-msgstr ""
+msgstr "Öffnet die reguläre Standardansicht."
 
 #: src/actions/resourceActions.tsx
 msgid "Data View"
-msgstr ""
+msgstr "Datenansicht"
 
 #: src/actions/resourceActions.tsx
 msgid "View the resource and its properties in the Data View."
-msgstr ""
+msgstr "Ressource und ihre Eigenschaften in der Datenansicht anzeigen."
 
 #: src/actions/resourceActions.tsx
 #: src/components/Drives/FavoriteButton.tsx
@@ -2147,7 +2147,7 @@ msgstr "Zu Favoriten hinzufügen"
 
 #: src/actions/resourceActions.tsx
 msgid "Toggle whether this resource appears in your Favorites."
-msgstr ""
+msgstr "Legt fest, ob diese Ressource in Ihren Favoriten angezeigt wird."
 
 #: src/actions/resourceActions.tsx
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
@@ -2158,89 +2158,89 @@ msgstr "Öffnen"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the resource"
-msgstr ""
+msgstr "Ressource öffnen"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the edit form."
-msgstr ""
+msgstr "Das Bearbeitungsformular öffnen."
 
 #: src/actions/resourceActions.tsx
 msgid "Add child"
-msgstr ""
+msgstr "Unterressource hinzufügen"
 
 #: src/actions/resourceActions.tsx
 msgid "Create a new resource under this resource."
-msgstr ""
+msgstr "Eine neue Ressource unter dieser Ressource erstellen."
 
 #: src/actions/resourceActions.tsx
 msgid "Use in code"
-msgstr ""
+msgstr "Im Code verwenden"
 
 #: src/actions/resourceActions.tsx
 msgid "Usage instructions for how to fetch and use the resource in your code."
-msgstr ""
+msgstr "Anweisungen zum Abrufen und Verwenden der Ressource in Ihrem Code."
 
 #: src/actions/resourceActions.tsx
 msgid "Add to chat"
-msgstr ""
+msgstr "Zum Chat hinzufügen"
 
 #: src/actions/resourceActions.tsx
 msgid "Add the resource as context to the AI sidebar"
-msgstr ""
+msgstr "Ressource als Kontext zur KI-Seitenleiste hinzufügen"
 
 #: src/actions/resourceActions.tsx
 msgid "Search children"
-msgstr ""
+msgstr "Unterressourcen durchsuchen"
 
 #: src/actions/resourceActions.tsx
 msgid "Scope search to resource"
-msgstr ""
+msgstr "Suche auf Ressource eingrenzen"
 
 #: src/actions/resourceActions.tsx
 msgid "Permissions & Invites"
-msgstr ""
+msgstr "Berechtigungen und Einladungen"
 
 #: src/actions/resourceActions.tsx
 msgid "Edit permissions and create invites."
-msgstr ""
+msgstr "Berechtigungen bearbeiten und Einladungen erstellen."
 
 #: src/actions/resourceActions.tsx
 msgid "Show the history of this resource"
-msgstr ""
+msgstr "Den Verlauf dieser Ressource anzeigen"
 
 #: src/actions/resourceActions.tsx
 msgid "Import Atomic Data to this resource"
-msgstr ""
+msgstr "Atomic Data in diese Ressource importieren"
 
 #: src/actions/resourceActions.tsx
 msgid "Confirm Delete"
-msgstr ""
+msgstr "Löschen bestätigen"
 
 #: src/actions/resourceActions.tsx
 msgid "Delete this resource."
-msgstr ""
+msgstr "Diese Ressource löschen."
 
 #. 0: ctx.resource.title
 #: src/components/ResourceContextMenu/index.tsx
 msgid "Open {0} menu"
-msgstr ""
+msgstr "{0}-Menü öffnen"
 
 #: src/actions/resourceActions.tsx
 msgid "Delete resource"
-msgstr ""
+msgstr "Ressource löschen"
 
 #. 0: subject
 #: src/views/ResourceInline/ResourceInline.tsx
 msgid "{0} is not a valid subject."
-msgstr ""
+msgstr "{0} ist kein gültiges Subjekt."
 
 #: src/components/Table.tsx
 msgid "subject"
-msgstr ""
+msgstr "Betreff"
 
 #: src/components/forms/ValueForm/ValueForm.tsx
 msgid "Edit value"
-msgstr ""
+msgstr "Wert bearbeiten"
 
 #: src/components/SignInButton.tsx
 #: src/helpers/managed/cloudSync.ts
@@ -2251,67 +2251,67 @@ msgstr "Anmelden"
 
 #: src/components/SignInButton.tsx
 msgid "Go the the User Settings page"
-msgstr ""
+msgstr "Gehen Sie zur Seite 'Benutzereinstellungen'"
 
 #: src/components/forms/ResourceField.tsx
 msgid "<0/> This field is calculated server-side."
-msgstr ""
+msgstr "<0/> Dieses Feld wird serverseitig berechnet."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not parse that secret."
-msgstr ""
+msgstr "Konnte dieses Geheimnis nicht analysieren."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Agent secret"
-msgstr ""
+msgstr "Agent-Geheimnis"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Signing in…"
-msgstr ""
+msgstr "Anmeldung läuft…"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "<0/> Back"
-msgstr ""
+msgstr "<0/> Zurück"
 
 #. 0: ' '; 1: resource.title
 #: src/components/ResourceUsage/ReferenceUsage.tsx
 msgid "<0/> resources reference{0} {1}"
-msgstr ""
+msgstr "<0/> Ressourcen referenzieren{0} {1}"
 
 #: src/views/BookmarkPage/BookmarkPreview.tsx
 msgid "no preview..."
-msgstr ""
+msgstr "keine Vorschau..."
 
 #: src/views/BookmarkPage/BookmarkPreview.tsx
 msgid "Could not load preview 😞"
-msgstr ""
+msgstr "Vorschau konnte nicht geladen werden 😞"
 
 #: src/views/Drive/PluginList.tsx
 msgid "No plugins installed"
-msgstr ""
+msgstr "Keine Plugins installiert"
 
 #: src/components/ResourceUsage/UsageCard.tsx
 #: src/views/Card/CollectionCard.tsx
 msgid "No resources"
-msgstr ""
+msgstr "Keine Ressourcen"
 
 #: src/views/File/FileCard.tsx
 msgid "Can not show file due to invalid data."
-msgstr ""
+msgstr "Datei kann aufgrund ungültiger Daten nicht angezeigt werden."
 
 #: src/views/Card/AIChatContentCard.tsx
 msgid "ai-chat"
-msgstr ""
+msgstr "KI-Chat"
 
 #: src/views/Card/DocumentV2Card.tsx
 msgid "document"
-msgstr ""
+msgstr "Dokument"
 
 #: src/views/Card/FolderCard.tsx
 msgid "folder"
-msgstr ""
+msgstr "Ordner"
 
 #: src/views/BookmarkPage/BookmarkPage.tsx
 #: src/views/Card/BookmarkCard.tsx
@@ -2324,15 +2324,15 @@ msgstr "KI wird geladen"
 
 #: src/views/Plugin/AssignRights.tsx
 msgid "<0/> Assign Rights"
-msgstr ""
+msgstr "<0/> Rechte zuweisen"
 
 #: src/views/Plugin/AssignRights.tsx
 msgid "Pick a resource"
-msgstr ""
+msgstr "Ressource auswählen"
 
 #: src/views/Plugin/AssignRights.tsx
 msgid "Assign"
-msgstr ""
+msgstr "Zuweisen"
 
 #: src/components/CodeBlock.tsx
 #: src/components/InviteForm.tsx
@@ -2365,11 +2365,11 @@ msgstr "Mögliche Werte:"
 
 #: src/views/Plugin/PluginPermissions.tsx
 msgid "No permissions required"
-msgstr ""
+msgstr "Keine Berechtigungen erforderlich"
 
 #: src/views/Plugin/PluginPermissions.tsx
 msgid "No reason provided"
-msgstr ""
+msgstr "Kein Grund angegeben"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewOntologyDialog.tsx
 msgid "New Ontology"
@@ -2406,7 +2406,7 @@ msgstr "OK"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 #: src/views/OntologyPage/Class/NewClassInstanceButton.tsx
 msgid "Table"
-msgstr ""
+msgstr "Tabelle"
 
 #. 0: opts.tableName
 #: src/chunks/TablePage/createTableFromSpec.ts
@@ -2417,11 +2417,11 @@ msgstr "Repräsentiert eine Zeile in der {0}-Tabelle"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "New Table"
-msgstr ""
+msgstr "Neue Tabelle"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "<0/> Use existing class"
-msgstr ""
+msgstr "<0/> Vorhandene Klasse verwenden"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewCollectionDialog.tsx
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewCollectionDialog.tsx
@@ -2532,116 +2532,116 @@ msgstr "{0} neu anordnen"
 
 #: src/chunks/RTE/NoteExtention/NoteComponent.tsx
 msgid "<0/> Note"
-msgstr ""
+msgstr "<0/> Notiz"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New Document"
-msgstr ""
+msgstr "Neues Dokument"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New Folder"
-msgstr ""
+msgstr "Neuer Ordner"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New ChatRoom"
-msgstr ""
+msgstr "Neuer ChatRoom"
 
 #. 0: truncated
 #: src/components/PropVal.tsx
 msgid "Loading {0}"
-msgstr ""
+msgstr "Lade {0}"
 
 #: src/components/NavBar.tsx
 msgid "Set Drive"
-msgstr ""
+msgstr "Laufwerk festlegen"
 
 #. 0: title
 #: src/components/NavBar.tsx
 msgid "Set {0} as current drive"
-msgstr ""
+msgstr "{0} als aktuelles Laufwerk festlegen"
 
 #. 0: displayShortcut(shortcuts.sidebarToggle)
 #: src/components/NavBar.tsx
 msgid "Show / hide sidebar ({0})"
-msgstr ""
+msgstr "Seitenleiste ein-/ausblenden ({0})"
 
 #: src/components/NavBar.tsx
 msgid "Go back"
-msgstr ""
+msgstr "Zurück"
 
 #: src/components/NavBar.tsx
 msgid "Go forward"
-msgstr ""
+msgstr "Vorwärts"
 
 #. 0: shortcuts.search
 #: src/components/NavBar.tsx
 msgid "Search ({0})"
-msgstr ""
+msgstr "Suche ({0})"
 
 #: src/components/NavBar.tsx
 msgid "Revert"
-msgstr ""
+msgstr "Rückgängig machen"
 
 #: src/components/NavBar.tsx
 msgid "Accept Changes"
-msgstr ""
+msgstr "Änderungen übernehmen"
 
 #: src/components/NavBar.tsx
 #: src/components/Share/ShareDialog.tsx
 msgid "Share"
-msgstr ""
+msgstr "Teilen"
 
 #: src/components/NavBar.tsx
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Breadcrumbs"
 
 #: src/components/NavBar.tsx
 msgid "Click to rename"
-msgstr ""
+msgstr "Klicken zum Umbenennen"
 
 #: src/components/forms/FilePicker/FilePickerDialog.tsx
 msgid "Search or enter a URL..."
-msgstr ""
+msgstr "Suche oder gib eine URL ein..."
 
 #: src/components/forms/FilePicker/FilePickerDialog.tsx
 msgid "Upload"
-msgstr ""
+msgstr "Hochladen"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Read Request"
-msgstr ""
+msgstr "Leseanfrage"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Write Request"
-msgstr ""
+msgstr "Schreibanfrage"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Allow all reads done by this plugin"
-msgstr ""
+msgstr "Alle Lesevorgänge dieses Plugins erlauben"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Allow all writes done by this plugin"
-msgstr ""
+msgstr "Alle Schreibvorgänge dieses Plugins erlauben"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Deny"
-msgstr ""
+msgstr "Ablehnen"
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "Allow"
-msgstr ""
+msgstr "Erlauben"
 
 #: src/views/PluginView/useResourcePicker.tsx
 msgid "Pick Resource"
-msgstr ""
+msgstr "Ressource auswählen"
 
 #: src/views/PluginView/useResourcePicker.tsx
 msgid "Confirm"
-msgstr ""
+msgstr "Bestätigen"
 
 #: src/components/forms/FileDropzone/FileDropzoneInput.tsx
 msgid "Drop a file or click here to upload."
@@ -2661,36 +2661,36 @@ msgstr "Basisklassen"
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Loading resource..."
-msgstr ""
+msgstr "Ressource wird geladen..."
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Loading class..."
-msgstr ""
+msgstr "Klasse wird geladen..."
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Invalid URL"
-msgstr ""
+msgstr "Ungültige URL"
 
 #: src/components/forms/ResourceForm.tsx
 msgid "That property already exists in this resource. It can only be added once."
-msgstr ""
+msgstr "Diese Eigenschaft existiert bereits in dieser Ressource. Sie kann nur einmal hinzugefügt werden."
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Cannot save edits: Agent does not have edit rights"
-msgstr ""
+msgstr "Bearbeitung nicht möglich: Agent hat keine Bearbeitungsrechte"
 
 #. 0: showAdvanced ? <FaCaretDown /> \\: <FaCaretRight />
 #: src/components/forms/ResourceForm.tsx
 msgid "{0} Advanced"
-msgstr ""
+msgstr "{0} Erweitert"
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Add another property..."
-msgstr ""
+msgstr "Weitere Eigenschaft hinzufügen..."
 
 #: src/components/forms/ResourceForm.tsx
 msgid "In Atomic Data, any Resource could have any single Property. Use this field to add new property-value combinations to your resource."
-msgstr ""
+msgstr "In Atomic Data kann jede Ressource eine beliebige einzelne Eigenschaft haben. Verwenden Sie dieses Feld, um neue Eigenschaft-Wert-Kombinationen zu Ihrer Ressource hinzuzufügen."
 
 #: src/components/Drives/DrivesCard.tsx
 msgid "Nothing to show"
@@ -2698,35 +2698,35 @@ msgstr "Nichts anzuzeigen"
 
 #: src/components/InviteForm.tsx
 msgid "Allow edits"
-msgstr ""
+msgstr "Bearbeitungen zulassen"
 
 #: src/components/InviteForm.tsx
 msgid "Invite text (optional)"
-msgstr ""
+msgstr "Einladungstext (optional)"
 
 #: src/components/InviteForm.tsx
 msgid "Limit Usages (optional)"
-msgstr ""
+msgstr "Nutzungen begrenzen (optional)"
 
 #: src/components/InviteForm.tsx
 msgid "Invite created and copied to clipboard! 🚀"
-msgstr ""
+msgstr "Einladung erstellt und in die Zwischenablage kopiert! 🚀"
 
 #: src/routes/Share/AgentRights.tsx
 msgid "Read access. Toggle to remove access."
-msgstr ""
+msgstr "Lesezugriff. Zum Entfernen umschalten."
 
 #: src/routes/Share/AgentRights.tsx
 msgid "No read access. Toggle to give read access."
-msgstr ""
+msgstr "Kein Lesezugriff. Zum Gewähren umschalten."
 
 #: src/routes/Share/AgentRights.tsx
 msgid "Write access. Toggle to remove access."
-msgstr ""
+msgstr "Schreibzugriff. Zum Entfernen umschalten."
 
 #: src/routes/Share/AgentRights.tsx
 msgid "No write access. Toggle to give write access."
-msgstr ""
+msgstr "Kein Schreibzugriff. Zum Gewähren umschalten."
 
 #. 0: date.toLocaleDateString(); 1: date.toLocaleTimeString()
 #. 0: datePart; 1: timeFormatter.format(date)
@@ -2764,80 +2764,80 @@ msgstr "Verlauf von {0}"
 
 #: src/components/forms/UploadForm.tsx
 msgid "You can add attachments after saving the resource."
-msgstr ""
+msgstr "Sie können Anhänge hinzufügen, nachdem die Ressource gespeichert wurde."
 
 #: src/components/forms/UploadForm.tsx
 msgid "Drop the files here ..."
-msgstr ""
+msgstr "Dateien hier ablegen ..."
 
 #: src/components/forms/UploadForm.tsx
 msgid "Upload file(s)..."
-msgstr ""
+msgstr "Datei(en) hochladen..."
 
 #: src/views/OntologyPage/Class/ClassCardRead.tsx
 #: src/views/OntologyPage/Class/ClassCardWrite.tsx
 msgid "Requires"
-msgstr ""
+msgstr "Erfordert"
 
 #: src/views/OntologyPage/Class/ClassCardRead.tsx
 #: src/views/OntologyPage/Class/ClassCardRead.tsx
 msgid "none"
-msgstr ""
+msgstr "keine"
 
 #: src/views/OntologyPage/Class/ClassCardRead.tsx
 #: src/views/OntologyPage/Class/ClassCardWrite.tsx
 msgid "Recommends"
-msgstr ""
+msgstr "Empfiehlt"
 
 #: src/views/Article/ArticleDescription.tsx
 msgid "Content saved"
-msgstr ""
+msgstr "Inhalt gespeichert"
 
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/views/Article/ArticleDescription.tsx
 msgid "Could not save resource..."
-msgstr ""
+msgstr "Ressource konnte nicht gespeichert werden..."
 
 #: src/views/Article/ArticleDescription.tsx
 msgid "<0/> Add Content"
-msgstr ""
+msgstr "<0/> Inhalt hinzufügen"
 
 #: src/views/Article/ArticleDescription.tsx
 msgid "Edit content"
-msgstr ""
+msgstr "Inhalt bearbeiten"
 
 #: src/views/OntologyPage/Class/ClassCardWrite.tsx
 msgid "Class name"
-msgstr ""
+msgstr "Klassenname"
 
 #: src/views/OntologyPage/Property/PropertyCardRead.tsx
 msgid "Allows only:"
-msgstr ""
+msgstr "Erlaubt nur:"
 
 #: src/views/OntologyPage/NewClassButton.tsx
 msgid "<0/> Add class"
-msgstr ""
+msgstr "<0/> Klasse hinzufügen"
 
 #: src/views/OntologyPage/NewClassButton.tsx
 msgid "New Class"
-msgstr ""
+msgstr "Neue Klasse"
 
 #: src/views/OntologyPage/CreateInstanceButton.tsx
 msgid "<0/> New Instance"
-msgstr ""
+msgstr "<0/> Neue Instanz"
 
 #: src/views/OntologyPage/NewPropertyButton.tsx
 msgid "<0/> Add property"
-msgstr ""
+msgstr "<0/> Eigenschaft hinzufügen"
 
 #: src/views/OntologyPage/NewPropertyButton.tsx
 msgid "New Property"
-msgstr ""
+msgstr "Neue Eigenschaft"
 
 #: src/components/forms/InputMarkdown.tsx
 #: src/components/forms/InputString.tsx
 msgid "Invalid value"
-msgstr ""
+msgstr "Ungültiger Wert"
 
 #: src/chunks/FormBuilder/FieldSettingsPanel.tsx
 #: src/chunks/TablePage/PropertyForm/PropertyForm.tsx
@@ -2863,20 +2863,20 @@ msgstr "Erforderlich"
 
 #: src/components/forms/InputResource.tsx
 msgid "Sorry, there is no support for editing nested resources yet"
-msgstr ""
+msgstr "Entschuldigung, die Bearbeitung von verschachtelten Ressourcen wird noch nicht unterstützt"
 
 #. 0: property.shortname
 #: src/components/forms/InputResourceArray.tsx
 msgid "Add an item to the {0} list"
-msgstr ""
+msgstr "Füge ein Element zur {0}-Liste hinzu"
 
 #: src/components/forms/InputResourceArray.tsx
 msgid "<0/> Clear"
-msgstr ""
+msgstr "<0/> Löschen"
 
 #: src/components/forms/InputResourceArray.tsx
 msgid "Remove all items from this list"
-msgstr ""
+msgstr "Alle Elemente aus dieser Liste entfernen"
 
 #: src/chunks/FormBuilder/ReorderableList.tsx
 #: src/components/forms/InputResourceArray.tsx
@@ -2885,28 +2885,28 @@ msgstr "Element verschieben"
 
 #: src/components/forms/InputSlug.tsx
 msgid "Invalid Slug"
-msgstr ""
+msgstr "Ungültiger Slug"
 
 #: src/components/forms/InputNumber.tsx
 msgid "Invalid Number"
-msgstr ""
+msgstr "Ungültige Zahl"
 
 #: src/components/forms/InputNumber.tsx
 msgid "Enter a number..."
-msgstr ""
+msgstr "Gib eine Zahl ein..."
 
 #: src/components/forms/InputJSON.tsx
 #: src/components/forms/InputJSON.tsx
 msgid "Invalid JSON"
-msgstr ""
+msgstr "Ungültiges JSON"
 
 #: src/components/forms/InputLoroDoc.tsx
 msgid "Editing LoroDoc directly is not supported"
-msgstr ""
+msgstr "Direkte Bearbeitung von LoroDoc wird nicht unterstützt"
 
 #: src/components/forms/InputURI.tsx
 msgid "Invalid URI"
-msgstr ""
+msgstr "Ungültige URI"
 
 #: src/components/AI/AISettings.tsx
 msgid "<0/> Show token usage in chats"
@@ -2964,119 +2964,119 @@ msgstr "Ändern, welches Modell für generative Funktionen verwendet wird"
 #. 0: e.message; 1: value?.toString()
 #: src/components/ValueComp.tsx
 msgid "{0} original value: {1}"
-msgstr ""
+msgstr "{0} Originalwert: {1}"
 
 #: src/components/forms/ValueForm/ValueFormEdit.tsx
 #: src/components/forms/hooks/useSaveResource.ts
 msgid "Resource saved"
-msgstr ""
+msgstr "Ressource gespeichert"
 
 #: src/components/NewIdentitySection.tsx
 msgid "The secret is invalid. Make sure you copied it correctly."
-msgstr ""
+msgstr "Das Geheimnis ist ungültig. Stellen Sie sicher, dass Sie es korrekt kopiert haben."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Generating..."
-msgstr ""
+msgstr "Generieren..."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Create new identity"
-msgstr ""
+msgstr "Neue Identität erstellen"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Generating your identity..."
-msgstr ""
+msgstr "Ihre Identität wird generiert..."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Creating your personal drive…"
-msgstr ""
+msgstr "Ihr persönliches Laufwerk wird erstellt…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Atomic Server — agent secret backup"
-msgstr ""
+msgstr "Atomic Server — Agent-Geheimnis-Backup"
 
 #: src/components/NewIdentitySection.tsx
 msgid "IMPORTANT: Store this file (or the secret line) somewhere only you can access."
-msgstr ""
+msgstr "WICHTIG: Bewahren Sie diese Datei (oder die Geheimniszeile) an einem Ort auf, auf den nur Sie Zugriff haben."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Without it you cannot sign in after clearing the browser or on another device."
-msgstr ""
+msgstr "Ohne sie können Sie sich nach dem Löschen des Browsers oder auf einem anderen Gerät nicht anmelden."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Anyone who gets this secret can access your account on this server."
-msgstr ""
+msgstr "Jeder, der dieses Geheimnis erhält, kann auf Ihr Konto auf diesem Server zugreifen."
 
 #. 0: when
 #: src/components/NewIdentitySection.tsx
 msgid "Created: {0}"
-msgstr ""
+msgstr "Erstellt: {0}"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Backup file downloaded — move it out of Downloads if you share this computer"
-msgstr ""
+msgstr "Backup-Datei heruntergeladen — verschieben Sie sie aus dem Download-Ordner, wenn Sie diesen Computer teilen"
 
 #: src/components/NewIdentitySection.tsx
 msgid "<0/> Save backup file…"
-msgstr ""
+msgstr "<0/> Backup-Datei speichern…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Yes, I've stored it — sign me out to verify"
-msgstr ""
+msgstr "Ja, ich habe es gespeichert — melden Sie mich ab, um zu überprüfen"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Yes, I've stored it safely"
-msgstr ""
+msgstr "Ja, ich habe es sicher gespeichert"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Copy the secret or save the backup file to continue"
-msgstr ""
+msgstr "Kopieren Sie das Geheimnis oder speichern Sie die Backup-Datei, um fortzufahren"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Verify your secret"
-msgstr ""
+msgstr "Überprüfen Sie Ihr Geheimnis"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Paste your secret here"
-msgstr ""
+msgstr "Fügen Sie Ihr Geheimnis hier ein"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Enter your Agent Secret"
-msgstr ""
+msgstr "Geben Sie Ihr Agent-Geheimnis ein"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Set your profile name!"
-msgstr ""
+msgstr "Legen Sie Ihren Profilnamen fest!"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Others can read this. You can change this later."
-msgstr ""
+msgstr "Andere können dies lesen. Sie können dies später ändern."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Enter your name"
-msgstr ""
+msgstr "Geben Sie Ihren Namen ein"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Profile Name"
-msgstr ""
+msgstr "Profilname"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Creating drive…"
-msgstr ""
+msgstr "Laufwerk wird erstellt…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save & continue"
-msgstr ""
+msgstr "Speichern und fortfahren"
 
 #: src/components/ResourceUsage/UsageCard.tsx
 msgid "Previous page"
-msgstr ""
+msgstr "Vorherige Seite"
 
 #: src/components/ResourceUsage/UsageCard.tsx
 msgid "Next page"
-msgstr ""
+msgstr "Nächste Seite"
 
 #: src/components/NewInstanceButton/Base.tsx
 msgid "You need to be logged in to create new things"
@@ -3110,45 +3110,45 @@ msgstr "JSON-AD-Vorschau"
 
 #: src/views/FolderPage/GridItem/ChatRoomGridItem.tsx
 msgid "Empty Chat"
-msgstr ""
+msgstr "Leerer Chat"
 
 #: src/views/File/FilePreviewThumbnail.tsx
 msgid "<0/> Could not display file preview."
-msgstr ""
+msgstr "<0/> Dateivorschau konnte nicht angezeigt werden."
 
 #: src/views/File/FilePreviewThumbnail.tsx
 msgid "To large for preview"
-msgstr ""
+msgstr "Zu groß für Vorschau"
 
 #: src/views/OntologyPage/Property/PropertyFormCommon.tsx
 msgid "Datatype"
-msgstr ""
+msgstr "Datentyp"
 
 #: src/views/OntologyPage/Property/PropertyFormCommon.tsx
 msgid "Classtype"
-msgstr ""
+msgstr "Klassentyp"
 
 #: src/views/OntologyPage/Property/EnumFormPart.tsx
 #: src/views/OntologyPage/Property/PropertyFormCommon.tsx
 msgid "Allows Only"
-msgstr ""
+msgstr "Erlaubt nur"
 
 #: src/components/Tag/TagSelectPopover.tsx
 msgid "There are no tags yet."
-msgstr ""
+msgstr "Es gibt noch keine Tags."
 
 #: src/components/Tag/TagSelectPopover.tsx
 msgid "Open tag page"
-msgstr ""
+msgstr "Tag-Seite öffnen"
 
 #. 0: showInherited ? <FaChevronDown /> \\: <FaChevronRight />
 #: src/components/Share/ShareDialog.tsx
 msgid "{0} Inherited permissions"
-msgstr ""
+msgstr "{0} Vererbte Berechtigungen"
 
 #: src/components/Share/ShareDialog.tsx
 msgid "<0><0/> Back</0> Create Invite"
-msgstr ""
+msgstr "<0><0/> Zurück</0> Einladung erstellen"
 
 #: src/chunks/FormBuilder/ShareLinkPanel.tsx
 #: src/components/Share/ShareDialog.tsx
@@ -3162,51 +3162,51 @@ msgstr "<0/> Link kopieren"
 
 #: src/components/ResourceContextMenu/ParentContextMenuTrigger.tsx
 msgid "More"
-msgstr ""
+msgstr "Mehr"
 
 #. 0: shortcuts.menu
 #. 0: shortcuts.menu
 #: src/components/ResourceContextMenu/MenuBarDropdownTrigger.tsx
 #: src/components/ResourceContextMenu/ParentContextMenuTrigger.tsx
 msgid "Open menu ({0})"
-msgstr ""
+msgstr "Menü öffnen ({0})"
 
 #: src/components/forms/FilePicker/FilePickerItem.tsx
 msgid "Resource not found"
-msgstr ""
+msgstr "Ressource nicht gefunden"
 
 #: src/views/CodeUsage/ResourceCodeUsageDialog.tsx
 msgid "Use <0/> in code"
-msgstr ""
+msgstr "<0/> im Code verwenden"
 
 #: src/components/forms/FilePicker/SelectedFile.tsx
 msgid "File preview not available at this time"
-msgstr ""
+msgstr "Dateivorschau zurzeit nicht verfügbar"
 
 #: src/components/forms/FilePicker/SelectedFile.tsx
 msgid "Will be uploaded when resource is saved"
-msgstr ""
+msgstr "Wird hochgeladen, wenn die Ressource gespeichert wird"
 
 #: src/components/forms/NewForm/SubjectField.tsx
 msgid "The identifier of the resource. DID subjects are determined by the genesis commit signature."
-msgstr ""
+msgstr "Der Bezeichner der Ressource. DID-Subjekte werden durch die Signatur des Genesis-Commits bestimmt."
 
 #: src/components/forms/NewForm/SubjectField.tsx
 msgid "URL of the new resource..."
-msgstr ""
+msgstr "URL der neuen Ressource..."
 
 #: src/components/forms/NewForm/SubjectField.tsx
 msgid "The identifier of the resource. This also determines where the resource is saved, by default."
-msgstr ""
+msgstr "Der Bezeichner der Ressource. Dies bestimmt auch standardmäßig, wo die Ressource gespeichert wird."
 
 #. 0: classSubject ? klassTitle \\: 'Resource'
 #: src/components/forms/NewForm/NewFormTitle.tsx
 msgid "new {0}"
-msgstr ""
+msgstr "neu {0}"
 
 #: src/components/forms/NewForm/NewFormTitle.tsx
 msgid "Toggle show Class details"
-msgstr ""
+msgstr "Klassendetails anzeigen umschalten"
 
 #: src/components/Drives/DriveRow.tsx
 msgid "Remove drive from list"
@@ -3228,7 +3228,7 @@ msgstr "Nächstes Element"
 
 #: src/components/forms/hooks/useSaveResource.ts
 msgid "Could not save resource"
-msgstr ""
+msgstr "Ressource konnte nicht gespeichert werden"
 
 #. 0: version.peer && <> by peer {version.peer.slice(0, 8)}...</>; 1: version.message && <> — {version.message}</>
 #: src/routes/History/VersionTitle.tsx
@@ -3237,49 +3237,49 @@ msgstr "Bearbeitet <0/> {0} {1}"
 
 #: src/views/OntologyPage/Property/PropertyLineRead.tsx
 msgid "Property does not exist anymore"
-msgstr ""
+msgstr "Die Eigenschaft existiert nicht mehr"
 
 #. 0: resource.title
 #: src/views/OntologyPage/Class/NewClassInstanceButton.tsx
 msgid "New instance of {0}"
-msgstr ""
+msgstr "Neue Instanz von {0}"
 
 #: src/views/OntologyPage/Class/NewClassInstanceButton.tsx
 msgid "Single instance"
-msgstr ""
+msgstr "Einzelinstanz"
 
 #: src/components/forms/NewForm/NewFormDialog.tsx
 msgid "No parent set"
-msgstr ""
+msgstr "Kein übergeordnetes Element festgelegt"
 
 #. 0: subject
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "This property does not exist any more ({0})"
-msgstr ""
+msgstr "Diese Eigenschaft existiert nicht mehr ({0})"
 
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Property shortname"
-msgstr ""
+msgstr "Eigenschaftskurzname"
 
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Property description"
-msgstr ""
+msgstr "Eigenschaftsbeschreibung"
 
 #. 0: BLOCK_KIND_LABELS[blockKind].toLowerCase()
 #. 0: resource.title
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/views/OntologyPage/Property/PropertyLineWrite.tsx
 msgid "Configure {0}"
-msgstr ""
+msgstr "{0} konfigurieren"
 
 #: src/components/ClassSelectorDialog.tsx
 msgid "Select a class"
-msgstr ""
+msgstr "Klasse auswählen"
 
 #: src/components/LoroDocValue.tsx
 #: src/components/forms/ValueForm/ValueForm.tsx
 msgid "Empty"
-msgstr ""
+msgstr "Leer"
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/LoroDocValue.tsx
@@ -3288,16 +3288,16 @@ msgstr "Ausblenden"
 
 #: src/components/LoroDocValue.tsx
 msgid "Inspect"
-msgstr ""
+msgstr "Inspizieren"
 
 #. 0: showState ? <FaEyeSlash /> \\: <FaEye />; 1: showState ? 'Hide' \\: 'Inspect'; 2: sizeStr; 3: inspection ? `, ${inspection.peers} peer(s)` \\: ''
 #: src/components/LoroDocValue.tsx
 msgid "{0} {1} Loro snapshot ({2} {3})"
-msgstr ""
+msgstr "{0} {1} Loro-Snapshot ({2} {3})"
 
 #: src/components/LoroDocValue.tsx
 msgid "Failed to decode Loro snapshot"
-msgstr ""
+msgstr "Loro-Snapshot konnte nicht dekodiert werden"
 
 #: src/components/ResourceUsage/ClassUsage.tsx
 msgid "No usage of class found."
@@ -3318,28 +3318,28 @@ msgstr "{0} bearbeiten"
 
 #: src/views/OntologyPage/PropertyDatatypePicker.tsx
 msgid "Property datatype"
-msgstr ""
+msgstr "Eigenschaftsdatentyp"
 
 #: src/views/OntologyPage/Property/EnumFormPart.tsx
 msgid "ResourceArray Types"
-msgstr ""
+msgstr "ResourceArray Typen"
 
 #: src/views/OntologyPage/Property/EnumFormPart.tsx
 msgid "Only allow its value to be selected from the following tags:"
-msgstr ""
+msgstr "Erlaube nur, dass sein Wert aus den folgenden Tags ausgewählt wird:"
 
 #. 0: isA ? typeResource.title \\: 'resource'
 #: src/components/forms/SearchBox/SearchBox.tsx
 msgid "Search for a {0} or enter a URL..."
-msgstr ""
+msgstr "Suche nach {0} oder gib eine URL ein..."
 
 #: src/views/CodeUsage/ResourceCodeUsage.tsx
 msgid "Read a property: <0/>"
-msgstr ""
+msgstr "Eine Eigenschaft lesen: <0/>"
 
 #: src/views/CodeUsage/ResourceCodeUsage.tsx
 msgid "<0/> Typescript"
-msgstr ""
+msgstr "<0/> TypeScript"
 
 #: src/components/Drives/WSIndicator.tsx
 msgid "Websocket Connected"
@@ -3359,27 +3359,27 @@ msgstr "Websocket wird verbunden..."
 
 #: src/components/ParentPicker/ParentPickerDialog.tsx
 msgid "Select a location"
-msgstr ""
+msgstr "Wähle einen Ort"
 
 #. 0: ' '; 1: ' '
 #: src/views/CodeUsage/CodeUsage.tsx
 msgid "Read the{0} <0>@tomic/lib docs</0>{1} for more info."
-msgstr ""
+msgstr "Lesen Sie die{0} <0>@tomic/lib-Dokumentation</0>{1} für weitere Informationen."
 
 #. 0: ' '; 1: ' '
 #: src/views/CodeUsage/CodeUsage.tsx
 msgid "Read the{0} <0>@tomic/react docs</0>{1} for more info."
-msgstr ""
+msgstr "Lesen Sie die{0} <0>@tomic/react-Dokumentation</0>{1} für weitere Informationen."
 
 #. 0: ' '; 1: ' '
 #: src/views/CodeUsage/CodeUsage.tsx
 msgid "Read the{0} <0>@tomic/svelte docs</0>{1} for more info."
-msgstr ""
+msgstr "Lesen Sie die{0} <0>@tomic/svelte-Dokumentation</0>{1} für weitere Informationen."
 
 #. 0: ' '
 #: src/views/CodeUsage/CodeUsage.tsx
 msgid "Read more about generating schema's using{0} <0>@tomic/cli</0> ."
-msgstr ""
+msgstr "Lesen Sie mehr über die Generierung von Schemas mit{0} <0>@tomic/cli</0> ."
 
 #: src/components/forms/SearchBox/SearchBoxWindow.tsx
 msgid "Start Searching"
@@ -3401,59 +3401,59 @@ msgstr "Keine"
 
 #: src/hooks/useDevDrive.ts
 msgid "Dev agent created — secret copied to clipboard"
-msgstr ""
+msgstr "Dev-Agent erstellt – Geheimnis in die Zwischenablage kopiert"
 
 #: src/hooks/useDevDrive.ts
 msgid "Dev agent created — secret available in localStorage (clipboard write blocked)"
-msgstr ""
+msgstr "Dev-Agent erstellt – Geheimnis im localStorage verfügbar (Zwischenablage-Schreibvorgang blockiert)"
 
 #: src/routes/DevDriveRoute.tsx
 msgid "Setting up dev drive..."
-msgstr ""
+msgstr "Entwicklerlaufwerk wird eingerichtet …"
 
 #: src/routes/PruneTestsRoute.tsx
 msgid "Prune Test Data"
-msgstr ""
+msgstr "Testdaten bereinigen"
 
 #: src/routes/PruneTestsRoute.tsx
 msgid "Prune"
-msgstr ""
+msgstr "Bereinigen"
 
 #: src/routes/PruneTestsRoute.tsx
 msgid "Pruning, this might take a while..."
-msgstr ""
+msgstr "Bereinigung läuft, dies könnte einen Moment dauern …"
 
 #: src/chunks/AI/AIChatPage.tsx
 msgid "Failed to create message resource"
-msgstr ""
+msgstr "Fehler beim Erstellen der Nachrichtenressource"
 
 #: src/chunks/AI/AIChatPage.tsx
 msgid "Failed to remove message resource"
-msgstr ""
+msgstr "Fehler beim Entfernen der Nachrichtenressource"
 
 #: src/chunks/AI/AIChatPage.tsx
 msgid "Failed to save summary message"
-msgstr ""
+msgstr "Fehler beim Speichern der Zusammenfassungsnachricht"
 
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "No object generated: could not parse the response."
-msgstr ""
+msgstr "Kein Objekt generiert: Antwort konnte nicht geparst werden."
 
 #: src/chunks/AI/useProcessMessages.test.ts
 msgid "First"
-msgstr ""
+msgstr "Erste"
 
 #: src/chunks/AI/useProcessMessages.test.ts
 msgid "Reply"
-msgstr ""
+msgstr "Antwort"
 
 #: src/chunks/AI/useProcessMessages.test.ts
 msgid "Second"
-msgstr ""
+msgstr "Zweite"
 
 #: src/chunks/AI/useProcessMessages.test.ts
 msgid "Hello"
-msgstr ""
+msgstr "Hallo"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Pick an emoji"
@@ -3461,56 +3461,56 @@ msgstr "Ein Emoji auswählen"
 
 #: src/chunks/HighlightedCode/HighlightedCodeBlock.tsx
 msgid "Copy code"
-msgstr ""
+msgstr "Code kopieren"
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "The update's identifier does not match the existing plugin."
-msgstr ""
+msgstr "Die Kennung des Updates stimmt nicht mit dem vorhandenen Plugin überein."
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "<0/> Update"
-msgstr ""
+msgstr "<0/> Aktualisieren"
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "Change Version"
-msgstr ""
+msgstr "Version ändern"
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "New Permissions"
-msgstr ""
+msgstr "Neue Berechtigungen"
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "Your config is not fully compatible with the new version."
-msgstr ""
+msgstr "Ihre Konfiguration ist nicht vollständig kompatibel mit der neuen Version."
 
 #: src/chunks/Plugins/UpdatePluginButton.tsx
 msgid "Apply"
-msgstr ""
+msgstr "Anwenden"
 
 #: src/chunks/CodeEditor/AsyncJSONEditor.tsx
 msgid "Enter valid JSON..."
-msgstr ""
+msgstr "Gültiges JSON eingeben …"
 
 #: src/chunks/Plugins/NewPluginButton.tsx
 msgid "Please fill in all fields"
-msgstr ""
+msgstr "Bitte füllen Sie alle Felder aus"
 
 #: src/chunks/Plugins/NewPluginButton.tsx
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "Plugin konnte nicht installiert werden"
 
 #: src/chunks/Plugins/NewPluginButton.tsx
 #: src/chunks/Plugins/NewPluginButton.tsx
 msgid "<0/> Upload Plugin"
-msgstr ""
+msgstr "<0/> Plugin hochladen"
 
 #: src/chunks/Plugins/NewPluginButton.tsx
 msgid "Add Plugin"
-msgstr ""
+msgstr "Plugin hinzufügen"
 
 #: src/chunks/Plugins/NewPluginButton.tsx
 msgid "Install"
-msgstr ""
+msgstr "Installieren"
 
 #: src/chunks/ResourceDiff/ResourceDiff.tsx
 #: src/chunks/ResourceDiff/ResourceDiff.tsx
@@ -3519,7 +3519,7 @@ msgstr ""
 #: src/chunks/ResourceDiff/ResourceDiff.tsx
 #: src/chunks/ResourceDiff/ResourceDiff.tsx
 msgid "unset"
-msgstr ""
+msgstr "nicht gesetzt"
 
 #: src/chunks/RTE/CollaborativeEditor.tsx
 msgid "Note"
@@ -3561,11 +3561,11 @@ msgstr "Roh-Markdown bearbeiten"
 
 #: src/chunks/RTE/ColorMenu.tsx
 msgid "Edit text color"
-msgstr ""
+msgstr "Textfarbe bearbeiten"
 
 #: src/chunks/RTE/ColorMenu.tsx
 msgid "Edit background color"
-msgstr ""
+msgstr "Hintergrundfarbe bearbeiten"
 
 #: src/chunks/RTE/NodeSelectMenu.tsx
 #: src/chunks/RTE/SlashMenu/CommandsExtension.ts
@@ -3715,24 +3715,24 @@ msgstr "Filter"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Hide in this view"
-msgstr ""
+msgstr "In dieser Ansicht ausblenden"
 
 #. 0: ' '
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Remove <0/> from{0} <1/>"
-msgstr ""
+msgstr "Entfernen Sie <0/> aus{0} <1/>"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "<0/> Delete property and its children"
-msgstr ""
+msgstr "<0/> Eigenschaft und ihre untergeordneten Elemente löschen"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Delete property"
-msgstr ""
+msgstr "Eigenschaft löschen"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Remove column"
-msgstr ""
+msgstr "Spalte entfernen"
 
 #: src/chunks/TablePage/TablePage.tsx
 msgid "Export to CSV"
@@ -3744,19 +3744,19 @@ msgstr "Unbenannte Ansicht"
 
 #: src/chunks/TablePage/TableFilterValueInput.tsx
 msgid "Any"
-msgstr ""
+msgstr "Alle"
 
 #: src/chunks/TablePage/TableFilterValueInput.tsx
 msgid "True"
-msgstr ""
+msgstr "Wahr"
 
 #: src/chunks/TablePage/TableFilterValueInput.tsx
 msgid "False"
-msgstr ""
+msgstr "Falsch"
 
 #: src/chunks/TablePage/TableFilterValueInput.tsx
 msgid "Value…"
-msgstr ""
+msgstr "Wert…"
 
 #: src/chunks/TablePage/TableFilterChip.tsx
 msgid "Remove filter"
@@ -3769,7 +3769,7 @@ msgstr "Filter-Operator"
 #: src/chunks/TablePage/useTableView.ts
 #: src/chunks/TablePage/useTableView.ts
 msgid "Default View"
-msgstr ""
+msgstr "Standardansicht"
 
 #: src/chunks/TablePage/TableRow.tsx
 msgid "Row is incomplete or has invalid data"
@@ -3777,40 +3777,40 @@ msgstr "Zeile ist unvollständig oder enthält ungültige Daten"
 
 #: src/chunks/TableEditor/Cell.tsx
 msgid "Open resource"
-msgstr ""
+msgstr "Ressource öffnen"
 
 #: src/components/ResourceUsage/UsageRow.tsx
 msgid "Insufficient rights to view resource"
-msgstr ""
+msgstr "Unzureichende Rechte zum Anzeigen der Ressource"
 
 #: src/components/Searchbar/Searchbar.tsx
 msgid "Search (Cmd+K)"
-msgstr ""
+msgstr "Suchen (Cmd+K)"
 
 #. 0: title
 #: src/components/Searchbar/Searchbar.tsx
 msgid "in:{0}"
-msgstr ""
+msgstr "in:{0}"
 
 #: src/components/Searchbar/Searchbar.tsx
 msgid "Clear scope"
-msgstr ""
+msgstr "Bereich löschen"
 
 #: src/components/Searchbar/TagSuggestionOverlay.tsx
 msgid "No tags found"
-msgstr ""
+msgstr "Keine Tags gefunden"
 
 #: src/components/Searchbar/SearchbarInput.tsx
 msgid "Caret"
-msgstr ""
+msgstr "Einfügemarke"
 
 #: src/components/Searchbar/SearchbarInput.tsx
 msgid "Enter an Atomic URL or search  (press \"/\")"
-msgstr ""
+msgstr "Gib eine Atomic-URL ein oder suche (drücke \"/\")"
 
 #: src/components/Searchbar/SearchbarInput.tsx
 msgid "Search"
-msgstr ""
+msgstr "Suchen"
 
 #: src/helpers/managed/cloudSync.ts
 #: src/helpers/managed/reconcile.test.ts
@@ -3830,19 +3830,19 @@ msgstr "Min muss kleiner als Max sein."
 
 #: src/routes/History/VersionContent.tsx
 msgid "Document body"
-msgstr ""
+msgstr "Dokumenteninhalt"
 
 #: src/routes/History/VersionContent.tsx
 msgid "(empty)"
-msgstr ""
+msgstr "(leer)"
 
 #: src/routes/Search/SearchOverlay.tsx
 msgid "Searching..."
-msgstr ""
+msgstr "Suche..."
 
 #: src/routes/Search/SearchOverlay.tsx
 msgid "<0/> open"
-msgstr ""
+msgstr "<0/> öffnen"
 
 #: src/chunks/RTE/AIChatInput/AsyncAIChatInput.tsx
 msgid "Ask me anything, / for commands, @ for context"
@@ -3858,30 +3858,30 @@ msgstr "Keine Ergebnisse gefunden"
 
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "Failed to save changes"
-msgstr ""
+msgstr "Änderungen konnten nicht gespeichert werden"
 
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "Review Edits"
-msgstr ""
+msgstr "Bearbeitungen überprüfen"
 
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "edit"
 msgid_plural "edits"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bearbeitung"
+msgstr[1] "Bearbeitungen"
 
 #. 0: editCount; 1: plural(editCount, ['edit', 'edits'])
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "Review {0} {1}"
-msgstr ""
+msgstr "{0} {1} überprüfen"
 
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "Revert Changes"
-msgstr ""
+msgstr "Änderungen rückgängig machen"
 
 #: src/components/AI/AIChanges/AIChangesRuntime.tsx
 msgid "Confirm Changes"
-msgstr ""
+msgstr "Änderungen bestätigen"
 
 #: src/chunks/RTE/SlashMenu/CommandsExtension.ts
 msgid "Quote"
@@ -3901,7 +3901,7 @@ msgstr "Spalte bearbeiten"
 
 #: src/chunks/TablePage/PropertyForm/ExternalPropertyDialog.tsx
 msgid "Add external property"
-msgstr ""
+msgstr "Externe Eigenschaft hinzufügen"
 
 #: src/chunks/TablePage/PropertyForm/NumberPropertyForm.tsx
 msgid "Number Format"
@@ -3922,7 +3922,7 @@ msgstr "Bereich"
 #. 0: ' '; 1: selectedCategory ? selectedCategory[0].toUpperCase() + selectedCategory.slice(1) \\: ''; 2: ' '
 #: src/chunks/TablePage/PropertyForm/NewPropertyDialog.tsx
 msgid "New{0} {1}{2} Column"
-msgstr ""
+msgstr "Neue{0} {1}{2} Spalte"
 
 #: src/chunks/TablePage/PropertyForm/PropertyForm.tsx
 msgid "Invalid Name"
@@ -4007,70 +4007,70 @@ msgstr "Dezimalstellen"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Setting up your account…"
-msgstr ""
+msgstr "Ihr Konto wird eingerichtet…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Could not back up your secret. You can still save it yourself."
-msgstr ""
+msgstr "Ihr Geheimnis konnte nicht gesichert werden. Sie können es trotzdem selbst speichern."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Back up your secret?"
-msgstr ""
+msgstr "Ihr Geheimnis sichern?"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Recovery password"
-msgstr ""
+msgstr "Wiederherstellungspasswort"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Skip, I'll save it myself"
-msgstr ""
+msgstr "Überspringen, ich speichere es selbst"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not restore your account."
-msgstr ""
+msgstr "Konnte Ihr Konto nicht wiederherstellen."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore account"
-msgstr ""
+msgstr "Konto wiederherstellen"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery password you set for {0}."
-msgstr ""
+msgstr "Geben Sie das Wiederherstellungspasswort ein, das Sie für {0} festgelegt haben."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
-msgstr ""
+msgstr "Wiederherstellung läuft…"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore & sign in"
-msgstr ""
+msgstr "Wiederherstellen & anmelden"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to access this drive"
-msgstr ""
+msgstr "Anmelden, um auf dieses Laufwerk zuzugreifen"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
-msgstr ""
+msgstr "Geben Sie Ihr Agent-Geheimnis ein, um dieses Laufwerk auf diesem Gerät zu entsperren."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Checking your {0} account…"
-msgstr ""
+msgstr "Überprüfe Ihr {0}-Konto…"
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "To restore your account, sign in to your {0} account first, then come back here."
-msgstr ""
+msgstr "Um Ihr Konto wiederherzustellen, melden Sie sich zuerst bei Ihrem {0}-Konto an und kehren Sie dann hierher zurück."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to your {0} account"
-msgstr ""
+msgstr "Bei Ihrem {0}-Konto anmelden"
 
 #. 0: text
 #: src/chunks/TablePage/TableHeading.tsx
@@ -4079,14 +4079,14 @@ msgstr "Sortieren nach {0}"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Edit unavailable"
-msgstr ""
+msgstr "Bearbeiten nicht verfügbar"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/TablePage/Kanban/useKanbanGroupBy.ts
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 msgid "Setting up the board…"
@@ -4094,11 +4094,11 @@ msgstr "Board wird eingerichtet…"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Start from"
-msgstr ""
+msgstr "Beginnen mit"
 
 #: src/components/forms/ValueForm/ValueForm.tsx
 msgid "Click to add a value"
-msgstr ""
+msgstr "Klicken, um einen Wert hinzuzufügen"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Rename"
@@ -4132,11 +4132,11 @@ msgstr "Nächster Monat"
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "Add item"
-msgstr ""
+msgstr "Element hinzufügen"
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "New item…"
-msgstr ""
+msgstr "Neues Element…"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 #: src/chunks/TablePage/createTableFromSpec.ts
@@ -4147,11 +4147,11 @@ msgstr "Zeile"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Each row is a"
-msgstr ""
+msgstr "Jede Zeile ist eine"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Names the class of the rows — e.g. every row of an Employees table is an Employee."
-msgstr ""
+msgstr "Benennt die Klasse der Zeilen — z.B. jede Zeile einer Tabelle 'Mitarbeiter' ist ein Mitarbeiter."
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
 #: src/routes/NewDriveRoute.tsx
@@ -4164,11 +4164,11 @@ msgstr "Fehler beim Erstellen des Laufwerks"
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Open a resource to see its comments."
-msgstr ""
+msgstr "Öffne eine Ressource, um ihre Kommentare zu sehen."
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Comments"
-msgstr ""
+msgstr "Kommentare"
 
 #: src/chunks/TablePage/TableResource.tsx
 msgid "Failed to insert row"
@@ -4176,83 +4176,83 @@ msgstr "Zeile einfügen fehlgeschlagen"
 
 #: src/components/Presence/ResourcePresenceRow.tsx
 msgid "Also viewing this resource"
-msgstr ""
+msgstr "Sieht diese Ressource ebenfalls"
 
 #: src/components/Presence/SidebarPresence.tsx
 msgid "Currently here"
-msgstr ""
+msgstr "Aktuell hier"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Show profile"
-msgstr ""
+msgstr "Profil anzeigen"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Stop following"
-msgstr ""
+msgstr "Nicht mehr folgen"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Follow"
-msgstr ""
+msgstr "Folgen"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "PresenceAvatarTrigger"
-msgstr ""
+msgstr "PresenceAvatarTrigger"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Don’t allow following me"
-msgstr ""
+msgstr "Mir nicht erlauben, mir zu folgen"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following you"
-msgstr ""
+msgstr "Folgt dir"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following"
-msgstr ""
+msgstr "Folge ich"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Disconnects current followers."
-msgstr ""
+msgstr "Trennt aktuelle Follower."
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following — press for actions"
-msgstr ""
+msgstr "Folge ich — drücken für Aktionen"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "These users follow you — press for actions"
-msgstr ""
+msgstr "Diese Benutzer folgen dir — drücken für Aktionen"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Enable following"
-msgstr ""
+msgstr "Folgen aktivieren"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "BadgedFollowTrigger"
-msgstr ""
+msgstr "BadgedFollowTrigger"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Jump to their location"
-msgstr ""
+msgstr "Zu ihrer Position springen"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Go to the resource they are viewing right now."
-msgstr ""
+msgstr "Gehe zu der Ressource, die sie gerade ansehen."
 
 #. 0: step + 1; 1: totalSteps
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Version {0} / {1}"
-msgstr ""
+msgstr "Version {0} / {1}"
 
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Discarded versions"
-msgstr ""
+msgstr "Verworfene Versionen"
 
 #. 0: i + 1
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Restore discarded version {0}"
-msgstr ""
+msgstr "Verworfene Version {0} wiederherstellen"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "Undo (Ctrl+Z) — drag horizontally to scrub history, hold to see discarded versions"
@@ -4267,15 +4267,15 @@ msgstr "Drive von {0}"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Create a new Agent on this server. We will set your username and create a private drive as your home."
-msgstr ""
+msgstr "Erstellen Sie einen neuen Agenten auf diesem Server. Wir werden Ihren Benutzernamen festlegen und ein privates Laufwerk als Ihr Zuhause erstellen."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Are you sure you've stored this secret somewhere safe? You cannot recover it if you lose it."
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie dieses Geheimnis sicher gespeichert haben? Sie können es nicht wiederherstellen, wenn Sie es verlieren."
 
 #: src/components/NewIdentitySection.tsx
 msgid "You have been signed out to verify that you saved your secret. Enter it below to sign in."
-msgstr ""
+msgstr "Sie wurden abgemeldet, um zu überprüfen, dass Sie Ihr Geheimnis gespeichert haben. Geben Sie es unten ein, um sich anzumelden."
 
 #. 0: classTitle
 #: src/hooks/useCreateAndNavigate.ts
@@ -4289,6 +4289,9 @@ msgid ""
 "\n"
 "{0}"
 msgstr ""
+"Erstellt über `/app/dev-drive` für lokale Entwicklung und E2E. Sie können diese mit „Prune test data“ unter `/app/prunetests` entfernen.\n"
+"\n"
+"{0}"
 
 #: src/routes/AboutRoute.tsx
 msgid "Atomic Data Browser"
@@ -4301,7 +4304,7 @@ msgstr "Atomic Data kombiniert die Benutzerfreundlichkeit von JSON, die Konnekti
 #. 0: ' '; 1: ' '
 #: src/routes/PruneTestsRoute.tsx
 msgid "This removes drives created for automated tests or local dev: names containing <0/> (E2E), or descriptions containing{0} <1/> (from{1} <2/>)."
-msgstr ""
+msgstr "Dies entfernt Laufwerke, die für automatisierte Tests oder lokale Entwicklung erstellt wurden: Namen, die <0/> (E2E) enthalten, oder Beschreibungen, die {0} <1/> (von {1} <2/>) enthalten."
 
 #: src/views/DocumentPage.tsx
 msgid "<0/> This document needs to be updated to the new format in order to be edited."
@@ -4396,13 +4399,13 @@ msgstr ""
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "AI chat title generation failed"
-msgstr ""
+msgstr "KI-Chat-Titelgenerierung fehlgeschlagen"
 
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "Project planning"
-msgstr ""
+msgstr "Projektplanung"
 
 #. 0: ' '
 #: src/chunks/RTE/CollaborativeEditor.tsx
@@ -4411,16 +4414,16 @@ msgstr "Im Editor ist ein Fehler aufgetreten. Bitte aktualisieren Sie die Seite,
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Caption"
-msgstr ""
+msgstr "Bildunterschrift"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Text Flow"
-msgstr ""
+msgstr "Textfluss"
 
 #. 0: propertyLabel; 1: rowIndex + 1
 #: src/chunks/TablePage/TableCell.tsx
 msgid "{0}, row {1}"
-msgstr ""
+msgstr "{0}, Zeile {1}"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Are you sure you want to delete the <0/> view? This only removes the view, not the rows."
@@ -4429,7 +4432,7 @@ msgstr "Möchten Sie die <0/>-Ansicht wirklich löschen? Dadurch wird nur die An
 #. 0: srcName
 #: src/chunks/TablePage/useTableView.ts
 msgid "{0} copy"
-msgstr ""
+msgstr "{0}-Kopie"
 
 #. 0: p; 1: theme.animation.duration
 #: src/helpers/transition.ts
@@ -4482,7 +4485,7 @@ msgstr "als ein Klassentyp."
 
 #: src/components/Share/ShareDialog.tsx
 msgid "Create Invite"
-msgstr ""
+msgstr "Einladung erstellen"
 
 #. 0: status.blockedCount
 #: src/components/SideBar/SyncMenuItem.tsx
@@ -4502,11 +4505,11 @@ msgstr "{0} wurde nach {1} verschoben."
 #. 0: classSubject
 #: src/components/forms/ResourceForm.tsx
 msgid "{0} is not a Class. Only resources with valid classes can be created or edited at this moment."
-msgstr ""
+msgstr "{0} ist keine Klasse. Nur Ressourcen mit gültigen Klassen können derzeit erstellt oder bearbeitet werden."
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Error in class, so this form could miss properties. You can still edit the resource, though. Error message: `"
-msgstr ""
+msgstr "Fehler in der Klasse, daher könnten Eigenschaften in diesem Formular fehlen. Sie können die Ressource jedoch weiterhin bearbeiten. Fehlermeldung: `"
 
 #: src/routes/Search/SearchRoute.tsx
 msgid "Searching for"
@@ -4518,7 +4521,7 @@ msgstr "für"
 
 #: src/routes/Share/AgentRights.tsx
 msgid "Public (anyone)"
-msgstr ""
+msgstr "Öffentlich (jeder)"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "<0>Scroll</0> · <1>Space</1>+drag · middle-mouse drag — pan the canvas"
@@ -4558,19 +4561,19 @@ msgstr "Versuchen Sie, die Seite neu zu laden. Wenn das Problem weiterhin besteh
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "wants to read a resource that is not contained in the current scope."
-msgstr ""
+msgstr "möchte eine Ressource lesen, die nicht im aktuellen Bereich enthalten ist."
 
 #: src/views/PluginView/useRequestPermissionDialog.tsx
 msgid "wants to modify a resource that is not contained in the current scope."
-msgstr ""
+msgstr "möchte eine Ressource ändern, die nicht im aktuellen Bereich enthalten ist."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "No recovery backup was found for"
-msgstr ""
+msgstr "Kein Wiederherstellungs-Backup gefunden für"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid ". Account recovery only works if you enabled it earlier."
-msgstr ""
+msgstr ". Die Kontowiederherstellung funktioniert nur, wenn Sie sie zuvor aktiviert haben."
 
 #: src/chunks/AI/ModelSelect/OpenRouterModelSelector.tsx
 msgid "/1K web search results"
@@ -4597,55 +4600,14 @@ msgstr "{0} wird geladen..."
 
 #: src/components/forms/FilePicker/FilePickerButton.tsx
 msgid "Select File"
-msgstr ""
+msgstr "Datei auswählen"
 
 #. 0: resource.title
 #. 0: file.name
 #: src/components/forms/FilePicker/SelectedFile.tsx
 #: src/components/forms/FilePicker/SelectedFile.tsx
 msgid "{0} preview"
-msgstr ""
-
-#~ msgid ""
-#~ "{0}{1}\n"
-#~ "const value = resource.get({2});\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid "{0}const resource = await store.getResource{1}('{2}');"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const value = {1};\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "\n"
-#~ "  return <div>{resource.title}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "  const [value] = {2}(resource, {3});\n"
-#~ "\n"
-#~ "  return <div>{value}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource{1}('{2}');\n"
-#~ "{3}\n"
-#~ "}"
-#~ msgstr ""
+msgstr "{0} Vorschau"
 
 #. 0: prefix; 1: formatImportNames(prefix, names); 2: file
 #: src/views/CodeUsage/generators/generatorUtils.ts
@@ -4671,16 +4633,16 @@ msgstr "Erstelle <0>{0} Ressourcen</0>"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Due date"
-msgstr ""
+msgstr "Fälligkeitsdatum"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Lead"
-msgstr ""
+msgstr "Leitfaden"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Wat"
-msgstr ""
+msgstr "Wat"
 
 #: src/components/Dropdown/index.tsx
 msgid "Filter actions…"
@@ -4697,16 +4659,16 @@ msgstr "Keine passenden Aktionen"
 #: src/actions/resourceActions.tsx
 #: src/components/OverlayContainer.tsx
 msgid "Go to parent"
-msgstr ""
+msgstr "Zur übergeordneten Ressource wechseln"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the parent of this resource."
-msgstr ""
+msgstr "Die übergeordnete Ressource öffnen."
 
 #. 0: ' '
 #: src/actions/resourceActions.tsx
 msgid "Are you sure you want to delete{0} <0/>"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie {0} <0/> löschen möchten?"
 
 #: src/routes/ShortcutsRoute.tsx
 msgid "<0/> Go to parent resource"
@@ -4714,15 +4676,15 @@ msgstr "<0/> Zur übergeordneten Ressource gehen"
 
 #: src/components/OverlayContainer.tsx
 msgid "Show or hide the sidebar"
-msgstr ""
+msgstr "Seitenleiste ein- oder ausblenden"
 
 #: src/components/OverlayContainer.tsx
 msgid "Filter shortcuts…"
-msgstr ""
+msgstr "Tastaturkürzel filtern…"
 
 #: src/components/OverlayContainer.tsx
 msgid "No matching shortcuts"
-msgstr ""
+msgstr "Keine passenden Tastaturkürzel"
 
 #: src/views/Meeting/MeetingPage.tsx
 msgid "End meeting"
@@ -4746,75 +4708,75 @@ msgstr "Demo-Arbeitsbereich verlassen"
 
 #: src/routes/DemoRoute.tsx
 msgid "Could not start the demo"
-msgstr ""
+msgstr "Demo konnte nicht gestartet werden"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo could not start"
-msgstr ""
+msgstr "Die Demo konnte nicht gestartet werden"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "Map"
-msgstr ""
+msgstr "Karte"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #. 0: new Date().toLocaleString(undefined, { month\\: 'short', day\\: 'numeric', hour\\: '2-digit', minute\\: '2-digit', })
 #: src/components/Presence/FollowContext.tsx
 msgid "Meeting · {0}"
-msgstr ""
+msgstr "Besprechung · {0}"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Open meeting chat"
-msgstr ""
+msgstr "Meeting-Chat öffnen"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Chat and the log of resources visited during the meeting."
-msgstr ""
+msgstr "Chat und das Protokoll der während des Meetings besuchten Ressourcen."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "End"
-msgstr ""
+msgstr "Ende"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave"
-msgstr ""
+msgstr "Verlassen"
 
 #. 0: participants.length
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "{0} here"
-msgstr ""
+msgstr "{0} hier"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending…"
-msgstr ""
+msgstr "Beenden..."
 
 #: src/components/Presence/MeetingBanner.tsx
 #: src/components/Presence/MeetingMessageToaster.tsx
 msgid "Open the meeting chat"
-msgstr ""
+msgstr "Besprechungschat öffnen"
 
 #. 0: title; 1: leaderName
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join {0} — led by {1}"
-msgstr ""
+msgstr "{0} beitreten — geleitet von {1}"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join"
-msgstr ""
+msgstr "Beitreten"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Try the live demo"
-msgstr ""
+msgstr "Live-Demo testen"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo needs the local database, which is disabled in this browser. Enable it on the Sync page and try again."
-msgstr ""
+msgstr "Die Demo benötigt die lokale Datenbank, die in diesem Browser deaktiviert ist. Aktivieren Sie sie auf der Synchronisationsseite und versuchen Sie es erneut."
 
 #. 0: name
 #: src/components/Presence/AgentAvatar.tsx
@@ -4823,35 +4785,35 @@ msgstr "{0} ist online"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Close the meeting chat"
-msgstr ""
+msgstr "Besprechungschat schließen"
 
 #: src/components/PairingCode.tsx
 msgid "Pairing code copied."
-msgstr ""
+msgstr "Pairing-Code kopiert."
 
 #: src/components/PairingCode.tsx
 msgid "Could not copy — select and copy the code manually."
-msgstr ""
+msgstr "Konnte nicht kopiert werden – bitte wählen Sie den Code manuell aus und kopieren Sie ihn."
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
-msgstr ""
+msgstr "Verbinden"
 
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> is typing"
-msgstr ""
+msgstr "<0/> tippt"
 
 #. 0: typers.length - 1
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and {0} others are typing"
-msgstr ""
+msgstr "<0/> und {0} andere tippen"
 
 #. 0: ' '
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and{0} <1/> are typing"
-msgstr ""
+msgstr "<0/> und{0} <1/> tippen"
 
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/routes/SettingsAgent.tsx
@@ -4892,7 +4854,7 @@ msgstr "Zuletzt besucht"
 
 #: src/routes/DemoRoute.tsx
 msgid "Setting up your demo…"
-msgstr ""
+msgstr "Demo wird eingerichtet …"
 
 #: src/routes/SyncRoute.tsx
 msgid "Your data lives on this device — it isn’t syncing anywhere yet."
@@ -4941,7 +4903,7 @@ msgstr "Jetzt synchronisieren"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Embedded (this device)"
-msgstr ""
+msgstr "Eingebettet (dieses Gerät)"
 
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
@@ -4987,15 +4949,15 @@ msgstr "Dieser Arbeitsbereich wurde nicht synchronisiert. Er ist hier sicher, ab
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Camera access is needed to scan a code."
-msgstr ""
+msgstr "Kamerazugriff ist erforderlich, um einen Code zu scannen."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Could not open the scanner."
-msgstr ""
+msgstr "Scanner konnte nicht geöffnet werden."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "<0/> Scan a QR code"
-msgstr ""
+msgstr "<0/> QR-Code scannen"
 
 #: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -5004,39 +4966,39 @@ msgstr "Ihre Daten befinden sich auf einem anderen Gerät"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "A server keeps your workspaces online and backed up, and lets you share them with other people."
-msgstr ""
+msgstr "Ein Server hält Ihre Arbeitsbereiche online und gesichert und ermöglicht es Ihnen, sie mit anderen zu teilen."
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Switch to"
-msgstr ""
+msgstr "Wechseln zu"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect to that device"
-msgstr ""
+msgstr "Mit diesem Gerät verbinden"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+msgstr "Sie sind angemeldet, aber dieses Gerät hat noch nicht Ihren Arbeitsbereich. Die Anmeldung stellt wieder her, wer Sie sind – Ihre Daten bleiben dort, wo Sie sie erstellt haben."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "…or let it scan this device"
-msgstr ""
+msgstr "…oder lassen Sie es dieses Gerät scannen"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+msgstr "Scannen Sie stattdessen diesen Code von Ihrem anderen Gerät. Er sagt nur, wo dieses Gerät erreicht werden kann – die andere Seite beweist weiterhin, dass sie Ihren Schlüssel besitzt."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
-msgstr ""
+msgstr "Vorerst überspringen"
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Paste a pairing code or did:ad:node:…"
-msgstr ""
+msgstr "Pairing-Code oder did:ad:node:… einfügen"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+msgstr "Öffnen Sie dort <0>Sync</0>, um den Code anzuzeigen, und scannen oder fügen Sie ihn hier ein."
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5146,19 +5108,19 @@ msgstr "{0}-Sicherung konnte nicht aktiviert werden."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
-msgstr ""
+msgstr "Trotzdem überspringen"
 
 #: src/actions/resourceActions.tsx
 msgid "Open original"
-msgstr ""
+msgstr "Original öffnen"
 
 #: src/helpers/draftsFolder.ts
 msgid "Drafts"
-msgstr ""
+msgstr "Entwürfe"
 
 #: src/helpers/forksFolder.ts
 msgid "Work in progress. Resources here are visible to people who can write to this drive, and are published by moving them somewhere publicly readable."
-msgstr ""
+msgstr "In Arbeit. Ressourcen hier sind für Personen sichtbar, die auf dieses Laufwerk schreiben können, und werden veröffentlicht, indem sie an einen öffentlich lesbaren Ort verschoben werden."
 
 #: src/components/ForkBar.tsx
 msgid "Discard"
@@ -5191,11 +5153,11 @@ msgstr "Ressource hat keinen bearbeitbaren Dokumentinhalt"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New Meeting"
-msgstr ""
+msgstr "Neues Meeting"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending meeting"
-msgstr ""
+msgstr "Besprechung beenden"
 
 #: src/components/forms/NewForm/CustomCreateActions/BasicInstanceHandlers.ts
 msgid "Meeting"
@@ -5211,27 +5173,27 @@ msgstr "Lade Meeting-Notizen…"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Notes"
-msgstr ""
+msgstr "Notizen"
 
 #: src/actions/resourceActions.tsx
 msgid "Edit as fork"
-msgstr ""
+msgstr "Als Fork bearbeiten"
 
 #: src/actions/resourceActions.tsx
 msgid "Fork this resource. The original is untouched until you merge the fork back."
-msgstr ""
+msgstr "Diese Ressource forken. Das Original bleibt unverändert, bis Sie den Fork zurückführen."
 
 #: src/actions/resourceActions.tsx
 msgid "Fork created"
-msgstr ""
+msgstr "Fork erstellt"
 
 #: src/actions/resourceActions.tsx
 msgid "Merge fork"
-msgstr ""
+msgstr "Fork zusammenführen"
 
 #: src/actions/resourceActions.tsx
 msgid "Write this fork onto the resource it was forked from, as a single commit."
-msgstr ""
+msgstr "Diesen Fork als einzelnen Commit auf die ursprüngliche Ressource schreiben."
 
 #: src/actions/resourceActions.tsx
 #: src/components/ForkBar.tsx
@@ -5240,7 +5202,7 @@ msgstr "Fork zusammengeführt"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the resource this fork was forked from."
-msgstr ""
+msgstr "Die Ressource öffnen, von der dieser Fork abgeleitet wurde."
 
 #. 0: conflicts.length; 1: conflicts.length === 1 ? 'y was' \\: 'ies were'; 2: conflicts .map(c => c.property.split('/').pop()) .join(', '); 3: conflicts.length === 1 ? 'it' \\: 'them'
 #: src/components/ForkBar.tsx
@@ -5262,11 +5224,11 @@ msgstr "{0} Forks schlagen Änderungen vor:"
 
 #: src/helpers/forksFolder.ts
 msgid "Forks"
-msgstr ""
+msgstr "Forks"
 
 #: src/helpers/draftsFolder.ts
 msgid "Unpublished new content. Resources here are visible to people who can write to this drive; publish one by moving it somewhere publicly readable."
-msgstr ""
+msgstr "Unveröffentlichte neue Inhalte. Die Ressourcen hier sind sichtbar für Personen, die in dieses Laufwerk schreiben können; veröffentlichen Sie eine, indem Sie sie an einen öffentlich lesbaren Ort verschieben."
 
 #: src/routes/AppSettings.tsx
 msgid "Virtual drive"
@@ -5382,20 +5344,20 @@ msgstr "Oder deren einfügen"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this from that device"
-msgstr ""
+msgstr "Scannen Sie dies von diesem Gerät"
 
 #. 0: serverLabel(baseURL)
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+msgstr "Synchronisiert Ihren Arbeitsbereich mit {0}, von dem dieser Browser liest. Sicher anzuzeigen: Ein Code leitet nur weiter."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect a device that has it"
-msgstr ""
+msgstr "Verbinden Sie ein Gerät, das es besitzt"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+msgstr "Ein ständig eingeschaltetes Gerät hat eine Adresse – fügen Sie sie hinzu und Ihr Arbeitsbereich erscheint."
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -5404,7 +5366,7 @@ msgstr "Fehler: Dieses Gerät konnte nicht getrennt werden"
 #. 0: title
 #: src/components/NavBar.tsx
 msgid "Go to {0}"
-msgstr ""
+msgstr "Zu {0} gehen"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5419,12 +5381,12 @@ msgstr "Sprache bereits hinzugefügt"
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Translation for {0}"
-msgstr ""
+msgstr "Übersetzung für {0}"
 
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Remove {0} translation"
-msgstr ""
+msgstr "{0}-Übersetzung entfernen"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5433,7 +5395,7 @@ msgstr "Neuer Sprachcode"
 
 #: src/components/forms/InputLocalizedText.tsx
 msgid "<0/> Add language"
-msgstr ""
+msgstr "<0/> Sprache hinzufügen"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5447,30 +5409,30 @@ msgstr "Lokalisierter Text"
 #. 0: contentLanguage; 1: title
 #: src/components/LocalizedTextValue.tsx
 msgid "No {0} translation. {1}"
-msgstr ""
+msgstr "Keine {0}-Übersetzung. {1}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 #: src/components/ContentLanguageSelect.tsx
 #: src/components/ContentLanguageSelect.tsx
 msgid "Content language"
-msgstr ""
+msgstr "Inhaltssprache"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Unsplit language columns"
-msgstr ""
+msgstr "Sprachspalten zusammenführen"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Split by language"
-msgstr ""
+msgstr "Nach Sprache aufteilen"
 
 #. 0: tag
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Language: {0}"
-msgstr ""
+msgstr "Sprache: {0}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Edit languages…"
-msgstr ""
+msgstr "Sprachen bearbeiten…"
 
 #: src/components/EditLanguagesDialog.tsx
 msgid "Languages"
@@ -5490,13 +5452,9 @@ msgstr "<0/> Hinzufügen"
 msgid "The languages this drive publishes content in (BCP 47 tags, e.g.{0} <0/> or <1/>). Language pickers offer these, and a missing translation is flagged against this set."
 msgstr "Die Sprachen, in denen dieses Laufwerk Inhalte veröffentlicht (BCP 47-Tags, z.B. {0} <0/> oder <1/>). Sprachauswahlen bieten diese an, und eine fehlende Übersetzung wird gegen diesen Satz gemeldet."
 
-#: src/chunks/TablePage/ColumnLanguageChip.tsx
-msgid "LanguageChipTrigger"
-msgstr ""
-
 #: src/components/forms/ResourceForm.tsx
 msgid "This property is server-managed and cannot be edited."
-msgstr ""
+msgstr "Diese Eigenschaft wird vom Server verwaltet und kann nicht bearbeitet werden."
 
 #: src/routes/SyncRoute.tsx
 msgid "Local storage is off, so this server is the only data source. Enable local storage below to work disconnected."
@@ -5524,7 +5482,7 @@ msgstr "Neues Laufwerk"
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Joep's phone"
-msgstr ""
+msgstr "Joeps Telefon"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
@@ -5533,30 +5491,30 @@ msgstr ""
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Tablet"
-msgstr ""
+msgstr "Tablet"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Phone"
-msgstr ""
+msgstr "Telefon"
 
 #: src/helpers/knownPeers.test.ts
 msgid "Real"
-msgstr ""
+msgstr "Echt"
 
 #: src/helpers/managedServer.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Failed to fetch"
-msgstr ""
+msgstr "Fehler beim Abrufen"
 
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Joep’s phone"
-msgstr ""
+msgstr "Joeps Telefon"
 
 #: src/helpers/managed/reconcile.test.ts
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #: src/routes/AppSettings.tsx
 msgid "Customize"
@@ -5565,12 +5523,12 @@ msgstr "Anpassen"
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "Add {0}"
-msgstr ""
+msgstr "Hinzufügen {0}"
 
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "{0} title…"
-msgstr ""
+msgstr "{0} Titel…"
 
 #. 0: ' '
 #: src/routes/AppSettings.tsx
@@ -5579,91 +5537,91 @@ msgstr "<0/>{0} Farbiger Modus"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave video call"
-msgstr ""
+msgstr "Videoanruf verlassen"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Start video call"
-msgstr ""
+msgstr "Videoanruf starten"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Microphone access was denied — allow it in your browser to join the call."
-msgstr ""
+msgstr "Mikrofonzugriff wurde verweigert – erlauben Sie ihn in Ihrem Browser, um am Anruf teilzunehmen."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "No microphone or camera found."
-msgstr ""
+msgstr "Kein Mikrofon oder keine Kamera gefunden."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Mute microphone"
-msgstr ""
+msgstr "Mikrofon stummschalten"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Unmute microphone"
-msgstr ""
+msgstr "Mikrofon stummschalten aufheben"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera off"
-msgstr ""
+msgstr "Kamera ausschalten"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera on"
-msgstr ""
+msgstr "Kamera einschalten"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Leave call"
-msgstr ""
+msgstr "Anruf verlassen"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change cover"
-msgstr ""
+msgstr "Titelbild ändern"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove cover"
-msgstr ""
+msgstr "Cover entfernen"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change icon"
-msgstr ""
+msgstr "Symbol ändern"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add icon"
-msgstr ""
+msgstr "Symbol hinzufügen"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add cover"
-msgstr ""
+msgstr "Titelbild hinzufügen"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an image shown as a banner at the top of this resource."
-msgstr ""
+msgstr "Wählen Sie ein Bild, das als Banner am oberen Rand dieser Ressource angezeigt wird."
 
 #: src/components/ResourceDecorations.tsx
 msgid "Icon"
-msgstr ""
+msgstr "Symbol"
 
 #: src/components/AvatarCropper.tsx
 msgid "Adjust image"
-msgstr ""
+msgstr "Bild anpassen"
 
 #: src/components/AvatarCropper.tsx
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove icon"
-msgstr ""
+msgstr "Symbol entfernen"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an emoji or image shown next to this resource wherever it appears."
-msgstr ""
+msgstr "Wählen Sie ein Emoji oder Bild, das überall neben dieser Ressource angezeigt wird."
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Upload image"
-msgstr ""
+msgstr "<0/> Bild hochladen"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Upload image"
@@ -5672,7 +5630,7 @@ msgstr "Bild hochladen"
 #. 0: file.name
 #: src/components/AvatarCropper.tsx
 msgid "Could not display \"{0}\" — it may not be a supported image format"
-msgstr ""
+msgstr "Konnte \"{0}\" nicht anzeigen — möglicherweise kein unterstütztes Bildformat"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Pick existing"
@@ -5680,20 +5638,20 @@ msgstr "Vorhandenes auswählen"
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Pick existing"
-msgstr ""
+msgstr "<0/> Aus vorhandenen auswählen"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Reposition"
-msgstr ""
+msgstr "Reposition"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Drag to reposition · release to save"
-msgstr ""
+msgstr "Zum Repositionieren ziehen · zum Speichern loslassen"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery code you saved for {0}."
-msgstr ""
+msgstr "Geben Sie den Wiederherstellungscode ein, den Sie für {0} gespeichert haben."
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
@@ -5705,24 +5663,24 @@ msgstr "Wiederherstellungscode"
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Copy the code to continue"
-msgstr ""
+msgstr "Kopieren Sie den Code, um fortzufahren"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Save your new recovery code"
-msgstr ""
+msgstr "Speichern Sie Ihren neuen Wiederherstellungscode"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Recovery code saved {0}"
-msgstr ""
+msgstr "Wiederherstellungscode gespeichert {0}"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save your recovery code"
-msgstr ""
+msgstr "Wiederherstellungscode speichern"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Are you sure you've stored this code somewhere safe? You cannot recover your account without it."
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie diesen Code an einem sicheren Ort gespeichert haben? Ohne ihn können Sie Ihr Konto nicht wiederherstellen."
 
 #: src/chunks/FormBuilder/FormAccessSection.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5732,63 +5690,59 @@ msgstr "Generieren…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Generate my recovery code"
-msgstr ""
-
-#: src/helpers/managed/recovery.ts
-msgid "PrfUnsupportedError"
-msgstr ""
+msgstr "Meinen Wiederherstellungscode generieren"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Passkey added {0}"
-msgstr ""
+msgstr "Passkey hinzugefügt {0}"
 
 #: src/helpers/managed/recovery.ts
 msgid "That passkey could not unlock this backup."
-msgstr ""
+msgstr "Dieser Passkey konnte dieses Backup nicht entsperren."
 
 #: src/helpers/managed/recovery.ts
 msgid "Wrong recovery code"
-msgstr ""
+msgstr "Falscher Wiederherstellungscode"
 
 #. 0: e.message
 #: src/components/NewIdentitySection.tsx
 msgid "{0} You can save a recovery code instead."
-msgstr ""
+msgstr "{0} Sie können stattdessen einen Wiederherstellungscode speichern."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Checking what this device supports…"
-msgstr ""
+msgstr "Überprüfe, was dieses Gerät unterstützt…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Waiting for your passkey…"
-msgstr ""
+msgstr "Warte auf Ihren Passkey…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use a recovery code instead"
-msgstr ""
+msgstr "Stattdessen einen Wiederherstellungscode verwenden"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
-msgstr ""
+msgstr "Atomares Konto"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not unlock with your passkey."
-msgstr ""
+msgstr "Konnte mit Ihrem Passkey nicht entsperren."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock with your passkey"
-msgstr ""
+msgstr "Mit Ihrem Passkey entsperren"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your passkey instead"
-msgstr ""
+msgstr "Stattdessen Ihren Passkey verwenden"
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5797,15 +5751,15 @@ msgstr "Ein Wiederherstellungscode konnte nicht hinzugefügt werden."
 
 #: src/components/NewIdentitySection.tsx
 msgid "This passkey only works on this device"
-msgstr ""
+msgstr "Dieser Passkey funktioniert nur auf diesem Gerät."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Give me a recovery code"
-msgstr ""
+msgstr "Wiederherstellungscode generieren"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Continue without one"
-msgstr ""
+msgstr "Ohne einen fortfahren"
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5829,66 +5783,66 @@ msgstr "Mein Agent-Geheimnis anzeigen"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This is your account"
-msgstr ""
+msgstr "Dies ist Ihr Konto"
 
 #. 0: PRODUCT_NAME
 #: src/components/NewIdentitySection.tsx
 msgid "Anyone who has this <0>is</0> you — on any device, forever. It can't be changed or revoked. It's also the only thing that still works if {0} disappears."
-msgstr ""
+msgstr "Jeder, der dies hat, <0>ist</0> Sie — auf jedem Gerät, für immer. Es kann nicht geändert oder widerrufen werden. Es ist auch das Einzige, das noch funktioniert, wenn {0} verschwindet."
 
 #. 0: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "Store it like a passport, not a password: a password manager, or{0} <0>Save backup file</0> below and move it somewhere private. Never email or chat it."
-msgstr ""
+msgstr "Bewahren Sie es wie einen Reisepass auf, nicht wie ein Passwort: ein Passwort-Manager oder{0} <0>Backup-Datei speichern</0> unten und verschieben Sie es an einen privaten Ort. Senden Sie es niemals per E-Mail oder Chat."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect your account"
-msgstr ""
+msgstr "Ihr Konto schützen"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+msgstr "Verwenden Sie Ihren Fingerabdruck, Ihr Gesicht oder Ihre Bildschirmsperre – dieselbe, mit der Sie dieses Gerät entsperren. Nichts zum Aufschreiben, und es funktioniert auch auf Ihren anderen Geräten."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
-msgstr ""
+msgstr "Passkey verwenden"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account."
-msgstr ""
+msgstr "Dieses Gerät kann keine Passkeys verwenden, daher geben wir Ihnen stattdessen einen Wiederherstellungscode – einen Ersatzschlüssel für Ihr Konto."
 
 #: src/components/NewIdentitySection.tsx
 msgid "A spare key for your account."
-msgstr ""
+msgstr "Ein Ersatzschlüssel für Ihr Konto."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save a recovery code"
-msgstr ""
+msgstr "Einen Wiederherstellungscode speichern"
 
 #. 0: passkeySupported === false ? 'This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account.' \\: 'A spare key for your account.'; 1: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
-msgstr ""
+msgstr "{0}{1} Sie müssen sich auch in Ihrer E-Mail anmelden, um es verwenden zu können, daher ist es sicher, es in einem Passwortmanager oder auf Papier aufzubewahren."
 
 #: src/components/NewIdentitySection.tsx
 msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+msgstr "Er wird nicht mit Ihren anderen Geräten synchronisiert. Wenn Sie dieses verlieren, werden Sie ausgesperrt. Ein Wiederherstellungscode ist ein Ersatzschlüssel – Sie benötigen Ihre E-Mail, um ihn zu verwenden, daher ist es sicher, ihn auf Papier aufzubewahren."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+msgstr "Bewahren Sie dies an einem sicheren Ort auf. Sie benötigen es – zusammen mit Ihrer E-Mail –, um wieder hineinzukommen. Wir können es nicht erneut anzeigen, aber Sie können jederzeit einen neuen aus den Einstellungen generieren."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
-msgstr ""
+msgstr "Mein Konto schützen"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip this?"
-msgstr ""
+msgstr "Dies überspringen?"
 
 #: src/components/NewIdentitySection.tsx
 msgid "<0>Then it's all on you.</0> We'll show you your secret next — it's the only copy that will ever exist, nobody can reset it for you, and losing it means losing your account and everything in it. Fine if you'll genuinely keep it safe."
-msgstr ""
+msgstr "<0>Dann liegt es ganz bei Ihnen.</0> Als Nächstes zeigen wir Ihnen Ihr Geheimnis – es ist die einzige Kopie, die jemals existieren wird, niemand kann es für Sie zurücksetzen, und wenn Sie es verlieren, verlieren Sie Ihr Konto und alles darin. In Ordnung, wenn Sie es wirklich sicher aufbewahren."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Nothing protects this account but the secret you saved during setup. That copy is the only one — we can't show it here, and we can't reset it. Keep it safe."
@@ -5907,15 +5861,15 @@ msgstr "Dies <0>ist</0> Ihr Konto – jeder, der es besitzt, ist Sie, auf jedem 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock {0} with your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "{0} mit Ihrem Fingerabdruck, Gesicht oder Bildschirmsperre entsperren."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "We've replaced your old recovery password with a stronger generated code. Keep it somewhere safe — you'll need it, plus your email, to get back in. We can't show it again, but you can generate a new one from Settings any time."
-msgstr ""
+msgstr "Wir haben Ihr altes Wiederherstellungspasswort durch einen stärkeren generierten Code ersetzt. Bewahren Sie ihn sicher auf – Sie benötigen ihn zusammen mit Ihrer E-Mail, um wieder Zugriff zu erhalten. Wir können ihn nicht erneut anzeigen, aber Sie können jederzeit in den Einstellungen einen neuen generieren."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Signed out of your account here — that secret belongs to a different one."
-msgstr ""
+msgstr "Sie haben sich von Ihrem Konto abgemeldet – dieses Geheimnis gehört zu einem anderen."
 
 #: src/routes/SettingsAgent.tsx
 msgid "More profile fields"
@@ -5947,12 +5901,12 @@ msgstr "Ein Bild hinzufügen"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "Verwenden Sie Ihren Fingerabdruck, Ihr Gesicht oder Ihre Bildschirmsperre."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "or sign in another way"
-msgstr ""
+msgstr "oder auf andere Weise anmelden"
 
 #: src/routes/SettingsAgent.tsx
 msgid "Sign out. You can get back in on this device with your passkey."
@@ -5977,7 +5931,7 @@ msgstr "Per URL öffnen"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Continue as"
-msgstr ""
+msgstr "Weiter als"
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not reach your backup. Try again."
@@ -5985,15 +5939,15 @@ msgstr "Ihr Backup konnte nicht erreicht werden. Versuchen Sie es erneut."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Paste your agent secret"
-msgstr ""
+msgstr "Agent-Geheimnis einfügen"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use my account instead"
-msgstr ""
+msgstr "Stattdessen mein Konto verwenden"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
-msgstr ""
+msgstr "Das sieht nicht wie ein gültiges Agent-Geheimnis aus."
 
 #: src/routes/SettingsAgent.tsx
 msgid "Whether this browser stays signed in as you when anyone opens it."
@@ -6044,11 +5998,11 @@ msgstr "Erneut starten"
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry started."
-msgstr ""
+msgstr "Als die Aufzeichnung dieses Eintrags begann."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry stopped."
-msgstr ""
+msgstr "Als die Aufzeichnung dieses Eintrags beendet wurde."
 
 #: src/chunks/TablePage/Timer/TimerToolbar.tsx
 msgid "One at a time"
@@ -6103,44 +6057,44 @@ msgstr "Berechnet"
 #. 0: spec.label
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove the {0} column from this view. It is computed, so no data is deleted — add it back any time."
-msgstr ""
+msgstr "Entfernen Sie die Spalte {0} aus dieser Ansicht. Sie wird berechnet, daher werden keine Daten gelöscht – Sie können sie jederzeit wieder hinzufügen."
 
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove computed column"
-msgstr ""
+msgstr "Berechnete Spalte entfernen"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Edit computed column"
-msgstr ""
+msgstr "Berechnete Spalte bearbeiten"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "New computed column"
-msgstr ""
+msgstr "Neue berechnete Spalte"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Computes"
-msgstr ""
+msgstr "Berechnet"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Choose a column…"
-msgstr ""
+msgstr "Wählen Sie eine Spalte…"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "A fixed number…"
-msgstr ""
+msgstr "Eine feste Zahl…"
 
 #. 0: arg.accepts === 'instant' ? 'date' \\: 'number'
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "This table has no {0} column to use here yet."
-msgstr ""
+msgstr "Diese Tabelle hat noch keine {0}-Spalte zur Verwendung hier."
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Add column"
-msgstr ""
+msgstr "Spalte hinzufügen"
 
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "No kind"
-msgstr ""
+msgstr "Keine Art"
 
 #: src/chunks/TablePage/TableSummaryBar.tsx
 msgid "Only the largest groups are shown."
@@ -6153,21 +6107,21 @@ msgstr "Pro {0}"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down by"
-msgstr ""
+msgstr "Aufschlüsseln nach"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per day"
-msgstr ""
+msgstr "Pro Tag"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per month"
-msgstr ""
+msgstr "Pro Monat"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per exact value"
-msgstr ""
+msgstr "Pro genauen Wert"
 
 #. 0: column.virtual?.label
 #: src/chunks/TablePage/TableHeading.tsx
@@ -6198,15 +6152,15 @@ msgstr "Aufschlüsselung löschen"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down the totals"
-msgstr ""
+msgstr "Summen aufschlüsseln"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Nothing — one total per column"
-msgstr ""
+msgstr "Nichts – eine Summe pro Spalte"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Splits each total per distinct value of a column — per project, per month, per status — under the table. Computed by the server over every matching row, like the totals themselves."
-msgstr ""
+msgstr "Teilt jede Summe pro eindeutigem Wert einer Spalte auf – pro Projekt, pro Monat, pro Status – unter der Tabelle. Vom Server über jede passende Zeile berechnet, genau wie die Summen selbst."
 
 #: src/chunks/TablePage/TableTotalsFooter.tsx
 msgid "Add a totals row"
@@ -6261,44 +6215,44 @@ msgstr "Zeilen nach einer Spalte filtern"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "This dashboard has no blocks yet."
-msgstr ""
+msgstr "Dieses Dashboard hat noch keine Blöcke."
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Configure"
-msgstr ""
+msgstr "Konfigurieren"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Width"
-msgstr ""
+msgstr "Breite"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move earlier"
-msgstr ""
+msgstr "Nach vorne verschieben"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move later"
-msgstr ""
+msgstr "Nach hinten verschieben"
 
 #. 0: kind
 #: src/chunks/DashboardPage/BlockRenderer.tsx
 msgid "This block is a “{0}”, which this version can’t show."
-msgstr ""
+msgstr "Dieser Block ist ein „{0}“, den diese Version nicht anzeigen kann."
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "What this shows"
-msgstr ""
+msgstr "Was dies anzeigt"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Every row"
-msgstr ""
+msgstr "Jede Zeile"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Rows"
-msgstr ""
+msgstr "Zeilen"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Measure"
-msgstr ""
+msgstr "Maß"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
@@ -6309,47 +6263,47 @@ msgstr "Spalte auswählen…"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Of"
-msgstr ""
+msgstr "Von"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "One bar per"
-msgstr ""
+msgstr "Ein Balken pro"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Each value"
-msgstr ""
+msgstr "Jeder Wert"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Bucket"
-msgstr ""
+msgstr "Eimer"
 
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
 msgid "Pick a table to show"
-msgstr ""
+msgstr "Wählen Sie eine anzuzeigende Tabelle"
 
 #: src/chunks/DashboardPage/blocks/TextBlock.tsx
 msgid "Nothing written here yet"
-msgstr ""
+msgstr "Hier wurde noch nichts geschrieben"
 
 #: src/chunks/DashboardPage/blocks/StatBlock.tsx
 msgid "Pick something to measure"
-msgstr ""
+msgstr "Wählen Sie etwas zum Messen"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Pick a number and something to group it by"
-msgstr ""
+msgstr "Wählen Sie eine Zahl und etwas, nach dem gruppiert werden soll"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "No data yet"
-msgstr ""
+msgstr "Noch keine Daten"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Showing the largest"
-msgstr ""
+msgstr "Zeige die größten"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "groups"
-msgstr ""
+msgstr "Gruppen"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/rowActions.ts
@@ -6359,35 +6313,35 @@ msgstr "Wert"
 #. 0: spec.label
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove the {0} button from this view. Nothing already recorded by pressing it is affected — add it back any time."
-msgstr ""
+msgstr "Entfernen Sie die Schaltfläche {0} aus dieser Ansicht. Nichts, was bereits durch Drücken aufgezeichnet wurde, wird beeinträchtigt – Sie können sie jederzeit wieder hinzufügen."
 
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove action"
-msgstr ""
+msgstr "Aktion entfernen"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Edit action"
-msgstr ""
+msgstr "Aktion bearbeiten"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Add an action"
-msgstr ""
+msgstr "Eine Aktion hinzufügen"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Does what"
-msgstr ""
+msgstr "Was tut es?"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "This table has no column of the right kind for that yet."
-msgstr ""
+msgstr "Diese Tabelle hat noch keine Spalte des richtigen Typs dafür."
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "To column"
-msgstr ""
+msgstr "Zu Spalte"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Pick an option…"
-msgstr ""
+msgstr "Wählen Sie eine Option…"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/RowActionDialog.tsx
@@ -6404,7 +6358,7 @@ msgstr "Ein Button in jeder Zeile: „Bewässert“, „Erledigt markieren“, �
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Creating table…"
-msgstr ""
+msgstr "Tabelle wird erstellt…"
 
 #: src/components/Template/ApplyTemplateDialog.tsx
 msgid "Applying template…"
@@ -6438,7 +6392,7 @@ msgstr "Feed protokollieren"
 
 #: src/chunks/TablePage/QuickAddDialog.tsx
 msgid "It sits above the rows and creates one. Everything else about the row is edited in the table."
-msgstr ""
+msgstr "Sie befindet sich über den Zeilen und erstellt eine. Alles andere an der Zeile wird in der Tabelle bearbeitet."
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 msgid "Ask for a value first"
@@ -6472,15 +6426,15 @@ msgstr "Auch festlegen"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Pick a table to add to"
-msgstr ""
+msgstr "Wählen Sie eine Tabelle zum Hinzufügen"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Say what the button does"
-msgstr ""
+msgstr "Sagen Sie, was der Button tut"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "That table has no row class yet"
-msgstr ""
+msgstr "Diese Tabelle hat noch keine Zeilenklasse"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDashboardDialog.tsx
 msgid "Dashboard"
@@ -6500,51 +6454,51 @@ msgstr "Neues Dashboard"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "Nothing here yet. Add a number, a chart, a button or a table."
-msgstr ""
+msgstr "Noch nichts hier. Fügen Sie eine Zahl, ein Diagramm, eine Schaltfläche oder eine Tabelle hinzu."
 
 #. 0: fn
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Pick a column for the {0} to measure"
-msgstr ""
+msgstr "Wählen Sie eine Spalte für die {0} zum Messen"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Last watered"
-msgstr ""
+msgstr "Zuletzt bewässert"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Meat & fish"
-msgstr ""
+msgstr "Fleisch & Fisch"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Quantity / unit"
-msgstr ""
+msgstr "Menge / Einheit"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Plan B2 - final"
-msgstr ""
+msgstr "Plan B2 - endgültig"
 
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "What do you need?"
-msgstr ""
+msgstr "Was brauchst du?"
 
 #: src/chunks/TablePage/tableAggregates.test.ts
 msgid "Total"
-msgstr ""
+msgstr "Gesamt"
 
 #: src/chunks/TablePage/rowActions.test.ts
 msgid "Do it"
-msgstr ""
+msgstr "Ausführen"
 
 #. 0: kind; 1: count
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "{0} takes {1} arguments; raise MAX_DERIVED_ARGS and add a subscription in DerivedCell"
-msgstr ""
+msgstr "{0} erwartet {1} Argumente; erhöhe MAX_DERIVED_ARGS und füge ein Abonnement in DerivedCell hinzu"
 
 #. 0: aggregate.computedColumn
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a computed column of this view"
-msgstr ""
+msgstr "{0} ist keine berechnete Spalte dieser Ansicht"
 
 #. 0: aggregate.column
 #. 0: value
@@ -6553,62 +6507,62 @@ msgstr ""
 #: src/chunks/TablePage/tableTemplates.test.ts
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a column"
-msgstr ""
+msgstr "{0} ist keine Spalte"
 
 #. 0: derived.name; 1: name
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is missing {1}"
-msgstr ""
+msgstr "{0} fehlt {1}"
 
 #. 0: derived.name; 1: name; 2: value
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0}.{1} reads {2}"
-msgstr ""
+msgstr "{0}.{1} liest {2}"
 
 #. 0: action.label; 1: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} writes \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} schreibt \"{1}\", was keine Spalte ist"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} stamps now into a {1} column"
-msgstr ""
+msgstr "{0} setzt jetzt einen Zeitstempel in eine {1}-Spalte"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} toggles a {1} column"
-msgstr ""
+msgstr "{0} schaltet eine {1}-Spalte um"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} increments a {1} column"
-msgstr ""
+msgstr "{0} erhöht eine {1}-Spalte"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a step"
-msgstr ""
+msgstr "{0} benötigt einen Schritt"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a value to write"
-msgstr ""
+msgstr "{0} benötigt einen zu schreibenden Wert"
 
 #. 0: action.label; 1: action.value; 2: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} sets \"{1}\", not an option of {2}"
-msgstr ""
+msgstr "{0} setzt \"{1}\", was keine Option von {2} ist"
 
 #. 0: quickAdd.label; 1: quickAdd.field
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} types into \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} gibt \"{1}\" ein, was keine Spalte ist"
 
 #. 0: quickAdd.label; 1: preset.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} presets \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} setzt \"{1}\" vor, was keine Spalte ist"
 
 #: src/chunks/FormBuilder/DeleteFormDialog.tsx
 msgid "Are you sure you want to delete this form?"
@@ -6967,36 +6921,58 @@ msgstr "Benennt die Klasse einer einzelnen Übermittlung – z. B. ist jede Antw
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Add a question before this one first"
-msgstr ""
+msgstr "Fügen Sie zuerst eine Frage vor dieser hinzu"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "and"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "<0/> Add condition"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "Show when"
-msgstr ""
+msgstr "und"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "All of these must match. Leave empty to always show."
-msgstr ""
+msgstr "Alle davon müssen zutreffen. Leer lassen für immer anzeigen."
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Remove condition"
-msgstr ""
+msgstr "Bedingung entfernen"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "checked"
-msgstr ""
+msgstr "markiert"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "unchecked"
-msgstr ""
+msgstr "nicht markiert"
 
 #: src/chunks/FormBuilder/FieldRow.tsx
+#: src/chunks/FormBuilder/PageTabBar.tsx
 msgid "Conditional"
-msgstr ""
+msgstr "Bedingt"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add condition"
+msgstr "Bedingung hinzufügen"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Done"
+msgstr "Fertig"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Always shown"
+msgstr "Immer anzeigen"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "1 condition"
+msgstr "1 Bedingung"
+
+#. 0: count
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "{0} conditions"
+msgstr "{0} Bedingungen"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Page When"
+msgstr "Seite anzeigen wenn"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Field When"
+msgstr "Feld anzeigen wenn"

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -1939,6 +1939,7 @@ msgstr "Please wait while we link your OpenRouter account..."
 msgid "Set a title"
 msgstr "Set a title"
 
+#: src/chunks/FormBuilder/useFormQuestions.ts
 #: src/components/EditableTitle.tsx
 #: src/components/NavBar.tsx
 msgid "Untitled"
@@ -6989,3 +6990,39 @@ msgstr "Each response is a"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewFormDialog.tsx
 msgid "Names the class of a single submission — e.g. every response of a Job Application form is an Application."
 msgstr "Names the class of a single submission — e.g. every response of a Job Application form is an Application."
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add a question before this one first"
+msgstr "Add a question before this one first"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "and"
+msgstr "and"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "<0/> Add condition"
+msgstr "<0/> Add condition"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show when"
+msgstr "Show when"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "All of these must match. Leave empty to always show."
+msgstr "All of these must match. Leave empty to always show."
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Remove condition"
+msgstr "Remove condition"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "checked"
+msgstr "checked"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "unchecked"
+msgstr "unchecked"
+
+#: src/chunks/FormBuilder/FieldRow.tsx
+msgid "Conditional"
+msgstr "Conditional"

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4609,70 +4609,6 @@ msgstr "Select File"
 msgid "{0} preview"
 msgstr "{0} preview"
 
-#~ msgid ""
-#~ "{0}{1}\n"
-#~ "const value = resource.get({2});\n"
-#~ ""
-#~ msgstr ""
-#~ "{0}{1}\n"
-#~ "const value = resource.get({2});\n"
-#~ ""
-
-#~ msgid "{0}const resource = await store.getResource{1}('{2}');"
-#~ msgstr "{0}const resource = await store.getResource{1}('{2}');"
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const value = {1};\n"
-#~ ""
-#~ msgstr ""
-#~ "{0}\n"
-#~ "const value = {1};\n"
-#~ ""
-
-#~ msgid ""
-#~ "{0}const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "\n"
-#~ "  return <div>{resource.title}</div>;\n"
-#~ "}"
-#~ msgstr ""
-#~ "{0}const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "\n"
-#~ "  return <div>{resource.title}</div>;\n"
-#~ "}"
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "  const [value] = {2}(resource, {3});\n"
-#~ "\n"
-#~ "  return <div>{value}</div>;\n"
-#~ "}"
-#~ msgstr ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "  const [value] = {2}(resource, {3});\n"
-#~ "\n"
-#~ "  return <div>{value}</div>;\n"
-#~ "}"
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource{1}('{2}');\n"
-#~ "{3}\n"
-#~ "}"
-#~ msgstr ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource{1}('{2}');\n"
-#~ "{3}\n"
-#~ "}"
-
 #. 0: prefix; 1: formatImportNames(prefix, names); 2: file
 #: src/views/CodeUsage/generators/generatorUtils.ts
 msgid "{0}import {1} from '{2}';"
@@ -5516,10 +5452,6 @@ msgstr "<0/> Add"
 msgid "The languages this drive publishes content in (BCP 47 tags, e.g.{0} <0/> or <1/>). Language pickers offer these, and a missing translation is flagged against this set."
 msgstr "The languages this drive publishes content in (BCP 47 tags, e.g.{0} <0/> or <1/>). Language pickers offer these, and a missing translation is flagged against this set."
 
-#: src/chunks/TablePage/ColumnLanguageChip.tsx
-msgid "LanguageChipTrigger"
-msgstr "LanguageChipTrigger"
-
 #: src/components/forms/ResourceForm.tsx
 msgid "This property is server-managed and cannot be edited."
 msgstr "This property is server-managed and cannot be edited."
@@ -5759,10 +5691,6 @@ msgstr "Generating…"
 #: src/components/NewIdentitySection.tsx
 msgid "Generate my recovery code"
 msgstr "Generate my recovery code"
-
-#: src/helpers/managed/recovery.ts
-msgid "PrfUnsupportedError"
-msgstr "PrfUnsupportedError"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
@@ -7000,14 +6928,6 @@ msgid "and"
 msgstr "and"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "<0/> Add condition"
-msgstr "<0/> Add condition"
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "Show when"
-msgstr "Show when"
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "All of these must match. Leave empty to always show."
 msgstr "All of these must match. Leave empty to always show."
 
@@ -7024,5 +6944,35 @@ msgid "unchecked"
 msgstr "unchecked"
 
 #: src/chunks/FormBuilder/FieldRow.tsx
+#: src/chunks/FormBuilder/PageTabBar.tsx
 msgid "Conditional"
 msgstr "Conditional"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add condition"
+msgstr "Add condition"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Done"
+msgstr "Done"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Always shown"
+msgstr "Always shown"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "1 condition"
+msgstr "1 condition"
+
+#. 0: count
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "{0} conditions"
+msgstr "{0} conditions"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Page When"
+msgstr "Show Page When"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Field When"
+msgstr "Show Field When"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -2147,7 +2147,7 @@ msgstr "Agregar a favoritos"
 
 #: src/actions/resourceActions.tsx
 msgid "Toggle whether this resource appears in your Favorites."
-msgstr ""
+msgstr "Alterna si este recurso aparece en tus Favoritos."
 
 #: src/actions/resourceActions.tsx
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
@@ -4007,70 +4007,70 @@ msgstr "Decimales"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Setting up your account…"
-msgstr ""
+msgstr "Configurando tu cuenta…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Could not back up your secret. You can still save it yourself."
-msgstr ""
+msgstr "No se pudo respaldar tu secreto. Todavía puedes guardarlo tú mismo."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Back up your secret?"
-msgstr ""
+msgstr "¿Respaldar tu secreto?"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Recovery password"
-msgstr ""
+msgstr "Contraseña de recuperación"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Skip, I'll save it myself"
-msgstr ""
+msgstr "Usar un código de recuperación en su lugar"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not restore your account."
-msgstr ""
+msgstr "No se pudo restaurar tu cuenta."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore account"
-msgstr ""
+msgstr "Restaurar cuenta"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery password you set for {0}."
-msgstr ""
+msgstr "Ingresa la contraseña de recuperación que configuraste para {0}."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
-msgstr ""
+msgstr "Restaurando…"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore & sign in"
-msgstr ""
+msgstr "Restaurar e iniciar sesión"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to access this drive"
-msgstr ""
+msgstr "Inicia sesión para acceder a esta unidad"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
-msgstr ""
+msgstr "Ingresa tu secreto de agente para desbloquear esta unidad en este dispositivo."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Checking your {0} account…"
-msgstr ""
+msgstr "Verificando tu cuenta de {0}…"
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "To restore your account, sign in to your {0} account first, then come back here."
-msgstr ""
+msgstr "Para restaurar tu cuenta, inicia sesión en tu cuenta de {0} primero, luego vuelve aquí."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to your {0} account"
-msgstr ""
+msgstr "Inicia sesión en tu cuenta de {0}"
 
 #. 0: text
 #: src/chunks/TablePage/TableHeading.tsx
@@ -4079,14 +4079,14 @@ msgstr "Ordenar por {0}"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Edit unavailable"
-msgstr ""
+msgstr "Editar no disponible"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/TablePage/Kanban/useKanbanGroupBy.ts
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 msgid "Setting up the board…"
@@ -4094,11 +4094,11 @@ msgstr "Configurando el tablero…"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Start from"
-msgstr ""
+msgstr "Empezar desde"
 
 #: src/components/forms/ValueForm/ValueForm.tsx
 msgid "Click to add a value"
-msgstr ""
+msgstr "Haz clic para agregar un valor"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Rename"
@@ -4132,11 +4132,11 @@ msgstr "Mes siguiente"
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "Add item"
-msgstr ""
+msgstr "Agregar elemento"
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "New item…"
-msgstr ""
+msgstr "Nuevo elemento…"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 #: src/chunks/TablePage/createTableFromSpec.ts
@@ -4147,11 +4147,11 @@ msgstr "Fila"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Each row is a"
-msgstr ""
+msgstr "Cada fila es una"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Names the class of the rows — e.g. every row of an Employees table is an Employee."
-msgstr ""
+msgstr "Nombra la clase de las filas — p. ej., cada fila de una tabla de Empleados es un Empleado."
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
 #: src/routes/NewDriveRoute.tsx
@@ -4164,11 +4164,11 @@ msgstr "No se pudo crear la unidad"
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Open a resource to see its comments."
-msgstr ""
+msgstr "Abre un recurso para ver sus comentarios."
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Comments"
-msgstr ""
+msgstr "Comentarios"
 
 #: src/chunks/TablePage/TableResource.tsx
 msgid "Failed to insert row"
@@ -4176,83 +4176,83 @@ msgstr "Error al insertar la fila"
 
 #: src/components/Presence/ResourcePresenceRow.tsx
 msgid "Also viewing this resource"
-msgstr ""
+msgstr "También viendo este recurso"
 
 #: src/components/Presence/SidebarPresence.tsx
 msgid "Currently here"
-msgstr ""
+msgstr "Actualmente aquí"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Show profile"
-msgstr ""
+msgstr "Mostrar perfil"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Stop following"
-msgstr ""
+msgstr "Dejar de seguir"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Follow"
-msgstr ""
+msgstr "Seguir"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "PresenceAvatarTrigger"
-msgstr ""
+msgstr "PresenceAvatarTrigger"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Don’t allow following me"
-msgstr ""
+msgstr "No permitir seguirme"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following you"
-msgstr ""
+msgstr "Te sigue"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following"
-msgstr ""
+msgstr "Siguiendo"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Disconnects current followers."
-msgstr ""
+msgstr "Desconecta seguidores actuales."
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following — press for actions"
-msgstr ""
+msgstr "Siguiendo — presiona para acciones"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "These users follow you — press for actions"
-msgstr ""
+msgstr "Estos usuarios te siguen — presiona para acciones"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Enable following"
-msgstr ""
+msgstr "Activar seguimiento"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "BadgedFollowTrigger"
-msgstr ""
+msgstr "BadgedFollowTrigger"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Jump to their location"
-msgstr ""
+msgstr "Saltar a su ubicación"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Go to the resource they are viewing right now."
-msgstr ""
+msgstr "Ir al recurso que están viendo ahora."
 
 #. 0: step + 1; 1: totalSteps
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Version {0} / {1}"
-msgstr ""
+msgstr "Versión {0} / {1}"
 
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Discarded versions"
-msgstr ""
+msgstr "Versiones descartadas"
 
 #. 0: i + 1
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Restore discarded version {0}"
-msgstr ""
+msgstr "Restaurar versión descartada {0}"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "Undo (Ctrl+Z) — drag horizontally to scrub history, hold to see discarded versions"
@@ -4393,13 +4393,13 @@ msgstr ""
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "AI chat title generation failed"
-msgstr ""
+msgstr "Falló la generación del título del chat de IA"
 
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "Project planning"
-msgstr ""
+msgstr "Planificación de proyectos"
 
 #. 0: ' '
 #: src/chunks/RTE/CollaborativeEditor.tsx
@@ -4408,16 +4408,16 @@ msgstr "Ha habido un error en el editor. Por favor, refresque la página para co
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Caption"
-msgstr ""
+msgstr "Leyenda"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Text Flow"
-msgstr ""
+msgstr "Flujo de texto"
 
 #. 0: propertyLabel; 1: rowIndex + 1
 #: src/chunks/TablePage/TableCell.tsx
 msgid "{0}, row {1}"
-msgstr ""
+msgstr "{0}, fila {1}"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Are you sure you want to delete the <0/> view? This only removes the view, not the rows."
@@ -4426,7 +4426,7 @@ msgstr "¿Estás seguro de que quieres eliminar la vista <0/>? Esto solo elimina
 #. 0: srcName
 #: src/chunks/TablePage/useTableView.ts
 msgid "{0} copy"
-msgstr ""
+msgstr "Copia de {0}"
 
 #. 0: p; 1: theme.animation.duration
 #: src/helpers/transition.ts
@@ -4503,7 +4503,7 @@ msgstr "{0} no es una Clase. Solo los recursos con clases válidas pueden ser cr
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Error in class, so this form could miss properties. You can still edit the resource, though. Error message: `"
-msgstr ""
+msgstr "Error en la clase, por lo que este formulario podría carecer de propiedades. Aun así, puedes editar el recurso. Mensaje de error: `"
 
 #: src/routes/Search/SearchRoute.tsx
 msgid "Searching for"
@@ -4515,7 +4515,7 @@ msgstr "para"
 
 #: src/routes/Share/AgentRights.tsx
 msgid "Public (anyone)"
-msgstr ""
+msgstr "Público (cualquiera)"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "<0>Scroll</0> · <1>Space</1>+drag · middle-mouse drag — pan the canvas"
@@ -4563,11 +4563,11 @@ msgstr "quiere modificar un recurso que no está contenido en el ámbito actual.
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "No recovery backup was found for"
-msgstr ""
+msgstr "No se encontró ninguna copia de seguridad de recuperación para"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid ". Account recovery only works if you enabled it earlier."
-msgstr ""
+msgstr ". La recuperación de la cuenta solo funciona si la habilitaste antes."
 
 #: src/chunks/AI/ModelSelect/OpenRouterModelSelector.tsx
 msgid "/1K web search results"
@@ -4601,48 +4601,7 @@ msgstr "Seleccionar Archivo"
 #: src/components/forms/FilePicker/SelectedFile.tsx
 #: src/components/forms/FilePicker/SelectedFile.tsx
 msgid "{0} preview"
-msgstr ""
-
-#~ msgid ""
-#~ "{0}{1}\n"
-#~ "const value = resource.get({2});\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid "{0}const resource = await store.getResource{1}('{2}');"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const value = {1};\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "\n"
-#~ "  return <div>{resource.title}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "  const [value] = {2}(resource, {3});\n"
-#~ "\n"
-#~ "  return <div>{value}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource{1}('{2}');\n"
-#~ "{3}\n"
-#~ "}"
-#~ msgstr ""
+msgstr "Vista previa de {0}"
 
 #. 0: prefix; 1: formatImportNames(prefix, names); 2: file
 #: src/views/CodeUsage/generators/generatorUtils.ts
@@ -4668,16 +4627,16 @@ msgstr "Creando <0>{0} recursos</0>"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Due date"
-msgstr ""
+msgstr "Fecha de vencimiento"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Lead"
-msgstr ""
+msgstr "Cliente potencial"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Wat"
-msgstr ""
+msgstr "Qué"
 
 #: src/components/Dropdown/index.tsx
 msgid "Filter actions…"
@@ -4694,16 +4653,16 @@ msgstr "No hay acciones coincidentes"
 #: src/actions/resourceActions.tsx
 #: src/components/OverlayContainer.tsx
 msgid "Go to parent"
-msgstr ""
+msgstr "Ir al padre"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the parent of this resource."
-msgstr ""
+msgstr "Abrir el padre de este recurso."
 
 #. 0: ' '
 #: src/actions/resourceActions.tsx
 msgid "Are you sure you want to delete{0} <0/>"
-msgstr ""
+msgstr "¿Estás seguro de que quieres eliminar{0} <0/>"
 
 #: src/routes/ShortcutsRoute.tsx
 msgid "<0/> Go to parent resource"
@@ -4711,15 +4670,15 @@ msgstr "<0/> Ir al recurso principal"
 
 #: src/components/OverlayContainer.tsx
 msgid "Show or hide the sidebar"
-msgstr ""
+msgstr "Mostrar u ocultar la barra lateral"
 
 #: src/components/OverlayContainer.tsx
 msgid "Filter shortcuts…"
-msgstr ""
+msgstr "Filtrar atajos…"
 
 #: src/components/OverlayContainer.tsx
 msgid "No matching shortcuts"
-msgstr ""
+msgstr "No hay atajos coincidentes"
 
 #: src/views/Meeting/MeetingPage.tsx
 msgid "End meeting"
@@ -4743,75 +4702,75 @@ msgstr "Abandonar el espacio de trabajo de demo"
 
 #: src/routes/DemoRoute.tsx
 msgid "Could not start the demo"
-msgstr ""
+msgstr "No se pudo iniciar la demostración"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo could not start"
-msgstr ""
+msgstr "La demostración no pudo iniciar"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "Map"
-msgstr ""
+msgstr "Mapa"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #. 0: new Date().toLocaleString(undefined, { month\\: 'short', day\\: 'numeric', hour\\: '2-digit', minute\\: '2-digit', })
 #: src/components/Presence/FollowContext.tsx
 msgid "Meeting · {0}"
-msgstr ""
+msgstr "Reunión · {0}"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Open meeting chat"
-msgstr ""
+msgstr "Abrir chat de la reunión"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Chat and the log of resources visited during the meeting."
-msgstr ""
+msgstr "Chat y el registro de recursos visitados durante la reunión."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "End"
-msgstr ""
+msgstr "Fin"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave"
-msgstr ""
+msgstr "Salir"
 
 #. 0: participants.length
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "{0} here"
-msgstr ""
+msgstr "{0} aquí"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending…"
-msgstr ""
+msgstr "Finalizando…"
 
 #: src/components/Presence/MeetingBanner.tsx
 #: src/components/Presence/MeetingMessageToaster.tsx
 msgid "Open the meeting chat"
-msgstr ""
+msgstr "Abrir el chat de la reunión"
 
 #. 0: title; 1: leaderName
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join {0} — led by {1}"
-msgstr ""
+msgstr "Unirse a {0} — dirigido por {1}"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join"
-msgstr ""
+msgstr "Unirse"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Try the live demo"
-msgstr ""
+msgstr "Probar la demo en vivo"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo needs the local database, which is disabled in this browser. Enable it on the Sync page and try again."
-msgstr ""
+msgstr "La demostración necesita la base de datos local, que está deshabilitada en este navegador. Habilítala en la página de Sincronización e inténtalo de nuevo."
 
 #. 0: name
 #: src/components/Presence/AgentAvatar.tsx
@@ -4820,35 +4779,35 @@ msgstr "{0} está en línea"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Close the meeting chat"
-msgstr ""
+msgstr "Cerrar el chat de la reunión"
 
 #: src/components/PairingCode.tsx
 msgid "Pairing code copied."
-msgstr ""
+msgstr "Código de emparejamiento copiado."
 
 #: src/components/PairingCode.tsx
 msgid "Could not copy — select and copy the code manually."
-msgstr ""
+msgstr "No se pudo copiar: selecciona y copia el código manualmente."
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
-msgstr ""
+msgstr "Conectar"
 
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> is typing"
-msgstr ""
+msgstr "<0/> está escribiendo"
 
 #. 0: typers.length - 1
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and {0} others are typing"
-msgstr ""
+msgstr "<0/> y {0} otros están escribiendo"
 
 #. 0: ' '
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and{0} <1/> are typing"
-msgstr ""
+msgstr "<0/> y{0} <1/> están escribiendo"
 
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/routes/SettingsAgent.tsx
@@ -4889,7 +4848,7 @@ msgstr "Visitadas recientemente"
 
 #: src/routes/DemoRoute.tsx
 msgid "Setting up your demo…"
-msgstr ""
+msgstr "Configurando tu demostración…"
 
 #: src/routes/SyncRoute.tsx
 msgid "Your data lives on this device — it isn’t syncing anywhere yet."
@@ -4938,7 +4897,7 @@ msgstr "Sincronizar ahora"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Embedded (this device)"
-msgstr ""
+msgstr "Integrado (este dispositivo)"
 
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
@@ -4984,15 +4943,15 @@ msgstr "Este espacio de trabajo no se ha sincronizado. Está a salvo aquí, pero
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Camera access is needed to scan a code."
-msgstr ""
+msgstr "Se necesita acceso a la cámara para escanear un código."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Could not open the scanner."
-msgstr ""
+msgstr "No se pudo abrir el escáner."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "<0/> Scan a QR code"
-msgstr ""
+msgstr "<0/> Escanear un código QR"
 
 #: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -5001,39 +4960,39 @@ msgstr "Tus datos están en otro dispositivo"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "A server keeps your workspaces online and backed up, and lets you share them with other people."
-msgstr ""
+msgstr "Un servidor mantiene tus espacios de trabajo en línea y respaldados, y te permite compartirlos con otras personas."
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Switch to"
-msgstr ""
+msgstr "Cambiar a"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect to that device"
-msgstr ""
+msgstr "Conectar con ese dispositivo"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+msgstr "Has iniciado sesión, pero este dispositivo aún no tiene tu espacio de trabajo. Iniciar sesión restaura quién eres; tus datos se quedan donde los creaste."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "…or let it scan this device"
-msgstr ""
+msgstr "…o déjalo escanear este dispositivo"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+msgstr "Escanea este código desde tu otro dispositivo. Solo indica dónde encontrar este; el otro lado aún demuestra que tiene tu clave."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
-msgstr ""
+msgstr "Omitir por ahora"
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Paste a pairing code or did:ad:node:…"
-msgstr ""
+msgstr "Pega un código de emparejamiento o did:ad:node:…"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+msgstr "Abre <0>Sincronización</0> allí para mostrar su código, luego escanéalo o pégalo aquí."
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5143,19 +5102,19 @@ msgstr "No se pudo activar la copia de seguridad de {0}."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
-msgstr ""
+msgstr "Omitir de todos modos"
 
 #: src/actions/resourceActions.tsx
 msgid "Open original"
-msgstr ""
+msgstr "Abrir original"
 
 #: src/helpers/draftsFolder.ts
 msgid "Drafts"
-msgstr ""
+msgstr "Borradores"
 
 #: src/helpers/forksFolder.ts
 msgid "Work in progress. Resources here are visible to people who can write to this drive, and are published by moving them somewhere publicly readable."
-msgstr ""
+msgstr "Trabajo en curso. Los recursos aquí son visibles para las personas que pueden escribir en esta unidad, y se publican moviéndolos a algún lugar legible públicamente."
 
 #: src/components/ForkBar.tsx
 msgid "Discard"
@@ -5188,11 +5147,11 @@ msgstr "El recurso no tiene contenido de documento editable"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New Meeting"
-msgstr ""
+msgstr "Nueva reunión"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending meeting"
-msgstr ""
+msgstr "Finalizar reunión"
 
 #: src/components/forms/NewForm/CustomCreateActions/BasicInstanceHandlers.ts
 msgid "Meeting"
@@ -5208,27 +5167,27 @@ msgstr "Cargando notas de la reunión…"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Notes"
-msgstr ""
+msgstr "Notas"
 
 #: src/actions/resourceActions.tsx
 msgid "Edit as fork"
-msgstr ""
+msgstr "Editar como fork"
 
 #: src/actions/resourceActions.tsx
 msgid "Fork this resource. The original is untouched until you merge the fork back."
-msgstr ""
+msgstr "Haz un fork de este recurso. El original no se modifica hasta que fusiones el fork de vuelta."
 
 #: src/actions/resourceActions.tsx
 msgid "Fork created"
-msgstr ""
+msgstr "Fork creado"
 
 #: src/actions/resourceActions.tsx
 msgid "Merge fork"
-msgstr ""
+msgstr "Fusionar fork"
 
 #: src/actions/resourceActions.tsx
 msgid "Write this fork onto the resource it was forked from, as a single commit."
-msgstr ""
+msgstr "Escribe este fork en el recurso del que se bifurcó, como un solo commit."
 
 #: src/actions/resourceActions.tsx
 #: src/components/ForkBar.tsx
@@ -5237,7 +5196,7 @@ msgstr "Bifurcación fusionada"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the resource this fork was forked from."
-msgstr ""
+msgstr "Abrir el recurso del que se bifurcó este fork."
 
 #. 0: conflicts.length; 1: conflicts.length === 1 ? 'y was' \\: 'ies were'; 2: conflicts .map(c => c.property.split('/').pop()) .join(', '); 3: conflicts.length === 1 ? 'it' \\: 'them'
 #: src/components/ForkBar.tsx
@@ -5259,11 +5218,11 @@ msgstr "{0} bifurcaciones proponen cambios a esto:"
 
 #: src/helpers/forksFolder.ts
 msgid "Forks"
-msgstr ""
+msgstr "Bifurcaciones"
 
 #: src/helpers/draftsFolder.ts
 msgid "Unpublished new content. Resources here are visible to people who can write to this drive; publish one by moving it somewhere publicly readable."
-msgstr ""
+msgstr "Contenido nuevo no publicado. Los recursos aquí son visibles para las personas que pueden escribir en esta unidad; publique uno moviéndolo a algún lugar legible públicamente."
 
 #: src/routes/AppSettings.tsx
 msgid "Virtual drive"
@@ -5379,20 +5338,20 @@ msgstr "O pega el suyo"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this from that device"
-msgstr ""
+msgstr "Escanea esto desde ese dispositivo"
 
 #. 0: serverLabel(baseURL)
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+msgstr "Sincroniza tu espacio de trabajo con {0}, que este navegador lee. Seguro de mostrar: un código solo enruta."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect a device that has it"
-msgstr ""
+msgstr "Conecta un dispositivo que lo tenga"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+msgstr "Un dispositivo siempre encendido tiene una dirección: agrégala y tu espacio de trabajo aparecerá."
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -5401,7 +5360,7 @@ msgstr "Error: no se pudo desconectar ese dispositivo"
 #. 0: title
 #: src/components/NavBar.tsx
 msgid "Go to {0}"
-msgstr ""
+msgstr "Ir a {0}"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5416,12 +5375,12 @@ msgstr "Idioma ya agregado"
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Translation for {0}"
-msgstr ""
+msgstr "Traducción para {0}"
 
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Remove {0} translation"
-msgstr ""
+msgstr "Eliminar traducción de {0}"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5430,7 +5389,7 @@ msgstr "Nueva etiqueta de idioma"
 
 #: src/components/forms/InputLocalizedText.tsx
 msgid "<0/> Add language"
-msgstr ""
+msgstr "<0/> Añadir idioma"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5444,30 +5403,30 @@ msgstr "Texto localizado"
 #. 0: contentLanguage; 1: title
 #: src/components/LocalizedTextValue.tsx
 msgid "No {0} translation. {1}"
-msgstr ""
+msgstr "No hay traducción para {0}. {1}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 #: src/components/ContentLanguageSelect.tsx
 #: src/components/ContentLanguageSelect.tsx
 msgid "Content language"
-msgstr ""
+msgstr "Idioma del contenido"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Unsplit language columns"
-msgstr ""
+msgstr "Unir columnas de idioma"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Split by language"
-msgstr ""
+msgstr "Dividir por idioma"
 
 #. 0: tag
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Language: {0}"
-msgstr ""
+msgstr "Idioma: {0}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Edit languages…"
-msgstr ""
+msgstr "Editar idiomas…"
 
 #: src/components/EditLanguagesDialog.tsx
 msgid "Languages"
@@ -5487,13 +5446,9 @@ msgstr "<0/> Agregar"
 msgid "The languages this drive publishes content in (BCP 47 tags, e.g.{0} <0/> or <1/>). Language pickers offer these, and a missing translation is flagged against this set."
 msgstr "Los idiomas en los que este drive publica contenido (etiquetas BCP 47, ej. {0} <0/> o <1/>). Los selectores de idioma ofrecen estos, y una traducción faltante se marca contra este conjunto."
 
-#: src/chunks/TablePage/ColumnLanguageChip.tsx
-msgid "LanguageChipTrigger"
-msgstr ""
-
 #: src/components/forms/ResourceForm.tsx
 msgid "This property is server-managed and cannot be edited."
-msgstr ""
+msgstr "Esta propiedad está gestionada por el servidor y no se puede editar."
 
 #: src/routes/SyncRoute.tsx
 msgid "Local storage is off, so this server is the only data source. Enable local storage below to work disconnected."
@@ -5521,7 +5476,7 @@ msgstr "Nueva unidad"
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Joep's phone"
-msgstr ""
+msgstr "Teléfono de Joep"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
@@ -5530,30 +5485,30 @@ msgstr ""
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Tablet"
-msgstr ""
+msgstr "Tableta"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Phone"
-msgstr ""
+msgstr "Teléfono"
 
 #: src/helpers/knownPeers.test.ts
 msgid "Real"
-msgstr ""
+msgstr "Real"
 
 #: src/helpers/managedServer.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Failed to fetch"
-msgstr ""
+msgstr "Error al obtener"
 
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Joep’s phone"
-msgstr ""
+msgstr "Teléfono de Joep"
 
 #: src/helpers/managed/reconcile.test.ts
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #: src/routes/AppSettings.tsx
 msgid "Customize"
@@ -5562,12 +5517,12 @@ msgstr "Personalizar"
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "Add {0}"
-msgstr ""
+msgstr "Agregar {0}"
 
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "{0} title…"
-msgstr ""
+msgstr "{0} título…"
 
 #. 0: ' '
 #: src/routes/AppSettings.tsx
@@ -5576,91 +5531,91 @@ msgstr "<0/>{0} Modo colorido"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave video call"
-msgstr ""
+msgstr "Salir de la videollamada"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Start video call"
-msgstr ""
+msgstr "Iniciar videollamada"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Microphone access was denied — allow it in your browser to join the call."
-msgstr ""
+msgstr "Se denegó el acceso al micrófono — permítelo en tu navegador para unirte a la llamada."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "No microphone or camera found."
-msgstr ""
+msgstr "No se encontró micrófono ni cámara."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Mute microphone"
-msgstr ""
+msgstr "Silenciar micrófono"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Unmute microphone"
-msgstr ""
+msgstr "Reactivar micrófono"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera off"
-msgstr ""
+msgstr "Apagar cámara"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera on"
-msgstr ""
+msgstr "Encender cámara"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Leave call"
-msgstr ""
+msgstr "Salir de la llamada"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change cover"
-msgstr ""
+msgstr "Omitir, lo guardaré yo mismo"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove cover"
-msgstr ""
+msgstr "Reposicionar"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change icon"
-msgstr ""
+msgstr "Arrastra para reposicionar · suelta para guardar"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add icon"
-msgstr ""
+msgstr "Cambiar icono"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add cover"
-msgstr ""
+msgstr "Añadir icono"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an image shown as a banner at the top of this resource."
-msgstr ""
+msgstr "Elige una imagen que se muestre como banner en la parte superior de este recurso."
 
 #: src/components/ResourceDecorations.tsx
 msgid "Icon"
-msgstr ""
+msgstr "Añadir portada"
 
 #: src/components/AvatarCropper.tsx
 msgid "Adjust image"
-msgstr ""
+msgstr "Ajustar imagen"
 
 #: src/components/AvatarCropper.tsx
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove icon"
-msgstr ""
+msgstr "Icono"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an emoji or image shown next to this resource wherever it appears."
-msgstr ""
+msgstr "Elige un emoji o imagen que se muestre junto a este recurso dondequiera que aparezca."
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Upload image"
-msgstr ""
+msgstr "<0/> Subir imagen"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Upload image"
@@ -5669,7 +5624,7 @@ msgstr "Subir imagen"
 #. 0: file.name
 #: src/components/AvatarCropper.tsx
 msgid "Could not display \"{0}\" — it may not be a supported image format"
-msgstr ""
+msgstr "No se pudo mostrar \"{0}\" — puede que no sea un formato de imagen compatible"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Pick existing"
@@ -5677,20 +5632,20 @@ msgstr "Seleccionar existente"
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Pick existing"
-msgstr ""
+msgstr "<0/> Subir imagen"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Reposition"
-msgstr ""
+msgstr "Cambiar portada"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Drag to reposition · release to save"
-msgstr ""
+msgstr "Eliminar portada"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery code you saved for {0}."
-msgstr ""
+msgstr "Ingresa el código de recuperación que guardaste para {0}."
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
@@ -5702,24 +5657,24 @@ msgstr "Código de recuperación"
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Copy the code to continue"
-msgstr ""
+msgstr "Copia el código para continuar"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Save your new recovery code"
-msgstr ""
+msgstr "Guarda tu nuevo código de recuperación"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Recovery code saved {0}"
-msgstr ""
+msgstr "Código de recuperación guardado {0}"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save your recovery code"
-msgstr ""
+msgstr "Guarda tu código de recuperación"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Are you sure you've stored this code somewhere safe? You cannot recover your account without it."
-msgstr ""
+msgstr "¿Estás seguro de que has guardado este código en un lugar seguro? No puedes recuperar tu cuenta sin él."
 
 #: src/chunks/FormBuilder/FormAccessSection.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5729,63 +5684,59 @@ msgstr "Generando…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Generate my recovery code"
-msgstr ""
-
-#: src/helpers/managed/recovery.ts
-msgid "PrfUnsupportedError"
-msgstr ""
+msgstr "Generar mi código de recuperación"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Passkey added {0}"
-msgstr ""
+msgstr "Clave de acceso añadida {0}"
 
 #: src/helpers/managed/recovery.ts
 msgid "That passkey could not unlock this backup."
-msgstr ""
+msgstr "Esa clave de acceso no pudo desbloquear esta copia de seguridad."
 
 #: src/helpers/managed/recovery.ts
 msgid "Wrong recovery code"
-msgstr ""
+msgstr "Código de recuperación incorrecto"
 
 #. 0: e.message
 #: src/components/NewIdentitySection.tsx
 msgid "{0} You can save a recovery code instead."
-msgstr ""
+msgstr "{0} Puedes guardar un código de recuperación en su lugar."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Checking what this device supports…"
-msgstr ""
+msgstr "Comprobando qué admite este dispositivo…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Waiting for your passkey…"
-msgstr ""
+msgstr "Usa tu huella dactilar, rostro o bloqueo de pantalla: el mismo que desbloquea este dispositivo. Nada que escribir, y también funciona en tus otros dispositivos."
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use a recovery code instead"
-msgstr ""
+msgstr "Usar una clave de acceso"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
-msgstr ""
+msgstr "Cuenta atómica"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not unlock with your passkey."
-msgstr ""
+msgstr "No se pudo desbloquear con tu clave de acceso."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock with your passkey"
-msgstr ""
+msgstr "Desbloquear con tu passkey"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your passkey instead"
-msgstr ""
+msgstr "Usar tu passkey en su lugar"
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5794,15 +5745,15 @@ msgstr "No se pudo añadir un código de recuperación."
 
 #: src/components/NewIdentitySection.tsx
 msgid "This passkey only works on this device"
-msgstr ""
+msgstr "Esta clave de acceso solo funciona en este dispositivo"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Give me a recovery code"
-msgstr ""
+msgstr "Dame un código de recuperación"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Continue without one"
-msgstr ""
+msgstr "Continuar sin uno"
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5826,66 +5777,66 @@ msgstr "Mostrar mi secreto de agente"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This is your account"
-msgstr ""
+msgstr "Esta es tu cuenta"
 
 #. 0: PRODUCT_NAME
 #: src/components/NewIdentitySection.tsx
 msgid "Anyone who has this <0>is</0> you — on any device, forever. It can't be changed or revoked. It's also the only thing that still works if {0} disappears."
-msgstr ""
+msgstr "Cualquiera que tenga esto <0>es</0> tú, en cualquier dispositivo, para siempre. No se puede cambiar ni revocar. También es lo único que aún funciona si {0} desaparece."
 
 #. 0: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "Store it like a passport, not a password: a password manager, or{0} <0>Save backup file</0> below and move it somewhere private. Never email or chat it."
-msgstr ""
+msgstr "Guárdalo como un pasaporte, no como una contraseña: un gestor de contraseñas, o{0} <0>Guardar archivo de respaldo</0> abajo y muévelo a un lugar privado. Nunca lo envíes por correo o chat."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect your account"
-msgstr ""
+msgstr "Omitir, lo guardaré yo mismo"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+msgstr "Proteger tu cuenta"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
-msgstr ""
+msgstr "Esperando tu clave de acceso…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account."
-msgstr ""
+msgstr "Este dispositivo no puede usar claves de acceso, así que te daremos un código de recuperación en su lugar: una llave de repuesto para tu cuenta."
 
 #: src/components/NewIdentitySection.tsx
 msgid "A spare key for your account."
-msgstr ""
+msgstr "Una llave de repuesto para tu cuenta."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save a recovery code"
-msgstr ""
+msgstr "Guardar un código de recuperación"
 
 #. 0: passkeySupported === false ? 'This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account.' \\: 'A spare key for your account.'; 1: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
-msgstr ""
+msgstr "{0}{1} También necesitarás iniciar sesión en tu correo electrónico para usarlo, así que es seguro guardarlo en un gestor de contraseñas o en papel."
 
 #: src/components/NewIdentitySection.tsx
 msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+msgstr "No está sincronizada con tus otros dispositivos, por lo que perder este te bloquearía. Un código de recuperación es una llave de repuesto; necesitarás tu correo electrónico para usarlo, así que es seguro guardarlo en papel."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+msgstr "Mantén esto en un lugar seguro. Lo necesitarás, junto con tu correo electrónico, para volver a entrar. No podemos mostrarlo de nuevo, pero puedes generar uno nuevo desde Ajustes cuando quieras."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
-msgstr ""
+msgstr "Proteger mi cuenta"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip this?"
-msgstr ""
+msgstr "¿Omitir esto?"
 
 #: src/components/NewIdentitySection.tsx
 msgid "<0>Then it's all on you.</0> We'll show you your secret next — it's the only copy that will ever exist, nobody can reset it for you, and losing it means losing your account and everything in it. Fine if you'll genuinely keep it safe."
-msgstr ""
+msgstr "<0>Entonces todo depende de ti.</0> A continuación te mostraremos tu secreto: es la única copia que existirá jamás, nadie puede restablecerlo por ti, y perderlo significa perder tu cuenta y todo lo que contiene. Bien si realmente lo mantendrás seguro."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Nothing protects this account but the secret you saved during setup. That copy is the only one — we can't show it here, and we can't reset it. Keep it safe."
@@ -5904,15 +5855,15 @@ msgstr "Esta <0>es</0> tu cuenta — cualquiera que la tenga eres tú, en cualqu
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock {0} with your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "Desbloquea {0} con tu huella digital, rostro o bloqueo de pantalla."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "We've replaced your old recovery password with a stronger generated code. Keep it somewhere safe — you'll need it, plus your email, to get back in. We can't show it again, but you can generate a new one from Settings any time."
-msgstr ""
+msgstr "Hemos reemplazado tu antigua contraseña de recuperación con un código generado más seguro. Guárdalo en un lugar seguro; lo necesitarás, junto con tu correo electrónico, para volver a acceder. No podemos mostrarlo de nuevo, pero puedes generar uno nuevo desde Configuración en cualquier momento."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Signed out of your account here — that secret belongs to a different one."
-msgstr ""
+msgstr "Se cerró sesión de tu cuenta aquí — ese secreto pertenece a una diferente."
 
 #: src/routes/SettingsAgent.tsx
 msgid "More profile fields"
@@ -5944,12 +5895,12 @@ msgstr "Añadir una foto"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "Usa tu huella digital, rostro o bloqueo de pantalla."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "or sign in another way"
-msgstr ""
+msgstr "o iniciar sesión de otra manera"
 
 #: src/routes/SettingsAgent.tsx
 msgid "Sign out. You can get back in on this device with your passkey."
@@ -5974,7 +5925,7 @@ msgstr "Abrir por URL"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Continue as"
-msgstr ""
+msgstr "Continuar como"
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not reach your backup. Try again."
@@ -5982,15 +5933,15 @@ msgstr "No se pudo acceder a tu copia de seguridad. Inténtalo de nuevo."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Paste your agent secret"
-msgstr ""
+msgstr "Pega tu secreto de agente"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use my account instead"
-msgstr ""
+msgstr "Usar mi cuenta en su lugar"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
-msgstr ""
+msgstr "Eso no parece un secreto de agente válido."
 
 #: src/routes/SettingsAgent.tsx
 msgid "Whether this browser stays signed in as you when anyone opens it."
@@ -6041,11 +5992,11 @@ msgstr "Iniciar de nuevo"
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry started."
-msgstr ""
+msgstr "Cuando comenzó el seguimiento de esta entrada."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry stopped."
-msgstr ""
+msgstr "Cuando terminó el seguimiento de esta entrada."
 
 #: src/chunks/TablePage/Timer/TimerToolbar.tsx
 msgid "One at a time"
@@ -6100,44 +6051,44 @@ msgstr "Calculado"
 #. 0: spec.label
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove the {0} column from this view. It is computed, so no data is deleted — add it back any time."
-msgstr ""
+msgstr "Elimina la columna {0} de esta vista. Es calculada, por lo que no se eliminan datos; puedes volver a agregarla en cualquier momento."
 
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove computed column"
-msgstr ""
+msgstr "Eliminar columna calculada"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Edit computed column"
-msgstr ""
+msgstr "Editar columna calculada"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "New computed column"
-msgstr ""
+msgstr "Nueva columna calculada"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Computes"
-msgstr ""
+msgstr "Calcula"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Choose a column…"
-msgstr ""
+msgstr "Elige una columna…"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "A fixed number…"
-msgstr ""
+msgstr "Un número fijo…"
 
 #. 0: arg.accepts === 'instant' ? 'date' \\: 'number'
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "This table has no {0} column to use here yet."
-msgstr ""
+msgstr "Esta tabla aún no tiene una columna {0} para usar aquí."
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Add column"
-msgstr ""
+msgstr "Agregar columna"
 
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "No kind"
-msgstr ""
+msgstr "Ningún tipo"
 
 #: src/chunks/TablePage/TableSummaryBar.tsx
 msgid "Only the largest groups are shown."
@@ -6150,21 +6101,21 @@ msgstr "Por {0}"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down by"
-msgstr ""
+msgstr "Desglosar por"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per day"
-msgstr ""
+msgstr "Por día"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per month"
-msgstr ""
+msgstr "Por mes"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per exact value"
-msgstr ""
+msgstr "Por valor exacto"
 
 #. 0: column.virtual?.label
 #: src/chunks/TablePage/TableHeading.tsx
@@ -6195,15 +6146,15 @@ msgstr "Limpiar desglose"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down the totals"
-msgstr ""
+msgstr "Desglosar los totales"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Nothing — one total per column"
-msgstr ""
+msgstr "Nada — un total por columna"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Splits each total per distinct value of a column — per project, per month, per status — under the table. Computed by the server over every matching row, like the totals themselves."
-msgstr ""
+msgstr "Divide cada total por valor distinto de una columna — por proyecto, por mes, por estado — debajo de la tabla. Calculado por el servidor sobre cada fila coincidente, como los totales mismos."
 
 #: src/chunks/TablePage/TableTotalsFooter.tsx
 msgid "Add a totals row"
@@ -6258,44 +6209,44 @@ msgstr "Filtrar filas por una columna"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "This dashboard has no blocks yet."
-msgstr ""
+msgstr "Este panel no tiene bloques todavía."
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Configure"
-msgstr ""
+msgstr "Configurar"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Width"
-msgstr ""
+msgstr "Ancho"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move earlier"
-msgstr ""
+msgstr "Mover antes"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move later"
-msgstr ""
+msgstr "Mover después"
 
 #. 0: kind
 #: src/chunks/DashboardPage/BlockRenderer.tsx
 msgid "This block is a “{0}”, which this version can’t show."
-msgstr ""
+msgstr "Este bloque es un “{0}”, que esta versión no puede mostrar."
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "What this shows"
-msgstr ""
+msgstr "Qué muestra esto"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Every row"
-msgstr ""
+msgstr "Cada fila"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Rows"
-msgstr ""
+msgstr "Filas"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Measure"
-msgstr ""
+msgstr "Medida"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
@@ -6306,47 +6257,47 @@ msgstr "Elige una columna…"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Of"
-msgstr ""
+msgstr "De"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "One bar per"
-msgstr ""
+msgstr "Una barra por"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Each value"
-msgstr ""
+msgstr "Cada valor"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Bucket"
-msgstr ""
+msgstr "Cubo"
 
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
 msgid "Pick a table to show"
-msgstr ""
+msgstr "Elige una tabla para mostrar"
 
 #: src/chunks/DashboardPage/blocks/TextBlock.tsx
 msgid "Nothing written here yet"
-msgstr ""
+msgstr "Nada escrito aquí aún"
 
 #: src/chunks/DashboardPage/blocks/StatBlock.tsx
 msgid "Pick something to measure"
-msgstr ""
+msgstr "Elige algo para medir"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Pick a number and something to group it by"
-msgstr ""
+msgstr "Elige un número y algo para agruparlo"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "No data yet"
-msgstr ""
+msgstr "Sin datos aún"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Showing the largest"
-msgstr ""
+msgstr "Mostrando el más grande"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "groups"
-msgstr ""
+msgstr "grupos"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/rowActions.ts
@@ -6356,35 +6307,35 @@ msgstr "Valor"
 #. 0: spec.label
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove the {0} button from this view. Nothing already recorded by pressing it is affected — add it back any time."
-msgstr ""
+msgstr "Elimina el botón {0} de esta vista. Nada de lo ya registrado al presionarlo se ve afectado; puedes volver a agregarlo en cualquier momento."
 
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove action"
-msgstr ""
+msgstr "Eliminar acción"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Edit action"
-msgstr ""
+msgstr "Editar acción"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Add an action"
-msgstr ""
+msgstr "Agregar una acción"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Does what"
-msgstr ""
+msgstr "Qué hace"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "This table has no column of the right kind for that yet."
-msgstr ""
+msgstr "Esta tabla aún no tiene una columna del tipo adecuado para eso."
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "To column"
-msgstr ""
+msgstr "Columna de destino"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Pick an option…"
-msgstr ""
+msgstr "Elige una opción…"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/RowActionDialog.tsx
@@ -6401,7 +6352,7 @@ msgstr "Un botón en cada fila: \"Regado\", \"Marcar como hecho\", \"+1\"."
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Creating table…"
-msgstr ""
+msgstr "Creando tabla…"
 
 #: src/components/Template/ApplyTemplateDialog.tsx
 msgid "Applying template…"
@@ -6435,7 +6386,7 @@ msgstr "Registrar un feed"
 
 #: src/chunks/TablePage/QuickAddDialog.tsx
 msgid "It sits above the rows and creates one. Everything else about the row is edited in the table."
-msgstr ""
+msgstr "Se encuentra encima de las filas y crea una. Todo lo demás sobre la fila se edita en la tabla."
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 msgid "Ask for a value first"
@@ -6469,15 +6420,15 @@ msgstr "También establecer"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Pick a table to add to"
-msgstr ""
+msgstr "Elige una tabla para agregar"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Say what the button does"
-msgstr ""
+msgstr "Di qué hace el botón"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "That table has no row class yet"
-msgstr ""
+msgstr "Esa tabla aún no tiene clase de fila"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDashboardDialog.tsx
 msgid "Dashboard"
@@ -6497,51 +6448,51 @@ msgstr "Nuevo panel de control"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "Nothing here yet. Add a number, a chart, a button or a table."
-msgstr ""
+msgstr "Aún no hay nada aquí. Añade un número, un gráfico, un botón o una tabla."
 
 #. 0: fn
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Pick a column for the {0} to measure"
-msgstr ""
+msgstr "Elige una columna para que {0} mida"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Last watered"
-msgstr ""
+msgstr "Último riego"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Meat & fish"
-msgstr ""
+msgstr "Carne y pescado"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Quantity / unit"
-msgstr ""
+msgstr "Cantidad / unidad"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Plan B2 - final"
-msgstr ""
+msgstr "Plan B2 - final"
 
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "What do you need?"
-msgstr ""
+msgstr "¿Qué necesitas?"
 
 #: src/chunks/TablePage/tableAggregates.test.ts
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: src/chunks/TablePage/rowActions.test.ts
 msgid "Do it"
-msgstr ""
+msgstr "Hacerlo"
 
 #. 0: kind; 1: count
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "{0} takes {1} arguments; raise MAX_DERIVED_ARGS and add a subscription in DerivedCell"
-msgstr ""
+msgstr "{0} toma {1} argumentos; aumenta MAX_DERIVED_ARGS y añade una suscripción en DerivedCell"
 
 #. 0: aggregate.computedColumn
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a computed column of this view"
-msgstr ""
+msgstr "{0} no es una columna calculada de esta vista"
 
 #. 0: aggregate.column
 #. 0: value
@@ -6550,62 +6501,62 @@ msgstr ""
 #: src/chunks/TablePage/tableTemplates.test.ts
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a column"
-msgstr ""
+msgstr "{0} no es una columna"
 
 #. 0: derived.name; 1: name
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is missing {1}"
-msgstr ""
+msgstr "A {0} le falta {1}"
 
 #. 0: derived.name; 1: name; 2: value
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0}.{1} reads {2}"
-msgstr ""
+msgstr "{0}.{1} lee {2}"
 
 #. 0: action.label; 1: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} writes \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} escribe \"{1}\", que no es una columna"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} stamps now into a {1} column"
-msgstr ""
+msgstr "{0} sella la hora actual en una columna de tipo {1}"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} toggles a {1} column"
-msgstr ""
+msgstr "{0} alterna una columna de tipo {1}"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} increments a {1} column"
-msgstr ""
+msgstr "{0} incrementa una columna de tipo {1}"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a step"
-msgstr ""
+msgstr "{0} necesita un paso"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a value to write"
-msgstr ""
+msgstr "{0} necesita un valor para escribir"
 
 #. 0: action.label; 1: action.value; 2: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} sets \"{1}\", not an option of {2}"
-msgstr ""
+msgstr "{0} establece \"{1}\", que no es una opción de {2}"
 
 #. 0: quickAdd.label; 1: quickAdd.field
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} types into \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} escribe en \"{1}\", que no es una columna"
 
 #. 0: quickAdd.label; 1: preset.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} presets \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} preestablece \"{1}\", que no es una columna"
 
 #: src/chunks/FormBuilder/DeleteFormDialog.tsx
 msgid "Are you sure you want to delete this form?"
@@ -6964,36 +6915,58 @@ msgstr "Nombra la clase de un único envío — p. ej., cada respuesta de un for
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Add a question before this one first"
-msgstr ""
+msgstr "Agregue una pregunta antes de esta primero"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "and"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "<0/> Add condition"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "Show when"
-msgstr ""
+msgstr "y"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "All of these must match. Leave empty to always show."
-msgstr ""
+msgstr "Todos deben coincidir. Déjelo vacío para mostrar siempre."
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Remove condition"
-msgstr ""
+msgstr "Eliminar condición"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "checked"
-msgstr ""
+msgstr "marcado"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "unchecked"
-msgstr ""
+msgstr "sin marcar"
 
 #: src/chunks/FormBuilder/FieldRow.tsx
+#: src/chunks/FormBuilder/PageTabBar.tsx
 msgid "Conditional"
-msgstr ""
+msgstr "Condicional"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add condition"
+msgstr "Agregar condición"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Done"
+msgstr "Hecho"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Always shown"
+msgstr "Siempre visible"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "1 condition"
+msgstr "1 condición"
+
+#. 0: count
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "{0} conditions"
+msgstr "{0} condiciones"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Page When"
+msgstr "Mostrar página cuando"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Field When"
+msgstr "Mostrar campo cuando"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -1939,6 +1939,7 @@ msgstr "Por favor, espera mientras conectamos tu cuenta de OpenRouter..."
 msgid "Set a title"
 msgstr "Establecer un título"
 
+#: src/chunks/FormBuilder/useFormQuestions.ts
 #: src/components/EditableTitle.tsx
 #: src/components/NavBar.tsx
 msgid "Untitled"
@@ -6960,3 +6961,39 @@ msgstr "Cada respuesta es una"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewFormDialog.tsx
 msgid "Names the class of a single submission — e.g. every response of a Job Application form is an Application."
 msgstr "Nombra la clase de un único envío — p. ej., cada respuesta de un formulario de solicitud de empleo es una Application."
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add a question before this one first"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "and"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "<0/> Add condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show when"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "All of these must match. Leave empty to always show."
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Remove condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "checked"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "unchecked"
+msgstr ""
+
+#: src/chunks/FormBuilder/FieldRow.tsx
+msgid "Conditional"
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -2147,7 +2147,7 @@ msgstr "Ajouter aux favoris"
 
 #: src/actions/resourceActions.tsx
 msgid "Toggle whether this resource appears in your Favorites."
-msgstr ""
+msgstr "Basculer l'affichage de cette ressource dans vos favoris."
 
 #: src/actions/resourceActions.tsx
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
@@ -4007,70 +4007,70 @@ msgstr "Nombre de décimales"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Setting up your account…"
-msgstr ""
+msgstr "Configuration de votre compte…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Could not back up your secret. You can still save it yourself."
-msgstr ""
+msgstr "Impossible de sauvegarder votre secret. Vous pouvez toujours le sauvegarder vous-même."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Back up your secret?"
-msgstr ""
+msgstr "Sauvegarder votre secret ?"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Recovery password"
-msgstr ""
+msgstr "Mot de passe de récupération"
 
 #: src/components/NewIdentitySection.tsx
 #: src/components/NewIdentitySection.tsx
 msgid "Skip, I'll save it myself"
-msgstr ""
+msgstr "Passer, je le sauvegarderai moi-même"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not restore your account."
-msgstr ""
+msgstr "Impossible de restaurer votre compte."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore account"
-msgstr ""
+msgstr "Restaurer le compte"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery password you set for {0}."
-msgstr ""
+msgstr "Saisissez le mot de passe de récupération que vous avez défini pour {0}."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
-msgstr ""
+msgstr "Restauration…"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restore & sign in"
-msgstr ""
+msgstr "Restaurer et se connecter"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to access this drive"
-msgstr ""
+msgstr "Connectez-vous pour accéder à ce disque"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
-msgstr ""
+msgstr "Entrez votre secret d'agent pour déverrouiller ce disque sur cet appareil."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Checking your {0} account…"
-msgstr ""
+msgstr "Vérification de votre compte {0}…"
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "To restore your account, sign in to your {0} account first, then come back here."
-msgstr ""
+msgstr "Pour restaurer votre compte, connectez-vous d’abord à votre compte {0}, puis revenez ici."
 
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Sign in to your {0} account"
-msgstr ""
+msgstr "Connectez-vous à votre compte {0}"
 
 #. 0: text
 #: src/chunks/TablePage/TableHeading.tsx
@@ -4079,14 +4079,14 @@ msgstr "Trier par {0}"
 
 #: src/chunks/TablePage/TableHeadingMenu.tsx
 msgid "Edit unavailable"
-msgstr ""
+msgstr "Modification indisponible"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/TablePage/Kanban/useKanbanGroupBy.ts
 msgid "Status"
-msgstr ""
+msgstr "Statut"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 msgid "Setting up the board…"
@@ -4094,11 +4094,11 @@ msgstr "Configuration du tableau…"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Start from"
-msgstr ""
+msgstr "Commencer à partir de"
 
 #: src/components/forms/ValueForm/ValueForm.tsx
 msgid "Click to add a value"
-msgstr ""
+msgstr "Cliquez pour ajouter une valeur"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Rename"
@@ -4132,11 +4132,11 @@ msgstr "Mois suivant"
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "Add item"
-msgstr ""
+msgstr "Ajouter un élément"
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "New item…"
-msgstr ""
+msgstr "Nouvel élément…"
 
 #: src/chunks/TablePage/Kanban/KanbanView.tsx
 #: src/chunks/TablePage/createTableFromSpec.ts
@@ -4147,11 +4147,11 @@ msgstr "Ligne"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Each row is a"
-msgstr ""
+msgstr "Chaque ligne est un"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Names the class of the rows — e.g. every row of an Employees table is an Employee."
-msgstr ""
+msgstr "Nomme la classe des lignes — par exemple, chaque ligne d'une table Employés est un Employé."
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
 #: src/routes/NewDriveRoute.tsx
@@ -4164,11 +4164,11 @@ msgstr "Échec de la création du drive"
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Open a resource to see its comments."
-msgstr ""
+msgstr "Ouvrez une ressource pour voir ses commentaires."
 
 #: src/components/CommentsPanel/CommentsPanelContainer.tsx
 msgid "Comments"
-msgstr ""
+msgstr "Commentaires"
 
 #: src/chunks/TablePage/TableResource.tsx
 msgid "Failed to insert row"
@@ -4176,83 +4176,83 @@ msgstr "Échec de l'insertion de la ligne"
 
 #: src/components/Presence/ResourcePresenceRow.tsx
 msgid "Also viewing this resource"
-msgstr ""
+msgstr "Consulte aussi cette ressource"
 
 #: src/components/Presence/SidebarPresence.tsx
 msgid "Currently here"
-msgstr ""
+msgstr "Actuellement présent"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Show profile"
-msgstr ""
+msgstr "Afficher le profil"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Stop following"
-msgstr ""
+msgstr "Arrêter de suivre"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "Follow"
-msgstr ""
+msgstr "Suivre"
 
 #: src/components/Presence/PresenceAvatarMenu.tsx
 msgid "PresenceAvatarTrigger"
-msgstr ""
+msgstr "Déclencheur d'avatar de présence"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Don’t allow following me"
-msgstr ""
+msgstr "Ne pas autoriser à me suivre"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following you"
-msgstr ""
+msgstr "Vous suit"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following"
-msgstr ""
+msgstr "Abonné"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Disconnects current followers."
-msgstr ""
+msgstr "Déconnecte les abonnés actuels."
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Following — press for actions"
-msgstr ""
+msgstr "Abonné — appuyez pour voir les actions"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "These users follow you — press for actions"
-msgstr ""
+msgstr "Ces utilisateurs vous suivent — appuyez pour voir les actions"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Enable following"
-msgstr ""
+msgstr "Activer le suivi"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "BadgedFollowTrigger"
-msgstr ""
+msgstr "BadgedFollowTrigger"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Jump to their location"
-msgstr ""
+msgstr "Aller à leur emplacement"
 
 #: src/components/Presence/FollowStatus.tsx
 msgid "Go to the resource they are viewing right now."
-msgstr ""
+msgstr "Aller à la ressource qu'ils consultent actuellement."
 
 #. 0: step + 1; 1: totalSteps
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Version {0} / {1}"
-msgstr ""
+msgstr "Version {0} / {1}"
 
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Discarded versions"
-msgstr ""
+msgstr "Versions supprimées"
 
 #. 0: i + 1
 #: src/views/Canvas/HistoryScrubOverlay.tsx
 msgid "Restore discarded version {0}"
-msgstr ""
+msgstr "Restaurer la version supprimée {0}"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "Undo (Ctrl+Z) — drag horizontally to scrub history, hold to see discarded versions"
@@ -4393,13 +4393,13 @@ msgstr ""
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "AI chat title generation failed"
-msgstr ""
+msgstr "Échec de la génération du titre du chat IA"
 
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 #: src/chunks/AI/useGenerativeData.test.ts
 msgid "Project planning"
-msgstr ""
+msgstr "Planification de projet"
 
 #. 0: ' '
 #: src/chunks/RTE/CollaborativeEditor.tsx
@@ -4408,16 +4408,16 @@ msgstr "Une erreur s'est produite dans l'éditeur, veuillez rafraîchir la page 
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Caption"
-msgstr ""
+msgstr "Légende"
 
 #: src/chunks/RTE/ImagePicker.tsx
 msgid "Text Flow"
-msgstr ""
+msgstr "Flux de texte"
 
 #. 0: propertyLabel; 1: rowIndex + 1
 #: src/chunks/TablePage/TableCell.tsx
 msgid "{0}, row {1}"
-msgstr ""
+msgstr "{0}, ligne {1}"
 
 #: src/chunks/TablePage/TableViewTabs.tsx
 msgid "Are you sure you want to delete the <0/> view? This only removes the view, not the rows."
@@ -4426,7 +4426,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer la vue <0/> ? Cela supprime uniquem
 #. 0: srcName
 #: src/chunks/TablePage/useTableView.ts
 msgid "{0} copy"
-msgstr ""
+msgstr "Copie de {0}"
 
 #. 0: p; 1: theme.animation.duration
 #: src/helpers/transition.ts
@@ -4503,7 +4503,7 @@ msgstr "{0} n'est pas une classe. Seules les ressources avec des classes valides
 
 #: src/components/forms/ResourceForm.tsx
 msgid "Error in class, so this form could miss properties. You can still edit the resource, though. Error message: `"
-msgstr ""
+msgstr "Erreur dans la classe, donc ce formulaire pourrait manquer de propriétés. Vous pouvez toujours modifier la ressource. Message d'erreur : `"
 
 #: src/routes/Search/SearchRoute.tsx
 msgid "Searching for"
@@ -4515,7 +4515,7 @@ msgstr "pour"
 
 #: src/routes/Share/AgentRights.tsx
 msgid "Public (anyone)"
-msgstr ""
+msgstr "Public (tout le monde)"
 
 #: src/views/Canvas/CanvasPage.tsx
 msgid "<0>Scroll</0> · <1>Space</1>+drag · middle-mouse drag — pan the canvas"
@@ -4563,11 +4563,11 @@ msgstr "veut modifier une ressource qui n'est pas contenue dans la portée actue
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "No recovery backup was found for"
-msgstr ""
+msgstr "Aucune sauvegarde de récupération n’a été trouvée pour"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid ". Account recovery only works if you enabled it earlier."
-msgstr ""
+msgstr ". La récupération du compte ne fonctionne que si vous l’avez activée au préalable."
 
 #: src/chunks/AI/ModelSelect/OpenRouterModelSelector.tsx
 msgid "/1K web search results"
@@ -4601,48 +4601,7 @@ msgstr "Sélectionner un fichier"
 #: src/components/forms/FilePicker/SelectedFile.tsx
 #: src/components/forms/FilePicker/SelectedFile.tsx
 msgid "{0} preview"
-msgstr ""
-
-#~ msgid ""
-#~ "{0}{1}\n"
-#~ "const value = resource.get({2});\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid "{0}const resource = await store.getResource{1}('{2}');"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const value = {1};\n"
-#~ ""
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "\n"
-#~ "  return <div>{resource.title}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource('{1}');\n"
-#~ "  const [value] = {2}(resource, {3});\n"
-#~ "\n"
-#~ "  return <div>{value}</div>;\n"
-#~ "}"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "{0}\n"
-#~ "const Component = () => {\n"
-#~ "  const resource = useResource{1}('{2}');\n"
-#~ "{3}\n"
-#~ "}"
-#~ msgstr ""
+msgstr "Aperçu de {0}"
 
 #. 0: prefix; 1: formatImportNames(prefix, names); 2: file
 #: src/views/CodeUsage/generators/generatorUtils.ts
@@ -4668,16 +4627,16 @@ msgstr "Création de <0>{0} ressources</0>"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Due date"
-msgstr ""
+msgstr "Date d'échéance"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Lead"
-msgstr ""
+msgstr "Piste"
 
 #: src/chunks/AI/jsonAdCompact.test.ts
 msgid "Wat"
-msgstr ""
+msgstr "Wat"
 
 #: src/components/Dropdown/index.tsx
 msgid "Filter actions…"
@@ -4694,16 +4653,16 @@ msgstr "Aucune action correspondante"
 #: src/actions/resourceActions.tsx
 #: src/components/OverlayContainer.tsx
 msgid "Go to parent"
-msgstr ""
+msgstr "Aller au parent"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the parent of this resource."
-msgstr ""
+msgstr "Ouvrir le parent de cette ressource."
 
 #. 0: ' '
 #: src/actions/resourceActions.tsx
 msgid "Are you sure you want to delete{0} <0/>"
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir supprimer{0} <0/>"
 
 #: src/routes/ShortcutsRoute.tsx
 msgid "<0/> Go to parent resource"
@@ -4711,15 +4670,15 @@ msgstr "<0/> Aller à la ressource parente"
 
 #: src/components/OverlayContainer.tsx
 msgid "Show or hide the sidebar"
-msgstr ""
+msgstr "Afficher ou masquer la barre latérale"
 
 #: src/components/OverlayContainer.tsx
 msgid "Filter shortcuts…"
-msgstr ""
+msgstr "Filtrer les raccourcis…"
 
 #: src/components/OverlayContainer.tsx
 msgid "No matching shortcuts"
-msgstr ""
+msgstr "Aucun raccourci correspondant"
 
 #: src/views/Meeting/MeetingPage.tsx
 msgid "End meeting"
@@ -4743,75 +4702,75 @@ msgstr "Quitter l'espace de travail de la démo"
 
 #: src/routes/DemoRoute.tsx
 msgid "Could not start the demo"
-msgstr ""
+msgstr "Impossible de démarrer la démo"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo could not start"
-msgstr ""
+msgstr "La démo n'a pas pu démarrer"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "Map"
-msgstr ""
+msgstr "Carte"
 
 #: src/chunks/Demo/SimulatedTypist.ts
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #. 0: new Date().toLocaleString(undefined, { month\\: 'short', day\\: 'numeric', hour\\: '2-digit', minute\\: '2-digit', })
 #: src/components/Presence/FollowContext.tsx
 msgid "Meeting · {0}"
-msgstr ""
+msgstr "Réunion · {0}"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Open meeting chat"
-msgstr ""
+msgstr "Ouvrir le chat de réunion"
 
 #: src/components/Presence/FollowStatus.tsx
 #: src/components/Presence/FollowStatus.tsx
 msgid "Chat and the log of resources visited during the meeting."
-msgstr ""
+msgstr "Chat et journal des ressources visitées pendant la réunion."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "End"
-msgstr ""
+msgstr "Fin"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave"
-msgstr ""
+msgstr "Quitter"
 
 #. 0: participants.length
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "{0} here"
-msgstr ""
+msgstr "{0} ici"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending…"
-msgstr ""
+msgstr "Fin…"
 
 #: src/components/Presence/MeetingBanner.tsx
 #: src/components/Presence/MeetingMessageToaster.tsx
 msgid "Open the meeting chat"
-msgstr ""
+msgstr "Ouvrir le chat de la réunion"
 
 #. 0: title; 1: leaderName
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join {0} — led by {1}"
-msgstr ""
+msgstr "Rejoindre {0} — dirigé par {1}"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Join"
-msgstr ""
+msgstr "Rejoindre"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Try the live demo"
-msgstr ""
+msgstr "Essayer la démo en direct"
 
 #: src/routes/DemoRoute.tsx
 msgid "The demo needs the local database, which is disabled in this browser. Enable it on the Sync page and try again."
-msgstr ""
+msgstr "La démo nécessite la base de données locale, qui est désactivée dans ce navigateur. Activez-la sur la page Synchronisation et réessayez."
 
 #. 0: name
 #: src/components/Presence/AgentAvatar.tsx
@@ -4820,35 +4779,35 @@ msgstr "{0} est en ligne"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Close the meeting chat"
-msgstr ""
+msgstr "Fermer le chat de la réunion"
 
 #: src/components/PairingCode.tsx
 msgid "Pairing code copied."
-msgstr ""
+msgstr "Code d'appairage copié."
 
 #: src/components/PairingCode.tsx
 msgid "Could not copy — select and copy the code manually."
-msgstr ""
+msgstr "Impossible de copier — sélectionnez et copiez le code manuellement."
 
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect"
-msgstr ""
+msgstr "Connecter"
 
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> is typing"
-msgstr ""
+msgstr "<0/> tape"
 
 #. 0: typers.length - 1
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and {0} others are typing"
-msgstr ""
+msgstr "<0/> et {0} autres tapent"
 
 #. 0: ' '
 #: src/components/Presence/TypingIndicator.tsx
 msgid "<0/> and{0} <1/> are typing"
-msgstr ""
+msgstr "<0/> et{0} <1/> tapent"
 
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/routes/SettingsAgent.tsx
@@ -4889,7 +4848,7 @@ msgstr "Visité récemment"
 
 #: src/routes/DemoRoute.tsx
 msgid "Setting up your demo…"
-msgstr ""
+msgstr "Configuration de votre démo…"
 
 #: src/routes/SyncRoute.tsx
 msgid "Your data lives on this device — it isn’t syncing anywhere yet."
@@ -4938,7 +4897,7 @@ msgstr "Synchroniser maintenant"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Embedded (this device)"
-msgstr ""
+msgstr "Intégré (cet appareil)"
 
 #: src/routes/SyncRoute.tsx
 msgid "Node ID"
@@ -4984,15 +4943,15 @@ msgstr "Cet espace de travail n’a pas été synchronisé. Il est en sécurité
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Camera access is needed to scan a code."
-msgstr ""
+msgstr "L'accès à la caméra est nécessaire pour scanner un code."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Could not open the scanner."
-msgstr ""
+msgstr "Impossible d'ouvrir le scanner."
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "<0/> Scan a QR code"
-msgstr ""
+msgstr "<0/> Scanner un code QR"
 
 #: src/routes/SyncRoute.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -5001,39 +4960,39 @@ msgstr "Vos données se trouvent sur un autre appareil"
 
 #: src/components/ConnectServerDialog.tsx
 msgid "A server keeps your workspaces online and backed up, and lets you share them with other people."
-msgstr ""
+msgstr "Un serveur garde vos espaces de travail en ligne et sauvegardés, et vous permet de les partager avec d'autres personnes."
 
 #: src/components/ConnectServerDialog.tsx
 msgid "Switch to"
-msgstr ""
+msgstr "Passer à"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect to that device"
-msgstr ""
+msgstr "Se connecter à cet appareil"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+msgstr "Vous êtes connecté, mais cet appareil n’a pas encore votre espace de travail. La connexion restaure votre identité — vos données restent là où vous les avez créées."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "…or let it scan this device"
-msgstr ""
+msgstr "…ou laissez-le scanner cet appareil"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+msgstr "Scannez plutôt ce code depuis votre autre appareil. Il indique seulement comment joindre celui-ci — l’autre appareil prouve toujours qu’il détient votre clé."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
-msgstr ""
+msgstr "Passer pour l’instant"
 
 #: src/components/ConnectToDeviceForm.tsx
 msgid "Paste a pairing code or did:ad:node:…"
-msgstr ""
+msgstr "Collez un code d'appairage ou did:ad:node:…"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+msgstr "Ouvrez <0>Sync</0> là-bas pour afficher son code, puis scannez-le ou collez-le ici."
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5143,19 +5102,19 @@ msgstr "Impossible d’activer la sauvegarde {0}."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
-msgstr ""
+msgstr "Passer quand même"
 
 #: src/actions/resourceActions.tsx
 msgid "Open original"
-msgstr ""
+msgstr "Ouvrir l'original"
 
 #: src/helpers/draftsFolder.ts
 msgid "Drafts"
-msgstr ""
+msgstr "Brouillons"
 
 #: src/helpers/forksFolder.ts
 msgid "Work in progress. Resources here are visible to people who can write to this drive, and are published by moving them somewhere publicly readable."
-msgstr ""
+msgstr "Travail en cours. Les ressources ici sont visibles par les personnes qui peuvent écrire sur ce lecteur, et sont publiées en les déplaçant vers un emplacement lisible publiquement."
 
 #: src/components/ForkBar.tsx
 msgid "Discard"
@@ -5188,11 +5147,11 @@ msgstr "La ressource ne contient aucun contenu de document modifiable"
 
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
 msgid "New Meeting"
-msgstr ""
+msgstr "Nouvelle réunion"
 
 #: src/components/Presence/MeetingBanner.tsx
 msgid "Ending meeting"
-msgstr ""
+msgstr "Fin de la réunion"
 
 #: src/components/forms/NewForm/CustomCreateActions/BasicInstanceHandlers.ts
 msgid "Meeting"
@@ -5208,27 +5167,27 @@ msgstr "Chargement des notes de réunion…"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Notes"
-msgstr ""
+msgstr "Notes"
 
 #: src/actions/resourceActions.tsx
 msgid "Edit as fork"
-msgstr ""
+msgstr "Modifier en tant que fork"
 
 #: src/actions/resourceActions.tsx
 msgid "Fork this resource. The original is untouched until you merge the fork back."
-msgstr ""
+msgstr "Forker cette ressource. L'original reste intact jusqu'à ce que vous fusionniez le fork."
 
 #: src/actions/resourceActions.tsx
 msgid "Fork created"
-msgstr ""
+msgstr "Fork créé"
 
 #: src/actions/resourceActions.tsx
 msgid "Merge fork"
-msgstr ""
+msgstr "Fusionner le fork"
 
 #: src/actions/resourceActions.tsx
 msgid "Write this fork onto the resource it was forked from, as a single commit."
-msgstr ""
+msgstr "Écrire ce fork sur la ressource source en un seul commit."
 
 #: src/actions/resourceActions.tsx
 #: src/components/ForkBar.tsx
@@ -5237,7 +5196,7 @@ msgstr "Fork fusionné"
 
 #: src/actions/resourceActions.tsx
 msgid "Open the resource this fork was forked from."
-msgstr ""
+msgstr "Ouvrir la ressource dont ce fork a été créé."
 
 #. 0: conflicts.length; 1: conflicts.length === 1 ? 'y was' \\: 'ies were'; 2: conflicts .map(c => c.property.split('/').pop()) .join(', '); 3: conflicts.length === 1 ? 'it' \\: 'them'
 #: src/components/ForkBar.tsx
@@ -5259,11 +5218,11 @@ msgstr "{0} forks proposent des modifications pour ceci :"
 
 #: src/helpers/forksFolder.ts
 msgid "Forks"
-msgstr ""
+msgstr "Fourches"
 
 #: src/helpers/draftsFolder.ts
 msgid "Unpublished new content. Resources here are visible to people who can write to this drive; publish one by moving it somewhere publicly readable."
-msgstr ""
+msgstr "Contenu inédit. Les ressources ici sont visibles par les personnes qui peuvent écrire sur ce lecteur ; publiez-en une en la déplaçant vers un emplacement lisible publiquement."
 
 #: src/routes/AppSettings.tsx
 msgid "Virtual drive"
@@ -5379,20 +5338,20 @@ msgstr "Ou coller le leur"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Scan this from that device"
-msgstr ""
+msgstr "Scanner ce code depuis cet appareil"
 
 #. 0: serverLabel(baseURL)
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+msgstr "Synchronise votre espace de travail avec {0}, depuis lequel ce navigateur lit les données. Sans danger à afficher : un code ne fait qu’acheminer."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Connect a device that has it"
-msgstr ""
+msgstr "Connecter un appareil qui le possède"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+msgstr "Un appareil toujours allumé a une adresse — ajoutez-la et votre espace de travail apparaît."
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -5401,7 +5360,7 @@ msgstr "Erreur : impossible de déconnecter cet appareil"
 #. 0: title
 #: src/components/NavBar.tsx
 msgid "Go to {0}"
-msgstr ""
+msgstr "Aller vers {0}"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5416,12 +5375,12 @@ msgstr "Langue déjà ajoutée"
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Translation for {0}"
-msgstr ""
+msgstr "Traduction pour {0}"
 
 #. 0: tag
 #: src/components/forms/InputLocalizedText.tsx
 msgid "Remove {0} translation"
-msgstr ""
+msgstr "Supprimer la traduction {0}"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5430,7 +5389,7 @@ msgstr "Nouvelle balise de langue"
 
 #: src/components/forms/InputLocalizedText.tsx
 msgid "<0/> Add language"
-msgstr ""
+msgstr "<0/> Ajouter une langue"
 
 #: src/components/EditLanguagesDialog.tsx
 #: src/components/forms/InputLocalizedText.tsx
@@ -5444,30 +5403,30 @@ msgstr "Texte localisé"
 #. 0: contentLanguage; 1: title
 #: src/components/LocalizedTextValue.tsx
 msgid "No {0} translation. {1}"
-msgstr ""
+msgstr "Aucune traduction {0}. {1}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 #: src/components/ContentLanguageSelect.tsx
 #: src/components/ContentLanguageSelect.tsx
 msgid "Content language"
-msgstr ""
+msgstr "Langue du contenu"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Unsplit language columns"
-msgstr ""
+msgstr "Dissocier les colonnes de langue"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Split by language"
-msgstr ""
+msgstr "Fractionner par langue"
 
 #. 0: tag
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Language: {0}"
-msgstr ""
+msgstr "Langue : {0}"
 
 #: src/chunks/TablePage/ColumnLanguageChip.tsx
 msgid "Edit languages…"
-msgstr ""
+msgstr "Modifier les langues…"
 
 #: src/components/EditLanguagesDialog.tsx
 msgid "Languages"
@@ -5487,13 +5446,9 @@ msgstr "<0/> Ajouter"
 msgid "The languages this drive publishes content in (BCP 47 tags, e.g.{0} <0/> or <1/>). Language pickers offer these, and a missing translation is flagged against this set."
 msgstr "Les langues dans lesquelles ce drive publie du contenu (balises BCP 47, p. ex. {0} <0/> ou <1/>). Les sélecteurs de langue les proposent, et une traduction manquante est signalée par rapport à cet ensemble."
 
-#: src/chunks/TablePage/ColumnLanguageChip.tsx
-msgid "LanguageChipTrigger"
-msgstr ""
-
 #: src/components/forms/ResourceForm.tsx
 msgid "This property is server-managed and cannot be edited."
-msgstr ""
+msgstr "Cette propriété est gérée par le serveur et ne peut pas être modifiée."
 
 #: src/routes/SyncRoute.tsx
 msgid "Local storage is off, so this server is the only data source. Enable local storage below to work disconnected."
@@ -5521,7 +5476,7 @@ msgstr "Nouveau lecteur"
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Joep's phone"
-msgstr ""
+msgstr "Téléphone de Joep"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
@@ -5530,30 +5485,30 @@ msgstr ""
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Tablet"
-msgstr ""
+msgstr "Tablette"
 
 #: src/helpers/knownPeers.test.ts
 #: src/helpers/knownPeers.test.ts
 msgid "Phone"
-msgstr ""
+msgstr "Téléphone"
 
 #: src/helpers/knownPeers.test.ts
 msgid "Real"
-msgstr ""
+msgstr "Réel"
 
 #: src/helpers/managedServer.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Failed to fetch"
-msgstr ""
+msgstr "Échec de la récupération"
 
 #: src/helpers/pairing.test.ts
 #: src/helpers/pairing.test.ts
 msgid "Joep’s phone"
-msgstr ""
+msgstr "Téléphone de Joep"
 
 #: src/helpers/managed/reconcile.test.ts
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #: src/routes/AppSettings.tsx
 msgid "Customize"
@@ -5562,12 +5517,12 @@ msgstr "Personnaliser"
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "Add {0}"
-msgstr ""
+msgstr "Ajouter {0}"
 
 #. 0: rowName
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 msgid "{0} title…"
-msgstr ""
+msgstr "Titre {0}…"
 
 #. 0: ' '
 #: src/routes/AppSettings.tsx
@@ -5576,91 +5531,91 @@ msgstr "<0/>{0} Mode coloré"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Leave video call"
-msgstr ""
+msgstr "Quitter l'appel vidéo"
 
 #: src/components/Presence/FollowSessionPanelContainer.tsx
 msgid "Start video call"
-msgstr ""
+msgstr "Lancer l'appel vidéo"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Microphone access was denied — allow it in your browser to join the call."
-msgstr ""
+msgstr "L'accès au microphone a été refusé — autorisez-le dans votre navigateur pour rejoindre l'appel."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "No microphone or camera found."
-msgstr ""
+msgstr "Aucun microphone ou caméra trouvé."
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Mute microphone"
-msgstr ""
+msgstr "Couper le microphone"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Unmute microphone"
-msgstr ""
+msgstr "Réactiver le microphone"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera off"
-msgstr ""
+msgstr "Désactiver la caméra"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Turn camera on"
-msgstr ""
+msgstr "Activer la caméra"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 msgid "Leave call"
-msgstr ""
+msgstr "Quitter l'appel"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change cover"
-msgstr ""
+msgstr "Changer la couverture"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove cover"
-msgstr ""
+msgstr "Supprimer la couverture"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Change icon"
-msgstr ""
+msgstr "Changer l'icône"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add icon"
-msgstr ""
+msgstr "Ajouter une icône"
 
 #: src/actions/resourceActions.tsx
 #: src/components/ResourceDecorations.tsx
 msgid "Add cover"
-msgstr ""
+msgstr "Ajouter une couverture"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an image shown as a banner at the top of this resource."
-msgstr ""
+msgstr "Choisissez une image affichée comme bannière en haut de cette ressource."
 
 #: src/components/ResourceDecorations.tsx
 msgid "Icon"
-msgstr ""
+msgstr "Icône"
 
 #: src/components/AvatarCropper.tsx
 msgid "Adjust image"
-msgstr ""
+msgstr "Ajuster l'image"
 
 #: src/components/AvatarCropper.tsx
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Remove icon"
-msgstr ""
+msgstr "Supprimer l'icône"
 
 #: src/actions/resourceActions.tsx
 msgid "Pick an emoji or image shown next to this resource wherever it appears."
-msgstr ""
+msgstr "Choisissez un emoji ou une image affiché(e) à côté de cette ressource partout où elle apparaît."
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Upload image"
-msgstr ""
+msgstr "<0/> Télécharger une image"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Upload image"
@@ -5669,7 +5624,7 @@ msgstr "Télécharger une image"
 #. 0: file.name
 #: src/components/AvatarCropper.tsx
 msgid "Could not display \"{0}\" — it may not be a supported image format"
-msgstr ""
+msgstr "Impossible d'afficher \"{0}\" — ce format d'image n'est peut-être pas pris en charge"
 
 #: src/chunks/EmojiInput/EmojiInput.tsx
 msgid "Pick existing"
@@ -5677,20 +5632,20 @@ msgstr "Choisir existant"
 
 #: src/components/ResourceDecorations.tsx
 msgid "<0/> Pick existing"
-msgstr ""
+msgstr "<0/> Choisir existant"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Reposition"
-msgstr ""
+msgstr "Repositionner"
 
 #: src/components/ResourceDecorations.tsx
 msgid "Drag to reposition · release to save"
-msgstr ""
+msgstr "Faites glisser pour repositionner · relâchez pour enregistrer"
 
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter the recovery code you saved for {0}."
-msgstr ""
+msgstr "Saisissez le code de récupération que vous avez enregistré pour {0}."
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
@@ -5702,24 +5657,24 @@ msgstr "Code de récupération"
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Copy the code to continue"
-msgstr ""
+msgstr "Copier le code pour continuer"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Save your new recovery code"
-msgstr ""
+msgstr "Enregistrer votre nouveau code de récupération"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Recovery code saved {0}"
-msgstr ""
+msgstr "Code de récupération enregistré le {0}"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save your recovery code"
-msgstr ""
+msgstr "Enregistrer votre code de récupération"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Are you sure you've stored this code somewhere safe? You cannot recover your account without it."
-msgstr ""
+msgstr "Êtes-vous sûr d'avoir stocké ce code en lieu sûr ? Vous ne pouvez pas récupérer votre compte sans lui."
 
 #: src/chunks/FormBuilder/FormAccessSection.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5729,63 +5684,59 @@ msgstr "Génération en cours…"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Generate my recovery code"
-msgstr ""
-
-#: src/helpers/managed/recovery.ts
-msgid "PrfUnsupportedError"
-msgstr ""
+msgstr "Générer mon code de récupération"
 
 #. 0: new Date().toISOString().slice(0, 10)
 #: src/helpers/managed/recovery.ts
 msgid "Passkey added {0}"
-msgstr ""
+msgstr "Clé d'accès ajoutée le {0}"
 
 #: src/helpers/managed/recovery.ts
 msgid "That passkey could not unlock this backup."
-msgstr ""
+msgstr "Cette clé d'accès n'a pas pu déverrouiller cette sauvegarde."
 
 #: src/helpers/managed/recovery.ts
 msgid "Wrong recovery code"
-msgstr ""
+msgstr "Code de récupération incorrect"
 
 #. 0: e.message
 #: src/components/NewIdentitySection.tsx
 msgid "{0} You can save a recovery code instead."
-msgstr ""
+msgstr "{0} Vous pouvez plutôt enregistrer un code de récupération."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Checking what this device supports…"
-msgstr ""
+msgstr "Vérification de ce que cet appareil prend en charge…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Waiting for your passkey…"
-msgstr ""
+msgstr "En attente de votre clé d'accès…"
 
 #: src/components/NewIdentitySection.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use a recovery code instead"
-msgstr ""
+msgstr "Utiliser un code de récupération à la place"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
-msgstr ""
+msgstr "Compte atomique"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Could not unlock with your passkey."
-msgstr ""
+msgstr "Impossible de déverrouiller avec votre clé d'accès."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock with your passkey"
-msgstr ""
+msgstr "Déverrouiller avec votre clé d’accès"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your passkey instead"
-msgstr ""
+msgstr "Utiliser votre clé d’accès à la place"
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/NewIdentitySection.tsx
@@ -5794,15 +5745,15 @@ msgstr "Impossible d'ajouter un code de récupération."
 
 #: src/components/NewIdentitySection.tsx
 msgid "This passkey only works on this device"
-msgstr ""
+msgstr "Cette clé d'accès ne fonctionne que sur cet appareil"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Give me a recovery code"
-msgstr ""
+msgstr "Donnez-moi un code de récupération"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Continue without one"
-msgstr ""
+msgstr "Continuer sans"
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5826,66 +5777,66 @@ msgstr "Afficher mon secret d'agent"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This is your account"
-msgstr ""
+msgstr "Ceci est votre compte"
 
 #. 0: PRODUCT_NAME
 #: src/components/NewIdentitySection.tsx
 msgid "Anyone who has this <0>is</0> you — on any device, forever. It can't be changed or revoked. It's also the only thing that still works if {0} disappears."
-msgstr ""
+msgstr "Quiconque possède ceci <0>est</0> vous — sur n'importe quel appareil, pour toujours. Il ne peut être modifié ni révoqué. C'est aussi la seule chose qui fonctionne encore si {0} disparaît."
 
 #. 0: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "Store it like a passport, not a password: a password manager, or{0} <0>Save backup file</0> below and move it somewhere private. Never email or chat it."
-msgstr ""
+msgstr "Stockez-le comme un passeport, pas comme un mot de passe : un gestionnaire de mots de passe, ou{0} <0>Enregistrer le fichier de sauvegarde</0> ci-dessous et déplacez-le dans un endroit privé. Ne l'envoyez jamais par e-mail ou par messagerie."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect your account"
-msgstr ""
+msgstr "Protéger votre compte"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+msgstr "Utilisez votre empreinte digitale, visage ou verrouillage d'écran — le même qui déverrouille cet appareil. Rien à écrire, et ça fonctionne aussi sur vos autres appareils."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
-msgstr ""
+msgstr "Utiliser une clé d'accès"
 
 #: src/components/NewIdentitySection.tsx
 msgid "This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account."
-msgstr ""
+msgstr "Cet appareil ne peut pas utiliser les clés d'accès, nous allons donc vous donner un code de récupération à la place — une clé de rechange pour votre compte."
 
 #: src/components/NewIdentitySection.tsx
 msgid "A spare key for your account."
-msgstr ""
+msgstr "Une clé de rechange pour votre compte."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Save a recovery code"
-msgstr ""
+msgstr "Enregistrer un code de récupération"
 
 #. 0: passkeySupported === false ? 'This device can’t use passkeys, so we’ll give you a recovery code instead — a spare key for your account.' \\: 'A spare key for your account.'; 1: ' '
 #: src/components/NewIdentitySection.tsx
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
-msgstr ""
+msgstr "{0}{1} Vous devrez également vous connecter à votre e-mail pour l'utiliser, donc il est sûr de le garder dans un gestionnaire de mots de passe ou sur papier."
 
 #: src/components/NewIdentitySection.tsx
 msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+msgstr "Elle n'est pas synchronisée avec vos autres appareils, donc perdre celui-ci vous bloquerait. Un code de récupération est une clé de rechange — vous aurez besoin de votre e-mail pour l'utiliser, donc il est sûr de le garder sur papier."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+msgstr "Conservez ceci en lieu sûr. Vous en aurez besoin — ainsi que votre e-mail — pour revenir. Nous ne pouvons pas le montrer à nouveau, mais vous pouvez en générer un nouveau depuis les Paramètres quand vous le souhaitez."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
-msgstr ""
+msgstr "Protéger mon compte"
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip this?"
-msgstr ""
+msgstr "Passer ?"
 
 #: src/components/NewIdentitySection.tsx
 msgid "<0>Then it's all on you.</0> We'll show you your secret next — it's the only copy that will ever exist, nobody can reset it for you, and losing it means losing your account and everything in it. Fine if you'll genuinely keep it safe."
-msgstr ""
+msgstr "<0>Alors tout repose sur vous.</0> Nous allons vous montrer votre secret ensuite — c'est la seule copie qui existera jamais, personne ne peut le réinitialiser pour vous, et le perdre signifie perdre votre compte et tout ce qu'il contient. C'est acceptable si vous le conservez vraiment en sécurité."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Nothing protects this account but the secret you saved during setup. That copy is the only one — we can't show it here, and we can't reset it. Keep it safe."
@@ -5904,15 +5855,15 @@ msgstr "Ce <0>est</0> votre compte — quiconque le possède est vous, sur n'imp
 #. 0: restore.email
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Unlock {0} with your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "Déverrouillez {0} avec votre empreinte digitale, votre visage ou le verrouillage d’écran."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "We've replaced your old recovery password with a stronger generated code. Keep it somewhere safe — you'll need it, plus your email, to get back in. We can't show it again, but you can generate a new one from Settings any time."
-msgstr ""
+msgstr "Nous avons remplacé votre ancien mot de passe de récupération par un code généré plus robuste. Conservez-le dans un endroit sûr — vous en aurez besoin, avec votre e-mail, pour vous reconnecter. Nous ne pouvons pas l’afficher à nouveau, mais vous pouvez en générer un nouveau à tout moment depuis les Paramètres."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Signed out of your account here — that secret belongs to a different one."
-msgstr ""
+msgstr "Déconnecté de votre compte ici — ce secret appartient à un compte différent."
 
 #: src/routes/SettingsAgent.tsx
 msgid "More profile fields"
@@ -5944,12 +5895,12 @@ msgstr "Ajouter une photo"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use your fingerprint, face, or screen lock."
-msgstr ""
+msgstr "Utilisez votre empreinte digitale, votre visage ou votre verrouillage d'écran."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "or sign in another way"
-msgstr ""
+msgstr "ou connectez-vous d'une autre manière"
 
 #: src/routes/SettingsAgent.tsx
 msgid "Sign out. You can get back in on this device with your passkey."
@@ -5974,7 +5925,7 @@ msgstr "Ouvrir par URL"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Continue as"
-msgstr ""
+msgstr "Continuer en tant que"
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not reach your backup. Try again."
@@ -5982,15 +5933,15 @@ msgstr "Impossible d'atteindre votre sauvegarde. Réessayez."
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Paste your agent secret"
-msgstr ""
+msgstr "Collez votre secret d'agent"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Use my account instead"
-msgstr ""
+msgstr "Utiliser mon compte à la place"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
-msgstr ""
+msgstr "Cela ne ressemble pas à un secret d'agent valide."
 
 #: src/routes/SettingsAgent.tsx
 msgid "Whether this browser stays signed in as you when anyone opens it."
@@ -6041,11 +5992,11 @@ msgstr "Relancer"
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry started."
-msgstr ""
+msgstr "Quand le suivi de cette entrée a commencé."
 
 #: src/chunks/TablePage/Timer/useTimerProps.ts
 msgid "When tracking of this entry stopped."
-msgstr ""
+msgstr "Quand le suivi de cette entrée s'est arrêté."
 
 #: src/chunks/TablePage/Timer/TimerToolbar.tsx
 msgid "One at a time"
@@ -6100,44 +6051,44 @@ msgstr "Calculé"
 #. 0: spec.label
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove the {0} column from this view. It is computed, so no data is deleted — add it back any time."
-msgstr ""
+msgstr "Retirez la colonne {0} de cette vue. Elle est calculée, donc aucune donnée n'est supprimée — vous pouvez la rajouter à tout moment."
 
 #: src/chunks/TablePage/DerivedColumnHeading.tsx
 msgid "Remove computed column"
-msgstr ""
+msgstr "Supprimer la colonne calculée"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Edit computed column"
-msgstr ""
+msgstr "Modifier la colonne calculée"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "New computed column"
-msgstr ""
+msgstr "Nouvelle colonne calculée"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Computes"
-msgstr ""
+msgstr "Calcule"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Choose a column…"
-msgstr ""
+msgstr "Choisissez une colonne…"
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "A fixed number…"
-msgstr ""
+msgstr "Un nombre fixe…"
 
 #. 0: arg.accepts === 'instant' ? 'date' \\: 'number'
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "This table has no {0} column to use here yet."
-msgstr ""
+msgstr "Ce tableau n'a pas encore de colonne {0} à utiliser ici."
 
 #: src/chunks/TablePage/DerivedColumnDialog.tsx
 msgid "Add column"
-msgstr ""
+msgstr "Ajouter une colonne"
 
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "No kind"
-msgstr ""
+msgstr "Aucun type"
 
 #: src/chunks/TablePage/TableSummaryBar.tsx
 msgid "Only the largest groups are shown."
@@ -6150,21 +6101,21 @@ msgstr "Par {0}"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down by"
-msgstr ""
+msgstr "Ventiler par"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per day"
-msgstr ""
+msgstr "Par jour"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per month"
-msgstr ""
+msgstr "Par mois"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Per exact value"
-msgstr ""
+msgstr "Par valeur exacte"
 
 #. 0: column.virtual?.label
 #: src/chunks/TablePage/TableHeading.tsx
@@ -6195,15 +6146,15 @@ msgstr "Effacer la répartition"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Break down the totals"
-msgstr ""
+msgstr "Ventiler les totaux"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Nothing — one total per column"
-msgstr ""
+msgstr "Rien — un total par colonne"
 
 #: src/chunks/TablePage/BreakdownDialog.tsx
 msgid "Splits each total per distinct value of a column — per project, per month, per status — under the table. Computed by the server over every matching row, like the totals themselves."
-msgstr ""
+msgstr "Divise chaque total par valeur distincte d'une colonne — par projet, par mois, par statut — sous le tableau. Calculé par le serveur sur chaque ligne correspondante, comme les totaux eux-mêmes."
 
 #: src/chunks/TablePage/TableTotalsFooter.tsx
 msgid "Add a totals row"
@@ -6258,44 +6209,44 @@ msgstr "Filtrer les lignes par une colonne"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "This dashboard has no blocks yet."
-msgstr ""
+msgstr "Ce tableau de bord n'a encore aucun bloc."
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Configure"
-msgstr ""
+msgstr "Configurer"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Width"
-msgstr ""
+msgstr "Largeur"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move earlier"
-msgstr ""
+msgstr "Déplacer plus tôt"
 
 #: src/chunks/DashboardPage/DashboardBlock.tsx
 msgid "Move later"
-msgstr ""
+msgstr "Déplacer plus tard"
 
 #. 0: kind
 #: src/chunks/DashboardPage/BlockRenderer.tsx
 msgid "This block is a “{0}”, which this version can’t show."
-msgstr ""
+msgstr "Ce bloc est un « {0} », que cette version ne peut pas afficher."
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "What this shows"
-msgstr ""
+msgstr "Ce que cela montre"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Every row"
-msgstr ""
+msgstr "Chaque ligne"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Rows"
-msgstr ""
+msgstr "Lignes"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Measure"
-msgstr ""
+msgstr "Mesure"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
@@ -6306,47 +6257,47 @@ msgstr "Choisir une colonne…"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Of"
-msgstr ""
+msgstr "De"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "One bar per"
-msgstr ""
+msgstr "Une barre par"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Each value"
-msgstr ""
+msgstr "Chaque valeur"
 
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Bucket"
-msgstr ""
+msgstr "Seau"
 
 #: src/chunks/DashboardPage/blocks/ViewBlock.tsx
 msgid "Pick a table to show"
-msgstr ""
+msgstr "Choisissez une table à afficher"
 
 #: src/chunks/DashboardPage/blocks/TextBlock.tsx
 msgid "Nothing written here yet"
-msgstr ""
+msgstr "Rien n’a encore été écrit ici"
 
 #: src/chunks/DashboardPage/blocks/StatBlock.tsx
 msgid "Pick something to measure"
-msgstr ""
+msgstr "Choisissez quelque chose à mesurer"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Pick a number and something to group it by"
-msgstr ""
+msgstr "Choisissez un nombre et un critère de regroupement"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "No data yet"
-msgstr ""
+msgstr "Aucune donnée pour le moment"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "Showing the largest"
-msgstr ""
+msgstr "Afficher les plus grands"
 
 #: src/chunks/DashboardPage/blocks/ChartBlock.tsx
 msgid "groups"
-msgstr ""
+msgstr "groupes"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/rowActions.ts
@@ -6356,35 +6307,35 @@ msgstr "Valeur"
 #. 0: spec.label
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove the {0} button from this view. Nothing already recorded by pressing it is affected — add it back any time."
-msgstr ""
+msgstr "Retirez le bouton {0} de cette vue. Rien de ce qui a déjà été enregistré en appuyant dessus n'est affecté — vous pouvez le rajouter à tout moment."
 
 #: src/chunks/TablePage/RowActionHeading.tsx
 msgid "Remove action"
-msgstr ""
+msgstr "Supprimer l'action"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Edit action"
-msgstr ""
+msgstr "Modifier l'action"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Add an action"
-msgstr ""
+msgstr "Ajouter une action"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Does what"
-msgstr ""
+msgstr "Fait quoi"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "This table has no column of the right kind for that yet."
-msgstr ""
+msgstr "Ce tableau n'a pas encore de colonne du bon type pour cela."
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "To column"
-msgstr ""
+msgstr "Vers la colonne"
 
 #: src/chunks/TablePage/RowActionDialog.tsx
 msgid "Pick an option…"
-msgstr ""
+msgstr "Choisissez une option…"
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 #: src/chunks/TablePage/RowActionDialog.tsx
@@ -6401,7 +6352,7 @@ msgstr "Un bouton sur chaque ligne : « Arrosé », « Marquer comme fait », «
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewTableDialog.tsx
 msgid "Creating table…"
-msgstr ""
+msgstr "Création de la table…"
 
 #: src/components/Template/ApplyTemplateDialog.tsx
 msgid "Applying template…"
@@ -6435,7 +6386,7 @@ msgstr "Enregistrer un flux"
 
 #: src/chunks/TablePage/QuickAddDialog.tsx
 msgid "It sits above the rows and creates one. Everything else about the row is edited in the table."
-msgstr ""
+msgstr "Elle se trouve au-dessus des lignes et en crée une. Tout le reste de la ligne se modifie dans le tableau."
 
 #: src/chunks/TablePage/QuickAddFields.tsx
 msgid "Ask for a value first"
@@ -6469,15 +6420,15 @@ msgstr "Définir également"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Pick a table to add to"
-msgstr ""
+msgstr "Choisissez une table à laquelle ajouter"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "Say what the button does"
-msgstr ""
+msgstr "Dites ce que fait le bouton"
 
 #: src/chunks/DashboardPage/blocks/CreateBlock.tsx
 msgid "That table has no row class yet"
-msgstr ""
+msgstr "Cette table n’a pas encore de classe de ligne"
 
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDashboardDialog.tsx
 msgid "Dashboard"
@@ -6497,51 +6448,51 @@ msgstr "Nouveau tableau de bord"
 
 #: src/chunks/DashboardPage/DashboardPage.tsx
 msgid "Nothing here yet. Add a number, a chart, a button or a table."
-msgstr ""
+msgstr "Rien ici pour l'instant. Ajoutez un nombre, un graphique, un bouton ou un tableau."
 
 #. 0: fn
 #: src/chunks/DashboardPage/BlockConfigDialog.tsx
 msgid "Pick a column for the {0} to measure"
-msgstr ""
+msgstr "Choisissez une colonne pour que {0} mesure"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Last watered"
-msgstr ""
+msgstr "Dernier arrosage"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Meat & fish"
-msgstr ""
+msgstr "Viande et poisson"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Quantity / unit"
-msgstr ""
+msgstr "Quantité / unité"
 
 #: src/helpers/stringToSlug.test.ts
 msgid "Plan B2 - final"
-msgstr ""
+msgstr "Plan B2 - final"
 
 #: src/chunks/TablePage/quickAdd.test.ts
 #: src/chunks/TablePage/quickAdd.test.ts
 msgid "What do you need?"
-msgstr ""
+msgstr "De quoi avez-vous besoin ?"
 
 #: src/chunks/TablePage/tableAggregates.test.ts
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: src/chunks/TablePage/rowActions.test.ts
 msgid "Do it"
-msgstr ""
+msgstr "Faire"
 
 #. 0: kind; 1: count
 #: src/chunks/TablePage/derivedColumns.test.ts
 msgid "{0} takes {1} arguments; raise MAX_DERIVED_ARGS and add a subscription in DerivedCell"
-msgstr ""
+msgstr "{0} prend {1} arguments ; augmentez MAX_DERIVED_ARGS et abonnez-vous dans DerivedCell"
 
 #. 0: aggregate.computedColumn
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a computed column of this view"
-msgstr ""
+msgstr "{0} n'est pas une colonne calculée de cette vue"
 
 #. 0: aggregate.column
 #. 0: value
@@ -6550,62 +6501,62 @@ msgstr ""
 #: src/chunks/TablePage/tableTemplates.test.ts
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is not a column"
-msgstr ""
+msgstr "{0} n'est pas une colonne"
 
 #. 0: derived.name; 1: name
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} is missing {1}"
-msgstr ""
+msgstr "{0} ne trouve pas {1}"
 
 #. 0: derived.name; 1: name; 2: value
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0}.{1} reads {2}"
-msgstr ""
+msgstr "{0}.{1} lit {2}"
 
 #. 0: action.label; 1: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} writes \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} écrit \"{1}\", qui n'est pas une colonne"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} stamps now into a {1} column"
-msgstr ""
+msgstr "{0} horodate maintenant dans une colonne {1}"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} toggles a {1} column"
-msgstr ""
+msgstr "{0} bascule une colonne {1}"
 
 #. 0: action.label; 1: type
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} increments a {1} column"
-msgstr ""
+msgstr "{0} incrémente une colonne {1}"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a step"
-msgstr ""
+msgstr "{0} nécessite une étape"
 
 #. 0: action.label
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} needs a value to write"
-msgstr ""
+msgstr "{0} nécessite une valeur à écrire"
 
 #. 0: action.label; 1: action.value; 2: action.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} sets \"{1}\", not an option of {2}"
-msgstr ""
+msgstr "{0} définit \"{1}\", qui n'est pas une option de {2}"
 
 #. 0: quickAdd.label; 1: quickAdd.field
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} types into \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} saisit dans \"{1}\", qui n'est pas une colonne"
 
 #. 0: quickAdd.label; 1: preset.column
 #: src/chunks/TablePage/tableTemplates.test.ts
 msgid "{0} presets \"{1}\", which is not a column"
-msgstr ""
+msgstr "{0} prédéfinit \"{1}\", qui n'est pas une colonne"
 
 #: src/chunks/FormBuilder/DeleteFormDialog.tsx
 msgid "Are you sure you want to delete this form?"
@@ -6964,36 +6915,58 @@ msgstr "Nomme la classe d'une seule soumission — par exemple, chaque réponse 
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Add a question before this one first"
-msgstr ""
+msgstr "Ajoutez d'abord une question avant celle-ci."
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "and"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "<0/> Add condition"
-msgstr ""
-
-#: src/chunks/FormBuilder/ConditionsEditor.tsx
-msgid "Show when"
-msgstr ""
+msgstr "et"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "All of these must match. Leave empty to always show."
-msgstr ""
+msgstr "Toutes ces conditions doivent être remplies. Laissez vide pour toujours afficher."
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "Remove condition"
-msgstr ""
+msgstr "Supprimer la condition"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "checked"
-msgstr ""
+msgstr "coché"
 
 #: src/chunks/FormBuilder/ConditionsEditor.tsx
 msgid "unchecked"
-msgstr ""
+msgstr "décoché"
 
 #: src/chunks/FormBuilder/FieldRow.tsx
+#: src/chunks/FormBuilder/PageTabBar.tsx
 msgid "Conditional"
-msgstr ""
+msgstr "Conditionnel"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add condition"
+msgstr "Ajouter une condition"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Done"
+msgstr "Terminé"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Always shown"
+msgstr "Toujours affiché"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "1 condition"
+msgstr "1 condition"
+
+#. 0: count
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "{0} conditions"
+msgstr "{0} conditions"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Page When"
+msgstr "Afficher la page quand"
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show Field When"
+msgstr "Afficher le champ quand"

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -1939,6 +1939,7 @@ msgstr "Veuillez patienter pendant que nous lions votre compte OpenRouter..."
 msgid "Set a title"
 msgstr "Définir un titre"
 
+#: src/chunks/FormBuilder/useFormQuestions.ts
 #: src/components/EditableTitle.tsx
 #: src/components/NavBar.tsx
 msgid "Untitled"
@@ -6960,3 +6961,39 @@ msgstr "Chaque réponse est une"
 #: src/components/forms/NewForm/CustomCreateActions/CustomForms/NewFormDialog.tsx
 msgid "Names the class of a single submission — e.g. every response of a Job Application form is an Application."
 msgstr "Nomme la classe d'une seule soumission — par exemple, chaque réponse d'un formulaire de candidature est une candidature."
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Add a question before this one first"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "and"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "<0/> Add condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Show when"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "All of these must match. Leave empty to always show."
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "Remove condition"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "checked"
+msgstr ""
+
+#: src/chunks/FormBuilder/ConditionsEditor.tsx
+msgid "unchecked"
+msgstr ""
+
+#: src/chunks/FormBuilder/FieldRow.tsx
+msgid "Conditional"
+msgstr ""

--- a/browser/data-browser/wuchale.config.js
+++ b/browser/data-browser/wuchale.config.js
@@ -67,7 +67,12 @@ const IGNORED_FUNCTIONS = ['effectFetch', 'JSON.stringify', 'JSON.parse'];
 export default defineConfig({
   // sourceLocale is en by default
   locales: ['en', 'es', 'fr', 'de'],
-  ai: openRouterTranslator(),
+  // `group` batches all target locales into ONE model request instead of one
+  // request per locale. In dev this matters a lot: wuchale's Vite transform
+  // BLOCKS the module (and thus the HMR update) until translation finishes,
+  // so ungrouped locales cost 3 sequential-ish OpenRouter round-trips
+  // (~6.5s measured) for every new string, vs ~1 round-trip grouped.
+  ai: openRouterTranslator({ group: { en: [['es', 'fr', 'de']] } }),
   adapters: {
     main: jsx({
       loader: 'react',

--- a/browser/e2e/tests/forms-submission.spec.ts
+++ b/browser/e2e/tests/forms-submission.spec.ts
@@ -545,6 +545,7 @@ test.describe('form publish and anonymous submit', () => {
     const requiredCheckbox = page.getByRole('checkbox');
     await requiredCheckbox.check();
 
+    await page.getByTestId('edit-conditions').click();
     await page.getByTestId('add-condition').click();
     await expect(page.getByTestId('condition-field')).toBeVisible();
     await expect(

--- a/browser/e2e/tests/forms-submission.spec.ts
+++ b/browser/e2e/tests/forms-submission.spec.ts
@@ -478,6 +478,194 @@ test.describe('form publish and anonymous submit', () => {
     await expect(page.getByText('Used', { exact: true })).toBeVisible();
   });
 
+  test('branching hides a follow-up unless its condition matches', async ({
+    page,
+    browser,
+  }) => {
+    test.slow();
+
+    const FORM_CONDITIONS =
+      'https://atomicdata.dev/properties/form-conditions';
+
+    await newResource('form', page);
+    await page.getByPlaceholder('New Form').fill('Pet survey');
+    await page.locator('dialog[open] button:has-text("Create")').click();
+    await page.waitForURL(url => url.pathname.startsWith('/app/show'), {
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('editable-title').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    const formSubject = await page.evaluate(() => {
+      const main = document.querySelector('main[about]');
+
+      return main?.getAttribute('about') ?? '';
+    });
+    expect(formSubject).toBeTruthy();
+
+    await page.getByTitle('Add field').click();
+    await page.getByRole('menuitem', { name: 'Radio group', exact: true }).click();
+    await expect(page.getByTestId('field-row-radio')).toBeVisible();
+    await page.getByTestId('field-row-radio').click();
+    await page.getByTestId('field-label-input').fill('Do you have a pet?');
+    const optionInputs = page.getByTestId('choice-option-input');
+    await optionInputs.nth(0).fill('Yes');
+    await optionInputs.nth(1).fill('No');
+    await page.waitForFunction(
+      ({ typeProp, optionsProp }) => {
+        for (const r of window.store.resources.values()) {
+          if (r.get(typeProp) === 'radio') {
+            const raw = r.get(optionsProp);
+            const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+
+            return parsed?.options?.[0] === 'Yes';
+          }
+        }
+
+        return false;
+      },
+      {
+        typeProp: 'https://atomicdata.dev/properties/form-field-type',
+        optionsProp: 'https://atomicdata.dev/properties/form-field-options',
+      },
+      { timeout: 10000 },
+    );
+
+    await page.getByTitle('Add field').click();
+    await page
+      .getByRole('menuitem', { name: 'Short text', exact: true })
+      .click();
+    await expect(page.getByTestId('field-row-short-text')).toBeVisible();
+    await page.getByTestId('field-row-short-text').click();
+    await page.getByTestId('field-label-input').fill("Pet's name");
+
+    // Required only applies while the field is visible — the interesting
+    // branching invariant the server also enforces.
+    const requiredCheckbox = page.getByRole('checkbox');
+    await requiredCheckbox.check();
+
+    await page.getByTestId('add-condition').click();
+    await expect(page.getByTestId('condition-field')).toBeVisible();
+    await expect(
+      page.getByTestId('condition-value').locator('option[value="Yes"]'),
+    ).toHaveCount(1, { timeout: 10000 });
+    await page.getByTestId('condition-value').selectOption('Yes');
+
+    const petNameSubject = await page.evaluate(
+      ({ fieldType, typeProp }) => {
+        for (const r of window.store.resources.values()) {
+          if (r.get(typeProp) === fieldType) {
+            return r.subject;
+          }
+        }
+
+        return undefined;
+      },
+      {
+        fieldType: 'short-text',
+        typeProp: 'https://atomicdata.dev/properties/form-field-type',
+      },
+    );
+    expect(petNameSubject).toBeTruthy();
+
+    await page.waitForFunction(
+      ({ subject, prop }) => {
+        const conds = window.store.resources.get(subject)?.get(prop);
+
+        return Array.isArray(conds) && conds.length > 0;
+      },
+      { subject: petNameSubject as string, prop: FORM_CONDITIONS },
+      { timeout: 15000 },
+    );
+    await page.waitForFunction(
+      () => window.store.getSyncStatus().pendingDirtyCount === 0,
+      undefined,
+      { timeout: 15000 },
+    );
+
+    await page.getByRole('button', { name: 'Publish', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Unpublish' })).toBeVisible();
+    await page.waitForFunction(
+      ({ subject, prop }) =>
+        typeof window.store.resources.get(subject)?.get(prop) === 'number',
+      { subject: formSubject, prop: FORM_PUBLISHED_AT },
+      { timeout: 10000 },
+    );
+    await page.waitForFunction(
+      () => window.store.getSyncStatus().pendingDirtyCount === 0,
+      undefined,
+      { timeout: 15000 },
+    );
+
+    await expect(async () => {
+      const res = await page.request.get(
+        `${SERVER_URL}/form/${encodeURIComponent(formSubject)}/definition`,
+      );
+      expect(res.ok()).toBe(true);
+      const body = await res.json();
+      const followUp = body.pages[0].blocks.find(
+        (b: { kind: string; label?: string }) =>
+          b.kind === 'field' && b.label === "Pet's name",
+      );
+      expect(followUp?.conditions?.[0]?.operator).toBe('equals');
+      expect(followUp?.conditions?.[0]?.value).toBe('Yes');
+    }).toPass({ timeout: 60000, intervals: [1000, 2000, 3000] });
+
+    const tableSubject = await page.evaluate(
+      ({ subject, prop }) =>
+        window.store.resources.get(subject)?.get(prop) as string | undefined,
+      { subject: formSubject, prop: FORM_TARGET_TABLE },
+    );
+    expect(tableSubject).toBeTruthy();
+
+    // Visitor 1: answers No — the required follow-up stays hidden and
+    // submit succeeds without it.
+    const visitorContext = await browser.newContext();
+    const visitorPage = await visitorContext.newPage();
+    await visitorPage.goto(`${SERVER_URL}/form/${formSubject}`);
+    await expect(
+      visitorPage.getByText('Do you have a pet?', { exact: false }),
+    ).toBeVisible({ timeout: 15000 });
+    await visitorPage.getByText('No', { exact: true }).click();
+    await expect(visitorPage.getByLabel("Pet's name")).toHaveCount(0);
+    const submit1 = visitorPage.getByRole('button', {
+      name: 'Submit',
+      exact: true,
+    });
+    await expect(submit1).toBeEnabled({ timeout: 30000 });
+    await submit1.click();
+    await expect(visitorPage.getByRole('status')).toContainText('Thank you', {
+      timeout: 15000,
+    });
+    await visitorContext.close();
+
+    // Visitor 2: answers Yes — follow-up appears, is required, then submits.
+    const visitor2Context = await browser.newContext();
+    const visitor2Page = await visitor2Context.newPage();
+    await visitor2Page.goto(`${SERVER_URL}/form/${formSubject}`);
+    await expect(
+      visitor2Page.getByText('Do you have a pet?', { exact: false }),
+    ).toBeVisible({ timeout: 15000 });
+    await visitor2Page.getByText('Yes', { exact: true }).click();
+    const petName = visitor2Page.getByLabel("Pet's name", { exact: false });
+    await expect(petName).toBeVisible();
+    await petName.fill('Spot');
+    const submit2 = visitor2Page.getByRole('button', {
+      name: 'Submit',
+      exact: true,
+    });
+    await expect(submit2).toBeEnabled({ timeout: 30000 });
+    await submit2.click();
+    await expect(visitor2Page.getByRole('status')).toContainText('Thank you', {
+      timeout: 15000,
+    });
+    await visitor2Context.close();
+
+    await openSubject(page, tableSubject as string);
+    await expect(page.getByText('Spot')).toBeVisible({ timeout: 15000 });
+  });
+
   test('unpublished form shows a friendly not-available page', async ({
     page,
     browser,

--- a/browser/form-app/README.md
+++ b/browser/form-app/README.md
@@ -25,7 +25,10 @@ Two ways to iterate:
 - **Through the embedded build** — `cd server && cargo run` (rebuilds the
   whole browser workspace, including this package, when sources change; set
   `ATOMICSERVER_SKIP_JS_BUILD=true` to skip and reuse the last build). Visit
-  `http://localhost:9883/form/:id`.
+  `http://localhost:9883/form/:id`. With the skip flag set, rebuild this
+  package yourself after `@tomic/form-renderer` changes (`pnpm --filter
+  @tomic/form-app build`) — otherwise the public route keeps a stale
+  renderer while the builder preview (Vite HMR) shows the new one.
 - **HMR against a running server** — `pnpm dev` here starts a Vite dev
   server on `:6748`. It fetches `/form/:id/definition` and POSTs to
   `/form/:id/submit` directly against `http://localhost:9883` (atomic-server

--- a/browser/form-app/vite.config.ts
+++ b/browser/form-app/vite.config.ts
@@ -1,14 +1,39 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const formRendererSrc = path.resolve(root, '../form-renderer/src');
 
 // TAURI is not relevant here — form-app is only ever server-embedded HTML,
 // never bundled into the desktop shell. `cspNonce` mirrors data-browser's
 // vite.config.ts: Vite stamps every script/link tag it emits with
 // `nonce="ATOMICSERVER_NONCE"`, and the server substitutes the real
 // per-request nonce at serve time (see server/src/handlers/form.rs).
+//
+// Resolve `@tomic/form-renderer` from source, not `dist/`. The published
+// `/form/:id` runtime is this package's production bundle (embedded by
+// server/build.rs); the builder preview imports the same renderer via
+// Vite HMR. Bundling from source keeps the two in lockstep when
+// form-renderer changes — otherwise a stale form-app/dist (common with
+// ATOMICSERVER_SKIP_JS_BUILD) ships an old renderer that ignores new
+// definition fields such as `conditions`.
 export default defineConfig({
   base: '/form-assets/',
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: '@tomic/form-renderer/style.css',
+        replacement: path.join(formRendererSrc, 'style.css'),
+      },
+      {
+        find: '@tomic/form-renderer',
+        replacement: path.join(formRendererSrc, 'index.ts'),
+      },
+    ],
+  },
   build: {
     outDir: 'dist',
   },

--- a/browser/form-renderer/package.json
+++ b/browser/form-renderer/package.json
@@ -21,7 +21,8 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   },
   "peerDependencies": {
     "react": ">19.2.0",
@@ -63,6 +64,7 @@
     "lint-fix": "oxlint -c ../.oxlintrc.json --fix . && pnpm format",
     "start": "pnpm watch",
     "watch": "tsup --watch",
-    "typecheck": "pnpm exec tsc --noEmit"
+    "typecheck": "pnpm exec tsc --noEmit",
+    "test": "vitest run"
   }
 }

--- a/browser/form-renderer/src/FormRenderer.tsx
+++ b/browser/form-renderer/src/FormRenderer.tsx
@@ -6,6 +6,7 @@ import {
   type FormValues,
 } from './types.js';
 import { validatePage, validateAll } from './validation.js';
+import { computeVisibility } from './conditions.js';
 import { FieldInput } from './FieldInput.js';
 import { FormMarkdown } from './FormMarkdown.js';
 
@@ -63,11 +64,38 @@ export function FormRenderer({
   }, [captchaEl]);
 
   const page = definition.pages[pageIndex];
-  const isLastPage = pageIndex === definition.pages.length - 1;
+  const visibility = computeVisibility(definition, values);
+  const visiblePageIndices = visibility.pageIndices;
+  const visiblePos = visiblePageIndices.indexOf(pageIndex);
+  const isLastPage =
+    visiblePageIndices.length === 0 ||
+    visiblePos === visiblePageIndices.length - 1 ||
+    (visiblePos < 0 && pageIndex >= (visiblePageIndices.at(-1) ?? 0));
   const progress =
-    definition.pages.length > 1 && definition.styling.showProgressBar !== false
-      ? Math.round(((pageIndex + 1) / definition.pages.length) * 100)
+    visiblePageIndices.length > 1 &&
+    definition.styling.showProgressBar !== false
+      ? Math.round(
+          ((Math.max(visiblePos, 0) + 1) / visiblePageIndices.length) * 100,
+        )
       : undefined;
+
+  const visiblePagesKey = visiblePageIndices.join(',');
+
+  // If the current page was hidden by a later answer change (unusual —
+  // page conditions typically reference earlier pages), snap to the
+  // nearest still-visible page so the visitor isn't stuck on a blank one.
+  useEffect(() => {
+    const indices = visiblePagesKey
+      ? visiblePagesKey.split(',').map(Number)
+      : [];
+
+    if (indices.length === 0) return;
+
+    if (indices.includes(pageIndex)) return;
+
+    const next = indices.find(i => i > pageIndex);
+    setPageIndex(next ?? indices[indices.length - 1]);
+  }, [pageIndex, visiblePagesKey]);
 
   const setValue = (mapsTo: string, value: unknown) => {
     setValues(prev => ({ ...prev, [mapsTo]: value }));
@@ -90,10 +118,21 @@ export function FormRenderer({
       return;
     }
 
-    setPageIndex(i => Math.min(i + 1, definition.pages.length - 1));
+    setPageIndex(i => {
+      const pos = visiblePageIndices.indexOf(i);
+      const nextPos = pos < 0 ? 0 : pos + 1;
+
+      return visiblePageIndices[nextPos] ?? i;
+    });
   };
 
-  const goBack = () => setPageIndex(i => Math.max(i - 1, 0));
+  const goBack = () =>
+    setPageIndex(i => {
+      const pos = visiblePageIndices.indexOf(i);
+      const prevPos = pos <= 0 ? 0 : pos - 1;
+
+      return visiblePageIndices[prevPos] ?? i;
+    });
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -105,12 +144,17 @@ export function FormRenderer({
     if (Object.keys(result.errors).length > 0) {
       setErrors(result.errors);
 
-      // Jump to the first page that has an error so the visitor sees it.
-      const firstErrorPage = definition.pages.findIndex(p =>
-        p.blocks.some(b => b.kind === 'field' && b.mapsTo in result.errors),
+      // Jump to the first *visible* page that has an error so the visitor sees it.
+      const firstErrorPage = visibility.pageIndices.find(i =>
+        definition.pages[i].blocks.some(
+          (b, bi) =>
+            b.kind === 'field' &&
+            visibility.blocks[i]?.has(bi) &&
+            b.mapsTo in result.errors,
+        ),
       );
 
-      if (firstErrorPage >= 0) setPageIndex(firstErrorPage);
+      if (firstErrorPage !== undefined) setPageIndex(firstErrorPage);
 
       return;
     }
@@ -173,6 +217,8 @@ export function FormRenderer({
 
       <div className='atomic-form-blocks'>
         {page?.blocks.map((block, i) => {
+          if (!visibility.blocks[pageIndex]?.has(i)) return null;
+
           if (block.kind === 'heading') {
             return (
               <h3 key={i} className='atomic-form-heading'>
@@ -275,7 +321,7 @@ export function FormRenderer({
       )}
 
       <div className='atomic-form-nav'>
-        {pageIndex > 0 && (
+        {pageIndex > 0 && visiblePos > 0 && (
           <button
             type='button'
             className='atomic-form-button atomic-form-button-secondary'

--- a/browser/form-renderer/src/conditions.test.ts
+++ b/browser/form-renderer/src/conditions.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { computeVisibility } from './conditions.js';
+import { validateAll } from './validation.js';
+import type {
+  FormDefinition,
+  FormPageDefinition,
+  FormValues,
+} from './types.js';
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../testdata/form-conditions.json',
+);
+
+interface FixtureCase {
+  name: string;
+  pages: FormPageDefinition[];
+  values: FormValues;
+  visibleFields: string[];
+  visiblePages: number[];
+  storedFields: string[];
+  valid: boolean;
+}
+
+interface FixtureFile {
+  cases: FixtureCase[];
+}
+
+const fixtures: FixtureFile = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+function asDefinition(pages: FormPageDefinition[]): FormDefinition {
+  return {
+    version: 1,
+    id: '',
+    name: 'fixture',
+    settings: {},
+    styling: {},
+    honeypotField: 'hp',
+    pages,
+  };
+}
+
+describe('form conditions (shared fixtures with server/src/forms.rs)', () => {
+  it.each(fixtures.cases)('$name', ({ pages, values, ...expected }) => {
+    const definition = asDefinition(pages);
+    const visibility = computeVisibility(definition, values);
+
+    expect([...visibility.fields]).toEqual(expected.visibleFields);
+    expect(visibility.pageIndices).toEqual(expected.visiblePages);
+
+    const result = validateAll(definition, values);
+    const stored = Object.keys(result.values);
+
+    expect(stored.sort()).toEqual([...expected.storedFields].sort());
+    expect(Object.keys(result.errors).length === 0).toBe(expected.valid);
+  });
+});

--- a/browser/form-renderer/src/conditions.ts
+++ b/browser/form-renderer/src/conditions.ts
@@ -1,0 +1,217 @@
+/**
+ * Visibility evaluator for FormCondition predicates. Mirrors
+ * `server/src/forms.rs` (`evaluate_condition` / `compute_visibility` /
+ * the hidden-field skip in `validate_submission`). Keep the two in
+ * lockstep — both are tested against `testdata/form-conditions.json`.
+ *
+ * AND semantics: every condition on a page/block must match. An empty
+ * list means always visible. Evaluation walks the form in document
+ * order; a referenced field that is itself hidden (or unanswered) fails
+ * the condition, so later questions cannot be unlocked by submitting a
+ * value for a hidden predecessor.
+ */
+import type {
+  FormBlock,
+  FormCondition,
+  FormDefinition,
+  FormPageDefinition,
+  FormValues,
+} from './types.js';
+
+export function blockConditions(block: FormBlock): FormCondition[] {
+  return block.conditions ?? [];
+}
+
+export function pageConditions(page: FormPageDefinition): FormCondition[] {
+  return page.conditions ?? [];
+}
+
+export function isEmptyValue(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.length === 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return false;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+
+    if (!Number.isNaN(n)) return n;
+  }
+
+  return undefined;
+}
+
+/** Numeric equality when both sides look like numbers; otherwise
+ * string/boolean/JSON equality. */
+export function jsonEqual(a: unknown, b: unknown): boolean {
+  const na = asNumber(a);
+  const nb = asNumber(b);
+
+  if (na !== undefined && nb !== undefined) {
+    return na === nb;
+  }
+
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return a === b;
+  }
+
+  if (typeof a === 'string' && typeof b === 'string') {
+    return a === b;
+  }
+
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function contains(answer: unknown, expected: unknown): boolean {
+  if (typeof answer === 'string') {
+    return answer.toLowerCase().includes(String(expected).toLowerCase());
+  }
+
+  if (Array.isArray(answer)) {
+    return answer.some(item => jsonEqual(item, expected));
+  }
+
+  return false;
+}
+
+function compare(answer: unknown, expected: unknown): number | undefined {
+  const na = asNumber(answer);
+  const nb = asNumber(expected);
+
+  if (na !== undefined && nb !== undefined) {
+    return na - nb;
+  }
+
+  if (typeof answer === 'string' && typeof expected === 'string') {
+    if (answer < expected) return -1;
+
+    if (answer > expected) return 1;
+
+    return 0;
+  }
+
+  return undefined;
+}
+
+/** A single predicate. Unanswered / hidden referenced fields fail
+ * (the dependent stays hidden). Unknown operators fail closed. */
+export function evaluateCondition(
+  condition: FormCondition,
+  answer: unknown,
+): boolean {
+  if (isEmptyValue(answer)) {
+    return false;
+  }
+
+  switch (condition.operator) {
+    case 'equals':
+      return jsonEqual(answer, condition.value);
+    case 'not-equals':
+      return !jsonEqual(answer, condition.value);
+    case 'contains':
+      return contains(answer, condition.value);
+
+    case 'greater-than': {
+      const cmp = compare(answer, condition.value);
+
+      return cmp !== undefined && cmp > 0;
+    }
+
+    case 'less-than': {
+      const cmp = compare(answer, condition.value);
+
+      return cmp !== undefined && cmp < 0;
+    }
+
+    default:
+      return false;
+  }
+}
+
+function conditionsMatch(
+  conditions: FormCondition[],
+  values: FormValues,
+  visibleFields: Set<string>,
+): boolean {
+  if (conditions.length === 0) return true;
+
+  return conditions.every(condition => {
+    const answer =
+      condition.field && visibleFields.has(condition.field)
+        ? values[condition.field]
+        : undefined;
+
+    return evaluateCondition(condition, answer);
+  });
+}
+
+export interface FormVisibility {
+  /** `mapsTo` of every visible input field, in document order. */
+  fields: Set<string>;
+  /** Indices of pages whose own conditions match. */
+  pageIndices: number[];
+  /** Per page, which block indices are visible (page-hidden → empty). */
+  blocks: Set<number>[];
+}
+
+/** Walk the definition in document order and decide what's shown. */
+export function computeVisibility(
+  definition: FormDefinition,
+  values: FormValues,
+): FormVisibility {
+  const fields = new Set<string>();
+  const pageIndices: number[] = [];
+  const blocks: Set<number>[] = [];
+
+  for (let p = 0; p < definition.pages.length; p++) {
+    const page = definition.pages[p];
+    const visibleBlocks = new Set<number>();
+
+    if (!conditionsMatch(pageConditions(page), values, fields)) {
+      blocks.push(visibleBlocks);
+      continue;
+    }
+
+    pageIndices.push(p);
+
+    for (let b = 0; b < page.blocks.length; b++) {
+      const block = page.blocks[b];
+
+      if (!conditionsMatch(blockConditions(block), values, fields)) {
+        continue;
+      }
+
+      visibleBlocks.add(b);
+
+      if (block.kind === 'field') {
+        fields.add(block.mapsTo);
+      }
+    }
+
+    blocks.push(visibleBlocks);
+  }
+
+  return { fields, pageIndices, blocks };
+}
+
+export function visibleFieldMaps(
+  definition: FormDefinition,
+  values: FormValues,
+): Set<string> {
+  return computeVisibility(definition, values).fields;
+}

--- a/browser/form-renderer/src/index.ts
+++ b/browser/form-renderer/src/index.ts
@@ -12,3 +12,10 @@ export {
   fieldBlocks,
 } from './validation.js';
 export type { ValidationResult } from './validation.js';
+export {
+  computeVisibility,
+  evaluateCondition,
+  visibleFieldMaps,
+  isEmptyValue,
+} from './conditions.js';
+export type { FormVisibility } from './conditions.js';

--- a/browser/form-renderer/src/types.ts
+++ b/browser/form-renderer/src/types.ts
@@ -27,11 +27,13 @@ export interface FieldOptions {
 export interface HeadingBlock {
   kind: 'heading';
   text: string;
+  conditions?: FormCondition[];
 }
 
 export interface ParagraphBlock {
   kind: 'paragraph';
   text: string;
+  conditions?: FormCondition[];
 }
 
 export interface FieldBlock {
@@ -42,14 +44,32 @@ export interface FieldBlock {
   type: FieldType;
   required: boolean;
   options: FieldOptions;
+  conditions?: FormCondition[];
 }
 
 export type FormBlock = HeadingBlock | ParagraphBlock | FieldBlock;
+
+export type ConditionOperator =
+  | 'equals'
+  | 'not-equals'
+  | 'contains'
+  | 'greater-than'
+  | 'less-than';
+
+/** Denormalized visibility predicate. `field` is the referenced question's
+ * `mapsTo` (property subject), not the FormField resource URL. Empty list on
+ * a page/block means always visible; multiple entries are ANDed. */
+export interface FormCondition {
+  field: string;
+  operator: ConditionOperator | string;
+  value: unknown;
+}
 
 export interface FormPageDefinition {
   name?: string | null;
   coverImage?: string | null;
   imagePosition?: string | null;
+  conditions?: FormCondition[];
   blocks: FormBlock[];
 }
 

--- a/browser/form-renderer/src/validation.ts
+++ b/browser/form-renderer/src/validation.ts
@@ -12,6 +12,7 @@ import type {
   FormErrors,
   FormValues,
 } from './types.js';
+import { computeVisibility, isEmptyValue } from './conditions.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -30,19 +31,7 @@ export function fieldBlocks(definition: FormDefinition): FieldBlock[] {
 }
 
 function isEmpty(value: unknown): boolean {
-  if (value === undefined || value === null) {
-    return true;
-  }
-
-  if (typeof value === 'string') {
-    return value.length === 0;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length === 0;
-  }
-
-  return false;
+  return isEmptyValue(value);
 }
 
 function checkMembership(
@@ -137,8 +126,10 @@ export interface ValidationResult {
   values: FormValues;
 }
 
-/** Validates every field on the given page (or every field in the whole
- * definition when `pageIndex` is omitted), including requiredness. */
+/** Validates every *visible* field on the given page (or every visible
+ * field in the whole definition when `pageIndex` is omitted), including
+ * requiredness. Hidden fields are skipped — required-on-hidden is not an
+ * error, and their values are not copied into the coerced result. */
 export function validatePage(
   definition: FormDefinition,
   pageIndex: number,
@@ -146,11 +137,19 @@ export function validatePage(
 ): ValidationResult {
   const errors: FormErrors = {};
   const coerced: FormValues = {};
+  const visibility = computeVisibility(definition, values);
+
+  if (!visibility.pageIndices.includes(pageIndex)) {
+    return { errors, values: coerced };
+  }
 
   const blocks: FormBlock[] = definition.pages[pageIndex]?.blocks ?? [];
+  const visibleBlocks = visibility.blocks[pageIndex] ?? new Set<number>();
 
-  for (const block of blocks) {
-    if (block.kind !== 'field') continue;
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+
+    if (block.kind !== 'field' || !visibleBlocks.has(i)) continue;
 
     const raw = values[block.mapsTo];
 

--- a/browser/form-renderer/tsconfig.json
+++ b/browser/form-renderer/tsconfig.json
@@ -10,5 +10,6 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/browser/lib/src/local-outbox.ts
+++ b/browser/lib/src/local-outbox.ts
@@ -153,6 +153,21 @@ export function isTerminalCommitErrorMessage(message: string): boolean {
  * Retrying spins the server (see the 401-flood); the only resolutions are a
  * rights change or the user abandoning the edit — neither helped by hammering.
  */
+/**
+ * Pattern-match the server's pending-deps rejection: "your Loro delta
+ * depends on ops I never received". Retrying the same delta can never
+ * succeed (the missing base ops won't materialize server-side), but the
+ * write is fully recoverable — the drain reacts by clearing the resource's
+ * save cursor so the next attempt exports a self-contained snapshot, which
+ * the server can always merge. So: not terminal (don't drop), not blocking
+ * (don't park); the caller resets the cursor and lets backoff retry.
+ */
+export function isPendingDepsCommitErrorMessage(message: string): boolean {
+  // Server emits: "Commit's Loro update depends on ops the server does not
+  // have — the update was parked as pending ..." (lib/src/commit.rs).
+  return message.includes('parked as pending');
+}
+
 export function isUnrecoverableCommitErrorMessage(message: string): boolean {
   // Server emits: "No https://atomicdata.dev/properties/write right has been found..."
   if (message.includes('/properties/write right has been found')) {

--- a/browser/lib/src/ontologies/forms.ts
+++ b/browser/lib/src/ontologies/forms.ts
@@ -13,6 +13,7 @@ export const forms = {
     formHeading: 'https://atomicdata.dev/classes/FormHeading',
     formParagraph: 'https://atomicdata.dev/classes/FormParagraph',
     formInviteCode: 'https://atomicdata.dev/classes/FormInviteCode',
+    formCondition: 'https://atomicdata.dev/classes/FormCondition',
   },
   properties: {
     formDataClass: 'https://atomicdata.dev/properties/form-data-class',
@@ -34,6 +35,11 @@ export const forms = {
     formAccess: 'https://atomicdata.dev/properties/form-access',
     formCode: 'https://atomicdata.dev/properties/form-code',
     usedAt: 'https://atomicdata.dev/properties/used-at',
+    formConditions: 'https://atomicdata.dev/properties/form-conditions',
+    formConditionField: 'https://atomicdata.dev/properties/form-condition-field',
+    formConditionOperator:
+      'https://atomicdata.dev/properties/form-condition-operator',
+    formConditionValue: 'https://atomicdata.dev/properties/form-condition-value',
   },
   __classDefs: {
     ['https://atomicdata.dev/classes/Form']: [
@@ -54,6 +60,7 @@ export const forms = {
       'https://atomicdata.dev/properties/name',
       'https://atomicdata.dev/properties/cover-image',
       'https://atomicdata.dev/properties/image-position',
+      'https://atomicdata.dev/properties/form-conditions',
     ],
     ['https://atomicdata.dev/classes/FormField']: [
       'https://atomicdata.dev/properties/name',
@@ -62,16 +69,24 @@ export const forms = {
       'https://atomicdata.dev/properties/description',
       'https://atomicdata.dev/properties/required',
       'https://atomicdata.dev/properties/form-field-options',
+      'https://atomicdata.dev/properties/form-conditions',
     ],
     ['https://atomicdata.dev/classes/FormHeading']: [
       'https://atomicdata.dev/properties/name',
+      'https://atomicdata.dev/properties/form-conditions',
     ],
     ['https://atomicdata.dev/classes/FormParagraph']: [
       'https://atomicdata.dev/properties/description',
+      'https://atomicdata.dev/properties/form-conditions',
     ],
     ['https://atomicdata.dev/classes/FormInviteCode']: [
       'https://atomicdata.dev/properties/form-code',
       'https://atomicdata.dev/properties/used-at',
+    ],
+    ['https://atomicdata.dev/classes/FormCondition']: [
+      'https://atomicdata.dev/properties/form-condition-field',
+      'https://atomicdata.dev/properties/form-condition-operator',
+      'https://atomicdata.dev/properties/form-condition-value',
     ],
   },
 } as const satisfies OntologyBaseObject;
@@ -84,6 +99,7 @@ export namespace Forms {
   export type FormHeading = typeof forms.classes.formHeading;
   export type FormParagraph = typeof forms.classes.formParagraph;
   export type FormInviteCode = typeof forms.classes.formInviteCode;
+  export type FormCondition = typeof forms.classes.formCondition;
 }
 
 declare module '../index.js' {
@@ -109,7 +125,8 @@ declare module '../index.js' {
       recommends:
         | 'https://atomicdata.dev/properties/name'
         | typeof forms.properties.coverImage
-        | typeof forms.properties.imagePosition;
+        | typeof forms.properties.imagePosition
+        | typeof forms.properties.formConditions;
     };
     [forms.classes.formField]: {
       requires:
@@ -120,19 +137,27 @@ declare module '../index.js' {
       recommends:
         | 'https://atomicdata.dev/properties/description'
         | typeof forms.properties.required
-        | typeof forms.properties.formFieldOptions;
+        | typeof forms.properties.formFieldOptions
+        | typeof forms.properties.formConditions;
     };
     [forms.classes.formHeading]: {
       requires: BaseProps | 'https://atomicdata.dev/properties/name';
-      recommends: never;
+      recommends: typeof forms.properties.formConditions;
     };
     [forms.classes.formParagraph]: {
       requires: BaseProps | 'https://atomicdata.dev/properties/description';
-      recommends: never;
+      recommends: typeof forms.properties.formConditions;
     };
     [forms.classes.formInviteCode]: {
       requires: BaseProps | typeof forms.properties.formCode;
       recommends: typeof forms.properties.usedAt;
+    };
+    [forms.classes.formCondition]: {
+      requires:
+        | BaseProps
+        | typeof forms.properties.formConditionField
+        | typeof forms.properties.formConditionOperator;
+      recommends: typeof forms.properties.formConditionValue;
     };
   }
 
@@ -155,6 +180,10 @@ declare module '../index.js' {
     [forms.properties.formAccess]: string;
     [forms.properties.formCode]: string;
     [forms.properties.usedAt]: number;
+    [forms.properties.formConditions]: string[];
+    [forms.properties.formConditionField]: string;
+    [forms.properties.formConditionOperator]: string;
+    [forms.properties.formConditionValue]: JSONValue;
   }
 
   interface PropSubjectToNameMapping {
@@ -176,5 +205,9 @@ declare module '../index.js' {
     [forms.properties.formAccess]: 'formAccess';
     [forms.properties.formCode]: 'formCode';
     [forms.properties.usedAt]: 'usedAt';
+    [forms.properties.formConditions]: 'formConditions';
+    [forms.properties.formConditionField]: 'formConditionField';
+    [forms.properties.formConditionOperator]: 'formConditionOperator';
+    [forms.properties.formConditionValue]: 'formConditionValue';
   }
 }

--- a/browser/lib/src/resource.test.ts
+++ b/browser/lib/src/resource.test.ts
@@ -489,6 +489,48 @@ describe('resource.ts', () => {
     const delta = doc.export({ mode: 'update', from: lvasAfterEcho });
     expect(delta.length).toBeGreaterThan(40);
   });
+
+  /**
+   * Regression: `cloneLoroStateFrom` used to stamp the CLONE's current
+   * oplog version as its save cursor whenever the source had any cursor.
+   * A clone (or `merge(…, { replaceLoroDocs: true })`) of a resource
+   * holding not-yet-drained local ops thereby marked those ops "already
+   * saved" — the next export started past them and the edit silently
+   * never reached the server. The clone must carry the source's cursor
+   * VALUE.
+   */
+  it('clone preserves the save cursor value, keeping un-drained ops exportable', async ({
+    expect,
+  }) => {
+    const name = 'https://atomicdata.dev/properties/name';
+    const r = new Resource('https://example.com/clone-cursor');
+    await r.set(name, 'a', false);
+    const doc = r.getLoroDoc()!;
+    doc.commit();
+
+    // Cursor state after a successful sign of "a".
+    const lvasAtSign = doc.oplogVersion();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (r as any)._loroVersionAtLastSave = lvasAtSign;
+
+    // A local edit that has NOT been drained yet.
+    await r.set(name, 'ab', false);
+    doc.commit();
+    expect(r.hasOpsPastSaveCursor()).toBe(true);
+
+    const cloned = r.clone();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clonedCursor = (cloned as any)._loroVersionAtLastSave;
+    expect(clonedCursor.encode()).toEqual(lvasAtSign.encode());
+    expect(cloned.hasOpsPastSaveCursor()).toBe(true);
+
+    // The next export from the clone still carries the un-drained op.
+    const delta = cloned
+      .getLoroDoc()!
+      .export({ mode: 'update', from: clonedCursor });
+    expect(delta.length).toBeGreaterThan(40);
+  });
 });
 
 describe('Resource.merge Loro options', () => {

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -1059,6 +1059,21 @@ export class Resource<C extends OptionalClass = any> {
     }
   }
 
+  /**
+   * Drop the save cursor entirely so the next drain export falls back to a
+   * FULL snapshot instead of a delta. Recovery path for the server's
+   * pending-deps rejection ("your update depends on ops I don't have"): the
+   * cursor sits past ops the server never received — usually because an
+   * earlier commit was lost in transit after the cursor advanced — so every
+   * delta exported from it is un-importable. A snapshot is self-contained:
+   * the server merges it and recovers the missing range along the way.
+   *
+   * @internal store-level drain only — not part of the public API.
+   */
+  public clearLoroSaveCursor(): void {
+    this._loroVersionAtLastSave = undefined;
+  }
+
   /** Base64-encode the current save cursor (last-synced Loro version) for
    *  durable storage. Returns undefined when nothing has synced yet (the
    *  cursor is the resource's whole history → handled as a first commit).
@@ -1254,8 +1269,18 @@ export class Resource<C extends OptionalClass = any> {
     this._loroDoc.import(snapshot);
     this._loroMap = this._loroDoc.getMap('properties');
 
+    // Carry over the source's cursor VALUE, not the doc's current version.
+    // Stamping `oplogVersion()` here would mark any not-yet-drained local
+    // ops as "already saved" — the next export would start past them and
+    // silently drop the edit on the wire (the incident class described in
+    // `initLoroSaveCursorIfFresh`). Copy via encode/decode: the clone's doc
+    // was seeded from the source's full snapshot, so the vector is valid
+    // for it, and sharing the WASM object would tie its lifetime to the
+    // source doc.
     this._loroVersionAtLastSave = resource._loroVersionAtLastSave
-      ? this._loroDoc.oplogVersion()
+      ? LoroLoader.Loro.VersionVector.decode(
+          resource._loroVersionAtLastSave.encode(),
+        )
       : undefined;
   }
 

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -450,6 +450,70 @@ describe('Store', () => {
     expect(store.getSyncStatus().pendingDirtyCount).toBe(0);
   });
 
+  it('recovers from a server pending-deps rejection by re-sending a full snapshot', async ({
+    expect,
+  }) => {
+    // Incident class: the save cursor sits PAST ops the server never
+    // received (an earlier commit was lost in transit after the cursor
+    // advanced), so every exported delta depends on ops the server doesn't
+    // have. The server now rejects those ("parked as pending"); the drain
+    // must react by dropping the cursor so the next attempt exports a
+    // self-contained snapshot that re-delivers the lost range.
+    const { store, posted, postCommitSpy } = await testStore();
+    const name = core.properties.name;
+    const description = core.properties.description;
+
+    const resource = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Folder',
+      propVals: { [name]: 'Before' },
+      parent: 'https://example.com/drive',
+    });
+    await resource.save();
+    const subject = resource.subject;
+
+    // The "lost" edit: committed locally, then the cursor is (wrongly)
+    // advanced past it without the server ever seeing a commit — the state
+    // the incident left the client in.
+    await resource.set(description, 'the lost edit', false);
+    resource.getLoroDoc()!.commit();
+    resource.markLoroSavedAt(resource.getLoroDoc()!.oplogVersion());
+
+    // Next edit exports a delta starting past the lost ops; the server
+    // rejects it the way lib/src/commit.rs now does.
+    postCommitSpy.mockImplementationOnce(async () => {
+      throw new Error(
+        "Commit's Loro update depends on ops the server does not have — the " +
+          'update was parked as pending and none of its changes could be applied.',
+      );
+    });
+    await resource.set(name, 'After', false);
+    const postedBefore = posted.length;
+    await resource.save();
+
+    // The rejected attempt must keep the entry queued (not drop it) …
+    expect(store.outbox.hasPending(subject)).toBe(true);
+
+    // … and the retry (once due) must send a FULL snapshot. Clear the
+    // backoff window so the next drain attempts immediately.
+    const entry = store.outbox.getEntry(subject)!;
+    entry.failures = 0;
+    entry.lastAttemptAt = undefined;
+    await store.syncDirtyResources();
+
+    expect(posted.length).toBe(postedBefore + 1);
+    const resent = posted[posted.length - 1];
+
+    // Self-contained proof: the resent bytes import COMPLETE into a fresh
+    // doc (a delta would leave pending ops) and carry BOTH edits — the
+    // lost one and the new one.
+    const probe = new Resource(subject);
+    const { complete } = probe.importLoroUpdate(resent.loroUpdate!);
+    expect(complete).toBe(true);
+    expect(probe.get(name)).toBe('After');
+    expect(probe.get(description)).toBe('the lost edit');
+    expect(store.outbox.hasPending(subject)).toBe(false);
+  });
+
   it('counts scheduled (debounce-pending) saves in sync status', ({
     expect,
   }) => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -50,6 +50,7 @@ import { DrivePresenceManager } from './presence.js';
 import { perfMark, perfSpan } from './perf-trace.js';
 import {
   LocalOutbox,
+  isPendingDepsCommitErrorMessage,
   isTerminalCommitError,
   isUnrecoverableCommitError,
   type OutboxEntry,
@@ -1305,7 +1306,25 @@ export class Store {
     builder.setLoroUpdate(delta);
     const commit = await builder.sign(agent);
 
-    const created = await this.postCommit(commit, endpoint);
+    let created: Commit;
+
+    try {
+      created = await this.postCommit(commit, endpoint);
+    } catch (e) {
+      // Pending-deps rejection: the delta we just sent starts past ops the
+      // server never received (an earlier commit was lost after the save
+      // cursor advanced). Retrying the same delta can never succeed — the
+      // missing base won't appear server-side. Drop the cursor so the next
+      // drain attempt (scheduled by the outbox backoff) exports a
+      // self-contained snapshot, which the server can always merge; that
+      // re-delivers the lost range too.
+      if (e instanceof Error && isPendingDepsCommitErrorMessage(e.message)) {
+        resource.clearLoroSaveCursor();
+      }
+
+      throw e;
+    }
+
     const commitId = commitIdOf(created);
 
     if (commit.signature) {

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -534,10 +534,13 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(supports-color@10.2.2)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   lib:
     dependencies:
@@ -577,7 +580,7 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(supports-color@10.2.2)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -642,7 +645,7 @@ importers:
         version: 5.3.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(supports-color@10.2.2)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -12776,7 +12779,7 @@ snapshots:
   '@parcel/watcher-wasm@2.5.6':
     dependencies:
       is-glob: 4.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
@@ -12792,7 +12795,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -13326,7 +13329,7 @@ snapshots:
   '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 8.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rolldown: 1.1.5
     optionalDependencies:
       '@babel/runtime': 7.29.2
@@ -13377,7 +13380,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.4
 
@@ -14455,7 +14458,7 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -14869,7 +14872,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   babel-plugin-styled-components@2.3.0(@babel/core@8.0.1)(styled-components@6.4.2(css-to-react-native@3.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
@@ -20051,8 +20054,8 @@ snapshots:
 
   tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
@@ -20167,7 +20170,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.22)(supports-color@10.2.2)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -20568,11 +20571,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/docs/src/schema/forms.md
+++ b/docs/src/schema/forms.md
@@ -44,6 +44,7 @@ Properties:
 - [`name`](https://atomicdata.dev/properties/name) - (recommended, String) the page's title.
 - [`cover-image`](https://atomicdata.dev/properties/cover-image) - (recommended, AtomicURL, File) an optional cover image.
 - [`image-position`](https://atomicdata.dev/properties/image-position) - (recommended, String) where the cover image is positioned. Same values as on Form (see above); currently unused by the builder, which themes at the Form level.
+- [`form-conditions`](https://atomicdata.dev/properties/form-conditions) - (recommended, ResourceArray, FormCondition) visibility predicates. All must match (AND) for the page to be shown; an empty list means always visible. Evaluated against answers from earlier pages.
 
 ## FormField
 
@@ -62,6 +63,7 @@ Properties:
 - [`description`](https://atomicdata.dev/properties/description) - (recommended, Markdown) helper text shown below the label.
 - [`required`](https://atomicdata.dev/properties/required) - (recommended, Boolean) whether an answer is mandatory.
 - [`form-field-options`](https://atomicdata.dev/properties/form-field-options) - (recommended, JSON) type-specific settings (placeholder, min/max, choice options, ...); shape depends on `form-field-type`.
+- [`form-conditions`](https://atomicdata.dev/properties/form-conditions) - (recommended, ResourceArray, FormCondition) visibility predicates. All must match (AND) for the field to be shown. Hidden fields are not validated and their submitted values are dropped.
 
 ## FormHeading
 
@@ -70,6 +72,7 @@ _URL: [`https://atomicdata.dev/classes/FormHeading`](https://atomicdata.dev/clas
 A heading layout block inside a FormPage's `form-fields` list.
 
 - [`name`](https://atomicdata.dev/properties/name) - (required, String) the heading text.
+- [`form-conditions`](https://atomicdata.dev/properties/form-conditions) - (recommended, ResourceArray, FormCondition) visibility predicates, same AND semantics as on FormField.
 
 ## FormParagraph
 
@@ -78,6 +81,27 @@ _URL: [`https://atomicdata.dev/classes/FormParagraph`](https://atomicdata.dev/cl
 A paragraph layout block inside a FormPage's `form-fields` list, rendered as markdown.
 
 - [`description`](https://atomicdata.dev/properties/description) - (required, Markdown) the paragraph body.
+- [`form-conditions`](https://atomicdata.dev/properties/form-conditions) - (recommended, ResourceArray, FormCondition) visibility predicates, same AND semantics as on FormField.
+
+## FormCondition
+
+_URL: [`https://atomicdata.dev/classes/FormCondition`](https://atomicdata.dev/classes/FormCondition)_
+
+A single visibility predicate on a page, field, or layout block. The parent
+lists its predicates in `form-conditions`; they are ANDed. Stored as a child
+of the thing it hides, so hierarchy rights keep them private to form editors
+— they appear in the public definition JSON only as denormalized
+`{ field, operator, value }` objects (`field` is the referenced question's
+`form-maps-to` property URL, not the FormField subject).
+
+- [`form-condition-field`](https://atomicdata.dev/properties/form-condition-field) - (required, AtomicURL, FormField) the question whose answer is inspected.
+- [`form-condition-operator`](https://atomicdata.dev/properties/form-condition-operator) - (required, String) one of: `equals`, `not-equals`, `contains`, `greater-than`, `less-than` — enforced by the application, not the store (see note below).
+- [`form-condition-value`](https://atomicdata.dev/properties/form-condition-value) - (recommended, JSON) the comparison value. Shape depends on the referenced field.
+
+An unanswered or hidden referenced field fails the condition (the dependent
+stays hidden). `contains` is a case-insensitive substring on strings and
+membership on multi-select arrays. `greater-than` / `less-than` compare
+numerically, falling back to lexicographic string order (ISO dates work).
 
 ## FormInviteCode
 
@@ -107,12 +131,8 @@ the resource.
 }
 ```
 
-Not yet in scope for this phase: conditional field/page visibility
-(`form-conditions`), and `form-styling` (colors, fonts, logo) — both are
-should-have follow-ups.
-
-Note on `form-field-type` / `image-position`: [`allowsOnly`](https://atomicdata.dev/properties/allowsOnly)
+Note on `form-field-type` / `image-position` / `form-condition-operator`: [`allowsOnly`](https://atomicdata.dev/properties/allowsOnly)
 can only restrict a property to a list of URL-parseable subjects, so it can't
-hold plain enum strings like `short-text`. These two properties are therefore
-unenforced `String`s at the store level for now; the enum is validated by the
-form builder and (in a later phase) by the submission endpoint.
+hold plain enum strings like `short-text`. These properties are therefore
+unenforced `String`s at the store level; the enum is validated by the
+form builder and the submission endpoint.

--- a/lib/defaults/forms.json
+++ b/lib/defaults/forms.json
@@ -194,7 +194,8 @@
     "https://atomicdata.dev/properties/recommends": [
       "https://atomicdata.dev/properties/name",
       "https://atomicdata.dev/properties/cover-image",
-      "https://atomicdata.dev/properties/image-position"
+      "https://atomicdata.dev/properties/image-position",
+      "https://atomicdata.dev/properties/form-conditions"
     ],
     "https://atomicdata.dev/properties/requires": [
       "https://atomicdata.dev/properties/form-fields"
@@ -252,7 +253,8 @@
     "https://atomicdata.dev/properties/recommends": [
       "https://atomicdata.dev/properties/description",
       "https://atomicdata.dev/properties/required",
-      "https://atomicdata.dev/properties/form-field-options"
+      "https://atomicdata.dev/properties/form-field-options",
+      "https://atomicdata.dev/properties/form-conditions"
     ],
     "https://atomicdata.dev/properties/requires": [
       "https://atomicdata.dev/properties/name",
@@ -268,6 +270,9 @@
       "https://atomicdata.dev/classes/Class"
     ],
     "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/classes",
+    "https://atomicdata.dev/properties/recommends": [
+      "https://atomicdata.dev/properties/form-conditions"
+    ],
     "https://atomicdata.dev/properties/requires": [
       "https://atomicdata.dev/properties/name"
     ],
@@ -280,10 +285,71 @@
       "https://atomicdata.dev/classes/Class"
     ],
     "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/classes",
+    "https://atomicdata.dev/properties/recommends": [
+      "https://atomicdata.dev/properties/form-conditions"
+    ],
     "https://atomicdata.dev/properties/requires": [
       "https://atomicdata.dev/properties/description"
     ],
     "https://atomicdata.dev/properties/shortname": "form-paragraph"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/form-conditions",
+    "https://atomicdata.dev/properties/classtype": "https://atomicdata.dev/classes/FormCondition",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/resourceArray",
+    "https://atomicdata.dev/properties/description": "Visibility conditions on a FormPage, FormField, or layout block. All conditions must match (AND) for the item to be shown; an empty list means always visible. Each entry is a FormCondition.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "form-conditions"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/form-condition-field",
+    "https://atomicdata.dev/properties/classtype": "https://atomicdata.dev/classes/FormField",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/atomicURL",
+    "https://atomicdata.dev/properties/description": "The FormField whose answer this FormCondition inspects.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "form-condition-field"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/form-condition-operator",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/string",
+    "https://atomicdata.dev/properties/description": "How a FormCondition compares the referenced field's answer to `form-condition-value`. One of: equals, not-equals, contains, greater-than, less-than. Unenforced at the store (plain String, same limitation as form-field-type); the form builder and submission validator check the enum.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "form-condition-operator"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/form-condition-value",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/json",
+    "https://atomicdata.dev/properties/description": "The comparison value for a FormCondition. Shape depends on the referenced field (string, number, boolean, ...).",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "form-condition-value"
+  },
+  {
+    "@id": "https://atomicdata.dev/classes/FormCondition",
+    "https://atomicdata.dev/properties/description": "A single visibility predicate: show the parent page/field/block when `form-condition-field`'s answer matches `form-condition-value` under `form-condition-operator`. Stored as a child of the thing it hides, listed in that resource's `form-conditions` array. Multiple conditions on one parent are ANDed.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Class"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/classes",
+    "https://atomicdata.dev/properties/recommends": [
+      "https://atomicdata.dev/properties/form-condition-value"
+    ],
+    "https://atomicdata.dev/properties/requires": [
+      "https://atomicdata.dev/properties/form-condition-field",
+      "https://atomicdata.dev/properties/form-condition-operator"
+    ],
+    "https://atomicdata.dev/properties/shortname": "form-condition"
   },
   {
     "@id": "https://atomicdata.dev/ontology/forms",
@@ -300,7 +366,8 @@
       "https://atomicdata.dev/classes/FormField",
       "https://atomicdata.dev/classes/FormHeading",
       "https://atomicdata.dev/classes/FormParagraph",
-      "https://atomicdata.dev/classes/FormInviteCode"
+      "https://atomicdata.dev/classes/FormInviteCode",
+      "https://atomicdata.dev/classes/FormCondition"
     ],
     "https://atomicdata.dev/properties/properties": [
       "https://atomicdata.dev/properties/form-data-class",
@@ -320,7 +387,11 @@
       "https://atomicdata.dev/properties/form-submission-summary",
       "https://atomicdata.dev/properties/form-access",
       "https://atomicdata.dev/properties/form-code",
-      "https://atomicdata.dev/properties/used-at"
+      "https://atomicdata.dev/properties/used-at",
+      "https://atomicdata.dev/properties/form-conditions",
+      "https://atomicdata.dev/properties/form-condition-field",
+      "https://atomicdata.dev/properties/form-condition-operator",
+      "https://atomicdata.dev/properties/form-condition-value"
     ]
   }
 ]

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -56,6 +56,12 @@ pub struct CommitApplied {
     /// present (an idempotent replay), so producing no state change is
     /// expected and correct, not a silent LWW loss.
     pub imported_new_ops: bool,
+    /// True when the commit's `loroUpdate` carried ops whose causal
+    /// dependencies are missing from the stored doc. Loro parks those ops
+    /// as *pending*: they don't advance the version vector and contribute
+    /// nothing to state, so without an explicit check they masquerade as
+    /// an idempotent replay while the client's writes silently vanish.
+    pub imported_pending_ops: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -596,6 +602,33 @@ impl Commit {
         // job of the genesis certificate (`planning/genesis-self-verifying.md`),
         // where identity metadata is signed into the DID, not a settable propval.
 
+        // Pending-import guard: the commit's loroUpdate contained ops whose
+        // causal dependencies are missing from the stored doc (e.g. the
+        // client's earlier commit never arrived, or the server's state was
+        // rolled back). Loro parks those ops as "pending": the version
+        // vector doesn't advance and the diff is empty, which makes the
+        // commit look exactly like an idempotent replay below — silently
+        // ACKing the client while its writes go nowhere, and every later
+        // delta from that client inherits the same fate. Reject instead so
+        // the client keeps its save cursor, refetches, and re-sends the
+        // full range.
+        if opts.validate_loro_causality && applied.imported_pending_ops {
+            tracing::warn!(
+                subject = %commit.subject,
+                loro_bytes = commit.loro_update.as_ref().map(|b| b.len()).unwrap_or(0),
+                "[causality-guard] rejecting commit whose Loro update depends on ops missing from the stored doc (import left ops pending)"
+            );
+
+            return Err(format!(
+                "Commit's Loro update depends on ops the server does not have — the update \
+                 was parked as pending and none of its changes could be applied. An earlier \
+                 commit from this client likely never arrived. Refetch the resource and \
+                 re-send the missing changes. subject={}",
+                commit.subject,
+            )
+            .into());
+        }
+
         // Causality guard: a commit with a non-trivial loroUpdate that
         // produces ZERO net state change.
         //
@@ -903,6 +936,7 @@ impl Commit {
         let mut add_atoms: Vec<Atom> = Vec::new();
         let mut changed_props: HashSet<String> = HashSet::new();
         let mut imported_new_ops = false;
+        let mut imported_pending_ops = false;
 
         if let Some(loro_update_bytes) = &self.loro_update {
             // Seed from the current resource state when no snapshot exists yet so
@@ -918,6 +952,7 @@ impl Commit {
             let diff = loro_doc
                 .import_update_with_diff(loro_update_bytes, &resource.get_subject().to_string())?;
             imported_new_ops = loro_doc.oplog_vv_map() != vv_before;
+            imported_pending_ops = diff.imported_pending_ops;
 
             // Track which properties changed
             for atom in &diff.add_atoms {
@@ -951,6 +986,7 @@ impl Commit {
             remove_atoms,
             changed_props,
             imported_new_ops,
+            imported_pending_ops,
         })
     }
 
@@ -2401,6 +2437,116 @@ mod test {
             after.get(crate::urls::NAME).unwrap().to_string(),
             "Renamed",
             "state must be unchanged by the idempotent replay",
+        );
+    }
+
+    /// A commit whose Loro delta depends on ops the server never received
+    /// must be REJECTED — not silently accepted as an "idempotent replay".
+    /// Loro parks such ops as pending (VV doesn't advance, diff is empty),
+    /// which without an explicit guard is indistinguishable from a replay:
+    /// the server ACKs, the client advances its save cursor, and the missing
+    /// edit is permanently lost on both sides. Regression test for a real
+    /// incident where a form's `form-pages` update vanished this way.
+    #[tokio::test]
+    async fn commit_with_pending_loro_deps_is_rejected() {
+        let (store, agent) = store_with_known_agent().await;
+        let subject = "https://localhost/pending_deps_target";
+
+        let opts = CommitOpts {
+            validate_schema: true,
+            validate_signature: true,
+            validate_timestamp: false,
+            validate_previous_commit: false,
+            validate_loro_causality: true,
+            validate_rights: false,
+            validate_for_agent: None,
+            update_index: true,
+            source_id: None,
+        };
+
+        // Commit 1: create the resource from a full snapshot.
+        let client_doc = crate::loro::AtomicLoroDoc::new();
+        client_doc
+            .set_property(crate::urls::NAME, &Value::String("Original".into()))
+            .unwrap();
+        client_doc
+            .set_property(
+                crate::urls::IS_A,
+                &Value::ResourceArray(vec![crate::urls::CLASS.to_string().into()]),
+            )
+            .unwrap();
+        client_doc
+            .set_property(crate::urls::SHORTNAME, &Value::String("orig".into()))
+            .unwrap();
+        client_doc
+            .set_property(crate::urls::DESCRIPTION, &Value::String("desc".into()))
+            .unwrap();
+        let empty = Resource::new(subject.into());
+        let mut builder = CommitBuilder::new(subject.into());
+        builder.set_loro_update(client_doc.export_snapshot());
+        let commit1 = builder.sign(&agent, &store, &empty).await.unwrap();
+        store.apply_commit(commit1, &opts).await.unwrap();
+        let after_first = store.get_resource(&subject.into()).await.unwrap();
+        let vv_synced = client_doc.oplog_vv();
+
+        // Edit A: never reaches the server (its commit was lost in transit).
+        client_doc
+            .set_property(
+                crate::urls::DESCRIPTION,
+                &Value::String("the lost edit".into()),
+            )
+            .unwrap();
+        client_doc.commit_with_message("edit A");
+        let vv_after_lost_edit = client_doc.oplog_vv();
+
+        // Edit B: exported as a delta that starts AFTER edit A, so its ops
+        // causally depend on ops the server never got.
+        client_doc
+            .set_property(crate::urls::NAME, &Value::String("Renamed".into()))
+            .unwrap();
+        client_doc.commit_with_message("edit B");
+        let orphan_delta = client_doc.export_updates_since(&vv_after_lost_edit);
+
+        let mut builder2 = CommitBuilder::new(subject.into());
+        builder2.set_loro_update(orphan_delta);
+        let commit2 = builder2.sign(&agent, &store, &after_first).await.unwrap();
+        let err = store
+            .apply_commit(commit2, &opts)
+            .await
+            .expect_err("a delta depending on ops the server never received must be rejected");
+        assert!(
+            err.to_string().contains("pending"),
+            "rejection should name the pending import, got: {err}"
+        );
+
+        let after = store.get_resource(&subject.into()).await.unwrap();
+        assert_eq!(
+            after.get(crate::urls::NAME).unwrap().to_string(),
+            "Original",
+            "the orphaned delta must not have changed stored state"
+        );
+
+        // Recovery: re-sending the FULL missing range (everything since the
+        // last acked version) is accepted and lands both edits.
+        let full_delta = client_doc.export_updates_since(&vv_synced);
+        let mut builder3 = CommitBuilder::new(subject.into());
+        builder3.set_loro_update(full_delta);
+        let commit3 = builder3.sign(&agent, &store, &after_first).await.unwrap();
+        store
+            .apply_commit(commit3, &opts)
+            .await
+            .expect("re-sending the full range must be accepted");
+        let recovered = store.get_resource(&subject.into()).await.unwrap();
+        assert_eq!(
+            recovered.get(crate::urls::NAME).unwrap().to_string(),
+            "Renamed"
+        );
+        assert_eq!(
+            recovered
+                .get(crate::urls::DESCRIPTION)
+                .unwrap()
+                .to_string(),
+            "the lost edit"
         );
     }
 

--- a/lib/src/loro.rs
+++ b/lib/src/loro.rs
@@ -108,6 +108,12 @@ impl std::fmt::Debug for AtomicLoroDoc {
 pub struct LoroDiff {
     pub add_atoms: Vec<Atom>,
     pub remove_atoms: Vec<Atom>,
+    /// True when the imported update contained ops whose causal
+    /// dependencies are missing from this doc. Loro parks such ops as
+    /// "pending": they don't advance the version vector and contribute
+    /// nothing to state, so accepting a commit in that condition silently
+    /// discards the client's writes.
+    pub imported_pending_ops: bool,
 }
 
 impl AtomicLoroDoc {
@@ -144,10 +150,25 @@ impl AtomicLoroDoc {
 
     /// Import a binary update (from a commit's loroUpdate field).
     pub fn import_update(&self, update: &[u8]) -> AtomicResult<()> {
-        self.doc
+        self.import_update_status(update).map(|_| ())
+    }
+
+    /// Import a binary update and report whether any of its ops were parked
+    /// as *pending* — ops whose causal dependencies are missing from this
+    /// doc. Pending ops don't advance the version vector and contribute
+    /// nothing to state; callers that must not lose data (the `/commit`
+    /// apply path) should treat `true` as a hard error rather than a
+    /// successful no-op.
+    pub fn import_update_status(&self, update: &[u8]) -> AtomicResult<bool> {
+        let status = self
+            .doc
             .import(update)
             .map_err(|e| format!("Failed to import Loro update: {e}"))?;
-        Ok(())
+        let has_pending = status
+            .pending
+            .as_ref()
+            .is_some_and(|range| range.iter().next().is_some());
+        Ok(has_pending)
     }
 
     /// Export a snapshot of the full document state.
@@ -764,7 +785,7 @@ impl AtomicLoroDoc {
     /// Compares the properties map before and after the import.
     pub fn import_update_with_diff(&self, update: &[u8], subject: &str) -> AtomicResult<LoroDiff> {
         let before = self.get_all_properties();
-        self.import_update(update)?;
+        let imported_pending_ops = self.import_update_status(update)?;
         let after = self.get_all_properties();
         // Tags are per-property and stable; one read after the import covers
         // both the before and after value of every property.
@@ -808,6 +829,7 @@ impl AtomicLoroDoc {
         Ok(LoroDiff {
             add_atoms,
             remove_atoms,
+            imported_pending_ops,
         })
     }
 }

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -340,6 +340,27 @@ mod test {
     }
 
     #[tokio::test]
+    async fn populate_forms_ontology() {
+        let store = init_store().await;
+        for url in [
+            urls::FORM,
+            urls::FORM_PAGE,
+            urls::FORM_FIELD,
+            urls::FORM_HEADING,
+            urls::FORM_PARAGRAPH,
+            urls::FORM_CONDITION,
+            urls::FORM_CONDITIONS,
+            urls::FORM_CONDITION_FIELD,
+            urls::FORM_CONDITION_OPERATOR,
+            urls::FORM_CONDITION_VALUE,
+        ] {
+            store.get_resource(&url.into()).await.unwrap();
+        }
+        let class = store.get_class(urls::FORM_CONDITION).await.unwrap();
+        assert_eq!(class.shortname, "form-condition");
+    }
+
+    #[tokio::test]
     async fn single_get_empty_server_to_class() {
         let store = Store::init().await.unwrap();
         crate::populate::populate_base_models(&store).await.unwrap();

--- a/lib/src/urls.rs
+++ b/lib/src/urls.rs
@@ -36,6 +36,7 @@ pub const FORM_FIELD: &str = "https://atomicdata.dev/classes/FormField";
 pub const FORM_HEADING: &str = "https://atomicdata.dev/classes/FormHeading";
 pub const FORM_PARAGRAPH: &str = "https://atomicdata.dev/classes/FormParagraph";
 pub const FORM_INVITE_CODE: &str = "https://atomicdata.dev/classes/FormInviteCode";
+pub const FORM_CONDITION: &str = "https://atomicdata.dev/classes/FormCondition";
 
 // Properties
 pub const ORIGINAL_SUBJECT: &str = "https://atomicdata.dev/properties/originalSubject";
@@ -249,6 +250,11 @@ pub const FORM_SUBMISSION_SUMMARY: &str =
 pub const FORM_ACCESS: &str = "https://atomicdata.dev/properties/form-access";
 pub const FORM_CODE: &str = "https://atomicdata.dev/properties/form-code";
 pub const USED_AT: &str = "https://atomicdata.dev/properties/used-at";
+pub const FORM_CONDITIONS: &str = "https://atomicdata.dev/properties/form-conditions";
+pub const FORM_CONDITION_FIELD: &str = "https://atomicdata.dev/properties/form-condition-field";
+pub const FORM_CONDITION_OPERATOR: &str =
+    "https://atomicdata.dev/properties/form-condition-operator";
+pub const FORM_CONDITION_VALUE: &str = "https://atomicdata.dev/properties/form-condition-value";
 // AI
 pub const TEXT_PART: &str = "https://atomicdata.dev/01jtjxtsa9syxmfca2zx5gcnmj/class/text-part";
 pub const REASONING_PART: &str =

--- a/planning/atomic-forms.md
+++ b/planning/atomic-forms.md
@@ -720,9 +720,38 @@ Rough priority order:
    picture choice, file upload (needs upload path for anonymous users — scoped,
    size-limited `POST /form/:id/upload` writing into the commit as a blob), choice
    matrix, table input, location/address.
-[] **Branching**: FormCondition resources; evaluator implemented once in TS
-   (renderer + preview) and once in Rust (server must ignore validation errors on
-   hidden fields); shared JSON fixtures keep the two in lockstep.
+[x] **Branching** — DONE. FormCondition resources on pages, fields, and layout
+   blocks; evaluator implemented once in TS (`form-renderer/src/conditions.ts`)
+   and once in Rust (`server/src/forms.rs`); shared fixtures
+   (`testdata/form-conditions.json`) keep the two in lockstep. Server
+   `validate_submission` skips hidden fields (required-on-hidden is not an
+   error; submitted values for them are dropped). Builder: "Show when" editor
+   in the field settings pane and the page pane (when no field is selected).
+- **Schema**: `FormCondition` class (`form-condition-field` required AtomicURL
+    to FormField, `form-condition-operator` required String enum, 
+    `form-condition-value` recommended JSON) + `form-conditions` ResourceArray
+    on FormPage / FormField / FormHeading / FormParagraph. Operator is a
+    plain String without `allowsOnly` (same limitation as `form-field-type`).
+    AND semantics; empty list = always visible.
+- **Definition JSON**: conditions inlined as `{ field, operator, value }`
+    where `field` is the referenced question's `form-maps-to` (the runtime
+    never sees FormField subjects). Omitted when empty.
+- **Evaluation** walks the form in document order. A referenced field that is
+    itself hidden (or unanswered) fails the condition, so later questions
+    cannot be unlocked by submitting a value for a hidden predecessor.
+    `contains` is a case-insensitive substring on strings and membership on
+    multi-select arrays. `greater-than` / `less-than` compare numerically,
+    falling back to lexicographic string order (ISO dates work).
+- **Renderer**: hidden blocks are not rendered; Next/Back/progress/Submit
+    skip hidden pages; the last *visible* page is the submit page.
+- **Human follow-up needed**: add `FormCondition` + `form-conditions` /
+    `form-condition-field` / `form-condition-operator` / `form-condition-value`
+    to the public atomicdata.dev forms ontology (same step as `form-styling`).
+    Local dev servers need one restart with `ATOMIC_REPOPULATE_DEFAULTS=true`.
+- Covered by: `testdata/form-conditions.json` (TS + Rust),
+    `definition_inlines_field_conditions`, `populate_forms_ontology`,
+    and `forms-submission.spec.ts` (radio → required follow-up hidden when
+    No, shown+filled when Yes).
 [x] **Styling/theming** — DONE (except fonts/logo, not requested). Shipped:
    cover image (5 position modes), text/main/background colors, 3 corner
    roundness levels, edited in a new **Settings tab** in `FormBuilderPage`.

--- a/server/build.rs
+++ b/server/build.rs
@@ -323,10 +323,38 @@ fn copy_form_assets(dirs: &Dirs) -> std::io::Result<()> {
         return Ok(());
     }
 
+    warn_if_form_app_stale(dirs);
+
     let dest = dirs.js_dist_tmp.join("form-assets");
     // Clear first so hashed bundle files from previous builds don't pile up.
     let _ = fs::remove_dir_all(&dest);
     dircpy::copy_dir(&dirs.form_app_dist_source, &dest)
+}
+
+/// ATOMICSERVER_SKIP_JS_BUILD reuses form-app/dist as-is. If form-renderer
+/// (or form-app src) is newer than that dist, published `/form/:id` pages
+/// silently run a stale renderer — which is how conditional questions
+/// shipped in the builder preview (Vite HMR) but not on the public route.
+fn warn_if_form_app_stale(dirs: &Dirs) {
+    let Some(dist_time) = find_newest_file_time(&dirs.form_app_dist_source) else {
+        return;
+    };
+    let form_app_inputs = [
+        PathBuf::from("../browser/form-renderer/src"),
+        PathBuf::from("../browser/form-app/src"),
+        PathBuf::from("../browser/form-app/vite.config.ts"),
+    ];
+    let newer_src = form_app_inputs.iter().any(|src_dir| {
+        find_newest_file_time(src_dir).is_some_and(|src_time| src_time > dist_time)
+    });
+    if newer_src {
+        p!(
+            "form-app/dist is older than form-renderer/form-app source — \
+             published /form/:id will not include the latest renderer \
+             (e.g. conditional questions). Run `pnpm --filter @tomic/form-app build` \
+             in browser/, then rebuild the server."
+        );
+    }
 }
 
 /// Pre-compress eligible files (`.wasm`, `.js`, `.css`, `.html`, `.svg`,

--- a/server/src/forms.rs
+++ b/server/src/forms.rs
@@ -86,7 +86,20 @@ pub struct FormPageDefinition {
     pub cover_image: Option<String>,
     #[serde(rename = "imagePosition")]
     pub image_position: Option<String>,
+    /// AND-ed visibility predicates. Empty (or omitted) means always shown.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<FormConditionDef>,
     pub blocks: Vec<FormBlock>,
+}
+
+/// Denormalized visibility predicate. `field` is the referenced question's
+/// `mapsTo` (property subject), not the FormField resource URL. Mirrors
+/// `FormCondition` in `@tomic/form-renderer`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FormConditionDef {
+    pub field: String,
+    pub operator: String,
+    pub value: JsonValue,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,9 +107,13 @@ pub struct FormPageDefinition {
 pub enum FormBlock {
     Heading {
         text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        conditions: Vec<FormConditionDef>,
     },
     Paragraph {
         text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        conditions: Vec<FormConditionDef>,
     },
     Field {
         #[serde(rename = "mapsTo")]
@@ -107,7 +124,166 @@ pub enum FormBlock {
         field_type: String,
         required: bool,
         options: JsonValue,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        conditions: Vec<FormConditionDef>,
     },
+}
+
+impl FormBlock {
+    pub fn conditions(&self) -> &[FormConditionDef] {
+        match self {
+            Self::Heading { conditions, .. }
+            | Self::Paragraph { conditions, .. }
+            | Self::Field { conditions, .. } => conditions,
+        }
+    }
+}
+
+/// Walk the definition in document order and decide what's shown.
+/// A referenced field that is itself hidden (or unanswered) fails the
+/// condition, so later questions cannot be unlocked by submitting a
+/// value for a hidden predecessor. AND semantics; empty list = visible.
+#[derive(Debug, Clone)]
+pub struct FormVisibility {
+    /// `mapsTo` of every visible input field, in document order.
+    pub fields: Vec<String>,
+    /// Indices of pages whose own conditions match.
+    pub page_indices: Vec<usize>,
+    /// Per page, which block indices are visible (page-hidden → empty).
+    /// Used by the TS renderer; kept here so the two visibility structs match.
+    #[allow(dead_code)]
+    pub blocks: Vec<HashSet<usize>>,
+}
+
+fn json_is_empty(value: Option<&JsonValue>) -> bool {
+    match value {
+        None | Some(JsonValue::Null) => true,
+        Some(JsonValue::String(s)) => s.is_empty(),
+        Some(JsonValue::Array(a)) => a.is_empty(),
+        _ => false,
+    }
+}
+
+fn json_as_number(value: &JsonValue) -> Option<f64> {
+    match value {
+        JsonValue::Number(n) => n.as_f64(),
+        JsonValue::String(s) if !s.is_empty() => s.parse().ok(),
+        _ => None,
+    }
+}
+
+fn json_as_str(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(s) => s.clone(),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Numeric equality when both sides look like numbers; otherwise JSON Eq.
+pub fn json_equal(a: &JsonValue, b: &JsonValue) -> bool {
+    if let (Some(na), Some(nb)) = (json_as_number(a), json_as_number(b)) {
+        return na == nb;
+    }
+    a == b
+}
+
+fn json_contains(answer: &JsonValue, expected: &JsonValue) -> bool {
+    match answer {
+        JsonValue::String(s) => s
+            .to_lowercase()
+            .contains(&json_as_str(expected).to_lowercase()),
+        JsonValue::Array(arr) => arr.iter().any(|item| json_equal(item, expected)),
+        _ => false,
+    }
+}
+
+fn json_compare(answer: &JsonValue, expected: &JsonValue) -> Option<std::cmp::Ordering> {
+    if let (Some(na), Some(nb)) = (json_as_number(answer), json_as_number(expected)) {
+        return na.partial_cmp(&nb);
+    }
+    if let (JsonValue::String(a), JsonValue::String(b)) = (answer, expected) {
+        return Some(a.cmp(b));
+    }
+    None
+}
+
+/// A single predicate. Unanswered / hidden referenced fields fail
+/// (the dependent stays hidden). Unknown operators fail closed.
+pub fn evaluate_condition(condition: &FormConditionDef, answer: Option<&JsonValue>) -> bool {
+    if json_is_empty(answer) {
+        return false;
+    }
+    let answer = answer.expect("checked non-empty above");
+    match condition.operator.as_str() {
+        "equals" => json_equal(answer, &condition.value),
+        "not-equals" => !json_equal(answer, &condition.value),
+        "contains" => json_contains(answer, &condition.value),
+        "greater-than" => matches!(
+            json_compare(answer, &condition.value),
+            Some(std::cmp::Ordering::Greater)
+        ),
+        "less-than" => matches!(
+            json_compare(answer, &condition.value),
+            Some(std::cmp::Ordering::Less)
+        ),
+        _ => false,
+    }
+}
+
+fn conditions_match(
+    conditions: &[FormConditionDef],
+    values: &Map<String, JsonValue>,
+    visible_fields: &[String],
+) -> bool {
+    if conditions.is_empty() {
+        return true;
+    }
+    conditions.iter().all(|condition| {
+        let answer = if !condition.field.is_empty()
+            && visible_fields.iter().any(|f| f == &condition.field)
+        {
+            values.get(&condition.field)
+        } else {
+            None
+        };
+        evaluate_condition(condition, answer)
+    })
+}
+
+pub fn compute_visibility(
+    definition: &FormDefinition,
+    values: &Map<String, JsonValue>,
+) -> FormVisibility {
+    let mut fields = Vec::new();
+    let mut page_indices = Vec::new();
+    let mut blocks = Vec::new();
+
+    for (p, page) in definition.pages.iter().enumerate() {
+        let mut visible_blocks = HashSet::new();
+        if !conditions_match(&page.conditions, values, &fields) {
+            blocks.push(visible_blocks);
+            continue;
+        }
+        page_indices.push(p);
+        for (b, block) in page.blocks.iter().enumerate() {
+            if !conditions_match(block.conditions(), values, &fields) {
+                continue;
+            }
+            visible_blocks.insert(b);
+            if let FormBlock::Field { maps_to, .. } = block {
+                fields.push(maps_to.clone());
+            }
+        }
+        blocks.push(visible_blocks);
+    }
+
+    FormVisibility {
+        fields,
+        page_indices,
+        blocks,
+    }
 }
 
 /// Walks Form -> form-pages -> FormPage -> form-fields, resolving each child
@@ -202,18 +378,75 @@ async fn build_page_definition(
     let mut blocks = Vec::with_capacity(field_subjects.len());
     for field_subject in field_subjects {
         let field = store.get_resource(&field_subject.into()).await?;
-        blocks.push(build_block(&field)?);
+        blocks.push(build_block(store, &field).await?);
     }
 
     Ok(FormPageDefinition {
         name,
         cover_image,
         image_position,
+        conditions: build_conditions(store, page).await,
         blocks,
     })
 }
 
-fn build_block(field: &Resource) -> AtomicResult<FormBlock> {
+async fn build_conditions(
+    store: &impl Storelike,
+    resource: &Resource,
+) -> Vec<FormConditionDef> {
+    let subjects = resource
+        .get(atomic_lib::urls::FORM_CONDITIONS)
+        .and_then(|v| v.to_subjects(None))
+        .unwrap_or_default();
+    let mut out = Vec::with_capacity(subjects.len());
+    for subject in subjects {
+        let Ok(cond) = store.get_resource(&subject.into()).await else {
+            continue;
+        };
+        let field_subject = cond
+            .get(atomic_lib::urls::FORM_CONDITION_FIELD)
+            .ok()
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let maps_to = if field_subject.is_empty() {
+            String::new()
+        } else {
+            match store.get_resource(&field_subject.into()).await {
+                Ok(field) => field
+                    .get(atomic_lib::urls::FORM_MAPS_TO)
+                    .ok()
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
+                Err(_) => String::new(),
+            }
+        };
+        let operator = cond
+            .get(atomic_lib::urls::FORM_CONDITION_OPERATOR)
+            .ok()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "equals".into());
+        let value = match cond.get(atomic_lib::urls::FORM_CONDITION_VALUE) {
+            Ok(Value::Json(v)) => v.clone(),
+            Ok(Value::String(s)) => {
+                serde_json::from_str(s).unwrap_or_else(|_| json!(s))
+            }
+            Ok(other) => json!(other.to_string()),
+            Err(_) => JsonValue::Null,
+        };
+        out.push(FormConditionDef {
+            field: maps_to,
+            operator,
+            value,
+        });
+    }
+    out
+}
+
+async fn build_block(
+    store: &impl Storelike,
+    field: &Resource,
+) -> AtomicResult<FormBlock> {
+    let conditions = build_conditions(store, field).await;
     let classes = field
         .get(atomic_lib::urls::IS_A)
         .and_then(|v| v.to_subjects(None))
@@ -221,14 +454,14 @@ fn build_block(field: &Resource) -> AtomicResult<FormBlock> {
 
     if classes.iter().any(|c| c == atomic_lib::urls::FORM_HEADING) {
         let text = field.get(atomic_lib::urls::NAME)?.to_string();
-        return Ok(FormBlock::Heading { text });
+        return Ok(FormBlock::Heading { text, conditions });
     }
     if classes
         .iter()
         .any(|c| c == atomic_lib::urls::FORM_PARAGRAPH)
     {
         let text = field.get(atomic_lib::urls::DESCRIPTION)?.to_string();
-        return Ok(FormBlock::Paragraph { text });
+        return Ok(FormBlock::Paragraph { text, conditions });
     }
     if classes.iter().any(|c| c == atomic_lib::urls::FORM_FIELD) {
         let maps_to = field.get(atomic_lib::urls::FORM_MAPS_TO)?.to_string();
@@ -253,6 +486,7 @@ fn build_block(field: &Resource) -> AtomicResult<FormBlock> {
             field_type,
             required,
             options,
+            conditions,
         });
     }
 
@@ -269,12 +503,14 @@ pub struct ValidationError {
     pub message: String,
 }
 
-/// Validates a submitted `values` map against a form's field blocks
-/// (required-ness, datatype shape, numeric bounds, option membership) and
-/// coerces accepted values into `atomic_lib::Value`s ready for
-/// `resource.set()`. Collects every error rather than failing fast, so a
-/// client can show all problems at once. Unknown keys in `values` (not
-/// matching any field's `mapsTo`) are also reported as errors.
+/// Validates a submitted `values` map against a form's *visible* field
+/// blocks (required-ness, datatype shape, numeric bounds, option
+/// membership) and coerces accepted values into `atomic_lib::Value`s ready
+/// for `resource.set()`. Hidden fields (conditions not matching) are
+/// skipped: required-on-hidden is not an error, and submitted values for
+/// them are dropped rather than stored. Collects every error rather than
+/// failing fast. Unknown keys in `values` (not matching any field's
+/// `mapsTo`) are also reported as errors.
 pub fn validate_submission(
     definition: &FormDefinition,
     values: &Map<String, JsonValue>,
@@ -295,6 +531,8 @@ pub fn validate_submission(
         })
         .collect();
 
+    let visibility = compute_visibility(definition, values);
+
     let mut errors = Vec::new();
     let mut coerced = Vec::new();
 
@@ -309,6 +547,10 @@ pub fn validate_submission(
     }
 
     for (maps_to, field_type, required, options) in fields {
+        if !visibility.fields.iter().any(|f| f == maps_to) {
+            continue;
+        }
+
         let raw = values.get(maps_to);
         let is_empty = match raw {
             None | Some(JsonValue::Null) => true,
@@ -833,6 +1075,7 @@ pub async fn mint_publish_slug(store: &Db, form: &mut Resource) -> AtomicResult<
 mod tests {
     use super::*;
     use atomic_lib::{test_utils::init_store, urls};
+    use serde::Deserialize;
     use serde_json::json;
 
     async fn make_class_and_property(
@@ -1153,6 +1396,7 @@ mod tests {
                 name: None,
                 cover_image: None,
                 image_position: None,
+                conditions: vec![],
                 blocks: vec![FormBlock::Field {
                     maps_to: "https://example.com/n".into(),
                     label: "Number".into(),
@@ -1160,6 +1404,7 @@ mod tests {
                     field_type: "number".into(),
                     required: true,
                     options: json!({"min": 1, "max": 10}),
+                    conditions: vec![],
                 }],
             }],
         };
@@ -1184,6 +1429,7 @@ mod tests {
                 name: None,
                 cover_image: None,
                 image_position: None,
+                conditions: vec![],
                 blocks: vec![FormBlock::Field {
                     maps_to: "https://example.com/r".into(),
                     label: "Radio".into(),
@@ -1191,6 +1437,7 @@ mod tests {
                     field_type: "radio".into(),
                     required: true,
                     options: json!({"options": ["A", "B"]}),
+                    conditions: vec![],
                 }],
             }],
         };
@@ -1497,5 +1744,206 @@ mod tests {
         let slug_a = mint_publish_slug(&store, &mut form_a).await.unwrap();
         let slug_b = mint_publish_slug(&store, &mut form_b).await.unwrap();
         assert_ne!(slug_a, slug_b);
+    }
+
+    #[derive(Deserialize)]
+    struct ConditionFixtureFile {
+        cases: Vec<ConditionFixtureCase>,
+    }
+
+    #[derive(Deserialize)]
+    struct ConditionFixtureCase {
+        name: String,
+        pages: Vec<FormPageDefinition>,
+        values: Map<String, JsonValue>,
+        #[serde(rename = "visibleFields")]
+        visible_fields: Vec<String>,
+        #[serde(rename = "visiblePages")]
+        visible_pages: Vec<usize>,
+        #[serde(rename = "storedFields")]
+        stored_fields: Vec<String>,
+        valid: bool,
+    }
+
+    #[test]
+    fn condition_fixtures_match_ts() {
+        let file: ConditionFixtureFile =
+            serde_json::from_str(include_str!("../../testdata/form-conditions.json"))
+                .expect("form-conditions.json should parse");
+
+        for case in file.cases {
+            let definition = FormDefinition {
+                version: 1,
+                id: String::new(),
+                name: "fixture".into(),
+                settings: json!({}),
+                styling: FormStyling::default(),
+                honeypot_field: HONEYPOT_FIELD.into(),
+                captcha: None,
+                pages: case.pages,
+            };
+            let vis = compute_visibility(&definition, &case.values);
+            assert_eq!(
+                vis.fields, case.visible_fields,
+                "{}: visible fields",
+                case.name
+            );
+            assert_eq!(
+                vis.page_indices, case.visible_pages,
+                "{}: visible pages",
+                case.name
+            );
+
+            match validate_submission(&definition, &case.values) {
+                Ok(coerced) => {
+                    assert!(
+                        case.valid,
+                        "{}: expected invalid, got stored {:?}",
+                        case.name, coerced
+                    );
+                    let mut stored: Vec<String> = coerced.into_iter().map(|(k, _)| k).collect();
+                    stored.sort();
+                    let mut expected = case.stored_fields.clone();
+                    expected.sort();
+                    assert_eq!(stored, expected, "{}: stored fields", case.name);
+                }
+                Err(errors) => {
+                    assert!(
+                        !case.valid,
+                        "{}: expected valid, got errors {:?}",
+                        case.name, errors
+                    );
+                    // Invalid cases still record which visible fields coerced.
+                    // Re-run isn't needed: the fixture's storedFields lists
+                    // what would have been kept had validation passed for
+                    // those keys; we only check `valid` here.
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn definition_inlines_field_conditions() {
+        let store = init_store().await;
+        let (form, email_prop) = build_test_form(&store).await;
+
+        // A second optional follow-up field on the same page, shown when the
+        // email equals a sentinel. Mirrors how the builder stores conditions
+        // as FormCondition children listed in `form-conditions`.
+        let mut follow_up = Resource::new_instance(urls::FORM_FIELD, &store)
+            .await
+            .unwrap();
+        follow_up
+            .set(
+                urls::NAME.into(),
+                Value::String("Follow-up".into()),
+                &store,
+            )
+            .await
+            .unwrap();
+        follow_up
+            .set(
+                urls::FORM_MAPS_TO.into(),
+                Value::AtomicUrl("https://example.com/follow-up".into()),
+                &store,
+            )
+            .await
+            .unwrap();
+        follow_up
+            .set(
+                urls::FORM_FIELD_TYPE.into(),
+                Value::String("short-text".into()),
+                &store,
+            )
+            .await
+            .unwrap();
+        follow_up.save_locally(&store).await.unwrap();
+
+        let mut cond = Resource::new_instance(urls::FORM_CONDITION, &store)
+            .await
+            .unwrap();
+        cond.set(
+            urls::PARENT.into(),
+            Value::AtomicUrl(follow_up.get_subject().to_string().into()),
+            &store,
+        )
+        .await
+        .unwrap();
+        // The existing email FormField is the first (only) field on the page.
+        let page_subject = form
+            .get(urls::FORM_PAGES)
+            .unwrap()
+            .to_subjects(None)
+            .unwrap()[0]
+            .clone();
+        let page = store.get_resource(&page_subject.clone().into()).await.unwrap();
+        let email_field = page
+            .get(urls::FORM_FIELDS)
+            .unwrap()
+            .to_subjects(None)
+            .unwrap()[0]
+            .clone();
+        cond.set(
+            urls::FORM_CONDITION_FIELD.into(),
+            Value::AtomicUrl(email_field.to_string().into()),
+            &store,
+        )
+        .await
+        .unwrap();
+        cond.set(
+            urls::FORM_CONDITION_OPERATOR.into(),
+            Value::String("equals".into()),
+            &store,
+        )
+        .await
+        .unwrap();
+        cond.set(
+            urls::FORM_CONDITION_VALUE.into(),
+            Value::Json(json!("trigger@example.com")),
+            &store,
+        )
+        .await
+        .unwrap();
+        cond.save_locally(&store).await.unwrap();
+
+        follow_up
+            .set(
+                urls::FORM_CONDITIONS.into(),
+                Value::ResourceArray(vec![cond.get_subject().to_string().into()]),
+                &store,
+            )
+            .await
+            .unwrap();
+        follow_up.save_locally(&store).await.unwrap();
+
+        let mut page = page;
+        let existing = page
+            .get(urls::FORM_FIELDS)
+            .unwrap()
+            .to_subjects(None)
+            .unwrap();
+        let mut fields: Vec<_> = existing.into_iter().map(|s| s.into()).collect();
+        fields.push(follow_up.get_subject().to_string().into());
+        page.set(urls::FORM_FIELDS.into(), Value::ResourceArray(fields), &store)
+            .await
+            .unwrap();
+        page.save_locally(&store).await.unwrap();
+
+        let definition = build_form_definition(&store, &form).await.unwrap();
+        assert_eq!(definition.pages[0].blocks.len(), 2);
+        match &definition.pages[0].blocks[1] {
+            FormBlock::Field {
+                maps_to,
+                conditions,
+                ..
+            } => {
+                assert_eq!(maps_to, "https://example.com/follow-up");
+                assert_eq!(conditions.len(), 1);
+                assert_eq!(conditions[0].field, email_prop);
+                assert_eq!(conditions[0].operator, "equals");
+                assert_eq!(conditions[0].value, json!("trigger@example.com"));
+            }
+            other => panic!("expected a Field block, got {other:?}"),
+        }
     }
 }

--- a/testdata/form-conditions.json
+++ b/testdata/form-conditions.json
@@ -1,0 +1,596 @@
+{
+  "_comment": [
+    "Shared fixtures for the form-condition evaluator. Both sides of the",
+    "lockstep load this file: Rust `server/src/forms.rs` (via include_str!)",
+    "and TS `browser/form-renderer/src/conditions.test.ts`.",
+    "`pages` is the denormalized definition shape (same as GET /form/:id/definition).",
+    "`visibleFields` / `visiblePages` are the evaluator's output.",
+    "`storedFields` is which mapsTo keys validate_submission keeps (hidden",
+    "values are dropped; missing required hidden fields are not errors).",
+    "`valid` is whether validation succeeds for the given `values`."
+  ],
+  "cases": [
+    {
+      "name": "no conditions: everything visible",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Name",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "Ada" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "equals match shows the follow-up",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Pet?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Pet name",
+              "type": "short-text",
+              "required": true,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "Yes", "p2": "Spot" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "equals miss hides the follow-up; required on hidden is ignored",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Pet?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Pet name",
+              "type": "short-text",
+              "required": true,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "No" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "visible required follow-up still errors when empty",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Pet?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Pet name",
+              "type": "short-text",
+              "required": true,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "Yes" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": false
+    },
+    {
+      "name": "submitted value for a hidden field is dropped, not stored",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Pet?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Pet name",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "No", "p2": "secret" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "page condition hides the whole page and its required fields",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Continue?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            }
+          ]
+        },
+        {
+          "conditions": [
+            { "field": "p1", "operator": "equals", "value": "Yes" }
+          ],
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Details",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "No" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "page condition match shows the later page",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Continue?",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            }
+          ]
+        },
+        {
+          "conditions": [
+            { "field": "p1", "operator": "equals", "value": "Yes" }
+          ],
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Details",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "Yes", "p2": "ok" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0, 1],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "AND semantics: both conditions must match",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "A",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "B",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p3",
+              "label": "C",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "x" },
+                { "field": "p2", "operator": "equals", "value": "y" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "x", "p2": "nope", "p3": "hidden" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "contains is a case-insensitive substring",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Bio",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Follow-up",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "contains", "value": "CAT" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "I have a cat", "p2": "ok" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "contains on multi-select is membership",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Colors",
+              "type": "multi-select",
+              "required": true,
+              "options": { "options": ["Red", "Green", "Blue"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Red follow-up",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "contains", "value": "Red" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": ["Green", "Red"], "p2": "ok" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "not-equals hides when the value matches",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Country",
+              "type": "short-text",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Other",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "not-equals", "value": "US" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "US", "p2": "dropped" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "greater-than on numbers",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Age",
+              "type": "number",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Adult Q",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "greater-than", "value": 18 }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": 21, "p2": "ok" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "less-than miss keeps the follow-up hidden",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Age",
+              "type": "number",
+              "required": true,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Child Q",
+              "type": "short-text",
+              "required": true,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "less-than", "value": 18 }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": 21 },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "unanswered referenced field fails the condition",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "A",
+              "type": "short-text",
+              "required": false,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "B",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "x" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": {},
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": [],
+      "valid": true
+    },
+    {
+      "name": "hidden field value is ignored when evaluating later conditions",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Gate",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Mid",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p3",
+              "label": "Late",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p2", "operator": "equals", "value": "cat" }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "No", "p2": "cat", "p3": "sneaky" },
+      "visibleFields": ["p1"],
+      "visiblePages": [0],
+      "storedFields": ["p1"],
+      "valid": true
+    },
+    {
+      "name": "checkbox equals true",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Agree",
+              "type": "checkbox",
+              "required": false,
+              "options": {}
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "More",
+              "type": "short-text",
+              "required": false,
+              "options": {},
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": true }
+              ]
+            }
+          ]
+        }
+      ],
+      "values": { "p1": true, "p2": "ok" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    },
+    {
+      "name": "heading/paragraph conditions hide layout without affecting fields",
+      "pages": [
+        {
+          "blocks": [
+            {
+              "kind": "field",
+              "mapsTo": "p1",
+              "label": "Gate",
+              "type": "radio",
+              "required": true,
+              "options": { "options": ["Yes", "No"] }
+            },
+            {
+              "kind": "heading",
+              "text": "Only if yes",
+              "conditions": [
+                { "field": "p1", "operator": "equals", "value": "Yes" }
+              ]
+            },
+            {
+              "kind": "field",
+              "mapsTo": "p2",
+              "label": "Always",
+              "type": "short-text",
+              "required": false,
+              "options": {}
+            }
+          ]
+        }
+      ],
+      "values": { "p1": "No", "p2": "still here" },
+      "visibleFields": ["p1", "p2"],
+      "visiblePages": [0],
+      "storedFields": ["p1", "p2"],
+      "valid": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Part of #875 (Phase 6 branching from `planning/atomic-forms.md`).

## What

Hide/show form questions and pages based on earlier answers.

- **Schema**: `FormCondition` class + `form-conditions` ResourceArray on pages, fields, headings, and paragraphs. Operators: `equals`, `not-equals`, `contains`, `greater-than`, `less-than`. AND semantics; empty list = always visible.
- **Evaluator**: implemented once in TS (`form-renderer/src/conditions.ts`) and once in Rust (`server/src/forms.rs`), kept in lockstep by `testdata/form-conditions.json`. Walks the form in document order; a hidden/unanswered referenced field fails the condition (later questions cannot be unlocked by POSTing a hidden predecessor's value).
- **Server**: `validate_submission` skips hidden fields — required-on-hidden is not an error; submitted values for them are dropped, not stored. Definition JSON inlines `{ field, operator, value }` where `field` is the referenced question's `form-maps-to`.
- **Renderer**: hidden blocks are not rendered; Next/Back/progress/Submit skip hidden pages; the last *visible* page is the submit page.
- **Builder**: "Show when" editor on field settings and on the page pane (when no field is selected). Conditions can only reference earlier questions.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed (`docs/src/schema/forms.md`, `planning/atomic-forms.md`, `TESTING_COVERAGE.md`)

## Tests run

- `cargo test -p atomic-server --lib forms::` — 23 passed (incl. `condition_fixtures_match_ts`, `definition_inlines_field_conditions`)
- `pnpm test` in `@tomic/form-renderer` — 17 passed (shared fixtures)
- form-renderer typecheck + lint — clean
- Manual: builder Preview — radio No hides the follow-up, Yes shows it

## Follow-up fix in this PR

Wuchale rewrote `<FaPlus /> Add condition` into `W_tx_` with an undefined `_w_ctx_`, which crashed the form builder as soon as the page settings pane mounted. The label is now a `<span>` so it extracts as a plain string.

## Human follow-up

Add `FormCondition` + `form-conditions` / `form-condition-field` / `form-condition-operator` / `form-condition-value` to the public atomicdata.dev forms ontology. Local servers need one restart with `ATOMIC_REPOPULATE_DEFAULTS=true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d52e320-c623-46a2-874f-0b1f5e50e473?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d52e320-c623-46a2-874f-0b1f5e50e473&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

