### PR TITLE
test(e2e): replace waitForTimeout with semantic waits

### DIFF
--- a/browser/e2e/tests/aggregates.spec.ts
+++ b/browser/e2e/tests/aggregates.spec.ts
@@ -4,6 +4,8 @@ import {
   createTableFromDialog,
   inDialog,
   pickTotal,
+  setGridCell,
+  waitForGridMounted,
 } from './test-utils';
 
 /** The grid row containing `text`. */
@@ -23,29 +25,7 @@ async function setCell(
   columnIndex: number,
   value: string,
 ) {
-  const cell = page.locator(
-    `[aria-rowindex="${rowIndex}"] > [aria-colindex="${columnIndex}"]`,
-  );
-
-  await expect(async () => {
-    // `click` scrolls into view AND re-resolves the locator if the grid remounts
-    // the cell under us; `scrollIntoViewIfNeeded` fails outright on that.
-    await cell.click();
-    const input = cell.locator('input');
-
-    if ((await input.count()) === 0) {
-      await expect(cell).toBeFocused({ timeout: 2_000 });
-      await page.keyboard.press('Enter');
-    }
-
-    await expect(input).toBeVisible({ timeout: 2_000 });
-    await input.fill(value);
-    // Tab commits the edit (Escape would revert it) and leaves the next cell,
-    // which Tab may have opened in edit mode.
-    await page.keyboard.press('Tab');
-    await page.keyboard.press('Escape');
-    await expect(cell).toHaveText(value, { timeout: 3_000 });
-  }).toPass({ timeout: 30_000 });
+  await setGridCell(page, rowIndex, columnIndex, value);
 }
 
 // Totals assertions use 30s budgets, not the 10s default: an aggregate value
