### PR TITLE
fix(lib): stop depending on a secure-context API for ids

### DIFF
--- a/browser/data-browser/src/chunks/AI/MCPConfigTab.tsx
+++ b/browser/data-browser/src/chunks/AI/MCPConfigTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useState } from 'react';
+import { randomUUID } from '@tomic/lib';
 import { createPortal } from 'react-dom';
 import { styled } from 'styled-components';
 import { Row, Column } from '@components/Row';
@@ -13,7 +14,7 @@ import { useAISettings } from '@components/AI/AISettingsContext';
 import type { MCPServer } from './types';
 import { getDefaultMCPServer } from './defaultMCPServers';
 
-const generateId = () => crypto.randomUUID();
+const generateId = () => randomUUID();
 
 const defaultNewServer: MCPServer = {
   id: '',

--- a/browser/data-browser/src/chunks/AI/RealAIChat.tsx
+++ b/browser/data-browser/src/chunks/AI/RealAIChat.tsx
@@ -11,7 +11,7 @@ import { IconButton } from '@components/IconButton/IconButton';
 import { Button } from '@components/Button';
 import { FaXmark, FaPaperclip, FaFile } from 'react-icons/fa6';
 import { ChatMessagesContainer } from '@components/ChatMessagesContainer';
-import { useStore, type Resource } from '@tomic/react';
+import { useStore, type Resource, randomUUID } from '@tomic/react';
 import { AIProvider } from '@components/AI/aiContstants';
 import {
   AIAgent,
@@ -470,13 +470,13 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
       if (mention.type === 'atomic-resource') {
         return {
           type: mention.type,
-          id: crypto.randomUUID(),
+          id: randomUUID(),
           subject: mention.id,
         } as AIAtomicResourceMessageContext;
       } else if (mention.type === 'mcp-resource') {
         return {
           type: mention.type,
-          id: crypto.randomUUID(),
+          id: randomUUID(),
           uri: mention.id,
           name: mention.label,
           serverId: mention.serverId,
@@ -484,7 +484,7 @@ const RealAIChatInner: React.FC<React.PropsWithChildren<RealAIChatProps>> = ({
       } else if (mention.type === 'skill') {
         return {
           type: 'skill',
-          id: crypto.randomUUID(),
+          id: randomUUID(),
           name: mention.label,
         } as AISkillMessageContext;
       }

--- a/browser/data-browser/src/chunks/AI/chatConversionUtils.ts
+++ b/browser/data-browser/src/chunks/AI/chatConversionUtils.ts
@@ -7,6 +7,7 @@ import {
   server,
   type JSONObject,
   dataBrowser,
+  randomUUID,
 } from '@tomic/react';
 import {
   getToolName,
@@ -511,7 +512,7 @@ const toSourceUrlPart = (
   resource: Resource<Ai.SourceUrlPart>,
 ): SourceUrlUIPart => ({
   type: 'source-url',
-  sourceId: crypto.randomUUID(), // Do we need real IDs?
+  sourceId: randomUUID(), // Do we need real IDs?
   url: resource.props.url,
   title: resource.props.name,
 });

--- a/browser/data-browser/src/chunks/AI/skills/skill.ts
+++ b/browser/data-browser/src/chunks/AI/skills/skill.ts
@@ -1,5 +1,6 @@
 // @wc-ignore-file
 import { tool } from 'ai';
+import { randomUUID } from '@tomic/lib';
 import { z } from 'zod';
 import { setLocalStorageValue, useLocalStorage } from '@hooks/useLocalStorage';
 
@@ -124,7 +125,7 @@ function isBundledSkillName(normalizedName: string): boolean {
 }
 
 function generateUserSkillId(): string {
-  return `user-skill.${crypto.randomUUID()}`;
+  return `user-skill.${randomUUID()}`;
 }
 
 function persistUserSkills(skills: AgentSkill[]): void {

--- a/browser/data-browser/src/components/AI/AISidebarContext.tsx
+++ b/browser/data-browser/src/components/AI/AISidebarContext.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useState, createContext } from 'react';
+import { randomUUID } from '@tomic/lib';
 
 import type { AIMessageContext } from '../../chunks/AI/types';
 import { useRightPanel } from '../RightPanel/RightPanelContext';
@@ -51,6 +52,6 @@ export function newContextItem<T extends AIMessageContext>(
 ): T {
   return {
     ...item,
-    id: crypto.randomUUID() as string,
+    id: randomUUID() as string,
   } as T;
 }

--- a/browser/data-browser/src/components/AI/OpenRouterLoginButton.tsx
+++ b/browser/data-browser/src/components/AI/OpenRouterLoginButton.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
+import { randomUUID } from '@tomic/lib';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { ButtonLink } from '../ButtonLink';
 import { paths } from '../../routes/paths';
-import { randomString } from '../../helpers/randomString';
 
 const TEXT = 'Login with OpenRouter';
 const AUTH_ENDPOINT = 'https://openrouter.ai/auth';
@@ -39,7 +39,7 @@ export const OpenRouterLoginButton = () => {
   const [challenge, setChallenge] = useState<string | null>(null);
 
   useEffect(() => {
-    const verifier = crypto.randomUUID ? crypto.randomUUID() : randomString(32);
+    const verifier = randomUUID();
     const generatedChallenge = createSHA256CodeChallenge(verifier);
     setChallenge(generatedChallenge);
     // Stored in localStorage (not sessionStorage) so the verifier survives the

--- a/browser/data-browser/src/helpers/managed/devices.ts
+++ b/browser/data-browser/src/helpers/managed/devices.ts
@@ -14,6 +14,7 @@
 // Canonical design: planning/device-pairing.md (§ SaaS-assisted pairing).
 
 import { managedFetch } from './api';
+import { randomUUID } from '@tomic/lib';
 import { getManagedAccount } from './session';
 import { getLocalServerOrigin, isRunningInTauri } from '../tauri';
 import { pairAndSync } from '../pairing';
@@ -48,7 +49,7 @@ export function getOrCreateDeviceId(): string | null {
 
     if (existing) return existing;
 
-    const fresh = crypto.randomUUID();
+    const fresh = randomUUID();
     localStorage.setItem(DEVICE_ID_KEY, fresh);
 
     return fresh;

--- a/browser/data-browser/src/views/Canvas/history-helpers.ts
+++ b/browser/data-browser/src/views/Canvas/history-helpers.ts
@@ -1,4 +1,4 @@
-import { parseCanvasStrokes, type CanvasStroke } from '@tomic/lib';
+import { parseCanvasStrokes, type CanvasStroke, randomUUID } from '@tomic/lib';
 import type { JSONValue } from '@tomic/lib';
 
 /**
@@ -156,7 +156,7 @@ export function archiveBranch(
 
   const next = [
     ...branches,
-    { id: crypto.randomUUID(), strokes: cloneStrokes(strokes) },
+    { id: randomUUID(), strokes: cloneStrokes(strokes) },
   ];
 
   return next.slice(-BRANCH_LIMIT);

--- a/browser/lib/src/client-db.ts
+++ b/browser/lib/src/client-db.ts
@@ -36,6 +36,7 @@ import type {
   ClientDbInitTimings,
 } from './client-db.worker.js';
 import { perfMark, perfSpan } from './perf-trace.js';
+import { randomUUID } from './random-uuid.js';
 
 /**
  * Duplicated from `client-db-open.ts` on purpose — do NOT import it here.
@@ -208,9 +209,10 @@ export class ClientDbWorker {
   private worker: Worker | null = null;
   private bc: BroadcastChannel | null = null;
   private role: Role = 'initializing';
-  private tabId = (crypto as Crypto & { randomUUID?: () => string }).randomUUID
-    ? crypto.randomUUID()
-    : Math.random().toString(36).slice(2);
+  // Was an inline guard falling back to `Math.random()` — same secure-context
+  // problem, but a fallback that is neither a UUID nor cryptographically
+  // random. Tab ids collide across tabs opened in the same millisecond.
+  private tabId = randomUUID();
   private nextId = 1;
   private pending = new Map<string, PendingRequest>();
   private workerUrl: string;

--- a/browser/lib/src/index.ts
+++ b/browser/lib/src/index.ts
@@ -51,6 +51,7 @@ export * from './genesis.js';
 export * from './commit.js';
 export * from './error.js';
 export * from './withDeadline.js';
+export * from './random-uuid.js';
 export * from './datatypes.js';
 export * from './parse.js';
 export * from './search.js';

--- a/browser/lib/src/presence.ts
+++ b/browser/lib/src/presence.ts
@@ -1,5 +1,6 @@
 import type { EphemeralStore } from 'loro-crdt';
 import { LoroLoader } from './loro-loader.js';
+import { randomUUID } from './random-uuid.js';
 import type { Store } from './store.js';
 
 /** What a session announces about itself on a drive's presence channel. */
@@ -79,7 +80,10 @@ export class DrivePresenceManager {
     private store: Store,
     private drive: string,
   ) {
-    this.sessionId = crypto.randomUUID();
+    // Not `crypto.randomUUID`: that is secure-context-only, and this
+    // constructor runs on every drive load, so over plain HTTP on a LAN it
+    // threw before first paint and the app rendered its error screen instead.
+    this.sessionId = randomUUID();
   }
 
   /**

--- a/browser/lib/src/random-uuid.test.ts
+++ b/browser/lib/src/random-uuid.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, vi, afterEach } from 'vitest';
+import { randomUUID } from './random-uuid.js';
+
+const V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('randomUUID', () => {
+  it('produces a v4 uuid', ({ expect }) => {
+    expect(randomUUID()).toMatch(V4);
+  });
+
+  /**
+   * The whole point: over plain HTTP on a LAN — `http://homeassistant.local`,
+   * `http://192.168.1.x` — the context is insecure and `crypto.randomUUID` is
+   * simply absent. `getRandomValues` is not gated, so we can still answer.
+   */
+  it('works where crypto.randomUUID does not exist', ({ expect }) => {
+    const real = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: <T extends ArrayBufferView | null>(a: T): T =>
+        real.getRandomValues(a as never) as T,
+    });
+
+    expect(globalThis.crypto.randomUUID).toBeUndefined();
+    expect(randomUUID()).toMatch(V4);
+  });
+
+  it('does not repeat itself', ({ expect }) => {
+    const seen = new Set(Array.from({ length: 500 }, () => randomUUID()));
+    expect(seen.size).toBe(500);
+  });
+});

--- a/browser/lib/src/random-uuid.ts
+++ b/browser/lib/src/random-uuid.ts
@@ -1,0 +1,39 @@
+/**
+ * A v4 UUID, in secure contexts and insecure ones alike.
+ *
+ * `crypto.randomUUID` is gated on a secure context, so over plain HTTP it is
+ * undefined on anything but localhost — which is exactly how a self-hosted
+ * server on a LAN gets reached (`http://homeassistant.local`,
+ * `http://192.168.1.x`). Calling it there throws, and a throw on a path that
+ * runs during drive load takes the whole first paint with it.
+ *
+ * `crypto.getRandomValues` carries no such gate, so the fallback is as random
+ * as the real thing; only the convenience wrapper is missing. This replaced a
+ * global `window.crypto.randomUUID = ...` patch in the data-browser entrypoint:
+ * a polyfill hides the constraint from every future caller, and the callers
+ * that matter live in this package anyway.
+ */
+export function randomUUID(): string {
+  const c = globalThis.crypto;
+
+  if (typeof c?.randomUUID === 'function') {
+    return c.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  c.getRandomValues(bytes);
+
+  // RFC 4122: version 4 in the high nibble of byte 6, variant 10x in byte 8.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join('-');
+}


### PR DESCRIPTION
`crypto.randomUUID` is gated on a secure context, so over plain HTTP it is undefined on anything but localhost — which is exactly how a self-hosted server on a LAN gets reached (`http://homeassistant.local`, `http://192.168.1.x`).

`DrivePresenceManager`'s constructor called it bare:

```ts
// browser/lib/src/presence.ts
this.sessionId = crypto.randomUUID();
```

and that runs on **every drive load**. So the app did not degrade a feature — it threw before first paint and rendered "Error loading resource". This is the Home Assistant add-on needing HTTPS or hard-crashing.

## What was there

The data-browser entrypoint carried a global `window.crypto.randomUUID = ...` patch to paper over it. That works, but it hides the constraint from every future caller and puts a monkey-patch in the app's first statement.

## What changed

An explicit `randomUUID()` in `@tomic/lib` — real `crypto.randomUUID` when it exists, `getRandomValues` otherwise. `getRandomValues` carries no secure-context gate, so the fallback is as random as the real thing; only the convenience wrapper is absent.

All **fifteen** call sites migrated, so nothing relies on the patch that is now gone.

Two had already grown their own guards, which suggests this had bitten before — and both fallbacks were worse than they look:

| Site | Old fallback | Problem |
| --- | --- | --- |
| `client-db.ts` tab id | `Math.random().toString(36)` | neither a UUID nor cryptographically random; collides for tabs opened in the same millisecond |
| `OpenRouterLoginButton` | `randomString(32)` | it is a **PKCE verifier** |

## Testing

`random-uuid.test.ts` stubs an insecure context where `crypto.randomUUID` is absent — the case the whole thing exists for, and one that cannot be observed on localhost. Plus v4 shape and a collision check.

- lib 283, data-browser 591, svelte 3 — pass
- workspace lint exit 0 (the polyfill was also the one file failing `oxfmt`)
- typecheck clean

## Checklist
- [x] Add or update tests if needed
- [ ] Update docs if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core init paths (presence, client-db tab RPC) and auth (OpenRouter PKCE); behavior change is intentional and low blast radius outside HTTP/insecure contexts, but incorrect UUID generation would affect session/tab identity.
> 
> **Overview**
> Fixes **first-paint crashes on plain HTTP** (e.g. LAN self-host) where `crypto.randomUUID` is missing because it is secure-context-only. `DrivePresenceManager` called it on every drive load, which surfaced as “Error loading resource” instead of a degraded feature.
> 
> Adds an explicit **`randomUUID()` in `@tomic/lib`**: native `crypto.randomUUID` when present, otherwise RFC 4122 v4 via `crypto.getRandomValues`. It is exported from the package and wired through **`@tomic/react`**.
> 
> **Replaces the data-browser entrypoint `window.crypto.randomUUID` polyfill** and migrates **~15 call sites** (AI context IDs, MCP config, canvas branches, device IDs, OpenRouter PKCE verifier, `ClientDbWorker` tab IDs, etc.). Ad-hoc fallbacks (`Math.random()` tab ids, non-UUID PKCE verifiers) go away in favor of one helper.
> 
> Adds **`random-uuid.test.ts`** for v4 shape, insecure-context stubbing, and collision checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdecf66d3e784b07a5ce925da368b5ec92631304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->