### PR TITLE
Keep the home server when opening an HTTP drive

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -90,6 +90,7 @@ Both matter because `iroh_transport` holds the router and node identity in
 | Browser records a peer and calls `/iroh-sync` | `data-browser/src/helpers/pairing.test.ts` | stubbed fetch |
 | Known-peer store: labels, dedupe, corrupt data, quota | `data-browser/src/helpers/knownPeers.test.ts` | |
 | `forgetServerPeer` signs the exact `?node=` URL, and fails soft | `data-browser/src/helpers/managedServer.test.ts` | mocked `signRequest` |
+| Opening a foreign HTTP drive does not move `serverUrl` | `browser/lib/src/store.set-drive.test.ts` | bare origin still switches the server; path-bearing HTTP is a drive |
 | Canvas editing session merges a peer's stroke | `flutter/rust/src/api/simple/tests.rs` | |
 | Whole-list rewrite (erase/undo) keeps a peer's stroke | `flutter/rust/src/api/simple/tests.rs` | |
 | Bridge `start_peer` → `add_known_peer` → `peer_sync` pushes a drawing to a real remote process | `flutter/rust/src/api/simple/peer_tests.rs` | receiving side writes the receipt |

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: opening an adopted HTTP drive no longer moves the home server. A bare origin (`https://host`) is still a server switch; an HTTP subject with a path is a workspace and is fetched cross-origin, so a pre-DID drive on `atomicdata.dev` cannot take the session with it (websocket, DID auth, every later fetch).
+
 - Dev: React Compiler now runs through native `oxc-transform-react` instead of `babel-plugin-react-compiler`. JSX/TS and Fast Refresh share that pass. styled-components `displayName` comes from Oxc's built-in plugin on Vite's oxc pass, so Babel is gone (`babel-plugin-react-compiler`, `babel-plugin-styled-components`, `@rolldown/plugin-babel`). Vite dev no longer pays a Babel tax per module (files that used to take ~100ms now land around ~10ms). Oxlint 1.79's compiler-powered Rules of React (`react/immutability`, `react/purity`, `react/error-boundaries`, …) are on; `set-state-in-effect` / `refs` / `static-components` stay warn until those call sites are cleaned up.
 
 - Fix: clicking a button in the navbar no longer draws a blue outline around the whole bar. The bar used `:has(:focus)`, which matched mouse clicks; keyboard focus still shows on the button itself.

--- a/browser/data-browser/src/App.tsx
+++ b/browser/data-browser/src/App.tsx
@@ -1,4 +1,4 @@
-import { StoreContext, Store, enableLoro } from '@tomic/react';
+import { StoreContext, Store, enableLoro, Client } from '@tomic/react';
 
 import { isDev } from './config';
 import { registerHandlers } from './handlers';