@@ -74,8 +54,7 @@ test.describe('table totals', () => {
     });
 
     await expect(page.getByTestId('timer-new-input')).toBeVisible();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     for (const name of ['Alpha', 'Beta']) {
       await page.getByTestId('timer-new-input').fill(name);

--- a/browser/e2e/tests/clientdb-edit-persistence.spec.ts
+++ b/browser/e2e/tests/clientdb-edit-persistence.spec.ts
@@ -28,13 +28,20 @@ test('edit persists to local ClientDb across the drain', async ({ page }) => {
     await r.set(NAME, 'PersistProbe-A');
     await r.save();
     const realSubject = r.subject;
-    await new Promise(res => setTimeout(res, 1500));
+    const db = s.getClientDb();
+
+    if (!db) {
+      throw new Error('ClientDb missing — cannot probe OPFS persistence');
+    }
+
+    // Writes commit with Durability::None; flush() is the durable signal.
+    await db.flush();
     const afterCreate = await asAny.fetchResourceFromClientDb(realSubject);
 
     const r2 = await s.getResource(realSubject);
     await r2.set(NAME, 'PersistProbe-B-EDITED');
     await r2.save();
-    await new Promise(res => setTimeout(res, 2500));
+    await db.flush();
     const afterEdit = await asAny.fetchResourceFromClientDb(realSubject);
     const srv = await s.fetchResourceFromServer(realSubject);
 

--- a/browser/e2e/tests/derived-columns.spec.ts
+++ b/browser/e2e/tests/derived-columns.spec.ts
@@ -246,12 +246,14 @@ test.describe('computed columns', () => {
     const narrowed = await widthOf(timer);
     expect(narrowed).toBeLessThan(70);
 
-    // Widths live on the table, so they survive a reload.
+    await waitForSynced(page);
     await page.reload();
     await waitForGridMounted(page);
 
-    expect(await widthOf(duration)).toBe(widened);
-    expect(await widthOf(timer)).toBe(narrowed);
+    await expect
+      .poll(() => widthOf(duration), { timeout: 15_000 })
+      .toBe(widened);
+    await expect.poll(() => widthOf(timer), { timeout: 15_000 }).toBe(narrowed);
   });
 
   test('columns can be reordered, including the ones a view adds', async ({
@@ -306,11 +308,11 @@ test.describe('computed columns', () => {
       reordered.indexOf('name'),
     );
 
-    // The order lives on the View, so it survives a reload.
+    await waitForSynced(page);
     await page.reload();
     await waitForGridMounted(page);
 
-    expect(await headings()).toEqual(reordered);
+    await expect.poll(headings, { timeout: 15_000 }).toEqual(reordered);
   });
   test('a computed column can be filtered on, in a unit that reads', async ({
     page,

--- a/browser/e2e/tests/derived-columns.spec.ts
+++ b/browser/e2e/tests/derived-columns.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect, type Page } from '@playwright/test';
-import { before, createTableFromDialog, inDialog } from './test-utils';
+import {
+  before,
+  createTableFromDialog,
+  inDialog,
+  setGridCell,
+  waitForGridMounted,
+  waitForSynced,
+} from './test-utils';
 
 /** The grid row containing `text`. */
 const row = (page: Page, text: string) =>
@@ -44,27 +51,9 @@ async function setCell(
   rowIndex: number,
   columnIndex: number,
   value: string,
-  opts: { replace?: boolean } = {},
+  _opts: { replace?: boolean } = {},
 ) {
-  const cell = page.locator(
-    `[aria-rowindex="${rowIndex}"] > [aria-colindex="${columnIndex}"]`,
-  );
-  await cell.click();
-
-  if ((await cell.locator('input').count()) === 0) {
-    await expect(cell).toBeFocused();
-    await page.keyboard.press('Enter');
-  }
-
-  if (opts.replace) {
-    await page.keyboard.press('ControlOrMeta+a');
-  }
-
-  await page.keyboard.type(value);
-  await page.keyboard.press('Tab');
-  await page.waitForTimeout(200);
-  await page.keyboard.press('Escape');
-  await page.waitForTimeout(200);
+  await setGridCell(page, rowIndex, columnIndex, value, { match: /\S/ });
 }
 
 test.describe('computed columns', () => {
@@ -81,8 +70,7 @@ test.describe('computed columns', () => {
     });
 
     await expect(page.getByTestId('timer-new-input')).toBeVisible();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     await page.getByTestId('timer-new-input').fill('Write docs');
     await page.getByTestId('timer-start-new').click();
@@ -186,23 +174,16 @@ test.describe('computed columns', () => {
       template: /Inventory/,
       name: 'Live values',
     });
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(1000);
-
+    await waitForGridMounted(page);
     await setCell(page, 2, 2, 'Bolts');
     await setCell(page, 2, 4, '4');
     await setCell(page, 2, 5, '0.25');
 
     // Reload once, so the row under test is a saved row rather than the trailing
     // draft — a draft's cells are a separate story (see the gaps list).
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 15_000 },
-    );
+    await waitForSynced(page);
     await page.reload();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(1000);
+    await waitForGridMounted(page);
 
     const bolts = row(page, 'Bolts');
     await expect(bolts.getByTestId('derived-value')).toHaveText('1', {
@@ -228,8 +209,7 @@ test.describe('computed columns', () => {
     });
 
     await expect(page.getByTestId('timer-new-input')).toBeVisible();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     // A timer view leads with its own columns: Duration (2) and the Start/Stop
     // button (3), then the stored ones.
@@ -253,7 +233,7 @@ test.describe('computed columns', () => {
       await page.mouse.down();
       await page.mouse.move(x + by, y, { steps: 10 });
       await page.mouse.up();
-      await page.waitForTimeout(1500);
+      await expect.poll(() => widthOf(column)).not.toBe(Math.round(box.width));
     };
 
     await resizeBy(duration, 90);
@@ -268,8 +248,7 @@ test.describe('computed columns', () => {
 
     // Widths live on the table, so they survive a reload.
     await page.reload();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     expect(await widthOf(duration)).toBe(widened);
     expect(await widthOf(timer)).toBe(narrowed);
@@ -284,8 +263,7 @@ test.describe('computed columns', () => {
     });
 
     await expect(page.getByTestId('timer-new-input')).toBeVisible();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     const headings = () =>
       page.evaluate(() =>
@@ -315,7 +293,13 @@ test.describe('computed columns', () => {
       steps: 15,
     });
     await page.mouse.up();
-    await page.waitForTimeout(1200);
+    await expect
+      .poll(async () => {
+        const h = await headings();
+
+        return h.indexOf('Duration') > h.indexOf('name');
+      })
+      .toBe(true);
 
     const reordered = await headings();
     expect(reordered.indexOf('Duration')).toBeGreaterThan(
@@ -324,8 +308,7 @@ test.describe('computed columns', () => {
 
     // The order lives on the View, so it survives a reload.
     await page.reload();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     expect(await headings()).toEqual(reordered);
   });
@@ -342,8 +325,7 @@ test.describe('computed columns', () => {
     });
 
     await expect(page.getByTestId('timer-new-input')).toBeVisible();
-    await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     // Log the short one and stop it...
     await page.getByTestId('timer-new-input').fill('Short task');
@@ -395,11 +377,7 @@ test.describe('computed columns', () => {
       undefined,
       { timeout: 30_000 },
     );
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 30_000 },
-    );
+    await waitForSynced(page, 30_000);
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('grid')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('filter-chip')).toContainText('1 hours');

--- a/browser/e2e/tests/did-folder-reload.spec.ts
+++ b/browser/e2e/tests/did-folder-reload.spec.ts
@@ -3,6 +3,7 @@ import {
   before,
   FRONTEND_URL,
   waitForClientDbFlush,
+  waitForServerConnected,
   waitForSynced,
 } from './test-utils';
 
@@ -61,38 +62,36 @@ test('DID folder page survives a reload', async ({ page }) => {
   );
   await page.reload();
 
-  // Wait for the WS to reconnect after reload, then poll the store's view of
-  // the folder for up to 12s to see whether it recovers or stays broken.
-  const diag = await page.evaluate(async f => {
+  // Wait for the WS to reconnect after reload, then wait until the store
+  // actually holds the folder's name — not a 500ms poll hoping it landed.
+  await waitForServerConnected(page);
+  await page.waitForFunction(
+    f => {
+      const s = window.store;
+      s?.getResource(f).catch(() => undefined);
+      const r = s?.resources.get(f);
+
+      return (
+        r?.get?.('https://atomicdata.dev/properties/name') === 'ReloadFolder'
+      );
+    },
+    folder,
+    { timeout: 12_000 },
+  );
+  const diag = await page.evaluate(f => {
     const s = window.store;
+    const r = s.resources.get(f);
 
-    const snap = async () => {
-      const r = s.resources.get(f);
-
-      return {
-        present: !!r,
-        entries: r?.getEntries ? r.getEntries().length : -1,
-        isA: (r?.get?.('https://atomicdata.dev/properties/isA') ??
-          null) as unknown,
-        name: r?.get?.('https://atomicdata.dev/properties/name') ?? null,
-        loading: r?.loading ?? null,
-        error: r?.error?.message ?? null,
-        serverConnected: s.getSyncStatus?.()?.serverConnected ?? null,
-      };
+    return {
+      present: !!r,
+      entries: r?.getEntries ? r.getEntries().length : -1,
+      isA: (r?.get?.('https://atomicdata.dev/properties/isA') ??
+        null) as unknown,
+      name: r?.get?.('https://atomicdata.dev/properties/name') ?? null,
+      loading: r?.loading ?? null,
+      error: r?.error?.message ?? null,
+      serverConnected: s.getSyncStatus?.()?.serverConnected ?? null,
     };
-
-    // Kick a fetch (don't throw if it fails) and poll.
-    s.getResource(f).catch(() => undefined);
-    let last = await snap();
-
-    for (let i = 0; i < 24; i++) {
-      last = await snap();
-      if (last.name === 'ReloadFolder') break;
-      await new Promise(res => setTimeout(res, 500));
-      s.getResource(f).catch(() => undefined);
-    }
-
-    return last;
   }, folder);
   console.log(
     '[did-folder-reload] post-reload store state:',

--- a/browser/e2e/tests/did-folder-reload.spec.ts
+++ b/browser/e2e/tests/did-folder-reload.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { before, FRONTEND_URL } from './test-utils';
+import {
+  before,
+  FRONTEND_URL,
+  waitForClientDbFlush,
+  waitForSynced,
+} from './test-utils';
 
 /**
  * Repro for: open a DID folder's own page, refresh → it renders BROKEN (raw
@@ -49,7 +54,8 @@ test('DID folder page survives a reload', async ({ page }) => {
   // Give the OPFS flush tick time, then turn OFF Local DB (the Sync-page
   // toggle the user used) so the reload must hydrate the folder purely from
   // the server — exercising the DID server-fetch path.
-  await page.waitForTimeout(2000);
+  await waitForSynced(page);
+  await waitForClientDbFlush(page);
   await page.evaluate(() =>
     localStorage.setItem('atomic-disable-client-db', '1'),
   );

--- a/browser/e2e/tests/documents.spec.ts
+++ b/browser/e2e/tests/documents.spec.ts
@@ -99,8 +99,7 @@ test.describe('documents', async () => {
     expect(await page2.title()).toEqual(title);
 
     await page2.getByLabel('Rich Text Editor').focus();
-    await page2.keyboard.press('ArrowDown');
-    await page2.waitForTimeout(50);
+    await page2.keyboard.press('End');
     await page2.keyboard.press('Enter');
     const syncText = 'New paragraph';
     await page2.keyboard.type(syncText);
@@ -146,7 +145,7 @@ test.describe('documents', async () => {
     }).toPass({ timeout: 15_000 });
 
     // Wait for AtomicServer to index the folder so the @-mention can find it.
-    await waitForSearchIndex(page2);
+    await waitForSearchIndex(page2, folderTitle);
     // Add a link to a folder via @ mention
     await page2.keyboard.press('Space');
     await page2.keyboard.type('@');

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -29,6 +29,7 @@ import {
   signIn,
   timestamp,
   waitForCommit,
+  waitForSynced,
   openAgentPage,
   fillSearchBox,
   selectHistoryVersionShowing,
@@ -286,7 +287,6 @@ test.describe('data-browser', async () => {
       });
     } catch {
       // Redirect may land outside the chatroom; open the same /app/show?subject=… URL as the owner.
-      await page2.waitForTimeout(500);
       await page2.goto(chatRoomHref);
       await expect(page2.locator(`text=${teststring}`)).toBeVisible({
         timeout: 15_000,
@@ -370,14 +370,30 @@ test.describe('data-browser', async () => {
       await editableTitle(page).type(letter, { delay: Math.random() * 300 });
     }
 
-    // After typing, we need the LAST debounce to fire (~100ms) then its
-    // commit to ack. `pendingDirtyCount === 0` polls too eagerly here —
-    // the last keystroke's debounce timer hasn't started yet at loop exit,
-    // so the count is briefly 0 (last save done, next not yet enqueued)
-    // and `waitForFunction` returns before the final value is committed.
-    // `waitForTimeout(1500)` gives the debounce + round-trip enough budget
-    // before we Escape (which would otherwise cancel the pending save).
-    await page.waitForTimeout(1500);
+    // The last keystroke's debounce may not have been scheduled yet at loop
+    // exit, so `pendingDirtyCount === 0` can be briefly true before the
+    // final character is applied. Wait until the store holds the full
+    // string — that's `useValue` applying the change — then drain the save
+    // before Escape (which would otherwise race a still-armed debounce).
+    await page.waitForFunction(
+      expected => {
+        const main = document.querySelector('main[about]');
+        const subject = main?.getAttribute('about');
+
+        if (!subject) {
+          return false;
+        }
+
+        const resource = window.store?.resources.get(subject);
+
+        return (
+          resource?.get?.('https://atomicdata.dev/properties/name') === expected
+        );
+      },
+      alphabet,
+      { timeout: 15_000 },
+    );
+    await waitForSynced(page);
     await page.keyboard.press('Escape');
 
     await expect(
@@ -426,11 +442,7 @@ test.describe('data-browser', async () => {
     await editTitle(docTitle, page);
 
     // Wait for the doc's save to flush before navigating away.
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     // Back to the folder — assert the child appears in the main page.
     await page.goto(folderUrl);

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -9,7 +9,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import {
   FRONTEND_URL,
-  SERVER_URL,
+  spaUrl,
   before,
   changeDrive,
   contextMenuClick,
@@ -241,13 +241,11 @@ test.describe('data-browser', async () => {
       'Message date missing after refresh — createdAt did not survive the round-trip',
     ).toHaveAttribute('datetime', new RegExp(`^${year}-`));
 
-    // Build the chatroom fallback URL on the SERVER's origin (same as the
-    // invite URL the guest opens), not the frontend dev server. The guest
-    // sets up their agent on `localhost:9883` after accepting the invite —
-    // crossing to `localhost:6747` would land on a fresh-origin localStorage
-    // with no agent and bounce the guest to the welcome page.
+    // Build the chatroom fallback URL on the SPA origin the guest already
+    // accepted the invite on. Mixing FRONTEND_URL (Vite) with SERVER_URL
+    // (embedded bundle) drops the guest's localStorage agent.
     const chatSubject = await getCurrentSubject(page);
-    const showFallback = new URL('/app/show', SERVER_URL);
+    const showFallback = new URL('/app/show', FRONTEND_URL);
     showFallback.searchParams.set('subject', chatSubject);
     const chatRoomHref = showFallback.href;
 
@@ -270,13 +268,14 @@ test.describe('data-browser', async () => {
         ?.getAttribute('data-code-content'),
     );
     expect(inviteUrl).toBeTruthy();
+    await waitForSynced(page);
 
     const context2 = await browser.newContext();
     await context2.grantPermissions(['clipboard-read', 'clipboard-write'], {
       origin: new URL(FRONTEND_URL).origin,
     });
     const page2 = await context2.newPage();
-    await page2.goto(inviteUrl as string);
+    await page2.goto(spaUrl(inviteUrl as string));
 
     await acceptInvite(page2);
     await page2.waitForURL(/\/app\//, { timeout: 15_000 });

--- a/browser/e2e/tests/local-db-off-did-render.spec.ts
+++ b/browser/e2e/tests/local-db-off-did-render.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { currentDriveTitle, FRONTEND_URL } from './test-utils';
+import {
+  currentDriveTitle,
+  FRONTEND_URL,
+  waitForServerConnected,
+} from './test-utils';
 import { applyCpuThrottle } from './perf-attach';
 
 /**
@@ -35,35 +39,32 @@ test('a DID drive renders (not bare subject) with Local DB off, server-only', as
     `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(drive ?? '')}`,
   );
 
-  // Diagnostics: what does the store hold for the drive after the refresh?
-  const diag = await page.evaluate(async d => {
+  // Diagnostics: wait until the store holds the drive's class, then snap.
+  await waitForServerConnected(page);
+  await page.waitForFunction(
+    d => {
+      const s = window.store;
+      s?.getResource(d).catch(() => undefined);
+      const r = s?.resources.get(d);
+
+      return !!r?.get?.('https://atomicdata.dev/properties/isA');
+    },
+    drive ?? '',
+    { timeout: 15_000 },
+  );
+  const diag = await page.evaluate(d => {
     const s = window.store;
+    const r = s.resources.get(d);
 
-    const snap = () => {
-      const r = s.resources.get(d);
-
-      return {
-        present: !!r,
-        loading: r?.loading ?? null,
-        error: r?.error?.message ?? null,
-        isA: (r?.get?.('https://atomicdata.dev/properties/isA') ??
-          null) as unknown,
-        entries: r?.getEntries ? r.getEntries().length : -1,
-        serverConnected: s.getSyncStatus?.()?.serverConnected ?? null,
-      };
+    return {
+      present: !!r,
+      loading: r?.loading ?? null,
+      error: r?.error?.message ?? null,
+      isA: (r?.get?.('https://atomicdata.dev/properties/isA') ??
+        null) as unknown,
+      entries: r?.getEntries ? r.getEntries().length : -1,
+      serverConnected: s.getSyncStatus?.()?.serverConnected ?? null,
     };
-
-    s.getResource(d).catch(() => undefined);
-    let last = snap();
-
-    for (let i = 0; i < 30; i++) {
-      last = snap();
-      if (last.isA) break;
-      await new Promise(res => setTimeout(res, 300));
-      s.getResource(d).catch(() => undefined);
-    }
-
-    return last;
   }, drive ?? '');
   console.log('[did-render] post-refresh drive state:', JSON.stringify(diag));
 
@@ -123,6 +124,9 @@ test('a DID drive renders (not bare subject) with Local DB off, server-only', as
 
     s.getResource(f).catch(() => undefined);
 
+    // Sampling a race window, not waiting for readiness: we need ~2s of
+    // snapshots to catch a settled-but-contentless flash. 25ms is the
+    // sample interval, not a "hope it landed" sleep.
     for (let i = 0; i < 80; i++) {
       const r = s.resources.get(f);
       out.push({

--- a/browser/e2e/tests/local-db-off-server-only.spec.ts
+++ b/browser/e2e/tests/local-db-off-server-only.spec.ts
@@ -46,7 +46,8 @@ test('drive contents load with Local DB disabled (server-only)', async ({
     return d;
   });
 
-  // Let the commit land server-side + the 1s OPFS flush tick run.
+  // Persist the create, then disable Local DB so the reload hydrates from
+  // the server only.
   await waitForSynced(page);
   await waitForClientDbFlush(page);
 

--- a/browser/e2e/tests/local-db-off-server-only.spec.ts
+++ b/browser/e2e/tests/local-db-off-server-only.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { before, newDrive, FRONTEND_URL } from './test-utils';
+import {
+  before,
+  newDrive,
+  FRONTEND_URL,
+  waitForClientDbFlush,
+  waitForSynced,
+} from './test-utils';
 
 /**
  * The Sync page "Local DB" toggle writes `atomic-disable-client-db=1` to
@@ -41,7 +47,8 @@ test('drive contents load with Local DB disabled (server-only)', async ({
   });
 
   // Let the commit land server-side + the 1s OPFS flush tick run.
-  await page.waitForTimeout(2000);
+  await waitForSynced(page);
+  await waitForClientDbFlush(page);
 
   // Toggle "Local DB" off (what the Sync page does) and reload. From here the
   // store never initialises ClientDb — the drive page is served purely from
@@ -94,7 +101,8 @@ test('UI-created drive contents load with Local DB disabled', async ({
     await f.save();
   }, driveURL);
 
-  await page.waitForTimeout(2000);
+  await waitForSynced(page);
+  await waitForClientDbFlush(page);
 
   await page.evaluate(() =>
     localStorage.setItem('atomic-disable-client-db', '1'),

--- a/browser/e2e/tests/localized-text.spec.ts
+++ b/browser/e2e/tests/localized-text.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
-import { before, inDialog, REBUILD_INDEX_TIME } from './test-utils';
+import {
+  before,
+  inDialog,
+  waitForGridMounted,
+  waitForSynced,
+} from './test-utils';
 
 const LOCALIZED_TEXT_DATATYPE =
   'https://atomicdata.dev/datatypes/localizedText';
@@ -12,12 +17,7 @@ const chips = (page: Page) => page.locator('button[title="Content language"]');
 const cell = (page: Page, rowIndex: number, colIndex: number) =>
   page.locator(`[aria-rowindex="${rowIndex}"] > [aria-colindex="${colIndex}"]`);
 
-const waitForSaved = (page: Page) =>
-  page.waitForFunction(
-    () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-    undefined,
-    { timeout: 10000 },
-  );
+const waitForSaved = (page: Page) => waitForSynced(page);
 
 /** Creates a table with the default name column plus a LocalizedText column. */
 async function createLocalizedTable(
@@ -52,7 +52,7 @@ async function createLocalizedTable(
   // click races React state initialization otherwise (same settle as
   // tables.spec).
   await expect(cell(page, 2, 2)).toBeVisible();
-  await page.waitForTimeout(1000);
+  await waitForGridMounted(page);
 }
 
 /**
@@ -193,11 +193,10 @@ test.describe('LocalizedText table columns', () => {
     // toggling split re-renders rows from the collection query, which only
     // sees the row after the server has rebuilt its index.
     await page.reload();
-    await page.waitForTimeout(REBUILD_INDEX_TIME);
+    await waitForGridMounted(page);
     await expect(page.getByRole('gridcell', { name: 'r1' })).toBeVisible({
       timeout: 15000,
     });
-    await page.waitForTimeout(1000);
 
     await declareLanguages(page, ['en', 'nl']);
 

--- a/browser/e2e/tests/localized-text.spec.ts
+++ b/browser/e2e/tests/localized-text.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import {
   before,
   inDialog,
+  pickFromMenu,
   waitForGridMounted,
   waitForSynced,
 } from './test-utils';
@@ -222,8 +223,10 @@ test.describe('LocalizedText table columns', () => {
     await expect(page.getByRole('gridcell', { name: 'Hello' })).toBeVisible();
 
     // Split into one column per declared language.
-    await chips(page).first().click();
-    await page.getByText('Split by language').click();
+    await pickFromMenu(
+      chips(page).first(),
+      page.getByText('Split by language'),
+    );
     await expect(chips(page)).toHaveCount(2);
     await expect(chips(page).nth(0)).toHaveText('en');
     await expect(chips(page).nth(1)).toHaveText('nl');

--- a/browser/e2e/tests/offline-tables.spec.ts
+++ b/browser/e2e/tests/offline-tables.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { FRONTEND_URL, editableTitle } from './test-utils';
+import {
+  FRONTEND_URL,
+  editableTitle,
+  setGridCell,
+  waitForClientDbFlush,
+} from './test-utils';
 
 /**
  * Offline-first table test.
@@ -59,17 +64,8 @@ test.describe('offline tables', () => {
     //    Double-click: first click sets Visual mode, second enters Edit mode.
     const nameCell = page.locator('[aria-rowindex="2"] [aria-colindex="2"]');
     await expect(nameCell).toBeVisible({ timeout: 10000 });
-    await nameCell.click();
-    await page.waitForTimeout(500);
-    await nameCell.click();
-    await page.waitForTimeout(300);
-
-    const cellInput = page.locator('[role="grid"] input').first();
-    await expect(cellInput).toBeVisible({ timeout: 5000 });
-    await cellInput.fill('Test Row 1');
-    // Tab commits the cell value (Escape would discard it).
-    await page.keyboard.press('Tab');
-    await page.waitForTimeout(2000);
+    await setGridCell(page, 2, 2, 'Test Row 1');
+    await waitForClientDbFlush(page);
 
     await expect(
       page.getByRole('gridcell', { name: 'Test Row 1' }),

--- a/browser/e2e/tests/ontology.spec.ts
+++ b/browser/e2e/tests/ontology.spec.ts
@@ -4,12 +4,12 @@ import {
   newDrive,
   newResource,
   before,
-  REBUILD_INDEX_TIME,
   inDialog,
   DIALOG_CLOSE_BUTTON,
   SEARCHBOX_PROPERTY_PLACEHOLDER,
   waitForSearchIndex,
   waitForClassInstanceSearchable,
+  waitForOntologyClass,
 } from './test-utils';
 
 test.describe('Ontology', async () => {
@@ -225,9 +225,10 @@ test.describe('Ontology', async () => {
       await closeDialogWith(DIALOG_CLOSE_BUTTON);
     });
 
-    // Create arrow-kind instances
-
-    await page.waitForTimeout(REBUILD_INDEX_TIME);
+    // Create arrow-kind instances. The New Instance dialog lists classes
+    // from the drive's ontologies — wait until Tantivy (and that filtered
+    // search) can see `arrow-kind` rather than sleeping for the index flush.
+    await waitForOntologyClass(page, 'arrow-kind');
 
     const createInstance = async (name: string) => {
       await page.getByRole('button', { name: 'New Instance' }).click();

--- a/browser/e2e/tests/perf-budgets.spec.ts
+++ b/browser/e2e/tests/perf-budgets.spec.ts
@@ -21,7 +21,12 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { before, newResource } from './test-utils';
+import {
+  before,
+  newResource,
+  waitForServerConnected,
+  waitForSynced,
+} from './test-utils';
 import { attachPerfSnapshot, resetPerfTrace } from './perf-attach';
 
 test.describe('perf budgets', () => {
@@ -31,20 +36,12 @@ test.describe('perf budgets', () => {
     page,
   }, testInfo) => {
     // `before` already navigated us; capture what happened.
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().serverConnected === true,
-      undefined,
-      { timeout: 15000 },
-    );
+    await waitForServerConnected(page, 15_000);
     await attachPerfSnapshot(page, testInfo, 'perf-cold-load');
   });
 
   test('reconnect: close WS + drive sync', async ({ page }, testInfo) => {
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().serverConnected === true,
-      undefined,
-      { timeout: 15000 },
-    );
+    await waitForServerConnected(page, 15_000);
 
     // Reset so the snapshot only contains the disconnect→reconnect window.
     await resetPerfTrace(page);
@@ -53,16 +50,20 @@ test.describe('perf budgets', () => {
     // the underlying WS hits the `_closed=true` branch and the auto-
     // retry loop never re-fires, so the test would just hang waiting
     // for `serverConnected===true`.
+    const syncBefore = await page.evaluate(
+      () => window.store.getSyncStatus().lastDriveSync?.timestamp ?? 0,
+    );
     await page.evaluate(() => {
       window.store.reconnect();
     });
+    await waitForServerConnected(page, 15_000);
     await page.waitForFunction(
-      () => window.store?.getSyncStatus().serverConnected === true,
-      undefined,
-      { timeout: 15000 },
+      beforeTs =>
+        (window.store?.getSyncStatus().lastDriveSync?.timestamp ?? 0) >
+        beforeTs,
+      syncBefore,
+      { timeout: 15_000 },
     );
-    // Give VV sync a moment to land.
-    await page.waitForTimeout(500);
 
     await attachPerfSnapshot(page, testInfo, 'perf-reconnect');
   });
@@ -70,11 +71,7 @@ test.describe('perf budgets', () => {
   test('genesis-creates: 5 sequential new folders', async ({
     page,
   }, testInfo) => {
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().serverConnected === true,
-      undefined,
-      { timeout: 15000 },
-    );
+    await waitForServerConnected(page, 15_000);
     await resetPerfTrace(page);
 
     // Create N folders in a row via the same sidebar flow other specs
@@ -86,11 +83,7 @@ test.describe('perf budgets', () => {
 
     for (let i = 0; i < N; i++) {
       await newResource('folder', page);
-      await page.waitForFunction(
-        () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-        undefined,
-        { timeout: 10000 },
-      );
+      await waitForSynced(page, 10_000);
     }
 
     // Reference `expect` to avoid an unused-import warning when this

--- a/browser/e2e/tests/query-drive-filter.spec.ts
+++ b/browser/e2e/tests/query-drive-filter.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { before, editableTitle } from './test-utils';
+import {
+  before,
+  editableTitle,
+  waitForClientDbFlush,
+  waitForDriveSettled,
+  waitForSynced,
+} from './test-utils';
 
 /**
  * Regression test: after creating a fresh dev-drive and refreshing the
@@ -62,13 +68,7 @@ test.describe('query GETs after refresh', () => {
     // useChildren hooks build their CollectionBuilders.
     await page.reload({ waitUntil: 'domcontentloaded' });
 
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().serverConnected === true,
-      undefined,
-      { timeout: 30000 },
-    );
-    // Idle window: let any deferred queries land.
-    await page.waitForTimeout(2000);
+    await waitForDriveSettled(page);
 
     expect(
       badRequests,
@@ -111,17 +111,8 @@ test.describe('query GETs after refresh', () => {
     // OPFS persist of the new document. If we reload before OPFS has
     // the data, the post-reload server queries are legitimate (cold
     // load), not the bug we're testing.
-    await page.waitForFunction(
-      () =>
-        window.store?.getSyncStatus().pendingDirtyCount === 0 &&
-        window.store?.getClientDb()?.isReady === true,
-      undefined,
-      { timeout: 30000 },
-    );
-
-    // Belt-and-braces: give the OPFS put queue a moment to drain so
-    // the post-reload bootstrap fingerprint matches.
-    await page.waitForTimeout(500);
+    await waitForSynced(page);
+    await waitForClientDbFlush(page);
 
     // Wire WS listeners BEFORE reload so we don't miss any framesent.
     // WS v2 framing is BINARY — see `ws-v2.ts:Tag`. GET = 0x10, encoded
@@ -161,21 +152,16 @@ test.describe('query GETs after refresh', () => {
     // Wait for steady state: WS connected, ClientDb ready, and the
     // OPFS bootstrap-fingerprint check has completed (logged as
     // "skipping seed" when the fingerprint matches).
-    await page.waitForFunction(
-      () =>
-        window.store?.getSyncStatus().serverConnected === true &&
-        window.store?.getClientDb()?.isReady === true,
-      undefined,
-      { timeout: 30000 },
-    );
+    await waitForDriveSettled(page);
 
     // Drop frames from the bootstrap window. `Collection.fetchPage` falls
     // through to `/query` while ClientDb isn't ready (or before this drive
     // has completed a local sync) — those are cold-load fetches, not the
-    // redundant post-ready storm this regression guards. Clear, then watch
-    // only the settle window where the local WASM DB must win.
+    // redundant post-ready storm this regression guards. Clear once the
+    // drive has settled, then watch only the window where the local WASM
+    // DB must win — the sidebar showing the seeded document is that UI.
     wsGetFrames.length = 0;
-    await page.waitForTimeout(2000);
+    await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
 
     // No `/query?` frames should fire at all — those are exclusively
     // collection queries that the local WASM DB can serve.

--- a/browser/e2e/tests/quick-add.spec.ts
+++ b/browser/e2e/tests/quick-add.spec.ts
@@ -4,6 +4,7 @@ import {
   createTableFromDialog,
   inDialog,
   reloadGrid,
+  waitForGridMounted,
 } from './test-utils';
 
 /**
@@ -30,7 +31,7 @@ async function createFromTemplate(
   }
 
   await expect(page.getByRole('grid')).toBeVisible();
-  await page.waitForTimeout(1000);
+  await waitForGridMounted(page);
 }
 
 /**

--- a/browser/e2e/tests/row-actions.spec.ts
+++ b/browser/e2e/tests/row-actions.spec.ts
@@ -4,6 +4,8 @@ import {
   createTableFromDialog,
   inDialog,
   reloadGrid,
+  setGridCell,
+  waitForGridInteractive,
 } from './test-utils';
 
 /**
@@ -34,8 +36,7 @@ async function createFromTemplate(
   }
 
   await expect(page.getByRole('grid')).toBeVisible();
-  // The grid binds its cell handlers after the first render.
-  await page.waitForTimeout(1000);
+  await waitForGridInteractive(page);
 }
 
 /** Types a value into one grid cell, addressed by its row and column index. */
@@ -45,21 +46,7 @@ async function setCell(
   columnIndex: number,
   value: string,
 ) {
-  const cell = page.locator(
-    `[aria-rowindex="${rowIndex}"] > [aria-colindex="${columnIndex}"]`,
-  );
-  await cell.click();
-
-  if ((await cell.locator('input').count()) === 0) {
-    await expect(cell).toBeFocused();
-    await page.keyboard.press('Enter');
-  }
-
-  await page.keyboard.type(value);
-  await page.keyboard.press('Tab');
-  await page.waitForTimeout(200);
-  await page.keyboard.press('Escape');
-  await page.waitForTimeout(200);
+  await setGridCell(page, rowIndex, columnIndex, value);
 }
 
 /** The column headings, left to right. */

--- a/browser/e2e/tests/sync.spec.ts
+++ b/browser/e2e/tests/sync.spec.ts
@@ -5,86 +5,12 @@ import {
   currentDriveTitle,
   FRONTEND_URL,
   getDevDriveSecret,
+  waitForClientDbFlush,
+  waitForClientDbReady,
+  waitForSearchIndex,
+  waitForServerConnected,
+  waitForSynced,
 } from './test-utils';
-
-/** Wait for the WASM ClientDb to be initialized and seeded. */
-async function waitForClientDb(page: import('@playwright/test').Page) {
-  await page.waitForFunction(
-    () => window.store?.getClientDb()?.isReady === true,
-    undefined,
-    { timeout: 30000 },
-  );
-}
-
-/** Wait for the store to be connected to the server. */
-async function waitForConnected(page: import('@playwright/test').Page) {
-  await page.waitForFunction(
-    () => window.store?.getSyncStatus().serverConnected === true,
-    undefined,
-    { timeout: 30000 },
-  );
-}
-
-/** Wait for all dirty resources to be synced (pendingDirtyCount === 0). */
-async function waitForSynced(page: import('@playwright/test').Page) {
-  try {
-    await page.waitForFunction(
-      () => {
-        const status = window.store?.getSyncStatus();
-
-        return status.serverConnected && status.pendingDirtyCount === 0;
-      },
-      undefined,
-      { timeout: 30000 },
-    );
-  } catch (e) {
-    // Surface WHY sync didn't settle. A stuck `pendingDirtyCount` means
-    // an outbox entry's post keeps throwing — `lastAttemptError` carries
-    // the server's rejection reason, which is otherwise invisible.
-    const diag = await page
-      .evaluate(() => {
-        const store = window.store;
-        const status = store.getSyncStatus();
-        // The outbox is Loro-delta based now (a pre-signed genesis + a save
-        // cursor), not a list of commits — surface those fields instead.
-        const entries = store.outbox.pending().map(entry => ({
-          subject: entry.subject,
-          enqueuedAt: entry.enqueuedAt,
-          hasSignedGenesis: !!entry.signedGenesis,
-          baseVersion: entry.baseVersion,
-          lastAttemptError: entry.lastAttemptError,
-        }));
-
-        return { status, entries };
-      })
-      .catch(() => undefined);
-    throw new Error(
-      `waitForSynced timed out. Outbox diagnostics: ${JSON.stringify(diag)}`,
-    );
-  }
-}
-
-/** Wait for the server's search index to process a commit (polls search endpoint). */
-async function waitForSearchable(
-  page: import('@playwright/test').Page,
-  query: string,
-) {
-  await page.waitForFunction(
-    async (q: string) => {
-      if (!window.store) return false;
-
-      try {
-        const results = await window.store.search(q);
-
-        return results.length > 0;
-      } catch {
-        return false;
-      }
-    },
-    query,
-    { timeout: 30000, polling: 1000 },
-  );
-}
 
 test.describe('sync', () => {
   test.beforeEach(before);
@@ -223,10 +149,10 @@ test.describe('sync', () => {
 
     // 4. Reload the page
     await page.reload({ waitUntil: 'domcontentloaded' });
-    await waitForClientDb(page);
+    await waitForClientDbReady(page);
 
     // Wait for the resource itself to report the offline edit before
-    // asserting on the DOM. `waitForClientDb` only confirms the worker/
+    // asserting on the DOM. `waitForClientDbReady` only confirms the worker/
     // OPFS bootstrap finished, not that THIS resource's local-first fetch
     // has resolved — under a contended runner that can outlast a bare
     // `toBeVisible` poll.
@@ -398,31 +324,20 @@ test.describe('sync', () => {
     // tick. The reload below would roll the edit back, and the server would
     // never hear about it — which is exactly this test's failure mode, right
     // down to the fresh context reading the pre-offline title.
-    await page.evaluate(async () => {
-      const db = window.store.getClientDb();
-
-      // Not optional-chained: `?.flush()` on an absent ClientDb is a silent
-      // no-op, and this test would then fail exactly as it does without the
-      // flush at all — blaming durability for a database that was never there.
-      if (!db) throw new Error('ClientDb missing when asking for a flush');
-
-      await db.flush();
-    });
+    await waitForClientDbFlush(page, { required: true });
 
     // 4. Go back online — navigate to force fresh WS connection
     await context.setOffline(false);
-    // Small delay to let the network stack come back up
-    await page.waitForTimeout(500);
     // Reload establishes a fresh store + WS
     await page.reload({ waitUntil: 'domcontentloaded' });
-    await waitForConnected(page);
+    await waitForServerConnected(page);
 
     // The dirty sync should push the offline edit to the server.
     // Wait for all pending resources to sync.
     await waitForSynced(page);
 
     // Wait for the search index to pick up the change
-    await waitForSearchable(page, 'Synced From Offline');
+    await waitForSearchIndex(page, 'Synced From Offline');
 
     // Ask the server for its own copy over HTTP, bypassing every local cache.
     // The two waits above both have blind spots — `waitForSynced` proves the
@@ -466,7 +381,7 @@ test.describe('sync', () => {
     // signal that the sign-in took, so wait for that instead.
 
     // Wait for the second page to connect
-    await waitForConnected(page2);
+    await waitForServerConnected(page2);
 
     // Navigate to the resource — the legacy `adress-bar` input is gone;
     // route directly via the SPA's /app/show entry.

--- a/browser/e2e/tests/table-refresh.spec.ts
+++ b/browser/e2e/tests/table-refresh.spec.ts
@@ -1,6 +1,13 @@
 // oxlint-disable no-await-in-loop
 import { test, expect } from '@playwright/test';
-import { before, editableTitle, FRONTEND_URL, newResource } from './test-utils';
+import {
+  before,
+  editableTitle,
+  FRONTEND_URL,
+  newResource,
+  setGridCell,
+  waitForSynced,
+} from './test-utils';
 
 /**
  * Regression: refreshing a Table's page must not grow the child-row count.
@@ -151,22 +158,11 @@ test.describe('table refresh', () => {
     // no separate sleep needed.
     const nameCell = page.locator('[aria-rowindex="2"] [aria-colindex="2"]');
     await expect(nameCell).toBeVisible({ timeout: 10000 });
-    await nameCell.click();
-    await page.waitForTimeout(300);
-    await nameCell.click();
-    await page.waitForTimeout(300);
-    const cellInput = page.locator('[role="grid"] input').first();
-    await expect(cellInput).toBeVisible({ timeout: 5000 });
-    await cellInput.fill('row-1');
-    await page.keyboard.press('Tab');
+    await setGridCell(page, 2, 2, 'row-1');
     // Wait for the cell save to drain into the server. The dirty queue is
     // 0 once the commit has been ack'd — that's the actual saved-and-
     // visible-on-reload signal we want the row count to reflect.
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     const rows = page.locator('[aria-rowindex]');
     const afterTypeCount = await rows.count();

--- a/browser/e2e/tests/table-refresh.spec.ts
+++ b/browser/e2e/tests/table-refresh.spec.ts
@@ -6,6 +6,7 @@ import {
   FRONTEND_URL,
   newResource,
   setGridCell,
+  waitForClientDbReady,
   waitForSynced,
 } from './test-utils';
 
@@ -95,56 +96,13 @@ test.describe('table refresh', () => {
   }) => {
     test.slow();
 
-    // Confirm the WASM ClientDb actually initialized in this browser — the
-    // user's bug is WASM-side, so a silent fallback would mask the issue.
+    // Confirm the WASM ClientDb actually initialized — a silent fallback
+    // would mask the bug this test exists to catch. `isReady` is the
+    // signal; a 200ms poll is not.
     await page.goto(`${FRONTEND_URL}/`, {
       waitUntil: 'domcontentloaded',
     });
-    const clientDbState = await page.evaluate(
-      () =>
-        new Promise<string>(resolve => {
-          const start = Date.now();
-
-          const tick = () => {
-            // `window.store` is published when the app bundle runs, and the
-            // navigation above only waits for `domcontentloaded` — so on a
-            // slower machine this polls before there is a store at all. It
-            // used to read straight through and throw a TypeError out of the
-            // promise, failing the test with "Cannot read properties of
-            // undefined" instead of waiting the extra tick it needed.
-            const db = window.store?.getClientDb?.();
-
-            if (db?.isReady) {
-              resolve('ready');
-
-              return;
-            }
-
-            if (db?.initError) {
-              resolve('error:' + db.initError.message);
-
-              return;
-            }
-
-            if (Date.now() - start > 20000) {
-              resolve(
-                `timeout: store=${!!window.store} db=${!!db} isReady=${db?.isReady}`,
-              );
-
-              return;
-            }
-
-            setTimeout(tick, 200);
-          };
-
-          tick();
-        }),
-    );
-    console.log(`ClientDb state: ${clientDbState}`);
-    expect(
-      clientDbState,
-      'WASM ClientDb must be ready for this test to be meaningful',
-    ).toBe('ready');
+    await waitForClientDbReady(page, 20_000);
 
     await newResource('table', page);
     const nameInput = page.getByPlaceholder('New Table');

--- a/browser/e2e/tests/table-templates.spec.ts
+++ b/browser/e2e/tests/table-templates.spec.ts
@@ -4,6 +4,8 @@ import {
   createTableFromDialog,
   newResource,
   reloadGrid,
+  setGridCell,
+  waitForGridInteractive,
   waitForRowsMaterialized,
 } from './test-utils';
 
@@ -25,10 +27,7 @@ const row = (page: Page, text: string) =>
 /** Creates a table from a template card and waits for its grid. */
 async function createFromTemplate(page: Page, template: RegExp, name: string) {
   await createTableFromDialog(page, { template, name });
-  await expect(page.getByRole('grid')).toBeVisible();
-  // The grid binds its cell handlers after the first render; clicking before
-  // that lands on nothing.
-  await page.waitForTimeout(1000);
+  await waitForGridInteractive(page);
 }
 
 /** The column headings, left to right, as the view renders them. */
@@ -45,41 +44,11 @@ async function setCell(
   rowIndex: number,
   columnIndex: number,
   value: string,
-  opts: { replace?: boolean } = {},
+  _opts: { replace?: boolean } = {},
 ) {
-  const cell = page.locator(
-    `[aria-rowindex="${rowIndex}"] > [aria-colindex="${columnIndex}"]`,
-  );
-  await cell.click();
-
-  // Clicking a cell that is already the active one enters edit mode directly,
-  // which is where Tab out of the previous cell leaves us — so only ask for edit
-  // mode when the click merely focused the cell.
-  if ((await cell.locator('input').count()) === 0) {
-    await expect(cell).toBeFocused();
-    await page.keyboard.press('Enter');
-  }
-
-  if (opts.replace) {
-    await page.keyboard.press('ControlOrMeta+a');
-  }
-
-  await page.keyboard.type(value);
-  // Tab commits the edit (Escape would revert it) and moves into the next cell,
-  // in edit mode — Escape leaves it, so the next click lands on a cell that can
-  // take focus again.
-  await page.keyboard.press('Tab');
-  await page.waitForTimeout(200);
-  await page.keyboard.press('Escape');
-  await page.waitForTimeout(200);
-
-  // Check the value actually arrived. Keystrokes can land on a grid that is
-  // not listening yet and nothing above would notice — the cell stays empty
-  // and the failure surfaces much later as a total with nothing to add or a
-  // filter that matches nothing, pointing at the wrong feature entirely.
-  // Matched loosely because a column may reformat what it was given ("4.50"
+  // Matched loosely when the column reformats what it was given ("4.50"
   // renders as "4.5"); what is being ruled out is the cell being empty.
-  await expect(cell).toContainText(/\S/);
+  await setGridCell(page, rowIndex, columnIndex, value, { match: /\S/ });
 }
 
 /**

--- a/browser/e2e/tests/tables.spec.ts
+++ b/browser/e2e/tests/tables.spec.ts
@@ -3,10 +3,15 @@ import {
   newResource,
   before,
   createTableFromDialog,
+  enterGridEdit,
+  focusCell,
   inDialog,
   reloadGrid,
+  tabToNextGridCell,
+  typeInActiveGridCell,
+  waitForGridMounted,
+  waitForSynced,
   waitForTableBuild,
-  REBUILD_INDEX_TIME,
 } from './test-utils';
 
 /**
@@ -63,8 +68,7 @@ test.describe('tables', async () => {
     };
 
     const tab = async () => {
-      await page.keyboard.press('Tab');
-      await page.waitForTimeout(150);
+      await tabToNextGridCell(page);
     };
 
     const createTag = async (emote: string, name: string) => {
@@ -115,12 +119,12 @@ test.describe('tables', async () => {
           `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`,
         ),
       ).toBeFocused();
-      await page
-        .locator(`[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`)
-        .fill(name);
-      await page.waitForTimeout(300);
+      const nameInput = page.locator(
+        `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`,
+      );
+      await nameInput.fill(name);
+      await expect(nameInput).toHaveValue(name);
       await tab();
-      await page.waitForTimeout(300);
       await expect(
         page.getByRole('rowheader', { name: `${currentRowNumber + 1}` }),
       ).toBeAttached();
@@ -231,11 +235,7 @@ test.describe('tables', async () => {
     // 'networkidle' is unreliable on SPAs with persistent WebSocket
     // connections (commit subscriptions, the open WS, etc.). The dirty
     // queue is the actual saved-to-server signal.
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
     await page.reload();
     await expect(
       page.getByRole('button', { name: selectColumnName }),
@@ -264,22 +264,12 @@ test.describe('tables', async () => {
         select: 'wtf',
       },
     ];
-    // Wait for the grid to be ready before fillRow starts clicking. The cell
-    // click races with TableEditor's React state initialization (handlers
-    // bound after first render); fillRow clicks without `force` so playwright
-    // auto-waits for actionability, but give the first render a moment to
-    // settle so the very first mousedown lands on bound handlers (which set
-    // `activeCell` + `CursorMode.Visual`, the precondition for Enter → Edit).
-    // fillRow owns all positioning — clicking an already-active cell enters
-    // edit mode instead of just focusing it, so we must not pre-click here.
-    // 30s, not the 10s default: the first data row renders after the new
-    // columns' commits clear the ClientDb worker queue, which under a loaded
-    // runner sits behind seconds of index-rebuilding writes (same measured
-    // budget as the rest of the totals/tables family).
-    await expect(
-      page.locator('[aria-rowindex="2"] > [aria-colindex="2"]'),
-    ).toBeVisible({ timeout: 30000 });
-    await page.waitForTimeout(1000);
+    // Wait for the collection's placeholder row before fillRow starts
+    // clicking. fillRow owns all positioning — clicking an already-active
+    // cell enters edit mode instead of just focusing it, so we must not
+    // pre-click here. 30s, not the 10s default: the first data row renders
+    // after the new columns' commits clear the ClientDb worker queue.
+    await waitForGridMounted(page);
 
     for (const [index, row] of rows.entries()) {
       await fillRow(index + 1, row);
@@ -331,10 +321,7 @@ test.describe('tables', async () => {
     await createBlankTable(page, 'Fast Entry Test');
 
     const firstCell = page.getByRole('gridcell').first();
-
-    // Click first cell to focus the table
-    await firstCell.click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, firstCell);
 
     // Enough rows to overflow the viewport and exercise react-window
     // virtualization + auto-scroll as new rows are added past the fold.
@@ -342,14 +329,9 @@ test.describe('tables', async () => {
 
     // Type each value and immediately press Enter to move to the next row
     for (const value of values) {
-      await page.keyboard.press('Enter');
-      await page.waitForTimeout(100);
-      await page.keyboard.type(value, { delay: 30 });
-      await page.waitForTimeout(100);
+      await enterGridEdit(page);
+      await typeInActiveGridCell(page, value);
     }
-
-    // Wait for last typed value to register before exiting edit mode
-    await page.waitForTimeout(500);
 
     // Every Enter must have created a row. This is the regression guard for
     // the bug where, once rows overflowed the viewport, a list remount snapped
@@ -418,7 +400,6 @@ test.describe('tables', async () => {
     // of that work back (the CI-only "row40 missing after refresh").
     await reloadGrid(page);
     await expect(page.getByTestId('editable-title').first()).toBeVisible();
-    await page.waitForTimeout(REBUILD_INDEX_TIME);
 
     // 30s, not the default: the post-reload re-drain queues forty rows of
     // writes ahead of the member query in the ClientDb worker, and on a
@@ -450,23 +431,16 @@ test.describe('tables', async () => {
     await createBlankTable(page, 'Sort Test');
 
     const firstCell = page.getByRole('gridcell').first();
-    await firstCell.click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, firstCell);
 
     // Enter rows whose names are NOT in alphabetical order.
     for (const name of ['gamma', 'alpha', 'beta']) {
-      await page.keyboard.press('Enter');
-      await page.waitForTimeout(100);
-      await page.keyboard.type(name, { delay: 20 });
-      await page.waitForTimeout(100);
+      await enterGridEdit(page);
+      await typeInActiveGridCell(page, name);
     }
 
     await page.keyboard.press('Escape');
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     // Default sort is by creation time → insertion order: gamma is row 1.
     await expect(
@@ -481,7 +455,6 @@ test.describe('tables', async () => {
       .getByRole('button', { name: 'name', exact: true })
       .first()
       .click();
-    await page.waitForTimeout(500);
 
     // After sort, the freshly-entered virtual rows must reorder: "alpha" first.
     await expect(
@@ -497,23 +470,16 @@ test.describe('tables', async () => {
     await createBlankTable(page, 'Insert Below Test');
 
     const firstCell = page.getByRole('gridcell').first();
-    await firstCell.click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, firstCell);
 
     // Two rows via normal fast entry.
     for (const value of ['rowA', 'rowB']) {
-      await page.keyboard.press('Enter');
-      await page.waitForTimeout(100);
-      await page.keyboard.type(value, { delay: 30 });
-      await page.waitForTimeout(100);
+      await enterGridEdit(page);
+      await typeInActiveGridCell(page, value);
     }
 
     await page.keyboard.press('Escape');
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     // Reload so the rows are collection members (positional insert targets
     // persisted rows; this-session virtual rows always append at the bottom).
@@ -524,8 +490,7 @@ test.describe('tables', async () => {
     });
 
     // Select rowA's name cell, then insert a row below it.
-    await page.getByText('rowA', { exact: true }).click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, page.getByText('rowA', { exact: true }));
     await page.keyboard.press('Shift+Enter');
 
     // The inserted row is persisted with a fractional sortOrder between rowA
@@ -536,15 +501,10 @@ test.describe('tables', async () => {
     ).toContainText('rowB', { timeout: 15000 });
 
     // The cursor moved to the inserted row; typing fills its name cell.
-    await page.keyboard.type('rowINSERTED', { delay: 30 });
-    await page.waitForTimeout(300);
+    await enterGridEdit(page);
+    await typeInActiveGridCell(page, 'rowINSERTED');
     await page.keyboard.press('Escape');
-
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     const expectOrder = async () => {
       await expect(page.locator('[aria-rowindex="2"]')).toContainText('rowA', {
@@ -575,24 +535,18 @@ test.describe('tables', async () => {
     await createBlankTable(page, 'Insert Session Test');
 
     const firstCell = page.getByRole('gridcell').first();
-    await firstCell.click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, firstCell);
 
     for (const value of ['rowA', 'rowB']) {
-      await page.keyboard.press('Enter');
-      await page.waitForTimeout(100);
-      await page.keyboard.type(value, { delay: 30 });
-      await page.waitForTimeout(100);
+      await enterGridEdit(page);
+      await typeInActiveGridCell(page, value);
     }
 
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(200);
 
     // Without reloading (rows are still session drafts), insert below rowA.
-    await page.getByText('rowA', { exact: true }).click({ force: true });
-    await page.waitForTimeout(300);
+    await focusCell(page, page.getByText('rowA', { exact: true }));
     await page.keyboard.press('Shift+Enter');
-    await page.waitForTimeout(300);
 
     // The spliced virtual row renders immediately at aria-rowindex 3,
     // pushing rowB down; the cursor is on it.
@@ -603,17 +557,10 @@ test.describe('tables', async () => {
     // Enter edit mode explicitly (focuses the cell input) before typing —
     // typing into a just-mounted cell via the type-to-edit relay can race
     // its event-listener registration at automation speed.
-    await page.keyboard.press('Enter');
-    await page.waitForTimeout(100);
-    await page.keyboard.type('rowMID', { delay: 30 });
-    await page.waitForTimeout(300);
+    await enterGridEdit(page);
+    await typeInActiveGridCell(page, 'rowMID');
     await page.keyboard.press('Escape');
-
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+    await waitForSynced(page);
 
     const expectOrder = async () => {
       await expect(page.locator('[aria-rowindex="2"]')).toContainText('rowA', {

--- a/browser/e2e/tests/tables.spec.ts
+++ b/browser/e2e/tests/tables.spec.ts
@@ -107,18 +107,24 @@ test.describe('tables', async () => {
       // cell to land here in edit mode. Click the target cell directly,
       // mirroring the initial cell setup — the trailing empty row is always
       // present once the previous row has gained content.
-      const rowFirstCell = page.locator(
-        `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"]`,
-      );
-      await rowFirstCell.scrollIntoViewIfNeeded();
-      await rowFirstCell.click();
-      await expect(rowFirstCell).toBeFocused();
-      await page.keyboard.press('Enter');
-      await expect(
-        page.locator(
-          `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`,
-        ),
-      ).toBeFocused();
+      //
+      // The grid remounts rows while they materialize; a locator that was
+      // attached a moment ago can detach mid-scroll. Retry until focus
+      // lands in this cell's editor.
+      await expect(async () => {
+        const rowFirstCell = page.locator(
+          `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"]`,
+        );
+        await rowFirstCell.scrollIntoViewIfNeeded();
+        await rowFirstCell.click();
+        await expect(rowFirstCell).toBeFocused({ timeout: 2_000 });
+        await page.keyboard.press('Enter');
+        await expect(
+          page.locator(
+            `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`,
+          ),
+        ).toBeFocused({ timeout: 2_000 });
+      }).toPass({ timeout: 15_000 });
       const nameInput = page.locator(
         `[aria-rowindex="${rowIndex}"] > [aria-colindex="2"] > input`,
       );

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -20,6 +20,28 @@ export const SERVER_URL = process.env.SERVER_URL || 'http://localhost:9883';
 export const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:6747';
 
 /**
+ * Rewrite a server-origin URL onto the SPA origin Playwright drives.
+ *
+ * Invite links and `/app/…` URLs are minted on the atomic-server origin.
+ * Locally that origin may serve a stub bundle while Vite is on
+ * `FRONTEND_URL`. Opening the server URL then loads an empty page and
+ * every "Create account and accept" wait times out. CI sets both to the
+ * same origin, so this is a no-op there.
+ */
+export function spaUrl(url: string): string {
+  try {
+    const parsed = new URL(url, FRONTEND_URL);
+    const frontend = new URL(FRONTEND_URL);
+    parsed.protocol = frontend.protocol;
+    parsed.host = frontend.host;
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Hostname the Node test process can actually reach.
  *
  * Dagger serves the SPA at `http://atomic.localhost:9883` so Chromium treats
@@ -1391,7 +1413,7 @@ export async function setGridCell(
     }
 
     await expect(input).toBeVisible({ timeout: 2_000 });
-    await input.fill(value);
+    await fillGridInput(input, value);
     await page.keyboard.press('Tab');
     await page.keyboard.press('Escape');
 
@@ -1404,18 +1426,38 @@ export async function setGridCell(
 }
 
 /**
- * Opens the menu behind `trigger` and clicks `item` in it.
- *
- * Two things go wrong with a plain click-then-click. The dropdown mounts
- * `visibility: hidden` and reveals itself a frame after it has been
- * positioned, and a dismissed menu can linger in the DOM — so an unscoped
- * locator can resolve to a hidden item and wait out its whole budget on
- * something that will never appear. And the trigger TOGGLES its menu, so a
- * click landing while a previous menu is still closing closes this one
- * instead of opening it.
- *
- * Hence: scope to a visible instance, and retry the open as well as the pick.
+ * Fill a grid editor. Native `type="date"` inputs reject `fill("15012026")`
+ * (`Malformed value`); they want ISO. The suite types ddMMyyyy because it
+ * runs in `en-GB` — convert that, then `fill` the ISO form.
  */
+async function fillGridInput(input: Locator, value: string) {
+  const type = await input.getAttribute('type');
+
+  if (type === 'date') {
+    const iso = ddmmyyyyToIso(value);
+    await input.fill(iso);
+
+    return;
+  }
+
+  await input.fill(value);
+}
+
+/** `15012026` / `2026-01-15` → `2026-01-15`. Other strings pass through. */
+function ddmmyyyyToIso(value: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+
+  const digits = value.replace(/\D/g, '');
+
+  if (digits.length === 8) {
+    return `${digits.slice(4)}-${digits.slice(2, 4)}-${digits.slice(0, 2)}`;
+  }
+
+  return value;
+}
+
 /**
  * Waits until every row typed into a grid is a real member of its table.
  *
@@ -1501,6 +1543,19 @@ export async function focusCell(page: Page, cell: Locator) {
   }).toPass({ timeout: 15_000 });
 }
 
+/**
+ * Opens the menu behind `trigger` and clicks `item` in it.
+ *
+ * Two things go wrong with a plain click-then-click. The dropdown mounts
+ * `visibility: hidden` and reveals itself a frame after it has been
+ * positioned, and a dismissed menu can linger in the DOM — so an unscoped
+ * locator can resolve to a hidden item and wait out its whole budget on
+ * something that will never appear. And the trigger TOGGLES its menu, so a
+ * click landing while a previous menu is still closing closes this one
+ * instead of opening it.
+ *
+ * Hence: scope to a visible instance, and retry the open as well as the pick.
+ */
 export async function pickFromMenu(trigger: Locator, item: Locator) {
   const visible = item.filter({ visible: true }).first();
 
@@ -1549,7 +1604,7 @@ export async function openNewSubjectWindow(
   // be visited directly — wrapping them in /app/show?subject=... would treat
   // them as resources to fetch and the server has no such resource.
   if (url.includes('/app/')) {
-    await page.goto(url);
+    await page.goto(spaUrl(url));
   } else {
     await openSubject(page, url);
   }

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -187,11 +187,9 @@ export const sidebarDriveButtonId = 'sidebar-drive-open';
 export const defaultDevServer = 'http://localhost:9883';
 export const currentDialogOkButton = 'dialog[open] >> footer >> text=Ok';
 // Fallback wait for the search index to catch up, for callers that can't
-// supply a probe to `waitForSearchIndex`. The e2e server runs with a short
-// `ATOMIC_SEARCH_INDEX_INTERVAL_MS` (see `commit_monitor.rs`), so the flush
-// happens in well under a second — this is a safe upper bound, not the 5s
-// production cadence. Prefer the probe form of `waitForSearchIndex`, which
-// polls real readiness and is independent of the server's flush interval.
+// supply a probe to `waitForSearchIndex`. Prefer the probe form, which
+// polls real readiness. Kept as a named budget for comments that still
+// refer to the server's flush interval (`commit_monitor.rs`).
 export const REBUILD_INDEX_TIME = 1500;
 
 /**
@@ -689,48 +687,36 @@ export async function waitForCommitOnCurrentResource(
   );
 
   await Promise.race([httpMatch, wsMatch]);
-  // Give the store a beat to apply the response before callers assert
-  // — matches the prior `waitForTimeout(200)` after HTTP detection.
-  await page.waitForTimeout(200);
+  // The commit is on the wire; wait until this resource is no longer saving
+  // so callers that read the store or UI are not racing the apply.
+  await page.waitForFunction(
+    subject => {
+      const r = window.store?.resources.get(subject);
+
+      return !!r && !r.loading && !r.isSaving;
+    },
+    currentSubject,
+    { timeout: 15_000 },
+  );
 }
 
 /**
- * Wait for the search index to catch up with recently-created resources.
- *
- * The e2e server runs with a short `ATOMIC_SEARCH_INDEX_INTERVAL_MS` (see
- * `commit_monitor.rs`), so the Tantivy flush + reader reload completes in well
- * under a second — {@link REBUILD_INDEX_TIME} is a safe upper bound, not the 5s
- * production cadence.
- *
- * Where a test searches for one specific resource in a single page/context,
- * prefer an explicit `store.search(query, { parents: drive })` poll for the
- * subject (see `search.spec.ts` "text search") — that's true readiness. A
- * generic probe here is deliberately avoided: it's unreliable across a second
- * browser context (drive scoping) and the overlay's streaming re-render races a
- * click that fires too soon.
- */
-/**
  * Waits until the server's search index can answer for `query`.
  *
- * Without a query this is the old fallback: a fixed sleep, hoping Tantivy
- * committed inside it. That is a guess, and on a loaded server it is wrong —
- * the search then returns fewer hits than the test expects and fails on
- * whatever it was about to select.
+ * Polls `store.search` until it returns at least `expected` hits. A fixed
+ * sleep (the old `REBUILD_INDEX_TIME` fallback) is not a signal: on a loaded
+ * server Tantivy may still be behind, and the search then returns fewer hits
+ * than the test is about to select.
  *
- * With a query it polls the real thing. `expected` is how many hits to wait
- * for, which matters when a test is about to index into the results.
+ * `expected` matters when a test indexes into the results. For a filtered
+ * picker (`filters: {isA: <class>}`), use {@link waitForClassInstanceSearchable}
+ * instead — those searches skip the local index.
  */
 export async function waitForSearchIndex(
   page: Page,
-  query?: string,
+  query: string,
   expected = 1,
 ): Promise<void> {
-  if (query === undefined) {
-    await page.waitForTimeout(REBUILD_INDEX_TIME);
-
-    return;
-  }
-
   await expect
     .poll(
       () =>
@@ -1155,11 +1141,266 @@ export async function createTableFromDialog(
  */
 export async function reloadReconnected(page: Page) {
   await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForServerConnected(page);
+}
+
+/**
+ * Wait until the WebSocket is up.
+ */
+export async function waitForServerConnected(page: Page, timeoutMs = 30_000) {
   await page.waitForFunction(
-    () => window.store.getSyncStatus().serverConnected === true,
+    () => window.store?.getSyncStatus().serverConnected === true,
     undefined,
-    { timeout: 30_000 },
+    { timeout: timeoutMs },
   );
+}
+
+/**
+ * Wait until the WASM ClientDb has finished init + seed.
+ */
+export async function waitForClientDbReady(page: Page, timeoutMs = 30_000) {
+  await page.waitForFunction(
+    () => window.store?.getClientDb()?.isReady === true,
+    undefined,
+    { timeout: timeoutMs },
+  );
+}
+
+/**
+ * Persist OPFS writes that commit with `Durability::None`.
+ *
+ * Reloading, going offline, or turning ClientDb off before this tick rolls
+ * those writes back. `flush()` is the durable signal; a sleep is not.
+ * No-op (and not an error) when ClientDb is disabled — there is nothing to
+ * flush.
+ */
+export async function waitForClientDbFlush(
+  page: Page,
+  opts: { required?: boolean } = {},
+) {
+  await page.evaluate(async required => {
+    const db = window.store?.getClientDb();
+
+    if (!db) {
+      if (required) {
+        throw new Error('ClientDb missing when asking for a flush');
+      }
+
+      return;
+    }
+
+    await db.flush();
+  }, opts.required === true);
+}
+
+/**
+ * Wait until nothing local is still waiting to reach the server.
+ *
+ * Covers the outbox, in-flight `save()`s, and UI debounce timers
+ * (`startScheduledSave`). `0` means a reload will not drop an edit.
+ */
+export async function waitForSynced(page: Page, timeoutMs = 30_000) {
+  try {
+    await page.waitForFunction(
+      () => {
+        const status = window.store?.getSyncStatus();
+
+        return !!status && status.pendingDirtyCount === 0;
+      },
+      undefined,
+      { timeout: timeoutMs },
+    );
+  } catch (cause) {
+    const diag = await page
+      .evaluate(() => {
+        const store = window.store;
+        const status = store?.getSyncStatus();
+        const entries =
+          store?.outbox
+            ?.pending?.()
+            .map(
+              (entry: {
+                subject: string;
+                enqueuedAt: number;
+                signedGenesis?: unknown;
+                lastAttemptError?: unknown;
+              }) => ({
+                subject: entry.subject,
+                enqueuedAt: entry.enqueuedAt,
+                hasSignedGenesis: !!entry.signedGenesis,
+                lastAttemptError: entry.lastAttemptError,
+              }),
+            ) ?? [];
+
+        return { status, entries };
+      })
+      .catch(() => undefined);
+    throw new Error(
+      `waitForSynced timed out. Outbox diagnostics: ${JSON.stringify(diag)}`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Wait until the current drive has finished its post-load handshake.
+ *
+ * Collection queries that fire during bootstrap have either already gone
+ * out or will go out as part of rendering the settled UI — so this is the
+ * point at which "no more /query traffic" assertions become meaningful.
+ * When ClientDb is disabled, readiness is just the WS + a finished drive
+ * sync (`clientDbAttached` is false).
+ */
+export async function waitForDriveSettled(page: Page, timeoutMs = 30_000) {
+  await page.waitForFunction(
+    () => {
+      const s = window.store?.getSyncStatus();
+
+      if (!s) {
+        return false;
+      }
+
+      const dbOk = s.clientDbAttached ? s.clientDbReady : true;
+
+      return (
+        s.serverConnected &&
+        !s.syncInProgress &&
+        s.pendingDirtyCount === 0 &&
+        dbOk &&
+        !!s.lastDriveSync
+      );
+    },
+    undefined,
+    { timeout: timeoutMs },
+  );
+}
+
+/**
+ * Wait until the table grid has mounted a data row.
+ *
+ * The grid element can paint before the collection's first page lands, and
+ * a timer / quick-add that creates a row in that window persists it without
+ * rendering it. The trailing placeholder (`aria-rowindex="2"`) is the
+ * collection's "I have rows to show" signal — including the empty table.
+ */
+export async function waitForGridMounted(page: Page, timeoutMs = 30_000) {
+  await expect(page.getByRole('grid')).toBeVisible({ timeout: timeoutMs });
+  await expect(page.locator('[aria-rowindex="2"]')).toBeVisible({
+    timeout: timeoutMs,
+  });
+}
+
+/**
+ * Wait until the grid will accept keyboard input.
+ *
+ * TableEditor binds cell handlers after the first render. A click in that
+ * window leaves focus on the title, and keystrokes never create a row.
+ * {@link focusCell} is the observable precondition.
+ */
+export async function waitForGridInteractive(page: Page) {
+  await waitForGridMounted(page);
+  await focusCell(
+    page,
+    page.locator('[aria-rowindex="2"] > [aria-colindex="2"]'),
+  );
+}
+
+/**
+ * Press Enter in the grid and wait until a cell editor is focused.
+ *
+ * In Visual mode this enters edit; in Edit mode it moves to the next row
+ * and stays in edit. Either way the signal is the same: an `<input>`
+ * inside the grid has focus.
+ */
+export async function enterGridEdit(page: Page) {
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[role="grid"] input').first()).toBeFocused({
+    timeout: 15_000,
+  });
+}
+
+/**
+ * Type into the focused grid cell editor and wait until the value stuck.
+ *
+ * Keystrokes that land before the editor mounts are dropped, and Enter
+ * on the next row then commits an empty cell. The input's value is the
+ * signal that React has the text.
+ */
+export async function typeInActiveGridCell(page: Page, value: string) {
+  const input = page.locator('[role="grid"] input').first();
+  await expect(input).toBeFocused({ timeout: 15_000 });
+  await input.fill(value);
+  await expect(input).toHaveValue(value);
+}
+
+/**
+ * Tab out of the current grid cell and wait until focus moved.
+ *
+ * The next cell's editor mounts asynchronously; typing before that
+ * writes into the previous cell or into the title.
+ */
+export async function tabToNextGridCell(page: Page) {
+  const from = await page.evaluate(
+    () =>
+      document.activeElement
+        ?.closest('[aria-colindex]')
+        ?.getAttribute('aria-colindex') ?? null,
+  );
+
+  await page.keyboard.press('Tab');
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            document.activeElement
+              ?.closest('[aria-colindex]')
+              ?.getAttribute('aria-colindex') ?? null,
+        ),
+      { timeout: 15_000 },
+    )
+    .not.toBe(from);
+}
+
+/**
+ * Put `value` in one grid cell, addressed by row and column index.
+ *
+ * Clicks until the grid takes focus, opens the editor if needed, fills,
+ * Tabs to commit (Escape would revert), and waits until the cell shows
+ * `match` (defaults to `value`). Retries the whole sequence when the
+ * grid remounts the cell under the pointer.
+ */
+export async function setGridCell(
+  page: Page,
+  rowIndex: number,
+  columnIndex: number,
+  value: string,
+  opts: { match?: string | RegExp } = {},
+) {
+  const cell = page.locator(
+    `[aria-rowindex="${rowIndex}"] > [aria-colindex="${columnIndex}"]`,
+  );
+
+  await expect(async () => {
+    await cell.click();
+    const input = cell.locator('input');
+
+    if ((await input.count()) === 0) {
+      await expect(cell).toBeFocused({ timeout: 2_000 });
+      await page.keyboard.press('Enter');
+    }
+
+    await expect(input).toBeVisible({ timeout: 2_000 });
+    await input.fill(value);
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Escape');
+
+    if (opts.match instanceof RegExp) {
+      await expect(cell).toContainText(opts.match, { timeout: 3_000 });
+    } else {
+      await expect(cell).toHaveText(opts.match ?? value, { timeout: 3_000 });
+    }
+  }).toPass({ timeout: 30_000 });
 }
 
 /**
@@ -1215,7 +1456,7 @@ export async function waitForRowsMaterialized(page: Page, timeoutMs = 15_000) {
   // worker handles its messages in order, so awaiting a flush means everything
   // queued ahead of it has landed. Without this a filter drops a matching row,
   // and a total reads an em-dash because the value it sums is not there yet.
-  await page.evaluate(() => window.store?.getClientDb()?.flush?.());
+  await waitForClientDbFlush(page);
 }
 
 /**
@@ -1232,9 +1473,7 @@ export async function reloadGrid(page: Page) {
   // answers post-reload queries with the pre-edit copy.
   await waitForRowsMaterialized(page);
   await page.reload();
-  await expect(page.getByRole('grid')).toBeVisible();
-  // The grid binds its cell handlers after the first render.
-  await page.waitForTimeout(500);
+  await waitForGridMounted(page);
 }
 
 /**

--- a/browser/e2e/tests/timer.spec.ts
+++ b/browser/e2e/tests/timer.spec.ts
@@ -4,6 +4,7 @@ import {
   createTableFromDialog,
   inDialog,
   pickTotal,
+  waitForGridMounted,
 } from './test-utils';
 
 /** Creates an Issue Tracker table (Board + All issues views, no timestamps). */
@@ -214,7 +215,7 @@ test.describe('timer view', () => {
     ).toBeAttached();
     // Wait for the grid itself, so the collection is loaded before adding.
     await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     // Starting an entry works immediately on a freshly-created table — no
     // reload needed (regression: the new row was persisted but not rendered).
@@ -234,7 +235,7 @@ test.describe('timer view', () => {
   }) => {
     await createTimeTracker(page, 'Config not code');
     await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     await page.getByTestId('timer-new-input').fill('Configured work');
     await page.getByTestId('timer-start-new').click();
@@ -277,7 +278,7 @@ test.describe('timer view', () => {
 
     await createTimeTracker(page, 'Totalled hours');
     await expect(page.getByRole('grid')).toBeVisible();
-    await page.waitForTimeout(500);
+    await waitForGridMounted(page);
 
     // Two logged entries, both stopped, so their durations are settled.
     for (const name of ['Invoicing', 'Standup']) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Reduces e2e flake from machine-speed-dependent sleeps (`page.waitForTimeout` and equivalent `setTimeout` waits).

## What changed

Playwright specs no longer wait a fixed number of milliseconds and then hope the app caught up. They wait on the actual signals:

- WebSocket connected (`waitForServerConnected`)
- WASM ClientDb ready (`waitForClientDbReady`)
- OPFS durable (`waitForClientDbFlush` / `db.flush()`)
- Outbox empty (`waitForSynced`)
- Drive handshake finished (`waitForDriveSettled`)
- Grid mounted / cell editor focused (`waitForGridMounted`, `enterGridEdit`, `setGridCell`)
- Search index / ontology class presence (`waitForSearchIndex`, `waitForOntologyClass`)

`setGridCell` converts `ddMMyyyy` date keystrokes to ISO before `fill()`, because native date inputs reject the locale-typed form. Invite links are opened on the SPA origin (`spaUrl`) so local Vite is not waiting on the server's embedded bundle.

Demo/recording scripts still sleep — those are video pacing, not assertions.

Quick-add's 2.5s WebSocket hold is intentional: it delays commit delivery so the second item is typed mid-save.

## Checklist
- [x] Add or update tests if needed
- [ ] Add changelog entry linking to issue, describe API changes
- [ ] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01cfdada-1b26-4e11-89a5-df15ab5fb2de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01cfdada-1b26-4e11-89a5-df15ab5fb2de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

