### PR TITLE
Keep develop as trunk; production and live docs follow tags

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -291,10 +291,10 @@ export class AtomicServer {
   async ci(
     @argument() netlifyAuthToken: Secret,
     /**
-     * Publish docs to the live sites instead of preview URLs. Pass `--publish-docs`
-     * only from a branch that should own the public docs (master). Left off,
-     * every branch build gets a Netlify preview and the published docs are
-     * whatever master last put there.
+     * Publish docs to the live sites instead of preview URLs. Pass
+     * `--publish-docs` only from a stable `v*` tag (the same ref production
+     * deploys). Left off, every build gets a Netlify preview and the published
+     * docs stay whatever the last stable tag put there.
      */
     @argument() publishDocs = false,
     /**

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -20,9 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Tag, branch or commit to deploy"
-        required: false
-        default: master
+        description: "Stable tag to deploy (e.g. v0.40.3). No default — do not pass a branch."
+        required: true
         type: string
       skip_ci_check:
         description: "Deploy even if no green pipeline is found (emergencies)"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,9 +1,9 @@
 name: Deployment Staging
 
-# Staging follows `develop` under the same rule as production follows `master`:
-# deploy the commit whose pipeline passed, not merely the latest commit. See
-# deploy_production.yml for why `workflow_run` rather than `push`, and why the
-# head_sha has to be passed explicitly.
+# Staging follows `develop`. Production follows a stable `v*` tag, not a
+# branch. Same rule otherwise: deploy the commit whose pipeline passed, not
+# merely the latest commit. See deploy_production.yml for why `workflow_run`
+# rather than `push`, and why the head_sha has to be passed explicitly.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -70,17 +70,21 @@ jobs:
           version: "latest"
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           verb: call
-          # `--publish-docs` only from master. This pipeline runs on every push
-          # to every branch, and netlifyDeploy used to pass `--prod`
-          # unconditionally — so any feature branch republished the public docs
-          # and typedoc. Every other branch now gets a preview URL instead.
-          # `--host-profile` selects parallelism (mancave hot / hosted quiet).
-          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} ${{ github.ref == 'refs/heads/master' && '--publish-docs' || '' }}
+          # `--publish-docs` only from a stable `v*` tag (no hyphen), matching
+          # production. This pipeline runs on every push, and netlifyDeploy
+          # used to pass `--prod` unconditionally — so any feature branch
+          # republished the public docs and typedoc. `master` used to own live
+          # docs while the app shipped from tags; both now follow the tag.
+          # Every other ref gets a preview URL. `--host-profile` selects
+          # parallelism (mancave hot / hosted quiet).
+          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && '--publish-docs' || '' }}
       - name: Dagger docker images (build images & publish)
-        # develop and master only. There is no `main` branch here — that clause
-        # could never fire, and left in place it invites someone to conclude
-        # one exists.
-        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        # Floating `:develop` image tracks the integration branch. There is no
+        # `main` branch here — that clause could never fire, and left in place
+        # it invites someone to conclude one exists. `master` is not a docker
+        # trigger either. Versioned images are published from tags via the
+        # release process (`dagger call create-docker-images --tags …`).
+        if: github.ref == 'refs/heads/develop'
         uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ Use todo lists and checkboxes to track progress.
 Make sure to update the planning as you find new insights and see outdated planning text.
 Remove planning documents that are completed.
 
+## Git
+
+Default branch is `develop`. Open PRs against it. Staging deploys from `develop`
+after green CI; production and live docs deploy from a stable `v*` tag. Do not
+introduce a `main` branch, treat `master` as production, or add a job that
+fast-forwards `main` when a tag is pushed — the tag is the release. Hotfixes
+branch from the tag and merge back to `develop`. See `CONTRIBUTING.md`.
+
 ## Quick Dev Setup
 
 Use the Charlotte MCP server and navigate to `http://localhost:6747/app/dev-drive` to instantly create a fresh agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Git / CI: one integration branch (`develop`) plus stable `v*` tags. Staging
+  follows `develop`; production and live docs follow a tagged release. `master`
+  is no longer a deploy or docs trigger, and `main` is not introduced as a
+  copy of the latest tag.
+
 ## [v0.41.0-beta.2] - 2026-08-01
 
 **This is the local-first release.** Atomic Data no longer needs a server to exist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Check out the [Roadmap](https://docs.atomicdata.dev/roadmap.html) if you want to
 - [Git policy](#git-policy)
   - [Open a PR](#open-a-pr)
   - [Branching](#branching)
+  - [Hotfixes](#hotfixes)
 - [Testing](#testing)
 - [Performance monitoring / benchmarks](#performance-monitoring--benchmarks)
   - [Tracing](#tracing)
@@ -106,6 +107,16 @@ Check the Dagger index.ts file to see how cross compilation is done in the CI.
 
 ## Git policy
 
+One long-lived branch: `develop`. Staging follows it. Production is a stable
+`v*` tag, not a branch.
+
+Do not add a `main` that is updated when you tag `develop`. The tag already
+*is* the release — a second pointer for the same commit drifts (failed update
+job, a direct push, a PR against the GitHub default), and production that
+deploys from both `main` and tags can disagree. `master` is not part of this
+flow either; it used to own live docs, which now publish from the same stable
+tags as production.
+
 ### Open a PR
 
 - Make sure your branch is up to date with `develop`.
@@ -115,6 +126,23 @@ Check the Dagger index.ts file to see how cross compilation is done in the CI.
 ### Branching
 
 Create new branches off `develop`. When an issue is ready for PR, open PR against `develop`.
+
+### Hotfixes
+
+When production needs a fix that must not wait for everything already on
+`develop`, branch from the tag, tag the fix, merge back:
+
+```sh
+git checkout -b hotfix/describe-it v0.40.3
+# fix, open a PR, merge
+git tag v0.40.4
+git push origin v0.40.4
+git checkout develop
+git merge hotfix/describe-it
+```
+
+The new tag is what production deploys. `develop` must get the fix too, or the
+next release reintroduces the bug.
 
 ## Testing
 
@@ -266,20 +294,22 @@ Nothing deploys until its pipeline is green.
 | Trigger | Deploys to | Docs |
 | --- | --- | --- |
 | push to `develop` | staging.atomicdata.dev | Netlify preview URL |
-| push to `master` | — | the live docs + typedoc sites |
-| a `v*` **tag** | atomicdata.dev | — |
+| a stable `v*` **tag** | atomicdata.dev | the live docs + typedoc sites |
 
 Staging follows a branch; **production runs a tagged release**. A branch pointer
 answers "what was merged most recently", which is not the question you are
 asking when production is misbehaving — "which release is this" is, and a tag
 answers it. It also means the deployed thing has a name that appears in the
-changelog, and that redeploying it later gets you the same bytes.
+changelog, and that redeploying it later gets you the same bytes. Live docs
+follow the same rule, so docs.atomicdata.dev describes the tagged software
+rather than whatever last landed on a docs-only branch.
 
-Pre-release tags (`v0.41.0-beta.2` and friends) do **not** deploy. They exist to
-be published and tested. Put one on production deliberately via the
-`workflow_dispatch` if you want it there.
+Pre-release tags (`v0.41.0-beta.2` and friends) do **not** deploy the app or
+publish live docs. They exist to be published and tested. Put one on production
+deliberately via the `workflow_dispatch` if you want it there.
 
-There is no `main` branch, and nothing refers to one.
+There is no `main` branch, and nothing should refer to one. Do not introduce
+one as a fast-forward of the latest tag — see [Git policy](#git-policy).
 
 `release-plz` used to live here, triggered on pushes to `main` — a branch this
 repo does not have — so it never ran once, while holding a
@@ -309,10 +339,12 @@ Two consequences worth knowing:
   Staging therefore passes `github.event.workflow_run.head_sha` into
   `deployment.yml`'s required `ref` input; production passes the resolved tag
   SHA. Leaving it out deploys something other than what CI tested, silently.
-- Docs publishing is opt-in per branch. `dagger call ci` takes `--publish-docs`,
-  and `main.yml` passes it only from `master`. Without it Netlify gets a preview
-  deploy. This used to be unconditional `--prod`, which meant pushing any
-  feature branch republished the public documentation.
+- Docs publishing is opt-in per ref. `dagger call ci` takes `--publish-docs`,
+  and `main-ci.yml` passes it only for a stable `v*` tag (no hyphen in the tag
+  name). Without it Netlify gets a preview deploy. This used to be
+  unconditional `--prod`, which meant pushing any feature branch republished
+  the public documentation, and later `master`-only, which left live docs on a
+  branch that was not production.
 
 Every deploy then has to prove itself: the job polls `/server` on the target
 until it answers `200` (with enough patience for a store migration). A deploy
@@ -328,9 +360,10 @@ export taken during the deploy, and expect to think.
 
 To deploy a specific commit — a rollback, or a fix that cannot wait for a full
 pipeline — use the `workflow_dispatch` on either deploy workflow and give it a
-ref. To require human approval for production, add reviewers to the `production`
-environment in the repository settings; the environment is already declared, so
-no workflow change is needed.
+ref. Production dispatch has no default on purpose: type the tag (or SHA) you
+mean; the old default was `master`. To require human approval for production,
+add reviewers to the `production` environment in the repository settings; the
+environment is already declared, so no workflow change is needed.
 
 ### Publishing manually - doing the CI's work
 
@@ -361,9 +394,12 @@ For a single local ARM64 image, use `dagger call create-docker-image --target aa
 
 #### Deploying to atomicdata.dev
 
-1. Run the [`deploy` Github action](https://github.com/atomicdata-dev/atomic-server/actions/workflows/deployment.yml)
+Push a stable `v*` tag. That is what production follows. To deploy a tag (or
+commit) by hand, run the
+[`deploy_production` GitHub Action](https://github.com/atomicdata-dev/atomic-server/actions/workflows/deploy_production.yml)
+and pass that ref.
 
-or do it manually:
+Or do it manually:
 
 1. `cd server`
 1. `cargo build --release --target x86_64-unknown-linux-musl --bin atomic-server` (if it fails, use cross, see above)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,8 @@ cargo install mdbook-linkcheck
 mdbook serve
 ```
 
-Publishing is done with Github actions - simply push the master branch.
+Live docs publish from a stable `v*` tag (the same ref as production). Pushes
+to `develop` and other branches get a Netlify preview URL. See `CONTRIBUTING.md`.
 
 ## Contributing
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

No linked issue — documents and wires the git flow we settled on: one integration branch, staging from `develop`, production (and live docs) from a stable `v*` tag. No `main` that copies the tag.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed (YAML parse of the three workflows; expression matrix below)
- [x] Update docs if needed

## What changed

**Keep `develop`. Do not add `main`.** Tagging `develop` and fast-forwarding `main` would create a second pointer for the same commit. The tag already is the release.

| Ref | App | Docs |
| --- | --- | --- |
| `develop` (after green CI) | staging.atomicdata.dev | Netlify preview |
| stable `v*` tag (no hyphen) | atomicdata.dev | live docs + typedoc |
| pre-release tag (`v0.41.0-beta.2`) | publish/test only | preview |

`master` is folded out of the flow: it used to own live docs while production already followed tags.

**Until the next stable tag, live docs stay whatever `master` last published.** Pre-release tags do not refresh them.

## File updates

- `CONTRIBUTING.md` — git policy, hotfix-from-tag recipe, deploy table, production dispatch note
- `AGENTS.md` — short git section so agents keep PRing `develop`
- `docs/README.md` — publishing is a stable tag, not `master`
- `.github/workflows/deploy_production.yml` — `workflow_dispatch` `ref` is required, no default (`master` was the old default)
- `.github/workflows/deploy_staging.yml` / `main-ci.yml` — comments and `--publish-docs` / docker `if` match the table
- `.dagger/src/index.ts` — `publishDocs` comment

Hotfixes: branch from the tag, push a new tag, merge back to `develop`.

## Checks

Workflow YAML parses. Simulated GitHub expressions:

| ref | `--publish-docs` | docker `:develop` | prod auto-deploy |
| --- | --- | --- | --- |
| `develop` | no | yes | no |
| `master` / `main` | no | no | no |
| `v0.40.3` | yes | no | yes |
| `v0.41.0-beta.2` | no | no | no |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c284ea0e-5714-45a6-9208-6e3d8e5d7587?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c284ea0e-5714-45a6-9208-6e3d8e5d7587&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