@@ -112,24 +112,14 @@ const store = new Store({
 const initialDrive = driveStorage.get();
 
 if (initialDrive) {
-  // `setDrive` reads an http(s) subject as a SERVER ORIGIN and repoints the
-  // app at it. That is intended when the user opens an external drive, but
-  // restoring the last session is not that choice — and a stored URL from a
-  // previous switch would re-apply it on every launch, stranding the app on a
-  // server it cannot authenticate against with no obvious way back.
-  const restoresForeignServer =
-    /^https?:\/\//.test(initialDrive) &&
-    (() => {
-      try {
-        return new URL(initialDrive).origin !== new URL(serverUrl).origin;
-      } catch {
-        return true;
-      }
-    })();
-
-  if (restoresForeignServer) {
+  // A stored *bare origin* used to be the pre-DID stand-in for a
+  // drive and would still move `serverUrl`. Skip that restore — the
+  // home server comes from `serverURLStorage`, not from `drive`.
+  // An HTTP URL with a path is a real legacy drive and is safe to
+  // restore: `setDrive` will not follow a foreign origin.
+  if (Client.isBareHttpOrigin(initialDrive)) {
     console.warn(
-      `[atomic] Ignoring stored drive '${initialDrive}': opening it would move this app to another server. Pick it from the drive switcher to switch deliberately.`,
+      `[atomic] Ignoring stored drive '${initialDrive}': it is a server origin, not a workspace.`,
     );
   } else {
     store.setDrive(initialDrive);

--- a/browser/data-browser/src/helpers/AppSettings.tsx
+++ b/browser/data-browser/src/helpers/AppSettings.tsx
@@ -14,6 +14,7 @@ import {
   Agent,
   useStore,
   StoreEvents,
+  Client,
 } from '@tomic/react';
 import toast from 'react-hot-toast';
 import { SIDEBAR_TOGGLE_WIDTH } from '../components/SideBar';
@@ -127,7 +128,13 @@ export const AppSettingsContextProvider = (
     (newDrive: string) => {
       innerSetDrive(newDrive);
 
-      if (newDrive.startsWith('http://') || newDrive.startsWith('https://')) {
+      // A bare origin is a server switch (`https://host`). An HTTP drive
+      // with a path is a workspace — including one on another origin.
+      // Following that origin would move the whole session (websocket,
+      // DID auth, every later fetch) onto a replica that may not speak
+      // this client's protocol. Fetch it cross-origin; keep the home
+      // server. `Store.setDrive` is the other half of this split.
+      if (Client.isBareHttpOrigin(newDrive)) {
         const url = new URL(newDrive);
         setBaseURL(url.origin);
         serverURLStorage.set(url.origin);

--- a/browser/lib/src/client.ts
+++ b/browser/lib/src/client.ts
@@ -134,6 +134,51 @@ export class Client {
   }
 
   /**
+   * True when `subject` is an HTTP(S) URL with no path, query, or hash —
+   * i.e. a server origin, not a drive. `https://example.com` and
+   * `https://example.com/` match; `https://example.com/drives/foo` does not.
+   *
+   * `Store.setDrive` treats a bare origin as `setServerUrl`. An HTTP
+   * subject with a path is a real (legacy) drive and must not move the
+   * home server.
+   */
+  public static isBareHttpOrigin(subject: string): boolean {
+    if (!subject.startsWith('http://') && !subject.startsWith('https://')) {
+      return false;
+    }
+
+    try {
+      const url = new URL(subject);
+
+      return (
+        (url.pathname === '/' || url.pathname === '') &&
+        !url.search &&
+        !url.hash
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * True when `subject` is an HTTP(S) URL that names a resource (has a
+   * path, query, or hash), not a server origin.
+   */
+  public static isHttpDriveSubject(subject: string): boolean {
+    if (!subject.startsWith('http://') && !subject.startsWith('https://')) {
+      return false;
+    }
+
+    try {
+      new URL(subject);
+
+      return !Client.isBareHttpOrigin(subject);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Removes query params from the URL if it can build a URL. Will return the
    * normal URL if things go wrong.
    */

--- a/browser/lib/src/store.set-drive.test.ts
+++ b/browser/lib/src/store.set-drive.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from 'vitest';
+import { Client } from './client.js';
+import { Store } from './store.js';
+
+const HOME = 'http://localhost:9883';
+
+describe('Client.isBareHttpOrigin / isHttpDriveSubject', () => {
+  it('treats a host with no path as a server origin', ({ expect }) => {
+    expect(Client.isBareHttpOrigin('https://atomicdata.dev')).toBe(true);
+    expect(Client.isBareHttpOrigin('https://atomicdata.dev/')).toBe(true);
+    expect(Client.isBareHttpOrigin('http://localhost:9883')).toBe(true);
+    expect(Client.isHttpDriveSubject('https://atomicdata.dev')).toBe(false);
+  });
+
+  it('treats an HTTP URL with a path as a drive subject', ({ expect }) => {
+    expect(Client.isHttpDriveSubject('https://atomicdata.dev/drives/foo')).toBe(
+      true,
+    );
+    expect(Client.isBareHttpOrigin('https://atomicdata.dev/drives/foo')).toBe(
+      false,
+    );
+  });
+
+  it('does not treat DIDs as either', ({ expect }) => {
+    expect(Client.isBareHttpOrigin('did:ad:abc')).toBe(false);
+    expect(Client.isHttpDriveSubject('did:ad:abc')).toBe(false);
+  });
+});
+
+describe('Store.setDrive does not move the home server for an HTTP drive', () => {
+  it('keeps serverUrl when opening a foreign HTTP drive', ({ expect }) => {
+    const store = new Store({ serverUrl: HOME });
+    store.setDrive('https://atomicdata.dev/drives/legacy');
+
+    expect(store.getServerUrl()).toBe(HOME);
+    expect(store.getDrive()).toBe('https://atomicdata.dev/drives/legacy');
+    expect(store.isForeignOriginSubject(store.getDrive()!)).toBe(true);
+    expect(store.isLiveSyncedDrive(store.getDrive()!)).toBe(false);
+  });
+
+  it('keeps serverUrl when opening a same-origin HTTP drive', ({ expect }) => {
+    const store = new Store({ serverUrl: HOME });
+    store.setDrive(`${HOME}/drives/on-this-node`);
+
+    expect(store.getServerUrl()).toBe(HOME);
+    expect(store.getDrive()).toBe(`${HOME}/drives/on-this-node`);
+    expect(store.isLiveSyncedDrive(store.getDrive()!)).toBe(true);
+  });
+
+  it('does not move the server for a DID drive', ({ expect }) => {
+    const store = new Store({ serverUrl: HOME });
+    store.setDrive('did:ad:personal');
+
+    expect(store.getServerUrl()).toBe(HOME);
+    expect(store.getDrive()).toBe('did:ad:personal');
+    expect(store.isLiveSyncedDrive('did:ad:personal')).toBe(true);
+  });
+
+  it('treats a bare origin as setServerUrl, not as a drive', ({ expect }) => {
+    const store = new Store({ serverUrl: HOME });
+    store.setDrive('did:ad:personal');
+    store.setDrive('https://atomicdata.dev');
+
+    expect(store.getServerUrl()).toBe('https://atomicdata.dev');
+    expect(store.getDrive()).toBe('did:ad:personal');
+  });
+
+  it('clears the drive on an empty string', ({ expect }) => {
+    const store = new Store({ serverUrl: HOME });
+    store.setDrive('did:ad:personal');
+    store.setDrive('');
+
+    expect(store.getDrive()).toBeUndefined();
+    expect(store.getServerUrl()).toBe(HOME);
+  });
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -600,10 +600,10 @@ export class Store {
     // actor free for the GET that almost always follows on share-
     // link / welcome-page cold opens.
     //
-    // A stored value that happens to be an HTTP URL (legacy data from
-    // pre-DID drives) is also ignored here for drive purposes —
-    // `setServerUrl` above already absorbed the origin, and an
-    // accidental URL-as-drive is exactly what we're avoiding.
+    // A stored *bare origin* (`https://host`) is not a drive — that used
+    // to be the pre-DID stand-in for "no workspace selected". A stored
+    // HTTP URL *with a path* is a real legacy drive subject and is
+    // restored; `setDrive` will not treat it as a server switch.
     let storedDrive: string | undefined = undefined;
 
     if (typeof window !== 'undefined') {
@@ -620,8 +620,11 @@ export class Store {
 
     if (
       storedDrive &&
-      !storedDrive.startsWith('http://') &&
-      !storedDrive.startsWith('https://')
+      (Client.isHttpDriveSubject(storedDrive) ||
+        !(
+          storedDrive.startsWith('http://') ||
+          storedDrive.startsWith('https://')
+        ))
     ) {
       this.drive = storedDrive;
     } else {
@@ -802,6 +805,34 @@ export class Store {
 
   public isLocalOnlyDrive(drive: string): boolean {
     return this.localOnlyDrives.has(drive);
+  }
+
+  /**
+   * True when `subject` is an HTTP(S) URL whose origin is not this
+   * store's home server. Opening that resource must not move the
+   * session: fetch it from its own origin, keep `serverUrl` here.
+   */
+  public isForeignOriginSubject(subject: string): boolean {
+    if (!subject.startsWith('http://') && !subject.startsWith('https://')) {
+      return false;
+    }
+
+    try {
+      return new URL(subject).origin !== new URL(this.serverUrl).origin;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Live SUB / SYNC_VV / presence go to the home server. Skip drives it
+   * cannot serve: local-only workspaces, and HTTP drives that live on
+   * another origin (fetched cross-origin, never subscribed here).
+   */
+  public isLiveSyncedDrive(drive: string): boolean {
+    if (!drive || this.isLocalOnlyDrive(drive)) return false;
+
+    return !this.isForeignOriginSubject(drive);
   }
 
   /**
@@ -4447,24 +4478,22 @@ export class Store {
 
   /** Sets the current Drive.
    *
-   *  Accepts either a drive subject (a DID — the only form that actually
-   *  identifies a drive in the index) or an HTTP URL. An HTTP URL is
-   *  treated as a *server origin*, not a drive: it updates `serverUrl`
-   *  but leaves `this.drive` untouched (i.e. `getDrive()` keeps
-   *  returning whatever real drive — possibly `undefined` — was set
-   *  before). This split is what prevents the SYNC_VV / encodeSub
-   *  paths from running against a bare host URL, which the server's
-   *  `collect_drive_subjects` cannot enumerate cheaply.
+   *  A DID (or other non-HTTP subject) is a drive. An HTTP URL with a
+   *  path is also a drive — including one whose origin is not this
+   *  store's home server. Those are fetched cross-origin; `serverUrl`
+   *  stays put. Only a *bare* HTTP origin (`https://host`, no path) is
+   *  treated as `setServerUrl`, and does not become `this.drive`. That
+   *  split is what prevents SYNC_VV / encodeSub from running against a
+   *  host URL, which `collect_drive_subjects` cannot enumerate cheaply.
    *
    *  Both forms still persist to localStorage and fire `DriveChanged`
    *  so AppSettings-style UI mirrors stay in sync.
    */
   public setDrive(drive: string): void {
-    const isUrl = drive.startsWith('http://') || drive.startsWith('https://');
-
-    if (isUrl) {
-      const url = new URL(drive);
-      this.setServerUrl(url.origin);
+    if (!drive) {
+      this.drive = undefined;
+    } else if (Client.isBareHttpOrigin(drive)) {
+      this.setServerUrl(new URL(drive).origin);
     } else {
       this.drive = drive;
     }
@@ -4806,12 +4835,12 @@ export class Store {
       drive,
       callback,
       () => {
-        if (this._serverConnected && !this.isLocalOnlyDrive(drive)) {
+        if (this._serverConnected && this.isLiveSyncedDrive(drive)) {
           this.presenceWebSocket(drive)?.subscribePresence(drive);
         }
       },
       () => {
-        if (this._serverConnected && !this.isLocalOnlyDrive(drive)) {
+        if (this._serverConnected && this.isLiveSyncedDrive(drive)) {
           this.presenceWebSocket(drive)?.unsubscribePresence(drive);
         }
       },
@@ -4822,9 +4851,9 @@ export class Store {
    *  drive's presence subscribers. */
   public broadcastPresenceUpdate(drive: string, update: Uint8Array): void {
     if (!this._serverConnected) return;
-    // Local-only drives have no peers behind a relay; their presence
-    // (including injected demo sessions) stays in this tab.
-    if (this.isLocalOnlyDrive(drive)) return;
+    // Local-only drives and foreign-origin HTTP drives have no live
+    // peers on the home websocket.
+    if (!this.isLiveSyncedDrive(drive)) return;
     this.presenceWebSocket(drive)?.sendPresenceUpdate(
       JSON.stringify({ subject: drive, update: encodeB64(update) }),
     );

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -1127,7 +1127,7 @@ export class WSClient {
 
     // Local-only drives are unknown to the server — a SUB would only
     // produce an error frame (and leak the drive subject).
-    if (drive && !this.store.isLocalOnlyDrive(drive)) {
+    if (drive && this.store.isLiveSyncedDrive(drive)) {
       this.sendBinary(encodeSub(drive));
     }
   }
@@ -1181,7 +1181,7 @@ export class WSClient {
       // `server/tests/ws_get_unauthorized_latency.rs`).
       // Local-only drives never reconcile with a server: a SYNC_VV would
       // upload the whole local drive's version state for nothing.
-      if (drive && !this.store.isLocalOnlyDrive(drive)) {
+      if (drive && this.store.isLiveSyncedDrive(drive)) {
         await this.startVVSync(drive);
       }
     };

--- a/planning/README.md
+++ b/planning/README.md
@@ -5,60 +5,110 @@ not public-facing product/spec documentation; that belongs in `docs/`.
 
 Use this folder to stay aligned on active architectural plans before making
 broad changes. Prefer updating an existing plan over adding a new root-level
-scratch document. When a plan becomes obsolete, delete it.
+scratch document. When a plan becomes obsolete, delete it. Fully-shipped
+checklists that are still useful as as-built notes stay here, listed under
+**Landed**.
 
-## Current Plans
+The status in this index should match the document's own status line. The
+document wins if they disagree.
 
-| Document                                                                                         | Scope                                                                                                                                                                                                                                             |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`multi-property-filter.md`](./multi-property-filter.md)                                          | **In progress:** queries/collections filter on multiple `(property, value)` constraints (AND), index-backed, full-stack (Rust → server → lib → WASM → React).                                                                                      |
-| [`atomic-lib-runtime.md`](./atomic-lib-runtime.md)                                               | Target architecture: `atomic_lib` as the complete HTTP-optional local node runtime.                                                                                                                                                               |
-| [`unified-sync.md`](./unified-sync.md)                                                           | **Active:** one sync API over WS or Iroh; mobile same as browser; retire manual `peer_sync`.                                                                                                                                                      |
-| [`reticulum-sync.md`](./reticulum-sync.md)                                                       | Proposal: carry the existing Atomic sync protocol over Reticulum as another transport beside WS and Iroh.                                                                                                                                         |
-| [`authorization-sync.md`](./authorization-sync.md)                                               | **Draft:** signed commit authorization, creator proof, grant-chain evidence, delegated/replica/indexer/DM/inbox patterns, and peer-sync trust boundaries.                                                                                         |
-| [`encryption.md`](./encryption.md)                                                               | **Exploration / undecided:** E2EE, verifier vs blind-replica roles, per-drive keys, encrypted checkpoints, backups, local encryption at rest, and logout / shared-browser cache session isolation.                                                                                                 |
-| [`encrypted-vault-format.md`](./encrypted-vault-format.md)                                       | **Open spec, v1 implemented (2026-08-04):** the on-the-wire format for encrypted vault backup — key hierarchy, object envelope, pack layout, object keys, restore semantics. Published deliberately: a blind backup nobody can independently restore is a promise, not a property. Implementation in `lib/src/vault/`. |
-| [`sync.md`](./sync.md)                                                                           | WS `COMMIT` flow, echo suppression, and the unified `UPDATE` / `DESTROY` channel. Mostly shipped; tracks remaining test gaps.                                                                                                                     |
-| [`unified-data-layer.md`](./unified-data-layer.md)                                               | Browser/JS data-layer simplification: one ingress, one outbox, one subscription model.                                                                                                                                                            |
-| [`loro-source-of-truth.md`](./loro-source-of-truth.md)                                           | Make the Loro doc authoritative; `PropVals` becomes a derived projection.                                                                                                                                                                         |
-| [`json-schema-code-first.md`](./json-schema-code-first.md)                                       | Proposal: JSON Schema compatible, code-first schema definitions that create local DID-backed Atomic Class and Property resources.                                                                                                                 |
-| [`commit-retention-and-state-certificates.md`](./commit-retention-and-state-certificates.md)     | Proposal: commits remain signed write certificates, but commit retention is optional node policy.                                                                                                                                                 |
-| [`genesis-self-verifying.md`](./genesis-self-verifying.md)                                       | Proposal: a resource carries its own genesis as an inline, binary, self-verifying certificate; verify authorship offline, no commit fetch.                                                                                                        |
-| [`deterministic-personal-drive.md`](./deterministic-personal-drive.md)                           | **Proposal (revised 2026-08-15):** personal drive DID is derived from the Agent key; existing `personalDrive` pointers are not identity. Repeat genesis merges via Loro. Best-effort list union only.                                              |
-| [`s3-blob-storage.md`](./s3-blob-storage.md)                                                     | Pluggable blob backend design for redb/S3/hybrid storage.                                                                                                                                                                                         |
-| [`disk-storage-and-persistence-optimization.md`](./disk-storage-and-persistence-optimization.md) | **Proposal:** why store size + boot time degrade with age (full-snapshot writes, no auto-compaction, O(file) open fsync) and how to fix it.                                                                                                       |
-| [`virtual-drive.md`](./virtual-drive.md)                                                         | Expose Atomic as a mountable filesystem (NFS / FUSE / native cloud-sync APIs); shared VFS backend trait for desktop and mobile.                                                                                                                   |
-| [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md)                                 | Consolidating the canvas undo/redo stacks across Flutter and Loro.                                                                                                                                                                                |
-| [`SDK-API-design.md`](./SDK-API-design.md)                                                       | SDK / developer-experience direction for app builders and LLM agents.                                                                                                                                                                             |
-| [`json-ad-compact.md`](./json-ad-compact.md)                                                     | **In progress:** one compact, class-scoped wire dialect (shortname keys, `@`-structural keys, tag names as values) for all LLM assistant tool I/O; single resolver module; never stored.                                                          |
-| [`llm-wasm-gui-plugins.md`](./llm-wasm-gui-plugins.md)                                           | Proposal for browser-built JS/TS applications with scoped Loro documents, blob checkpoints, and optional future WASM modules.                                                                                                                     |
-| [`personal-information-suite.md`](./personal-information-suite.md)                               | Exploration: contacts, calendar, and email as first-class Atomic resources, with provider connectors for Google, Microsoft, IMAP/SMTP, CalDAV, and CardDAV.                                                                                       |
-| [`rust-dependency-upgrade-audit.md`](./rust-dependency-upgrade-audit.md)                         | Audit notes for the Rust dependency upgrade pass.                                                                                                                                                                                                 |
-| [`cleanup-update-encoding.md`](./cleanup-update-encoding.md)                                     | **Active:** Refactor UPDATE frame encoding/decoding, unify parser, and remove magic numbers.                                                                                                                                                      |
-| [`commit-fanout-drive-isolation.md`](./commit-fanout-drive-isolation.md)                         | **Active:** Drive-scoped WS commit fan-out — closes the cross-tenant commit leak and the e2e 401-spillover flake; tracks the chatroom guest-drive client-hydration regression and its fix.                                                        |
-| [`structural-problems-index.md`](./structural-problems-index.md)                                 | 2026-05-28 audit: ranked open structural issues with per-item plan files. Covers React Compiler / Resource proxy mismatch, subscription unification, save-state signals, Loro-as-authority, subject typing, and remaining actor-message Arc-wrap. |
-| [`nextgraph-interop.md`](./nextgraph-interop.md)                                                 | **Proposal:** read/edit `did:ng:` (NextGraph) resources via a pluggable, scheme-routed Store backend; use Atomic components chrome-free in NextGraph apps. Builds on the elfa-tables proof.                                                       |
-| [`drive-reconciliation.md`](./drive-reconciliation.md)                                           | **Proposal (2026-07-08):** replace the flat whole-drive VV hash with range-based set reconciliation (RBSR) so sync cost tracks the delta, not the drive; optional signed drive state root (reusing genesis `stateHash`) closes F1 + enables offline verification. Records the RBSR-over-hierarchy-Merkle and VV-leaves-first decisions before any build. |
-| [`sync-onboarding-ux.md`](./sync-onboarding-ux.md)                                              | **Guideline:** the language, the rules of what can reach what, every account/device path, where each client's logic lives, and what is tested. Read before changing a sync or onboarding screen in any client.                                     |
-| [`device-pairing.md`](./device-pairing.md)                                                       | **Proposal (2026-07-08):** one-scan pairing between a server and a phone/tablet — `atomic://pair` QR/deep-link envelope (`onboard` with secret now, channel-provisioned secret later), mDNS/pkarr as routing-only discovery, and a SaaS per-account device directory for zero-scan "sign in and it syncs". Resolves serverless-p2p OQ3, narrows OQ1/OQ4. |
-| [`importers.md`](./importers.md)                                                                 | **Analysis (2026-07-14):** importers for existing data — the LLM writes only a pure, sandboxed mapping function; the host owns acquire/parse/validate/preview/commit; schema validation is the feedback-loop oracle. Ontola-authored trusted importer skills (hash-pinned transform + verifiable fixtures, Notion export first) precede client publishing; promotion path to server-side connectors. |
-| [`habits-app.md`](./habits-app.md)                                                               | **Proposal (2026-07-13):** habit tracker built strictly as an external app (`@tomic/lib`, plugin iframe view, code-first schema, assistant skill, Wear OS Flutter watch client) — append-only Completion event log for conflict-free counter taps; doubles as a dogfooding exercise whose gaps feed the SDK, plugin, and query plans.                        |
-| [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md)               | **Proposal (2026-07-14):** local-first Chromium extension using Atomic WASM/OPFS to read approved webpage context, preview and fill forms from scoped personal data, and persist existing `AiChat` resources; Free local pairing first, Vault/Server optional.                                                     |
-| [`p2p-presence.md`](./p2p-presence.md)                                                           | **Proposal (2026-07-10):** carry ephemeral presence (cursors, viewing/following/typing) device-to-device over the Iroh live channel via the reserved `EPHEMERAL 0x40` frame and a server-side WS⇄peer bridge — never persisted. Same-agent (own devices) only; multi-user P2P presence deferred to `authorization-sync.md`. |
-| [`meetings.md`](./meetings.md)                                                                   | **Built (2026-07-14):** one Meeting-only resource with rich-text Agenda/Notes/Minutes, child chat, persisted lifecycle, a dedicated page, and an explicit prepare-then-start flow. Clean cutover; no backwards compatibility. |
-| [`dashboards.md`](./dashboards.md)                                                               | **Proposal (2026-07-15):** user- and LLM-composable dashboards — `Dashboard` resource + standalone `Block` resources (embedded View, stat, constrained-Vega-Lite chart, text) with JSON grid layout; `create_dashboard` tool mirroring `create_table`; blocks reusable later as DocumentV2 embeds.                                                        |
-| [`social-apps.md`](./social-apps.md)                                                             | **Requirements (2026-07-17):** platform gaps for social-network-shaped apps (recipes app as driver): generic `atomic_flutter` SDK extraction, mobile blobs, push notifications, feed primitives (client fan-out now, hub feed endpoint later), invite-link onboarding, web share views, groups, moderation-by-display-filtering. Companion to `zones.md`.                                  |
-| [`zones.md`](./zones.md)                                                                         | **Proposal (2026-07-17):** any ACL-bearing resource is a "zone" — the single unit of access, sync, quota, keys, and (opt-in) announce; rights live only on zone roots, `subject → zone` is a derived index (drive stamp leaves signed state), authority is evaluated at commit time via `AuthImpact` replay, discovery is one pkarr record per agent. "Share a doc" = promote it to a zone.                                  |
-| [`drafts-and-suggestions.md`](./drafts-and-suggestions.md)                                       | **Active (2026-07-15):** two generic capabilities, no Website-specific path. A **Fork** (`Fork` class + `originalSubject`) proposes a change to an existing resource and merges onto it; a **Draft** is unpublished new content defined by location (a resource in a private Drafts folder) and publishes by moving. Visibility is location; needs no deny rule. Milestone 11 (headless CMS): #467, mechanism half of #1000. |
-| [`content-i18n.md`](./content-i18n.md)                                                           | **Proposal (2026-07-20):** content translations (#1069) as document-level localization — a translation is an ordinary resource with `language` + `translationOf`, drafts/queries/zones/templates compose for free; locale-per-branch rejected (LWW divergence), `TranslationBox` concept dead; field-level `LocalizedText` datatype is the planned second layer for shared-structure fragments (nav labels, feature cards), gated on the primitive-first `Value` reshape. Milestone 11 (headless CMS).                                  |
+Protocol reference lives in the public docs:
+[`docs/src/websockets.md`](../docs/src/websockets.md). Planning documents may
+discuss how that protocol is used internally, but should not duplicate the
+wire reference.
 
-| [`android-data-reuse.md`](./android-data-reuse.md)                                               | **Draft (2026-07-23):** one Atomic store/agent/Iroh node per Android device — an elected host app owns the store and serves other apps over Binder (ContentProvider/AIDL, on-demand, cert-bound caller identity); commits are the IPC write protocol; canvas gains a client mode and reuses an installed atomic-server. Supersedes the localhost-daemon transport in `on-device-atomic-daemon.md`.                                  |
-| [`index-performance.md`](./index-performance.md)                                                 | **Diagnosis (2026-07-24):** comparative benchmark vs. NextGraph found collection queries costing ~100µs/matching resource. Root cause: every match is fully Loro-decoded plus permission-checked (which itself re-decodes the drive resource) even when only subjects are requested. One fix shipped (redundant snapshot re-export); the structural fix for the permission-check half is `zones.md`'s zone index, not yet built. |
-| [`partial-sync.md`](./partial-sync.md)                                                           | **Proposal (2026-07-31):** replicate part of a drive per device. Absence is currently overloaded ("I lack X" ⇒ "send me X"), so a partial replica gets refilled and never matches the whole-drive hash. Devices declare a positive scope (subtree/zone roots + a blob-bytes axis) plus fill state; enforcement in both bulk reconcile and live fan-out; eviction must not tombstone. Requires keying RBSR by `zone \|\| subject` before `drive-reconciliation.md` Phase 2 builds the tree. |
+## Active
 
-Protocol reference lives in the public docs: [`docs/src/websockets.md`](../docs/src/websockets.md).
-Planning documents may discuss how that protocol is used internally, but should
-not duplicate the wire reference.
+Remaining work, not "this file exists."
+
+| Document | Status |
+| --- | --- |
+| [`unified-sync.md`](./unified-sync.md) | **Active.** One sync API over WS or Iroh. Remaining: AUTH-before-SYNC fail-closed, signed destroys on the wire, outbox port to `atomic_lib`, Layer 2 provenance. |
+| [`serverless-p2p.md`](./serverless-p2p.md) | **Planned.** Same-agent device sync without a hub. P0 remaining: AUTH-before-SYNC, bind `AUTH.requestedSubject` to the drive, OQ5 bootstrap admission. |
+| [`authorization-sync.md`](./authorization-sync.md) | **Draft.** Signed commit authorization, grant-chain evidence, peer-sync trust boundaries. |
+| [`encryption.md`](./encryption.md) | **Exploration.** E2EE / blind replicas undecided. Local cache at rest **shipped** — see [`opfs-per-agent-encryption.md`](./opfs-per-agent-encryption.md). |
+| [`unified-data-layer.md`](./unified-data-layer.md) | Browser/JS: one ingress, one outbox, one subscription model. Sign-at-drain (S4a) shipped separately. |
+| [`loro-source-of-truth.md`](./loro-source-of-truth.md) | **Partial.** Sparse `datatypes` map + Phase 2a–2c shipped (`Tree::Resources` is a derived cache). Remaining: drop the untagged heuristic, Phase 1.6 `Value` reshape, Flutter undo. |
+| [`atomic-lib-runtime.md`](./atomic-lib-runtime.md) | Target: `atomic_lib` as the complete HTTP-optional local node runtime. |
+| [`genesis-self-verifying.md`](./genesis-self-verifying.md) | **Partial.** Server and browser mint and verify inline genesis certs. Remaining: DataRoute verify UI, `genesis` propval immutability. |
+| [`drive-reconciliation.md`](./drive-reconciliation.md) | **Partial.** Algorithm core in `lib/src/sync/rbsr.rs`. Not on the WS/Iroh wire yet; fingerprint tree still O(range). |
+| [`zones.md`](./zones.md) | **Proposal.** Nothing built. Structural fix for the permission-check half of [`index-performance.md`](./index-performance.md). |
+| [`partial-sync.md`](./partial-sync.md) | **Proposal.** Replicate part of a drive per device. |
+| [`drafts-and-suggestions.md`](./drafts-and-suggestions.md) | **Mechanism shipped** (`Fork` class, `diffFork`/`mergeFork`, document body CRDT merge). Review/diff UI, suggest-for-non-writers, Canvas fork still open. |
+| [`device-pairing.md`](./device-pairing.md) | **Proposal.** One-scan pairing; QR is routing only (no secret). C0 and M6 closed. Remaining: extra-workspace inventory, M4. |
+| [`pairing-ux-field-test.md`](./pairing-ux-field-test.md) | **Field notes (through 2026-08-20).** C0 and M6 closed. Open: M4 (pre-0.40 auth), M8 (desktop "saved locally" toast), M12 (presence over Iroh), extra-workspace inventory. |
+| [`json-ad-compact.md`](./json-ad-compact.md) | **Phase 1–2 shipped** (resolver, tool I/O, context providers). Remaining: rebase `create_table.rows` on `fromCompact`; server `format=compact`. |
+| [`table-view-filters.md`](./table-view-filters.md) | **Default View shipped** (filters, sort, columns, operators). Remaining: multi-view switcher; index-accelerated range scans. |
+| [`table-templates-and-mini-apps.md`](./table-templates-and-mini-apps.md) | Steps 3–6 shipped (computed columns, aggregates, assistant tools, catalogue). Remaining: derived columns in filters/aggregates. |
+| [`dashboards.md`](./dashboards.md) | **First slice shipped.** Remaining: the sixth action verb, parameters, reaching a dashboard from its table. |
+| [`content-i18n.md`](./content-i18n.md) | **LocalizedText + template locales shipped.** Remaining: TranslationsBar, `useTranslation`, `/query` `lang`, search language filter. |
+| [`website-templates.md`](./website-templates.md) | Template repair complete (DID). Remaining CMS product: drafts-from-site, i18n tooling, canonical paths. |
+| [`structural-problems-index.md`](./structural-problems-index.md) | Ranked structural issues. Highest remaining: React Compiler / Resource proxy (#1). |
+| [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Planned.** Stale UI from Compiler memoizing Resource proxy reads. |
+| [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md) | Phase A + C landed (browser). Phase B (Flutter action-stack removal) open. |
+| [`index-performance.md`](./index-performance.md) | First tranche shipped. Structural permission-check fix is `zones.md`, not built. |
+| [`disk-storage-and-persistence-optimization.md`](./disk-storage-and-persistence-optimization.md) | **Proposal.** Full-snapshot writes, no auto-compaction, O(file) open fsync. |
+| [`virtual-drive.md`](./virtual-drive.md) | Mountable filesystem (NFS / FUSE / native cloud-sync APIs). |
+| [`commit-retention-and-state-certificates.md`](./commit-retention-and-state-certificates.md) | **Proposal.** Commits stay signed write certificates; retention is node policy. |
+| [`p2p-presence.md`](./p2p-presence.md) | **Proposal.** Ephemeral presence over Iroh (`EPHEMERAL 0x40`). Same-agent only. |
+| [`reticulum-sync.md`](./reticulum-sync.md) | **Proposal.** Atomic sync protocol over Reticulum. |
+| [`json-schema-code-first.md`](./json-schema-code-first.md) | **Proposal.** Code-first JSON Schema → local DID-backed Class/Property resources. |
+| [`SDK-API-design.md`](./SDK-API-design.md) | SDK / agent DX direction. |
+| [`llm-wasm-gui-plugins.md`](./llm-wasm-gui-plugins.md) | **Proposal.** Browser-built JS/TS apps with scoped Loro docs. |
+| [`personal-information-suite.md`](./personal-information-suite.md) | Exploration: contacts, calendar, email. |
+| [`social-apps.md`](./social-apps.md) | Requirements for social-network-shaped apps. Companion to `zones.md`. |
+| [`android-data-reuse.md`](./android-data-reuse.md) | **Draft.** One store/agent/Iroh node per Android device. Supersedes `on-device-atomic-daemon.md`. |
+| [`nextgraph-interop.md`](./nextgraph-interop.md) | **Proposal.** `did:ng:` via a scheme-routed Store backend. |
+| [`s3-blob-storage.md`](./s3-blob-storage.md) | Pluggable blob backend (redb/S3/hybrid). |
+| [`importers.md`](./importers.md) | Analysis: sandboxed mapping functions; host owns acquire/parse/commit. |
+| [`habits-app.md`](./habits-app.md) | **Proposal.** External-app dogfood; RPC `query` is the hard blocker. |
+| [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md) | **Proposal.** Local-first Chromium extension. |
+| [`tours.md`](./tours.md) | Design, not built. |
+| [`rust-dependency-upgrade-audit.md`](./rust-dependency-upgrade-audit.md) | Audit notes for a Rust dependency upgrade pass. |
+
+## Slices and companions
+
+Not top-level plans. Indexed so they do not go missing.
+
+| Document | Status |
+| --- | --- |
+| [`unify-subscription-primitives.md`](./unify-subscription-primitives.md) | Planned. Server-side: one `Subscription` shape. Slice of [`unified-data-layer.md`](./unified-data-layer.md). |
+| [`unify-subscription-actors.md`](./unify-subscription-actors.md) | Planned. Fold LoroSyncBroadcaster into CommitMonitor. |
+| [`unify-resource-representations.md`](./unify-resource-representations.md) | Planned. Browser dual of [`loro-source-of-truth.md`](./loro-source-of-truth.md) (`Resource._cache`). |
+| [`unify-resource-dirty-signals.md`](./unify-resource-dirty-signals.md) | Planned. Single `getSaveState(subject)` enum. |
+| [`subject-types-end-to-end.md`](./subject-types-end-to-end.md) | Partial. Brand type in `@tomic/lib`; Rust `DidKind` shipped. Consumer migration open. |
+| [`arc-actor-message-payloads.md`](./arc-actor-message-payloads.md) | Partial. WS encode-once shipped; `CommitMessage` Arc-wrap deferred. |
+| [`sync-onboarding-ux.md`](./sync-onboarding-ux.md) | Cross-client copy for what can reach what. Companion to [`device-pairing.md`](./device-pairing.md). |
+| [`on-device-atomic-daemon.md`](./on-device-atomic-daemon.md) | Draft. Android transport superseded by [`android-data-reuse.md`](./android-data-reuse.md); may still fit desktop. |
+| [`main-drive-and-paths.md`](./main-drive-and-paths.md) | Strategy. DID-branch deployment: root drive, legacy URLs, human-readable paths. |
+| [`actions.md`](./actions.md) | Unified action registry (menus, shortcuts, AI tools). |
+| [`table-creation-ux-audit.md`](./table-creation-ux-audit.md) | Observation log (2026-07-03). First pass addressed. |
+| [`kanban-views-test-spec.md`](./kanban-views-test-spec.md) | Manual test spec for kanban + `create_table`. |
+
+Fixed notes live in [`completed/`](./completed/).
+
+## Landed
+
+As-built notes. Remaining follow-ups, if any, live in the Active table or in
+the document itself.
+
+| Document | What shipped |
+| --- | --- |
+| [`deterministic-personal-drive.md`](./deterministic-personal-drive.md) | Personal-drive DID derived from the Agent key. Repeat genesis merges. Pointer is not identity. `Db::create_drive` lists on the personal drive. |
+| [`multi-property-filter.md`](./multi-property-filter.md) | AND filters, full-stack (Rust → server → lib → WASM → React → e2e). UI lives in `table-view-filters.md`. |
+| [`commit-fanout-drive-isolation.md`](./commit-fanout-drive-isolation.md) | Drive-scoped WS commit fan-out + server-side drive safety net. |
+| [`cleanup-update-encoding.md`](./cleanup-update-encoding.md) | Unified `decode_update`; TS client exports compact Loro deltas. |
+| [`sign-at-drain.md`](./sign-at-drain.md) | One signed commit per dirty subject per drain pass. |
+| [`sync.md`](./sync.md) | WS `COMMIT`, echo suppression, unified `UPDATE`/`DESTROY`. Remaining: test gaps, Flutter WS session. |
+| [`encrypted-vault-format.md`](./encrypted-vault-format.md) | Vault backup v1 in `lib/src/vault/` (2026-08-04). |
+| [`opfs-per-agent-encryption.md`](./opfs-per-agent-encryption.md) | One encrypted OPFS database per agent. Session isolation on sign-out. |
+| [`meetings.md`](./meetings.md) | Meeting resource, page, prepare-then-start flow. |
+| [`node-did-canonicalization.md`](./node-did-canonicalization.md) | `did:ad:node:<hex>` is the only user-facing node ID form. |
+| [`migrate-jsonarray-to-json.md`](./migrate-jsonarray-to-json.md) | Canvas `strokeData` datatype is `json`. |
+| [`emoji-cover-images.md`](./emoji-cover-images.md) | Emoji + cover images on resources. |
+| [`presence-views.md`](./presence-views.md) | Presence on canvas, tables, navbar, sidebar. |
+| [`demo-experience.md`](./demo-experience.md) | v1 demo workspace. |
+| [`cloud-sync-managed-node.md`](./cloud-sync-managed-node.md) | Bootstrap-grace admission gate for managed nodes. |
 
 ## Agent Workflow
 

--- a/planning/SDK-API-design.md
+++ b/planning/SDK-API-design.md
@@ -1,6 +1,8 @@
 Using the Atomic ecosystem should be a breeze for any software engineer or LLM agent.
 We want people to get control over their data, and have true interoperability between apps.
 
+**Status:** Direction. SDK / agent DX; not a build checklist.
+
 ## Old (HTTP) situation
 
 In the "old" HTTP based Atomic(Server) UX, an app developer had to:

--- a/planning/actions.md
+++ b/planning/actions.md
@@ -1,5 +1,7 @@
 # Unified Actions
 
+**Status:** Design. Nothing built.
+
 ## Problem
 
 Resource actions (view, edit, delete, share, history, favorite, …) are invocable

--- a/planning/canvas-undo-consolidation.md
+++ b/planning/canvas-undo-consolidation.md
@@ -26,7 +26,7 @@
 | Concern | Browser | Flutter |
 | --- | --- | --- |
 | `strokeData` Loro storage | `LoroList<LoroMap>` ✓ | `LoroList<LoroMap>` ✓ |
-| Ontology declared datatype | `jsonArray` ✓ | `jsonArray` ✓ |
+| Ontology declared datatype | `json` ✓ | `json` ✓ |
 | Tap-undo / tap-redo | `resource.undo()` / `resource.redo()` via Loro `UndoManager` ✓ | Same — `AtomicClient.undoCanvas()` → Rust `resource.undo()` ✓ |
 | Undo-button drag-to-scrub gesture | Released — pointer-capture handler on the button, `getLoroHistory()` for preview, `replaceListItems()` on release ✓ | Released — same gesture, `_loroStrokeStates`/`_loroVersionIds` precomputed via `warmResourceHistory`/`getResourceAtVersion` ✓ |
 | Discarded-branch (scrub-back-then-draw → returnable forward fork) | ❌ Missing | ✓ Implemented (in-memory, ephemeral) |
@@ -120,7 +120,7 @@ A horizontal strip of thumbnails along the bottom edge (toggle-able to keep it o
 Flutter's branches today are lost on app close (the planning doc flags it: *"Decide whether `CANVAS_CACHE` undo history should persist"*). Options:
 
 - *Ephemeral.* Match Flutter. Cheapest. Branches vanish on reload.
-- *Stored on the canvas resource.* Add a `discardedBranches` propval (jsonArray of branch records). Persists; survives reload; consumes a property slot and bandwidth on every commit.
+- *Stored on the canvas resource.* Add a `discardedBranches` propval (json of branch records). Persists; survives reload; consumes a property slot and bandwidth on every commit.
 - *Stored in `ClientDb` only.* Browser-local, survives reload, doesn't sync. Splits the UX (you see your branches but not your collaborators'). Probably the right trade-off — branches are inherently a per-author concept.
 
 Lean toward **ClientDb-only** (browser) + a similar **`canvas_branches` table in the Iroh/sled store** (Flutter), with no cross-device sync. That cleanly matches the *"undo is local"* semantics already chosen for the underlying `UndoManager`.

--- a/planning/canvas-undo-consolidation.md
+++ b/planning/canvas-undo-consolidation.md
@@ -1,7 +1,9 @@
 # Canvas undo/redo: consolidation plan
 
 > **Status:** Phase A landed (browser scrub gesture, `replaceListItems`,
-> `strokeData` datatype = `jsonArray`, legacy string parser dropped).
+> `strokeData` datatype = `json` — `jsonArray` was retired; see
+> [`migrate-jsonarray-to-json.md`](./migrate-jsonarray-to-json.md), legacy
+> string parser dropped).
 > **Phase C landed** (browser discarded-branches: hold the undo button →
 > version overlay + thumbnail panel; drag over a thumbnail and release to
 > restore; branches persist in `localStorage` alongside the undo/redo

--- a/planning/cleanup-update-encoding.md
+++ b/planning/cleanup-update-encoding.md
@@ -1,5 +1,8 @@
 # Refactor UPDATE Frame Decoding to Unified Helper & Fix TS Client Delta Sync
 
+**Status:** Shipped. Unified `decode_update`; the TS client exports compact
+Loro deltas instead of full snapshots.
+
 Clean up the confusing, duplicated, and potentially buggy UPDATE frame decoding logic in `atomic_lib`, document the protocol wire format, and optimize the TypeScript client to export compact CRDT deltas instead of full snapshots on every edit.
 
 ## Proposed Changes

--- a/planning/commit-fanout-drive-isolation.md
+++ b/planning/commit-fanout-drive-isolation.md
@@ -1,8 +1,8 @@
 # Drive-scoped commit fan-out: tenant isolation + the chatroom regression
 
-> **Status:** Shipped & verified (uncommitted on `did-rebased2`) — drive-scoped
-> fan-out + a server-side drive safety net close both the leak and the chatroom
-> regression. Full genesis-cert wiring (Part B) deferred. Builds on
+> **Status:** Shipped. Drive-scoped fan-out + a server-side drive safety net
+> close both the leak and the chatroom regression. Full genesis-cert wiring
+> (Part B) deferred. Builds on
 > [`sync.md`](./sync.md) (the WS `UPDATE`/`DESTROY` fan-out channel) and
 > [`genesis-self-verifying.md`](./genesis-self-verifying.md) (the immutable
 > `drive` field this fan-out routes by). Full genesis-cert wiring is deferred to

--- a/planning/content-i18n.md
+++ b/planning/content-i18n.md
@@ -1,17 +1,18 @@
 # Content i18n: localized resources, not localized values
 
-> **Status: Active (2026-07-20).** Issue #1069, milestone 11 (Local-first
-> headless CMS). Supersedes the `TranslationBox` concept in
+> **Status:** LocalizedText + template locales shipped (2026-07). Remaining:
+> TranslationsBar UI, `useTranslation` sibling resolution, `/query` `lang`,
+> search language filter. Issue #1069, milestone 11 (Local-first headless CMS).
+> Supersedes the `TranslationBox` concept in
 > `docs/src/schema/translations.md` (2020, pre-Loro, pre-DID). Companion to
 > [`website-templates.md`](./website-templates.md) §Internationalization and
 > [`drafts-and-suggestions.md`](./drafts-and-suggestions.md).
 >
-> **Sequencing amendment (2026-07-20):** the `LocalizedText` datatype is
-> being built *now* (decision in session), ahead of the document-level
-> tooling and without waiting for the primitive-first `Value` reshape —
-> the reshape collapses variants Loro can't distinguish, whereas
-> `LocalizedText` is a tagged structural shape (like `json`) and survives
-> it. Build progress tracked in the checklist at the bottom.
+> **Sequencing amendment (2026-07-20):** `LocalizedText` was built ahead of
+> the document-level tooling and without waiting for the primitive-first
+> `Value` reshape — the reshape collapses variants Loro can't distinguish,
+> whereas `LocalizedText` is a tagged structural shape (like `json`) and
+> survives it. Build progress tracked in the checklist at the bottom.
 
 ## The question
 

--- a/planning/deterministic-personal-drive.md
+++ b/planning/deterministic-personal-drive.md
@@ -1,6 +1,10 @@
 # Deterministic Personal Drive
 
-> **Status:** Implementing (2026-08-15). Builds on
+> **Status:** Shipped (core, 2026-08). Both sides call `personalDriveSubject()`
+> / `fetchPersonalDriveSubject`; pairing no longer mints a random drive.
+> Remaining: eager vs lazy first write (M23 in
+> [`pairing-ux-field-test.md`](./pairing-ux-field-test.md)), and pre-0.40 DID
+> auth (M4). Builds on
 > [`genesis-self-verifying.md`](./genesis-self-verifying.md).
 >
 > Every Agent needs a personal drive — it is the home index for `drives`,

--- a/planning/device-pairing.md
+++ b/planning/device-pairing.md
@@ -12,12 +12,13 @@
 >
 > **2026-08-15 — field test.**
 > [`pairing-ux-field-test.md`](./pairing-ux-field-test.md) walks this UX on a
-> real self-hosted server plus the desktop app. Transport and pairing work;
-> **drive transfer does not** (C0). A blank node signs in, finds no
-> `personalDrive` on the peer's agent copy, provisions one locally, and
-> reports "Your workspace is here" — onto a drive it just invented. The two
-> nodes end up with disjoint drive sets. Nothing in the flow asks the peer
-> what it holds.
+> real self-hosted server plus the desktop app. C0 (a blank node minting a
+> *different* personal-drive DID because it looked up the `personalDrive`
+> pointer) is **superseded**: the home subject is derived from the Agent key,
+> so every device names the same drive. Pairing + live sync between desktop
+> and the HA node was verified 2026-08-17. What remains is not identity —
+> extra workspaces still have to arrive via that shared home's `drives` list
+> (or an explicit pull), and M4 still blocks reading pre-0.40 HTTP drives.
 >
 > **2026-08-20 — M6 closed.** Opening an adopted `https://…` drive no longer
 > moves the home server. A bare origin is still a server switch; an HTTP

--- a/planning/device-pairing.md
+++ b/planning/device-pairing.md
@@ -13,10 +13,15 @@
 > **2026-08-15 — field test.**
 > [`pairing-ux-field-test.md`](./pairing-ux-field-test.md) walks this UX on a
 > real self-hosted server plus the desktop app. Transport and pairing work;
-> **drive transfer does not**. A blank node signs in, finds no `personalDrive`
-> on the peer's agent copy, provisions one locally, and reports "Your
-> workspace is here" — onto a drive it just invented. The two nodes end up
-> with disjoint drive sets. Nothing in the flow asks the peer what it holds.
+> **drive transfer does not** (C0). A blank node signs in, finds no
+> `personalDrive` on the peer's agent copy, provisions one locally, and
+> reports "Your workspace is here" — onto a drive it just invented. The two
+> nodes end up with disjoint drive sets. Nothing in the flow asks the peer
+> what it holds.
+>
+> **2026-08-20 — M6 closed.** Opening an adopted `https://…` drive no longer
+> moves the home server. A bare origin is still a server switch; an HTTP
+> drive with a path is fetched cross-origin. See the field-test M6 write-up.
 >
 > Context: the Android Tauri app boots and syncs as of 2026-07-08 (embedded
 > server + webview, Iroh transport ready). What's missing is any humane way

--- a/planning/device-pairing.md
+++ b/planning/device-pairing.md
@@ -1,7 +1,10 @@
 # Device Pairing — sync onboarding UX between a server and a phone/tablet
 
 > **Status:** Proposal (2026-07-08), revised 2026-07-10. Owns the
-> pairing/onboarding UX and the QR/deep-link envelope. Resolves
+> pairing/onboarding UX and the QR/deep-link envelope. C0 (invented
+> personal-drive DID) is **superseded** by derivation; M6 (HTTP drive
+> hijacks `serverUrl`) is **closed**. Remaining: extra-workspace inventory,
+> M4 (pre-0.40 DID auth). Resolves
 > [`serverless-p2p.md`](./serverless-p2p.md) Open Question 3 (key transport)
 > and narrows OQ1 (LAN discovery) and OQ4 (drive enrollment). Trust rules are
 > inherited from serverless-p2p Principle 1 and are not renegotiated here.

--- a/planning/drafts-and-suggestions.md
+++ b/planning/drafts-and-suggestions.md
@@ -1,9 +1,11 @@
 # Forks, drafts, publishing, and suggestions
 
-> **Status:** design agreed 2026-07-14; **terminology split 2026-07-15.** Covers
-> milestone 11 (Local-first headless CMS): issue #467 (drafts / publishing /
-> archiving) and the mechanism half of #1000 (edit content from a webpage).
-> Content i18n (#1069) is out of scope for this round.
+> **Status:** Mechanism shipped (`Fork` class, `diffFork`/`mergeFork`, document
+> body CRDT merge, `PendingForks` / `ForkBar`). Remaining: review/diff UI,
+> suggest-for-non-writers, Canvas fork. Design agreed 2026-07-14; terminology
+> split 2026-07-15. Covers milestone 11 (Local-first headless CMS): issue #467
+> (drafts / publishing / archiving) and the mechanism half of #1000 (edit
+> content from a webpage). Content i18n (#1069) is out of scope for this round.
 
 ## Two orthogonal things, neither of them CMS-specific
 

--- a/planning/drive-reconciliation.md
+++ b/planning/drive-reconciliation.md
@@ -1,9 +1,10 @@
 # Scalable drive reconciliation & signed state roots
 
-> **Status:** Proposal (2026-07-08). Direction agreed, nothing built beyond the
-> foundation below. Records the decision so RBSR/Merkle work isn't started
-> before the design is settled. Builds on the drive-scoped VV read and the
-> hash-first probe already landed (see [Foundation](#foundation-already-landed)).
+> **Status:** Partial. Algorithm core lives in `lib/src/sync/rbsr.rs` (fingerprint
+> + recursive reconcile, pinned by unit tests). Not on the WS/Iroh wire yet;
+> range fingerprints are still O(range), not an incrementally-maintained tree.
+> Builds on the drive-scoped VV read and the hash-first probe already landed
+> (see [Foundation](#foundation-already-landed)).
 > Ties the reconciliation redesign to the signed-state-certificate direction in
 > [`genesis-self-verifying.md`](./genesis-self-verifying.md),
 > [`commit-retention-and-state-certificates.md`](./commit-retention-and-state-certificates.md),

--- a/planning/genesis-self-verifying.md
+++ b/planning/genesis-self-verifying.md
@@ -1,6 +1,9 @@
 # Self-Verifying Genesis Certificate
 
-> **Status:** Proposal (2026-06-03). Builds on
+> **Status:** Partial. Server and browser mint, store, and verify inline
+> genesis certs (`create_did` / `mintCertDid` / `verifyGenesisCert`, golden
+> vectors). Remaining: DataRoute "Verify signature" UI, `genesis` propval
+> immutability, reading the cert's signed `drive` in `check_rights`. Builds on
 > [`commit-retention-and-state-certificates.md`](./commit-retention-and-state-certificates.md),
 > [`sign-at-drain.md`](./sign-at-drain.md), and
 > [`loro-source-of-truth.md`](./loro-source-of-truth.md).
@@ -276,38 +279,32 @@ nested-grant checks.
 
 1. ✅ **Spec freeze** — the v1 byte layout above (version + flags). Done
    (`genesis.rs` / `genesis.ts`, pinned known-byte-vector test).
-2. 🟡 **DID derivation** — **Rust done**: `create_did` (`lib/src/commit.rs`) now
-   signs the binary cert and derives the DID from it (the commit keeps a
-   separate content signature). **Browser + wasm pending** — browser-minted
-   resources still use the legacy commit-signature DID, accepted via the
-   dual-accept path below.
+2. ✅ **DID derivation** — **Rust and browser done.** `create_did`
+   (`lib/src/commit.rs`) signs the binary cert and derives the DID from it
+   (the commit keeps a separate content signature). Browser
+   `Store.mintCertDid` / `mintFromCert` (`browser/lib/src/store.ts`) mint
+   the same layout; `verifyGenesisCert` + golden vectors pin TS↔Rust
+   byte-identity. Dual-accept remains for legacy commit-signature DIDs.
 
-   > **Browser minting attempt — root cause of the desync (diagnosed, then
-   > reverted to dual-accept).** A first browser implementation (mint cert in
-   > `mintGenesisCert`, derive DID from `signBytes` of the cert, stamp it as the
-   > `genesis` propval, call from `signChanges`) failed e2e with "Genesis
-   > certificate signature is invalid": the subject DID and the shipped propval
-   > were derived from **two different mints**. Proof from instrumentation: the
-   > browser computed `sign(certC1) = a6aUk…` and stored `certC1` as the propval,
-   > but the resource's subject DID embedded `xHe1SZ…` — a signature over a
-   > *different* cert. The cert is non-deterministic (`Date.now()` createdAt +
-   > random 16-byte nonce), so re-minting yields a new cert each time. The
+   > **Historical: browser minting desync (diagnosed, then fixed).** A first
+   > browser implementation (mint cert in `mintGenesisCert`, derive DID from
+   > `signBytes` of the cert, stamp it as the `genesis` propval, call from
+   > `signChanges`) failed e2e with "Genesis certificate signature is
+   > invalid": the subject DID and the shipped propval were derived from
+   > **two different mints**. Proof from instrumentation: the browser
+   > computed `sign(certC1) = a6aUk…` and stored `certC1` as the propval, but
+   > the resource's subject DID embedded `xHe1SZ…` — a signature over a
+   > *different* cert. The cert is non-deterministic (`Date.now()` createdAt
+   > + random 16-byte nonce), so re-minting yields a new cert each time. The
    > sequence: **mint #1** sets the subject DID (locked once the resource is
-   > registered under it / the genesis commit drains) → **mint #2** (a freshly
-   > reconstructed `Resource` instance whose per-instance `_mintedGenesisCertB64`
-   > cache is empty, and whose `this.get(GENESIS)` returns `undefined` because
-   > the propval was dropped by `rebuildCacheFromLoro`) re-mints and *overwrites*
-   > the propval, but cannot change the already-locked subject. Result: subject
-   > from C0/C1, propval from C2.
-   >
-   > **The fix for the follow-up** (not a per-instance cache — that's what
-   > failed): mint **exactly once per resource**, keyed somewhere that survives
-   > `Resource` reconstruction (store-level, keyed by the placeholder subject),
-   > and never re-derive the subject without re-reading the *same* stored cert.
-   > Equivalently: make the cert deterministic for a given resource so any
-   > re-mint reproduces identical bytes. Adding `genesis` to the `serverManaged`
-   > preserve list in `rebuildCacheFromLoro` is necessary but **not sufficient**
-   > on its own (the second instance still re-minted).
+   > registered under it / the genesis commit drains) → **mint #2** (a
+   > freshly reconstructed `Resource` instance whose per-instance
+   > `_mintedGenesisCertB64` cache is empty, and whose `this.get(GENESIS)`
+   > returns `undefined` because the propval was dropped by
+   > `rebuildCacheFromLoro`) re-mints and *overwrites* the propval, but
+   > cannot change the already-locked subject. Result: subject from C0/C1,
+   > propval from C2. The live path mints once in `newResource` and stamps
+   > the same cert as the `genesis` propval.
 3. ✅ **Store** — the `genesis` blob rides inline in the loro snapshot and is
    materialized + persisted at apply. (Reject-overwrite intentionally omitted:
    forge-resistance is the signature, like `createdAt`/`createdBy`.) `genesis`
@@ -316,20 +313,20 @@ nested-grant checks.
    from the cert at apply (`resources.rs::materialize_genesis_metadata`), legacy
    oplog fallback for cert-less resources.
    - **Validation is dual-accept** (`validate_signature`): verify the cert when a
-     `genesis` propval is present, else the legacy DID==commit-sig rule — so the
-     not-yet-cert browser keeps working. Verified: 185 lib tests, `drive_rights`,
+     `genesis` propval is present, else the legacy DID==commit-sig rule — so
+     pre-cert resources keep working. Verified: 185 lib tests, `drive_rights`,
      genesis unit, `ws_commit_isolation`, `ws_drive_membership`, full 2-worker e2e.
 5. **Rights** — `check_rights` already resolves drive-first via the `drive`
    propval (drive-in-genesis); moving it to read the cert's signed `drive` is a
    follow-up.
-6. **`verifyGenesis(resource)`** in `@tomic/lib` — decode + Ed25519 verify + DID
-   check. Pending (needs the browser slice).
-7. **UI** — decoded display + "Verify signature" button in `DataRoute`. Pending.
+6. ✅ **`verifyGenesisCert`** in `@tomic/lib` (`browser/lib/src/genesis.ts`) —
+   decode + Ed25519 verify + DID check. Golden vectors match Rust.
+7. **UI** — DataRoute shows genesis creator/time. A "Verify signature" button
+   that surfaces `verifyGenesisCert` is still pending.
 
-> **Status (this branch):** server mints + validates + materializes genesis certs
-> (dual-accept). Remaining: browser cert minting (step 2) + `verifyGenesis` +
-> UI. The dev-server `optimizeDeps.entries` fix (pre-bundling lazy chunks) was
-> needed to get a stable e2e while verifying this.
+> **Status:** server and browser mint + validate + materialize genesis certs
+> (dual-accept for legacy DIDs). Remaining: DataRoute verify button, `genesis`
+> propval immutability, cert-signed `drive` in `check_rights`.
 
 ## Migration
 
@@ -370,12 +367,12 @@ Where this stands (2026-07-10), driving toward
   use base64url-no-pad (`URL_SAFE_NO_PAD`); keys are `[seedByte; 32]` Ed25519
   seeds (test-only). A signed layout can never change silently — regenerate the
   fixture *and* update the TS side together, behind a new `version`.
-- ⏳ **Next: the browser mints certs** (TS `GenesisCert` byte-identical to the
-  Rust layout, DID derived from it), tested against the golden fixture. Closes
-  the legacy Path 2 so browser-minted resources — including onboarding drives —
-  carry certs, which is what lets `genesis_signer()` (and thus P3) apply
-  universally.
+- ✅ **Browser mints certs.** TS `GenesisCert` is byte-identical to the Rust
+  layout (golden fixture). `Store.newResource` / `mintCertDid` derive the DID
+  from the cert and stamp it as the `genesis` propval.
 - ⏳ **`genesis`-propval immutability** isn't enforced yet (the doc above claims
   it, but the `createdAt`/`createdBy` mechanism it cites deliberately doesn't
   reject). Not required for `genesis_signer()` soundness (it re-verifies), but
   worth closing.
+- ⏳ **DataRoute "Verify signature"** — creator/time already display; the
+  explicit verify action does not.

--- a/planning/json-ad-compact.md
+++ b/planning/json-ad-compact.md
@@ -1,10 +1,11 @@
 # JSON-AD-Compact: one wire dialect for the LLM assistant
 
-> Status: **In progress** (started 2026-07-08). First consumer: the data-browser
-> AI assistant tools (`useAtomicTools.ts`). Related: [[SDK-API-design]] (agent
-> DX), the `create_table` spec vocabulary in `createTableFromSpec.ts` (the
-> shipped prototype of this idea), and the drive-structure / custom-classes
-> system-prompt inventories that provide the ambient name→subject map.
+> Status: **Phase 1–2 shipped** (resolver, tool I/O, table/context providers).
+> Remaining: rebase `create_table.rows` on `fromCompact`; server
+> `format=compact`. First consumer: the data-browser AI assistant tools
+> (`useAtomicTools.ts`). Related: [[SDK-API-design]] (agent DX), the
+> `create_table` spec vocabulary in `createTableFromSpec.ts`, and the
+> drive-structure / custom-classes system-prompt inventories.
 
 ## Problem
 
@@ -103,15 +104,15 @@ section); tool descriptions just say "compact form".
 
 | Phase | Surface | Status |
 | ----- | ------- | ------ |
-| 1 | Resolver module + unit tests for pure resolution/coercion | **this round** |
-| 1 | Reads emit compact: `get_atomic_resource`, `query` results | **this round** |
-| 1 | Writes accept compact: `create_resource` (incl. batch), `edit_atomic_resource` property-by-shortname + tag-name values | **this round** |
-| 1 | `query` gains `class` param: shortname `where` keys, tag-name values, implied `isA` filter | **this round** |
-| 1 | System-prompt grammar section; slim per-tool JSON-AD explanations | **this round** |
-| 1 | Short subject refs (`#xxxxxxxx`) at the tool boundary + drive-tree/custom-classes seeding + markdown-link and tool-bubble expansion | **this round** |
-| 2 | Context items (`processAtomicResources`) emit compact; per-class context providers (table → row-class schema + tag map + first N rows + count in transient context) | next |
-| 3 | `create_table.rows` / `rowToPropVals` re-based on `fromCompact` | next |
-| 4 | Server-side `format=compact` so MCP server & other clients share it instead of reimplementing resolution | later |
+| 1 | Resolver module + unit tests for pure resolution/coercion | **done** |
+| 1 | Reads emit compact: `get_atomic_resource`, `query` results | **done** |
+| 1 | Writes accept compact: `create_resource` (incl. batch), `edit_atomic_resource` property-by-shortname + tag-name values | **done** |
+| 1 | `query` gains `class` param: shortname `where` keys, tag-name values, implied `isA` filter | **done** |
+| 1 | System-prompt grammar section; slim per-tool JSON-AD explanations | **done** |
+| 1 | Short subject refs (`#xxxxxxxx`) at the tool boundary + drive-tree/custom-classes seeding + markdown-link and tool-bubble expansion | **done** |
+| 2 | Context items (`processAtomicResources`) emit compact; per-class context providers (table → row-class schema + tag map + first N rows + count in transient context) | **done** |
+| 3 | `create_table.rows` / `rowToPropVals` re-based on `fromCompact` | remaining |
+| 4 | Server-side `format=compact` so MCP server & other clients share it instead of reimplementing resolution | remaining |
 
 ## Decisions record
 

--- a/planning/json-schema-code-first.md
+++ b/planning/json-schema-code-first.md
@@ -1,5 +1,7 @@
 # JSON Schema compatible, code-first schemas
 
+**Status:** Proposal. Nothing built.
+
 ## Goal
 
 Make Atomic usable by app developers who want to define their data model in

--- a/planning/llm-wasm-gui-plugins.md
+++ b/planning/llm-wasm-gui-plugins.md
@@ -1,5 +1,7 @@
 # LLM-Generated JS Applications and Future WASM Plugins
 
+**Status:** Proposal. Nothing built.
+
 ## Goal
 
 Let Atomic host existing and LLM-generated applications that use Atomic for

--- a/planning/loro-source-of-truth.md
+++ b/planning/loro-source-of-truth.md
@@ -1,9 +1,13 @@
 # Loro as the single source of truth
 
-> **Status:** Active plan (2026-05). Defines the storage end-state that
-> [`unified-data-layer.md`](./unified-data-layer.md) and [`unified-sync.md`](./unified-sync.md)
-> assume but do not specify. Concerns `lib/src` (core `Db`) and the Flutter
-> embedding (`flutter/rust`, `flutter/lib`).
+> **Status:** Partial. Sparse `datatypes` map shipped (Rust + TS). Phase 2a–2c
+> shipped: `Tree::Resources` is a derived cache; `loroUpdate` is stripped from
+> the blob for CRDT resources. Remaining: drop the untagged heuristic (explicit
+> `string` tag), Phase 1.6 `Value` reshape, Flutter undo. Defines the storage
+> end-state that [`unified-data-layer.md`](./unified-data-layer.md) and
+> [`unified-sync.md`](./unified-sync.md) assume but do not specify. Concerns
+> `lib/src` (core `Db`) and the Flutter embedding (`flutter/rust`,
+> `flutter/lib`).
 
 ## Goal
 
@@ -11,18 +15,20 @@ For mutable resources, the **Loro CRDT document is the authoritative state**.
 The flat `PropVals` map becomes a **derived read/index projection**, rebuilt
 from the doc on every write and never authored independently.
 
-Today the dependency runs backwards: `PropVals` is the primary write target and
-the Loro doc is seeded *from* it. The same logical state is also persisted
-twice and re-copied up the stack — see [Current state](#current-state).
+The write path is now doc-first for CRDT resources (Phase 2a); `Tree::Resources`
+is a derived cache and `loroUpdate` is stripped from the blob (Phase 2c). What
+remains is the untagged heuristic, the 3-way `build_state_doc` fallback, and
+Flutter's parallel undo trees — see the checklists below. The table in
+[Current state](#current-state) describes the shape this plan started from.
 
-## Current state (honest)
+## Current state (honest, as of 2026-05; #2 later stripped)
 
 A single resource's mergeable state exists in up to five representations:
 
 | # | Representation | Where | Notes |
 | --- | --- | --- | --- |
 | 1 | Loro oplog snapshot | `Tree::LoroSnapshots`, key `pure_id()` | The real merge truth. |
-| 2 | `loroUpdate` propval **inside** the `Tree::Resources` blob | `Tree::Resources` | Redundant; after a commit it can be a *stale incremental delta* (see `db.rs` `get_resource` comment). |
+| 2 | `loroUpdate` propval **inside** the `Tree::Resources` blob | `Tree::Resources` | **Removed in Phase 2c** for CRDT resources. Commits keep it (signed payload). |
 | 3 | Flat queryable `PropVals` | `Tree::Resources` | The index/query projection. |
 | 4 | Live `Resource` (in-memory doc + undo stack) | Flutter `CANVAS_CACHE` static (`flutter/rust/src/api/simple.rs`) | Undo history persisted nowhere. |
 | 5 | Materialized display copies | Dart `CanvasEntry.strokes`, `InfiniteCanvas._strokes`, `_loroStrokeStates` | Two parallel undo trees. |

--- a/planning/migrate-jsonarray-to-json.md
+++ b/planning/migrate-jsonarray-to-json.md
@@ -1,5 +1,8 @@
 # Migrate Canvas strokeData Datatype from jsonArray to json
 
+**Status:** Shipped. Canvas `strokeData` datatype is `json`. `jsonArray` is
+retired.
+
 Change the datatype of `https://atomicdata.dev/ontology/canvas/strokeData` from the non-existent `jsonArray` datatype to the standard native `json` datatype, and update the Rust backend, browser frontend, and Flutter mobile clients to support it.
 
 ## Decision

--- a/planning/multi-property-filter.md
+++ b/planning/multi-property-filter.md
@@ -1,9 +1,10 @@
 # Multi-property filtering (AND)
 
-> Status: **In progress** (started 2026-06-13). Goal: queries/collections can
-> filter on **multiple `(property, value)` constraints combined with AND**,
-> index-backed (sorted + paginated), full-stack (Rust core → server `/query` →
-> `@tomic/lib` → WASM client-db → React `useCollection`).
+> Status: **Shipped** (full-stack, 2026-06). Queries/collections filter on
+> **multiple `(property, value)` constraints combined with AND**, index-backed
+> (sorted + paginated), full-stack (Rust core → server `/query` → `@tomic/lib`
+> → WASM client-db → React `useCollection`). UI lives in
+> [`table-view-filters.md`](./table-view-filters.md).
 >
 > **Phase 1 (Rust core) — DONE & tested.** `QueryFilter` now holds
 > `filters: Vec<PropVal>` (AND); `Query` keeps `property`/`value` and gains

--- a/planning/nextgraph-interop.md
+++ b/planning/nextgraph-interop.md
@@ -1,5 +1,7 @@
 # NextGraph interop — `did:ng:` resources via a pluggable Store backend
 
+> **Status:** Proposal. Nothing built.
+
 > Scope note: this is about making Atomic and **NextGraph** (`did:ng:`,
 > RDF + CRDT graph store, [nextgraph.org]) interoperate at the browser data
 > layer. It builds on the `Store`/`Resource` contract described in

--- a/planning/node-did-canonicalization.md
+++ b/planning/node-did-canonicalization.md
@@ -1,5 +1,8 @@
 # Node DID canonicalization
 
+**Status:** Shipped. `did:ad:node:<hex>` is the only user-facing and HTTP API
+form for peer node IDs.
+
 ## Decision
 
 - [x] `did:ad:node:<hex>` is the only user-facing and HTTP API form for peer node IDs.

--- a/planning/pairing-ux-field-test.md
+++ b/planning/pairing-ux-field-test.md
@@ -5,11 +5,14 @@
 > which owns the pairing/onboarding UX; anything adopted from here belongs
 > there.
 >
-> **Outcome: a blank node still cannot pull a peer's drives.** On current
-> code the pairing dialog reports "Your workspace is here" — but the drive it
-> opens was **provisioned locally on sign-in**, not received. The two nodes
-> end up holding disjoint drive sets, each returning "not found locally" for
-> the other's.
+> **Outcome (revised 2026-08-20):** C0 below is a pre-derivation finding.
+> The personal-drive DID is derived from the Agent key
+> ([`deterministic-personal-drive.md`](./deterministic-personal-drive.md)), so
+> two devices with the same secret name the same home. They cannot invent
+> disjoint personal-drive subjects. Pairing + live sync between desktop and
+> the HA node was verified 2026-08-17. The 2026-08-15 header ("a blank node
+> still cannot pull a peer's drives") described looking up the
+> `personalDrive` pointer and minting when it was absent — that path is gone.
 >
 > **This note has been wrong in both directions in one day.** The first draft
 > called it a bootstrap deadlock; the second declared it fixed after a
@@ -48,9 +51,10 @@ Disjoint. See C0 for why.
 
 ## Confirmed on a current build
 
-### C0 — A blank node invents a drive instead of pulling the peer's
+### C0 — A blank node invents a drive instead of pulling the peer's (superseded)
 
-The agent resource for one DID exists in two divergent copies:
+**Historical (2026-08-15).** The agent resource for one DID existed in two
+divergent copies, and the home was still a `personalDrive` pointer:
 
 | | desktop | server |
 | --- | --- | --- |
@@ -58,24 +62,27 @@ The agent resource for one DID exists in two divergent copies:
 | `name` | joep.io | Joep Meindertsma |
 | `publicKey` | `Qmfp…rcQ` | `Qmfp…rcQ=` |
 
-Sequence: sign in on the desktop → `fetchPersonalDriveSubject`
-(`helpers/personalDrive.ts:34`) asks a server for the agent's
-`personalDrive` → the server's copy has none → `adoptLegacyDriveList`
-provisions a fresh private drive locally → pairing resolves *that* drive and
-reports "Your workspace is here". The server's actual drives are never
-requested, because **nothing asks the peer what it holds**.
+Sequence then: sign in on the desktop → `fetchPersonalDriveSubject` asked a
+server for the agent's `personalDrive` → the server's copy had none →
+`adoptLegacyDriveList` provisioned a fresh private drive locally → pairing
+resolved *that* drive and reported "Your workspace is here". The two nodes
+held disjoint drive sets (`bkvN8DuZ…` vs `kZR5Rbwu…`). Nothing asked the peer
+what it held.
 
-Failing honestly ("your workspace didn't arrive") would be better than
-succeeding onto an invented drive, which is indistinguishable from success
-until you notice the drive is empty.
+**Why this cannot happen for the personal drive anymore.**
+`fetchPersonalDriveSubject` (`helpers/personalDrive.ts`) derives the subject
+from the Agent key (`agent.personalDriveSubject()`). The pointer is not
+identity. `createDrive({ personal: true })` pins that same DID; a repeat
+genesis merges. Two devices with the same secret therefore *name* the same
+home before any network round-trip. M23 then stopped *materializing* that
+subject before `deviceHasDriveData`, so an empty local shell is no longer
+read as "you already have your workspace".
 
-The `publicKey` padding difference between the two copies — same agent, one
-with the trailing `=` and one without — may be incidental or may be why they
-never reconcile. Worth checking on its own.
-
-**Fix direction:** pairing should ask the peer which drives it holds for this
-agent and offer them, rather than resolving against local state. Same
-conclusion the first draft reached; it survives the rebuild.
+What is still true, and is not C0: pairing syncs the named drive (and
+whatever the peer pushes for it). Extra workspaces the agent holds elsewhere
+arrive by being listed on that shared home, or by an explicit pull — there is
+still no "ask the peer which drives you have" inventory. That is a sync-scope
+question, not an identity one.
 
 ### C1 — The pairing input rejects a server address
 

--- a/planning/pairing-ux-field-test.md
+++ b/planning/pairing-ux-field-test.md
@@ -349,11 +349,11 @@ was load-bearing and unenforced on the client. Deriving identity from a
 signature requires the signer to be deterministic — a requirement worth
 stating wherever it is relied upon.
 
-### M6 — Adopting a drive hands the whole session to the old server (open, top of the list)
+### M6 — Adopting a drive hands the whole session to the old server (fixed, 2026-08-20)
 
-The migration working is what breaks the app.
+The migration working is what used to break the app.
 
-`AppSettings.setDrive` repoints the entire app at a drive's origin:
+`AppSettings.setDrive` used to repoint the entire app at *any* HTTP drive's origin:
 
 ```ts
 if (newDrive.startsWith('http://') || newDrive.startsWith('https://')) {
@@ -362,10 +362,10 @@ if (newDrive.startsWith('http://') || newDrive.startsWith('https://')) {
 }
 ```
 
-Migration restores drives that live on `atomicdata.dev`. Opening one moves the
+Migration restores drives that live on `atomicdata.dev`. Opening one moved the
 session to that pre-0.40 server — which cannot do DID auth and does not speak
-the v2 websocket — so authentication times out after 30s, the socket retries
-forever, and every local `did:ad:` resource 404s because the client is asking
+the v2 websocket — so authentication timed out after 30s, the socket retried
+forever, and every local `did:ad:` resource 404ed because the client was asking
 the wrong machine.
 
 Measured on a run with the app's own server captured: **0 requests from the
@@ -381,15 +381,22 @@ Auth error: Timed out waiting 30000ms for WS tag 2
 The embedded server was healthy throughout — HTTP root in 0.9ms, correct
 default agent, 100ms durable-flush tick running.
 
-This is the parent of most of the evening's symptoms: "Server error" on every
+This was the parent of most of that evening's symptoms: "Server error" on every
 drive, the private drive not resolving, the migration fetch timing out (`curl`
 gets that same resource in 120ms), and the lost edits.
 
-**Not yet fixed** — it is a semantics decision, not a bug with one right
-answer. Either refuse to follow a drive to an origin that fails a capability
-check, or keep the home server fixed and fetch foreign drives cross-origin. The
-second is more defensible: a drive adopted from a server you are migrating
-*away from* should not be able to take the session with it.
+**Decision, not a blanket ban on HTTP origins.** A bare origin
+(`https://host`, no path) is still a server switch — that *is* what "open this
+URL" means when the URL is the machine. An HTTP subject *with a path* is a
+drive. `Store.setDrive` / `AppSettings.setDrive` set it as the current
+workspace and leave `serverUrl` alone. Fetch goes to the subject's own origin;
+live SUB / SYNC_VV / presence stay on the home websocket (`isLiveSyncedDrive`).
+A drive adopted from a server you are migrating *away from* cannot take the
+session with it.
+
+Pinned by `browser/lib/src/store.set-drive.test.ts`. Reading those drives
+still needs M4 (legacy auth against a pre-0.40 origin); this fix only stops
+the session move.
 
 ### M7 — A foreign origin's websocket took the whole app offline (fixed)
 

--- a/planning/pairing-ux-field-test.md
+++ b/planning/pairing-ux-field-test.md
@@ -1,9 +1,11 @@
 # Pairing UX — field test notes from a real self-hosted setup
 
-> **Status:** Findings (2026-08-15), **substantially revised the same day
-> after rebuilding.** Companion to [`device-pairing.md`](./device-pairing.md),
-> which owns the pairing/onboarding UX; anything adopted from here belongs
-> there.
+> **Status:** Field notes (2026-08-15 through 2026-08-20). C0 (pairing invents
+> a drive) is superseded — both sides derive. M6 (opening an HTTP drive moves
+> the home server) is closed. Open: M4 (pre-0.40 DID auth), M8 (desktop
+> “saved locally” toast), M12 (presence over Iroh), extra-workspace inventory.
+> Companion to [`device-pairing.md`](./device-pairing.md), which owns the
+> pairing/onboarding UX; anything adopted from here belongs there.
 >
 > **Outcome (revised 2026-08-20):** C0 below is a pre-derivation finding.
 > The personal-drive DID is derived from the Agent key

--- a/planning/reticulum-sync.md
+++ b/planning/reticulum-sync.md
@@ -1,5 +1,7 @@
 # Reticulum transport for Atomic sync
 
+**Status:** Proposal. Nothing built.
+
 ## Goal
 
 Make the Atomic sync protocol work over Reticulum, so Atomic nodes can sync over

--- a/planning/s3-blob-storage.md
+++ b/planning/s3-blob-storage.md
@@ -1,5 +1,7 @@
 # S3-compatible Blob Storage
 
+**Status:** Proposal. Nothing built.
+
 ## Problem
 
 `Tree::Blobs` (the content-addressed store for file bytes, keyed by BLAKE3 hash) currently lives inside the same redb instance as resources, indexes, and Loro snapshots. That works for a single-server install with modest file volume, but it conflates two very different storage workloads:

--- a/planning/sign-at-drain.md
+++ b/planning/sign-at-drain.md
@@ -1,10 +1,9 @@
 # Sign at drain (one commit per save boundary)
 
-> **Status:** Shipped uncommitted (2026-05-29). Real sign-at-drain
-> landed in working tree — local Loro ops mark the subject dirty in the
-> outbox; the store-level drain exports the accumulated Loro delta,
-> signs ONE commit per dirty subject, POSTs. 26 keystrokes ≠ 26 signed
-> commits — at most one batched commit per drain pass per subject.
+> **Status:** Shipped (2026-05). Local Loro ops mark the subject dirty in the
+> outbox; the store-level drain exports the accumulated Loro delta, signs ONE
+> commit per dirty subject, POSTs. 26 keystrokes ≠ 26 signed commits — at most
+> one batched commit per drain pass per subject.
 >
 > The earlier "option 2" (keep eager sign, async POST) shipped as steps
 > 1-3 (commits `a909ad32`..`1e9e2f08`); the working-tree changes
@@ -328,7 +327,7 @@ Each step is independently shippable; tests stay green after each.
    `a909ad32`..`1e9e2f08`)_. Eager-sign, async-POST. See option 2 in
    "Why we returned to option 1" — kept for context; step 4 supersedes
    the `_saveInner` contract here.
-4. **Browser: real sign-at-drain.** ✅ _shipped (uncommitted)_. Loro
+4. **Browser: real sign-at-drain.** ✅ _shipped_. Loro
    doc is the source of truth for what to sign. The outbox holds a
    dirty bit + an optional pre-signed genesis envelope. The store-
    level drain (`drainOutboxSubject`) exports the accumulated Loro
@@ -352,7 +351,7 @@ Each step is independently shippable; tests stay green after each.
 
 ## Step 6: collapse the public API surface
 
-> **Status:** Partially shipped (2026-05-29, uncommitted). Done:
+> **Status:** Shipped (2026-05-30). Done:
 > `save()` now awaits durability and returns `SaveResult`
 > (`'persisted' | 'offline' | 'noop'`), `differentAgent` param dropped;
 > `signChanges` / `markNextCommitAsGenesis` / the Loro drain helpers

--- a/planning/structural-problems-index.md
+++ b/planning/structural-problems-index.md
@@ -14,8 +14,10 @@ Several open items overlap with broader existing plans:
   — the browser data-layer redesign. Doing those three in isolation
   risks landing partial layouts that the bigger plan then has to undo.
 - **#6** has a Rust/Flutter dual in [`loro-source-of-truth.md`](./loro-source-of-truth.md).
-  The browser `Resource._cache` and Rust `PropVals` should converge to
-  "derived from Loro" together.
+  The sparse `datatypes` map and `Tree::Resources` derived cache shipped on
+  the Rust side. The browser `Resource._cache` dual
+  ([unify-resource-representations.md](./unify-resource-representations.md))
+  is still open.
 
 The remaining standalone items (#1 react-compiler, #3 subscription
 actors, #7 arc-wrap, #8 subject types) don't overlap with the broader
@@ -27,9 +29,9 @@ plans and can be tackled independently.
 | 2 | [unify-subscription-primitives.md](./unify-subscription-primitives.md) | Cleanup | Medium | Single `Subscription` shape with `Match::{Subject, Drive, Filter}` |
 | 3 | [unify-subscription-actors.md](./unify-subscription-actors.md) | Cleanup | Medium | Fold LoroSyncBroadcaster's subject-sub into CommitMonitor |
 | 5 | [unify-resource-dirty-signals.md](./unify-resource-dirty-signals.md) | Correctness | Medium | Single `getSaveState(subject)` enum |
-| 6 | [unify-resource-representations.md](./unify-resource-representations.md) | Correctness | High | Make Loro doc authoritative; `_cache` becomes memoized read |
-| 7 | [arc-actor-message-payloads.md](./arc-actor-message-payloads.md) | Performance | Low | ✅ Stretch landed (uncommitted) — `SendFrame` + encode-once + `Bytes::from_owner` zero-copy at WS write; 6/6 WS tests green. `MembershipNotification` already Arc-wrapped (committed earlier). `CommitMessage` Arc-wrap (atomic_lib change) deferred. |
-| 8 | [subject-types-end-to-end.md](./subject-types-end-to-end.md) | Correctness | High | 🟡 Started (uncommitted) — `Subject` brand + `asSubject`/`tryAsSubject`/`isValidSubject` added in `browser/lib/src/subject.ts` with 8 passing tests. Consumer migration not started. |
+| 6 | [unify-resource-representations.md](./unify-resource-representations.md) | Correctness | High | 🟡 Rust `datatypes` map + derived `Tree::Resources` cache shipped. Browser `_cache` dual still open. |
+| 7 | [arc-actor-message-payloads.md](./arc-actor-message-payloads.md) | Performance | Low | ✅ Stretch landed — `SendFrame` + encode-once + `Bytes::from_owner` zero-copy at WS write. `MembershipNotification` already Arc-wrapped. `CommitMessage` Arc-wrap (`atomic_lib` change) deferred. |
+| 8 | [subject-types-end-to-end.md](./subject-types-end-to-end.md) | Correctness | High | 🟡 Started — `Subject` brand + `asSubject`/`tryAsSubject`/`isValidSubject` in `browser/lib/src/subject.ts`. Rust `DidKind` classifier shipped. Consumer migration not started. |
 
 ## Suggested execution order
 

--- a/planning/table-templates-and-mini-apps.md
+++ b/planning/table-templates-and-mini-apps.md
@@ -2,12 +2,12 @@
 
 ## Status
 
-In progress (2026-07-31). Prompted by the Timer view: building it as a bespoke
-renderer meant re-implementing the table badly, which raised the question of
-what should happen as templates multiply. Steps 3 (derived columns), 4
-(aggregation with breakdowns), 5 (assistant tools) and 6 (the catalogue) have
-shipped. What's left is the list of gaps below — chiefly making derived columns
-first-class in filters and aggregates.
+Steps 3–6 shipped (2026-07-31). Prompted by the Timer view: building it as a
+bespoke renderer meant re-implementing the table badly, which raised the
+question of what should happen as templates multiply. Steps 3 (derived
+columns), 4 (aggregation with breakdowns), 5 (assistant tools) and 6 (the
+catalogue) have shipped. What's left is the list of gaps below — chiefly
+making derived columns first-class in filters and aggregates.
 
 ## The Problem
 

--- a/planning/table-view-filters.md
+++ b/planning/table-view-filters.md
@@ -1,8 +1,10 @@
 # Table view: multi-property filtering UI (+ Views)
 
-> Status: **In progress** (started 2026-06-13). Builds on the completed
-> full-stack multi-property (AND) filtering core
-> ([[multi-property-filter]] / `planning/multi-property-filter.md`).
+> Status: **Default View shipped** (filters, sort, columns, operators).
+> Remaining: multi-view switcher (create / switch / delete); index-accelerated
+> range scans. Builds on the completed full-stack multi-property (AND)
+> filtering core ([[multi-property-filter]] /
+> `planning/multi-property-filter.md`).
 
 ## Goal
 

--- a/planning/virtual-drive.md
+++ b/planning/virtual-drive.md
@@ -1,5 +1,7 @@
 # Virtual Drive: Atomic as a Filesystem
 
+**Status:** Proposal. Nothing built.
+
 AtomicServer runs offline-first as a desktop app and syncs across devices.
 A natural extension is to expose its hierarchy as a filesystem that the OS can
 mount — similar to how Google Drive or Dropbox surface remote storage. Files


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Closes the M6 finding in `planning/pairing-ux-field-test.md` (session hijack when opening an adopted pre-DID drive).

## What

Opening a drive whose subject is `https://atomicdata.dev/drives/…` used to rewrite `serverUrl` to that origin. During migration that moved the whole session onto a pre-0.40 server: DID auth timed out, the v2 websocket never came up, and every local `did:ad:` resource 404ed.

A **bare origin** (`https://host`) is still a server switch — that is what the URL is. An HTTP subject **with a path** is a drive. `Store.setDrive` / `AppSettings.setDrive` set it as the current workspace and leave the home server alone. Fetch goes to the subject's own origin; live SUB / SYNC_VV / presence stay on the home websocket.

Pinned by `browser/lib/src/store.set-drive.test.ts`. Reading those drives still needs M4 (legacy auth); this only stops the session move.

Also corrects a stale pairing note: C0 (a blank node minting a *different* personal-drive DID) is pre-derivation. The home subject is computed from the Agent key.

## Planning docs

`planning/README.md` is now Active vs Landed vs companion slices. Status headers in the docs themselves match the code: filters, genesis minting (`verifyGenesisCert` / `mintCertDid`), RBSR core, Loro `datatypes` map + derived `Tree::Resources` cache, JSON-AD compact phases 1–2, pairing C0/M6, canvas `strokeData` as `json`.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-602501bf-5208-4826-8364-54cc412fb25f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-602501bf-5208-4826-8364-54cc412fb25f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

