### PR TITLE
Silently migrate v1 documents to Loro instead of throwing

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -271,6 +271,15 @@ is only kept in step by mirroring the tests, so do that deliberately.
 derivation (`personal_drive_subject` / `personalDriveSubject`). The cross-lang
 vector (`personal_drive_cross_lang_vector`) pins the nonce, signature, and DID.
 
+## Documents
+
+| Flow | Layer | Where |
+|---|---|---|
+| V1 element list + paragraph markdown (+ resource embed) → TipTap JSON; leftover Yjs `XmlFragment` walker; `{ type: 'ydoc' }` detection without loading `yjs` | glue | `browser/data-browser/src/views/Document/documentMigrationUtils.test.ts` |
+| Opening a writable v1 document migrates it silently into the Loro editor (no "Update Document" button) | flow | `browser/e2e/tests/documents.spec.ts` |
+
+Not covered: leftover Yjs-era DocumentV2 bodies end-to-end (needs a stored `{ type: 'ydoc' }` fixture); read-only v1 documents stay on the element list and have no e2e.
+
 ## Personal drive identity
 
 | Flow | Where |

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: opening a v1 document no longer shows a read-only page with an "Update Document" button that throws. Writable v1 documents migrate silently to the Loro-backed editor. Leftover Yjs-era V2 bodies still convert, but `yjs` is loaded only when those bytes are present.
+
 - Dev: React Compiler now runs through native `oxc-transform-react` instead of `babel-plugin-react-compiler`. JSX/TS and Fast Refresh share that pass. styled-components `displayName` comes from Oxc's built-in plugin on Vite's oxc pass, so Babel is gone (`babel-plugin-react-compiler`, `babel-plugin-styled-components`, `@rolldown/plugin-babel`). Vite dev no longer pays a Babel tax per module (files that used to take ~100ms now land around ~10ms). Oxlint 1.79's compiler-powered Rules of React (`react/immutability`, `react/purity`, `react/error-boundaries`, …) are on; `set-state-in-effect` / `refs` / `static-components` stay warn until those call sites are cleaned up.
 
 - Fix: clicking a button in the navbar no longer draws a blue outline around the whole bar. The bar used `:has(:focus)`, which matched mouse clicks; keyboard focus still shows on the button itself.

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -98,6 +98,7 @@
     "workbox-build": "^7.4.1",
     "workbox-window": "^7.4.1",
     "wuchale": "^0.25.6",
+    "yjs": "^13.6.30",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/browser/data-browser/src/views/Document/DocumentV2FullPage.tsx
+++ b/browser/data-browser/src/views/Document/DocumentV2FullPage.tsx
@@ -1,6 +1,6 @@
 import { EditableTitle } from '@components/EditableTitle';
 import { ResourceCoverImage } from '@components/ResourceDecorations';
-import { dataBrowser, useLoroDoc, useLoroReady } from '@tomic/react';
+import { dataBrowser, useLoroDoc, useLoroReady, useStore } from '@tomic/react';
 import type { ResourcePageProps } from '@views/ResourcePage';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -9,6 +9,11 @@ import {
   DIVIDER,
 } from '@components/ResourceContextMenu';
 import { FaFilePdf } from 'react-icons/fa6';
+import {
+  isYjsMigrationCandidate,
+  loroDocHasVisibleContent,
+  upgradeDocument,
+} from './upgradeDocument';
 
 const CollaborativeEditor = lazy(
   () => import('@chunks/RTE/CollaborativeEditor'),
@@ -28,6 +33,7 @@ const customMenuItems = [
 export const DocumentV2FullPage: React.FC<ResourcePageProps> = ({
   resource,
 }) => {
+  const store = useStore();
   const doc = useLoroDoc(resource);
   const loroReady = useLoroReady();
 
@@ -40,6 +46,11 @@ export const DocumentV2FullPage: React.FC<ResourcePageProps> = ({
   // loaded sits on "Loading..." forever with no signal. Give the WASM
   // import a bounded grace window, then surface a real error.
   const [graceExpired, setGraceExpired] = useState(false);
+  const leftoverYjs = isYjsMigrationCandidate(
+    resource.get(dataBrowser.properties.documentContent),
+    doc ? !loroDocHasVisibleContent(doc) : true,
+  );
+  const [yjsMigrated, setYjsMigrated] = useState(!leftoverYjs);
 
   useEffect(() => {
     if (doc || loroReady) {
@@ -52,6 +63,31 @@ export const DocumentV2FullPage: React.FC<ResourcePageProps> = ({
 
     return () => clearTimeout(id);
   }, [doc, loroReady]);
+
+  useEffect(() => {
+    if (!leftoverYjs || !doc) {
+      return;
+    }
+
+    let cancelled = false;
+
+    upgradeDocument(resource, store)
+      .catch(error => {
+        console.error(
+          '[upgradeDocument] Yjs leftover migration failed:',
+          error,
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setYjsMigrated(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [doc, leftoverYjs, resource, store]);
 
   if (!doc) {
     // Loro is ready (or gave up) but we still have no doc → the editor
@@ -73,6 +109,10 @@ export const DocumentV2FullPage: React.FC<ResourcePageProps> = ({
       );
     }
 
+    return <div>Loading...</div>;
+  }
+
+  if (!yjsMigrated) {
     return <div>Loading...</div>;
   }
 

--- a/browser/data-browser/src/views/Document/documentMigrationUtils.test.ts
+++ b/browser/data-browser/src/views/Document/documentMigrationUtils.test.ts
@@ -1,0 +1,152 @@
+// @wc-ignore-file
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import {
+  extractYDocBytes,
+  isSerializedYDoc,
+  isYjsMigrationCandidate,
+  resourceEmbedNode,
+  tiptapJsonHasVisibleContent,
+  wrapTiptapContent,
+  yjsXmlFragmentToTiptapJSON,
+} from './documentMigrationUtils';
+
+describe('isSerializedYDoc', () => {
+  it('accepts the JSON-AD ydoc wrapper', () => {
+    expect(isSerializedYDoc({ type: 'ydoc', data: 'AAAA' })).toBe(true);
+  });
+
+  it('accepts an Unsupported leftover tagged as ydoc', () => {
+    expect(
+      isSerializedYDoc({
+        value: 'AAAA',
+        datatype: 'https://atomicdata.dev/datatypes/ydoc',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects lorodoc wrappers, strings, and bytes', () => {
+    expect(isSerializedYDoc({ type: 'lorodoc', data: 'AAAA' })).toBe(false);
+    expect(isSerializedYDoc('not-a-ydoc')).toBe(false);
+    expect(isSerializedYDoc(new Uint8Array([1, 2, 3]))).toBe(false);
+    expect(isSerializedYDoc(undefined)).toBe(false);
+  });
+});
+
+describe('isYjsMigrationCandidate', () => {
+  it('always treats a typed ydoc wrapper as a candidate', () => {
+    expect(isYjsMigrationCandidate({ type: 'ydoc', data: 'AAAA' }, false)).toBe(
+      true,
+    );
+  });
+
+  it('ignores bare strings and bytes once Loro already has a body', () => {
+    expect(isYjsMigrationCandidate('a'.repeat(40), false)).toBe(false);
+    expect(isYjsMigrationCandidate(new Uint8Array([1, 2, 3]), false)).toBe(
+      false,
+    );
+  });
+
+  it('treats long strings and bytes as candidates only when Loro is empty', () => {
+    expect(isYjsMigrationCandidate('a'.repeat(40), true)).toBe(true);
+    expect(isYjsMigrationCandidate(new Uint8Array([1, 2, 3]), true)).toBe(true);
+    expect(isYjsMigrationCandidate('short', true)).toBe(false);
+  });
+});
+
+describe('extractYDocBytes', () => {
+  it('decodes the JSON-AD wrapper', () => {
+    const data = Buffer.from([1, 2, 3, 4]).toString('base64');
+
+    expect(Array.from(extractYDocBytes({ type: 'ydoc', data }) ?? [])).toEqual([
+      1, 2, 3, 4,
+    ]);
+  });
+});
+
+describe('v1 element assembly', () => {
+  it('wraps paragraph JSON and resource embeds into a doc', () => {
+    const doc = wrapTiptapContent([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello from v1' }],
+      },
+      resourceEmbedNode('https://example.com/table'),
+    ]);
+
+    expect(doc).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello from v1' }],
+        },
+        {
+          type: 'atomic-data-resource',
+          attrs: { subject: 'https://example.com/table' },
+        },
+      ],
+    });
+    expect(tiptapJsonHasVisibleContent(doc)).toBe(true);
+  });
+
+  it('uses an empty paragraph when there is nothing to migrate', () => {
+    expect(wrapTiptapContent([])).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    });
+    expect(tiptapJsonHasVisibleContent(wrapTiptapContent([]))).toBe(false);
+  });
+});
+
+describe('yjsXmlFragmentToTiptapJSON', () => {
+  it('walks paragraphs, marks, headings, and resource embeds', () => {
+    const ydoc = new Y.Doc();
+    const fragment = ydoc.getXmlFragment('content');
+
+    const paragraph = new Y.XmlElement('paragraph');
+    const text = new Y.XmlText();
+    text.insert(0, 'Hello world');
+    text.format(0, 5, { bold: true });
+    paragraph.insert(0, [text]);
+
+    const heading = new Y.XmlElement('heading');
+    heading.setAttribute('level', '1');
+    const headingText = new Y.XmlText();
+    headingText.insert(0, 'Title');
+    heading.insert(0, [headingText]);
+
+    const embed = new Y.XmlElement('atomic-data-resource');
+    embed.setAttribute('subject', 'https://example.com/embed');
+
+    fragment.insert(0, [heading, paragraph, embed]);
+
+    expect(yjsXmlFragmentToTiptapJSON(fragment)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 1 },
+          content: [{ type: 'text', text: 'Title' }],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              marks: [{ type: 'bold' }],
+            },
+            { type: 'text', text: ' world' },
+          ],
+        },
+        {
+          type: 'atomic-data-resource',
+          attrs: { subject: 'https://example.com/embed' },
+        },
+      ],
+    });
+
+    ydoc.destroy();
+  });
+});

--- a/browser/data-browser/src/views/Document/documentMigrationUtils.ts
+++ b/browser/data-browser/src/views/Document/documentMigrationUtils.ts
@@ -1,0 +1,370 @@
+import type { JSONContent } from '@tiptap/core';
+import { decodeB64 } from '@tomic/lib';
+import type { LoroDoc } from 'loro-crdt';
+
+/**
+ * JSON-AD shape used while Yjs was a first-class value (`{ type: 'ydoc', data }`),
+ * plus the Unsupported leftover the Rust v2→v3 migrator emits for `ValueV2::YDoc`.
+ *
+ * Does not treat bare strings or `Uint8Array` as Yjs — those collide with
+ * `lorodoc` property values. Call {@link isYjsMigrationCandidate} when the
+ * Loro body is empty and a looser check is warranted.
+ */
+export function isSerializedYDoc(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || value instanceof Uint8Array) {
+    return false;
+  }
+
+  const rec = value as Record<string, unknown>;
+
+  if (rec.type === 'ydoc' && typeof rec.data === 'string') {
+    return true;
+  }
+
+  return typeof rec.datatype === 'string' && rec.datatype.includes('ydoc');
+}
+
+/**
+ * True when `documentContent` might still hold a Yjs update and we should
+ * lazy-load `yjs` to find out. Bare strings / bytes are only candidates
+ * when the Loro `doc` map is still empty, so a live Loro-backed V2 is never
+ * delayed by this check.
+ */
+export function isYjsMigrationCandidate(
+  value: unknown,
+  loroBodyEmpty: boolean,
+): boolean {
+  if (isSerializedYDoc(value)) {
+    return true;
+  }
+
+  if (!loroBodyEmpty) {
+    return false;
+  }
+
+  if (value instanceof Uint8Array) {
+    return value.byteLength > 0;
+  }
+
+  return typeof value === 'string' && value.length > 32;
+}
+
+export function extractYDocBytes(value: unknown): Uint8Array | undefined {
+  if (value instanceof Uint8Array) {
+    return value.byteLength > 0 ? value : undefined;
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    try {
+      const bytes = decodeB64(value);
+
+      return bytes.byteLength > 0 ? bytes : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const rec = value as Record<string, unknown>;
+
+  if (rec.type === 'ydoc' && typeof rec.data === 'string') {
+    try {
+      return decodeB64(rec.data);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (
+    typeof rec.datatype === 'string' &&
+    rec.datatype.includes('ydoc') &&
+    typeof rec.value === 'string'
+  ) {
+    try {
+      const nested = JSON.parse(rec.value) as unknown;
+
+      if (isSerializedYDoc(nested)) {
+        return extractYDocBytes(nested);
+      }
+
+      return decodeB64(rec.value);
+    } catch {
+      try {
+        return decodeB64(rec.value);
+      } catch {
+        return undefined;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function loroDocBodyIsEmpty(loroDoc: LoroDoc): boolean {
+  try {
+    const nodeName = loroDoc.getMap('doc').get('nodeName');
+
+    return nodeName === null || nodeName === undefined;
+  } catch {
+    return true;
+  }
+}
+
+export function tiptapJsonHasVisibleContent(doc: JSONContent): boolean {
+  const walk = (node: JSONContent | undefined): boolean => {
+    if (!node) {
+      return false;
+    }
+
+    if (typeof node.text === 'string' && node.text.length > 0) {
+      return true;
+    }
+
+    if (node.type === 'atomic-data-resource' && node.attrs?.subject) {
+      return true;
+    }
+
+    if (node.type === 'image' && node.attrs?.src) {
+      return true;
+    }
+
+    return (node.content ?? []).some(walk);
+  };
+
+  return walk(doc);
+}
+
+export const RESOURCE_EMBED_TYPE = 'atomic-data-resource';
+
+/** True when the Loro `doc` map already has user-visible body (text / embed). */
+export function loroDocHasVisibleContent(loroDoc: LoroDoc): boolean {
+  if (loroDocBodyIsEmpty(loroDoc)) {
+    return false;
+  }
+
+  const walk = (node: unknown): boolean => {
+    if (!node || typeof node !== 'object') {
+      return false;
+    }
+
+    const rec = node as Record<string, unknown>;
+
+    if (typeof rec.text === 'string' && rec.text.length > 0) {
+      return true;
+    }
+
+    if (
+      rec.nodeName === RESOURCE_EMBED_TYPE ||
+      rec.type === RESOURCE_EMBED_TYPE
+    ) {
+      return true;
+    }
+
+    if (Array.isArray(rec.content)) {
+      return rec.content.some(walk);
+    }
+
+    return false;
+  };
+
+  try {
+    return walk(loroDoc.getMap('doc').toJSON());
+  } catch {
+    return false;
+  }
+}
+
+export function resourceEmbedNode(subject: string): JSONContent {
+  return {
+    type: RESOURCE_EMBED_TYPE,
+    attrs: { subject },
+  };
+}
+
+export function emptyTiptapDoc(): JSONContent {
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph' }],
+  };
+}
+
+export function wrapTiptapContent(content: JSONContent[]): JSONContent {
+  if (content.length === 0) {
+    return emptyTiptapDoc();
+  }
+
+  return { type: 'doc', content };
+}
+
+type YXmlDelta = {
+  insert?: string | unknown;
+  attributes?: Record<string, unknown>;
+};
+
+type YXmlTextLike = {
+  toDelta: () => YXmlDelta[];
+};
+
+type YXmlElementLike = {
+  nodeName: string;
+  getAttributes: () => Record<string, unknown>;
+  toArray: () => unknown[];
+};
+
+function isXmlText(node: unknown): node is YXmlTextLike {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as YXmlTextLike).toDelta === 'function' &&
+    typeof (node as YXmlElementLike).nodeName !== 'string'
+  );
+}
+
+function isXmlElement(node: unknown): node is YXmlElementLike {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as YXmlElementLike).nodeName === 'string' &&
+    typeof (node as YXmlElementLike).toArray === 'function'
+  );
+}
+
+function coerceAttrValue(value: unknown): unknown {
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  if (typeof value === 'string' && /^-?\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  return value;
+}
+
+function coerceAttrs(
+  attrs: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    out[key] = coerceAttrValue(value);
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function marksFromDeltaAttrs(
+  attrs: Record<string, unknown> | undefined,
+): JSONContent['marks'] {
+  if (!attrs) {
+    return undefined;
+  }
+
+  const marks: NonNullable<JSONContent['marks']> = [];
+
+  for (const [type, value] of Object.entries(attrs)) {
+    if (value === false || value === undefined || value === null) {
+      continue;
+    }
+
+    if (value === true || value === 1) {
+      marks.push({ type });
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      marks.push(
+        type === 'link'
+          ? { type, attrs: { href: value } }
+          : { type, attrs: { [type]: value } },
+      );
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      marks.push({ type, attrs: value as Record<string, unknown> });
+    }
+  }
+
+  return marks.length > 0 ? marks : undefined;
+}
+
+function textNodesFromDelta(delta: YXmlDelta[]): JSONContent[] {
+  const nodes: JSONContent[] = [];
+
+  for (const item of delta) {
+    if (typeof item.insert !== 'string' || item.insert.length === 0) {
+      continue;
+    }
+
+    const marks = marksFromDeltaAttrs(item.attributes);
+    const node: JSONContent = { type: 'text', text: item.insert };
+
+    if (marks) {
+      node.marks = marks;
+    }
+
+    nodes.push(node);
+  }
+
+  return nodes;
+}
+
+function xmlElementToNode(element: YXmlElementLike): JSONContent {
+  const content: JSONContent[] = [];
+
+  for (const child of element.toArray()) {
+    if (isXmlText(child)) {
+      content.push(...textNodesFromDelta(child.toDelta()));
+    } else if (isXmlElement(child)) {
+      content.push(xmlElementToNode(child));
+    }
+  }
+
+  const node: JSONContent = { type: element.nodeName };
+  const attrs = coerceAttrs(element.getAttributes() ?? {});
+
+  if (attrs) {
+    node.attrs = attrs;
+  }
+
+  if (content.length > 0) {
+    node.content = content;
+  }
+
+  return node;
+}
+
+/**
+ * Walk a y-prosemirror / y-tiptap `XmlFragment` (`content`) into TipTap JSON
+ * without loading `@tiptap/y-tiptap`.
+ */
+export function yjsXmlFragmentToTiptapJSON(fragment: {
+  toArray: () => unknown[];
+}): JSONContent {
+  const content: JSONContent[] = [];
+
+  for (const child of fragment.toArray()) {
+    if (isXmlElement(child)) {
+      content.push(xmlElementToNode(child));
+    } else if (isXmlText(child)) {
+      content.push({
+        type: 'paragraph',
+        content: textNodesFromDelta(child.toDelta()),
+      });
+    }
+  }
+
+  return wrapTiptapContent(content);
+}

--- a/browser/data-browser/src/views/Document/upgradeDocument.ts
+++ b/browser/data-browser/src/views/Document/upgradeDocument.ts
@@ -1,15 +1,286 @@
-import { type DataBrowser, type Resource, type Store } from '@tomic/react';
+import {
+  core,
+  dataBrowser,
+  enableLoro,
+  type Resource,
+  type Store,
+} from '@tomic/react';
+import type { JSONContent } from '@tiptap/core';
+import {
+  extractYDocBytes,
+  isSerializedYDoc,
+  isYjsMigrationCandidate,
+  loroDocHasVisibleContent,
+  resourceEmbedNode,
+  tiptapJsonHasVisibleContent,
+  wrapTiptapContent,
+  yjsXmlFragmentToTiptapJSON,
+} from './documentMigrationUtils';
+
+const inFlight = new Map<string, Promise<boolean>>();
+
+function markdownParseToContent(parsed: unknown): JSONContent[] {
+  if (!parsed || typeof parsed !== 'object') {
+    return [];
+  }
+
+  const rec = parsed as { content?: unknown; toJSON?: () => JSONContent };
+
+  if (Array.isArray(rec.content)) {
+    return rec.content as JSONContent[];
+  }
+
+  if (typeof rec.toJSON === 'function') {
+    const json = rec.toJSON();
+
+    return Array.isArray(json.content) ? json.content : [];
+  }
+
+  return [];
+}
+
+async function v1ElementsToTiptapDoc(
+  resource: Resource,
+  store: Store,
+): Promise<{ doc: JSONContent; ownedParagraphs: Resource[] }> {
+  const { MarkdownManager } = await import('@tiptap/markdown');
+  const { getCollaborativeEditorSchema } =
+    await import('@chunks/RTE/getCollaborativeEditorSchema');
+
+  const { extensions } = getCollaborativeEditorSchema(store);
+  const mdManager = new MarkdownManager({ extensions });
+
+  const elements = (
+    await Promise.allSettled(
+      (resource.props.elements ?? []).map((element: string) =>
+        store.getResource(element),
+      ),
+    )
+  )
+    .filter(
+      (result): result is PromiseFulfilledResult<Resource> =>
+        result.status === 'fulfilled',
+    )
+    .map(result => result.value);
+
+  const tiptapContent: JSONContent[] = [];
+  const ownedParagraphs: Resource[] = [];
+
+  for (const element of elements) {
+    if (element.hasClasses(dataBrowser.classes.paragraph)) {
+      const description = element.get(core.properties.description);
+
+      if (element.props.parent === resource.subject) {
+        ownedParagraphs.push(element);
+      }
+
+      if (!description || typeof description !== 'string') {
+        continue;
+      }
+
+      const parsed = mdManager.parse(description);
+      const content = markdownParseToContent(parsed);
+
+      if (content.length === 0) {
+        continue;
+      }
+
+      tiptapContent.push(...content);
+    } else {
+      tiptapContent.push(resourceEmbedNode(element.subject));
+    }
+  }
+
+  return { doc: wrapTiptapContent(tiptapContent), ownedParagraphs };
+}
+
+async function writeTiptapJsonToLoro(
+  resource: Resource,
+  store: Store,
+  patchedJson: JSONContent,
+): Promise<void> {
+  await enableLoro();
+
+  const loroDoc = resource.getLoroDoc();
+
+  if (!loroDoc) {
+    throw new Error('Loro failed to initialize while migrating a document');
+  }
+
+  const { applyPatchedJsonToLoroDocCollaborative } =
+    await import('@chunks/RTE/applyPatchedJsonToLoroDocCollaborative');
+
+  await applyPatchedJsonToLoroDocCollaborative({
+    store,
+    loroDoc,
+    subject: resource.subject,
+    patchedJson,
+  });
+
+  resource.markDirty();
+}
+
+async function yjsBytesToTiptapJSON(
+  bytes: Uint8Array,
+): Promise<JSONContent | undefined> {
+  const Y = await import('yjs');
+
+  const tryFragment = (apply: (doc: InstanceType<typeof Y.Doc>) => void) => {
+    const ydoc = new Y.Doc();
+
+    try {
+      apply(ydoc);
+      const fragment = ydoc.getXmlFragment('content');
+      const json = yjsXmlFragmentToTiptapJSON(fragment);
+
+      if (tiptapJsonHasVisibleContent(json) || fragment.length > 0) {
+        return json;
+      }
+
+      return undefined;
+    } finally {
+      ydoc.destroy();
+    }
+  };
+
+  try {
+    const fromV2 = tryFragment(ydoc => {
+      Y.applyUpdateV2(ydoc, bytes);
+    });
+
+    if (fromV2) {
+      return fromV2;
+    }
+  } catch {
+    // V2 updates fail on V1 payloads; try the original encoder next.
+  }
+
+  try {
+    return tryFragment(ydoc => {
+      Y.applyUpdate(ydoc, bytes);
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function migrateLeftoverYjs(
+  resource: Resource,
+  store: Store,
+): Promise<boolean> {
+  await enableLoro();
+
+  const loroDoc = resource.getLoroDoc();
+  const hasVisible = !!loroDoc && loroDocHasVisibleContent(loroDoc);
+  const raw = resource.get(dataBrowser.properties.documentContent);
+
+  if (!isYjsMigrationCandidate(raw, !hasVisible)) {
+    return false;
+  }
+
+  if (hasVisible) {
+    if (isSerializedYDoc(raw) || raw instanceof Uint8Array) {
+      resource.remove(dataBrowser.properties.documentContent);
+      await resource.save();
+
+      return true;
+    }
+
+    return false;
+  }
+
+  const bytes = extractYDocBytes(raw);
+
+  if (!bytes) {
+    return false;
+  }
+
+  const json = await yjsBytesToTiptapJSON(bytes);
+
+  if (!json) {
+    return false;
+  }
+
+  await writeTiptapJsonToLoro(resource, store, json);
+  resource.remove(dataBrowser.properties.documentContent);
+  await resource.save();
+
+  return true;
+}
+
+async function migrateV1(resource: Resource, store: Store): Promise<boolean> {
+  const { doc, ownedParagraphs } = await v1ElementsToTiptapDoc(resource, store);
+
+  await writeTiptapJsonToLoro(resource, store, doc);
+
+  resource.remove(dataBrowser.properties.elements);
+  await resource.set(core.properties.isA, [dataBrowser.classes.documentV2]);
+
+  const leftover = resource.get(dataBrowser.properties.documentContent);
+
+  if (isSerializedYDoc(leftover) || leftover instanceof Uint8Array) {
+    resource.remove(dataBrowser.properties.documentContent);
+  }
+
+  await resource.save();
+
+  for (const paragraph of ownedParagraphs) {
+    await paragraph.destroy();
+  }
+
+  return true;
+}
+
+async function upgradeDocumentInner(
+  resource: Resource,
+  store: Store,
+): Promise<boolean> {
+  if (resource.hasClasses(dataBrowser.classes.documentV2)) {
+    return migrateLeftoverYjs(resource, store);
+  }
+
+  if (resource.hasClasses(dataBrowser.classes.document)) {
+    return migrateV1(resource, store);
+  }
+
+  return false;
+}
 
 /**
- * V1→V2 document upgrade is no longer supported after the Yjs→Loro migration.
- * V1 documents should be upgraded to V2 using an older version of the app,
- * then migrated to Loro-backed V3 documents.
+ * Silently migrate a writable document onto the current Loro-backed
+ * DocumentV2 format.
+ *
+ * - V1 (`elements` + paragraph children) → TipTap JSON → Loro `doc` map.
+ * - Leftover Yjs `documentContent` (Yjs-era V2) → same, loading `yjs` only
+ *   when those bytes are actually present.
+ *
+ * Concurrent calls for the same subject share one in-flight promise
+ * (React Strict Mode, DocumentPage + DocumentV2FullPage overlap).
+ *
+ * @returns `true` when a migration commit was written.
  */
 export async function upgradeDocument(
-  _resource: Resource<DataBrowser.Document>,
-  _store: Store,
-) {
-  throw new Error(
-    'V1→V2 document upgrade is no longer supported. Please use the Loro-native document format.',
-  );
+  resource: Resource,
+  store: Store,
+): Promise<boolean> {
+  const existing = inFlight.get(resource.subject);
+
+  if (existing) {
+    return existing;
+  }
+
+  const promise = upgradeDocumentInner(resource, store).finally(() => {
+    inFlight.delete(resource.subject);
+  });
+
+  inFlight.set(resource.subject, promise);
+
+  return promise;
 }
+
+export {
+  isSerializedYDoc,
+  isYjsMigrationCandidate,
+  loroDocBodyIsEmpty,
+  loroDocHasVisibleContent,
+} from './documentMigrationUtils';

--- a/browser/data-browser/src/views/DocumentPage.tsx
+++ b/browser/data-browser/src/views/DocumentPage.tsx
@@ -1,26 +1,44 @@
-import { useState, type JSX } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { useArray, useCanWrite, dataBrowser, useStore } from '@tomic/react';
 import { styled } from 'styled-components';
-import { FaCircleInfo } from 'react-icons/fa6';
 
 import { ElementShow } from './Element';
-import { Button } from '../components/Button';
 import { ResourcePageProps } from './ResourcePage';
 import { Column, Row } from '../components/Row';
+import { Spinner } from '../components/Spinner';
 import { upgradeDocument } from './Document/upgradeDocument';
-import toast from 'react-hot-toast';
 import {
   PAGE_TITLE_TRANSITION_TAG,
   transitionName,
 } from '../helpers/transitionName';
 import { ViewTransitionProps } from '../helpers/ViewTransitionProps';
 
-/** A full page, editable document, consisting of Elements */
+/** Full-page view for a V1 document. Writable ones migrate to V2 silently. */
 export function DocumentPage({ resource }: ResourcePageProps): JSX.Element {
   const store = useStore();
   const canWrite = useCanWrite(resource);
   const [elements] = useArray(resource, dataBrowser.properties.elements);
-  const [upgrading, setUpgrading] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!canWrite || failed) {
+      return;
+    }
+
+    let cancelled = false;
+
+    upgradeDocument(resource, store).catch(error => {
+      console.error('[upgradeDocument] V1 migration failed:', error);
+
+      if (!cancelled) {
+        setFailed(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canWrite, failed, resource, store]);
 
   return (
     <FullPageWrapper>
@@ -31,33 +49,17 @@ export function DocumentPage({ resource }: ResourcePageProps): JSX.Element {
               {resource.title}
             </DocumentTitle>
           </Row>
-          {canWrite && (
-            <UpgradeMessage>
-              <Row align='baseline'>
-                <FaCircleInfo />
-                This document needs to be updated to the new format in order to
-                be edited.
-              </Row>
-              <Button
-                disabled={upgrading}
-                onClick={() => {
-                  setUpgrading(true);
-                  upgradeDocument(resource, store).catch(e => {
-                    console.error(e);
-                    toast.error('Could not update document');
-                    setUpgrading(false);
-                  });
-                }}
-              >
-                Update Document
-              </Button>
-            </UpgradeMessage>
+          {canWrite && !failed ? (
+            <LoadingRow>
+              <Spinner size='2rem' />
+            </LoadingRow>
+          ) : (
+            <div>
+              {elements.map(subject => (
+                <ElementShow subject={subject} key={subject} />
+              ))}
+            </div>
           )}
-          <div>
-            {elements.map(subject => (
-              <ElementShow subject={subject} key={subject} />
-            ))}
-          </div>
         </Column>
       </DocumentContainer>
     </FullPageWrapper>
@@ -91,12 +93,10 @@ const FullPageWrapper = styled.div`
   box-sizing: border-box;
 `;
 
-const UpgradeMessage = styled(Column)`
-  background-color: ${p => p.theme.colors.mainSelectedBg};
-  border: 1px solid ${p => p.theme.colors.mainSelectedFg};
-  color: ${p => p.theme.colors.mainSelectedFg};
-  padding: ${p => p.theme.size()};
-  border-radius: ${p => p.theme.radius};
+const LoadingRow = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: ${p => p.theme.size(4)};
 `;
 
 export default DocumentPage;

--- a/browser/data-browser/vite.config.ts
+++ b/browser/data-browser/vite.config.ts
@@ -347,6 +347,10 @@ export default defineConfig({
       // instance (see the exclude note below re: the DecorationGroup crash).
       // `loro-crdt` stays external, so the WASM is unaffected.
       'loro-prosemirror',
+      // Lazy-loaded only when a leftover Yjs-era DocumentV2 is opened. Listed
+      // so the first `import('yjs')` does not trigger a mid-session re-optimize
+      // that 504s the dynamic import.
+      'yjs',
     ],
     // `loro-crdt` ships a WASM module that `vite-plugin-wasm` (see the
     // `wasm()` plugin above) handles. esbuild's dep-optimizer CANNOT —

--- a/browser/e2e/tests/documents.spec.ts
+++ b/browser/e2e/tests/documents.spec.ts
@@ -6,6 +6,7 @@ import {
   getCurrentSubject,
   makeDrivePublic,
   openNewSubjectWindow,
+  openSubject,
   timestamp,
   before,
   setTitle,
@@ -231,5 +232,93 @@ test.describe('documents', async () => {
     // persisted into the doc), and it carries the peer's color via inline style.
     await expect(remoteCursor).toHaveCount(1);
     await expect(remoteCursor).toHaveAttribute('style', /border-color/);
+  });
+
+  test('opens a v1 document and migrates it silently into the editor', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await page.waitForFunction(
+      () =>
+        window.store?.getClientDb()?.isReady === true &&
+        window.store?.getSyncStatus().serverConnected === true,
+      undefined,
+      { timeout: 30_000 },
+    );
+
+    const unique = `Migrated paragraph ${timestamp()}`;
+    const subject = await page.evaluate(async text => {
+      const store = window.store;
+      const drive = store.getDrive();
+
+      if (!drive) {
+        throw new Error('no drive');
+      }
+
+      const doc = await store.newResource({
+        parent: drive,
+        isA: 'https://atomicdata.dev/classes/Document',
+        propVals: {
+          'https://atomicdata.dev/properties/name': 'V1 Legacy Document',
+        },
+      });
+      await doc.save();
+
+      const paragraph = await store.newResource({
+        parent: doc.subject,
+        isA: 'https://atomicdata.dev/classes/elements/Paragraph',
+        propVals: {
+          'https://atomicdata.dev/properties/description': text,
+        },
+      });
+      await paragraph.save();
+
+      await doc.set('https://atomicdata.dev/properties/documents/elements', [
+        paragraph.subject,
+      ]);
+      await doc.save();
+
+      return doc.subject;
+    }, unique);
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => window.store?.getSyncStatus().pendingDirtyCount === 0,
+          ),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    await openSubject(page, subject);
+
+    await expect(
+      page.getByRole('button', { name: 'Update Document' }),
+    ).toHaveCount(0);
+
+    await expect(page.getByLabel('Rich Text Editor')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await expect(async () => {
+      expect(await editorPlainText(page)).toContain(unique);
+    }).toPass({ timeout: 20_000 });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(s => {
+            const resource = window.store.resources.get(s);
+            const isA = resource?.get(
+              'https://atomicdata.dev/properties/isA',
+            ) as string[] | undefined;
+
+            return Array.isArray(isA) ? isA[0] : undefined;
+          }, subject),
+        { timeout: 15_000 },
+      )
+      .toBe('https://atomicdata.dev/classes/DocumentV2');
   });
 });

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 9.1.7
       netlify-cli:
         specifier: 26.0.2
-        version: 26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.4)(rollup@4.60.4)
+        version: 26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.5)(rollup@4.60.4)
       oxfmt:
         specifier: ^0.51.0
         version: 0.51.0(svelte@5.55.9(@typescript-eslint/types@8.60.0))
@@ -381,6 +381,9 @@ importers:
       wuchale:
         specifier: ^0.25.6
         version: 0.25.6
+      yjs:
+        specifier: ^13.6.30
+        version: 13.6.30
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -11934,7 +11937,7 @@ snapshots:
       yaml: 2.9.0
       yargs: 17.7.2
 
-  '@netlify/build@35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.4)(rollup@4.60.4)':
+  '@netlify/build@35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.5)(rollup@4.60.4)':
     dependencies:
       '@bugsnag/js': 8.9.0
       '@netlify/blobs': 10.7.8(supports-color@10.2.2)
@@ -11953,7 +11956,7 @@ snapshots:
       ansis: 4.3.0
       clean-stack: 5.3.0
       execa: 8.0.1
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       figures: 6.1.0
       filter-obj: 6.1.0
       hot-shots: 11.4.0
@@ -13287,7 +13290,7 @@ snapshots:
   '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 8.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rolldown: 1.1.5
     optionalDependencies:
       '@babel/runtime': 7.29.2
@@ -17941,13 +17944,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  netlify-cli@26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.4)(rollup@4.60.4):
+  netlify-cli@26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.5)(rollup@4.60.4):
     dependencies:
       '@fastify/static': 9.1.3
       '@netlify/ai': 0.4.1
       '@netlify/api': 14.0.19
       '@netlify/blobs': 10.7.8(supports-color@10.2.2)
-      '@netlify/build': 35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.4)(rollup@4.60.4)
+      '@netlify/build': 35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.5)(rollup@4.60.4)
       '@netlify/build-info': 10.5.1
       '@netlify/config': 24.5.1
       '@netlify/dev': 4.18.6(@types/node@25.9.1)(idb-keyval@6.2.4)(rollup@4.60.4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Restores V1 document opening after the Yjs→Loro migration. Writable v1 docs convert automatically; leftover Yjs-era V2 bodies still convert, but `yjs` loads only when those bytes are present.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

## What changed

Opening a writable v1 document (`elements` + paragraph children) no longer shows a read-only page with an **Update Document** button whose handler throws.

- `upgradeDocument` writes TipTap JSON into the resource’s Loro `doc` map, switches `isA` to DocumentV2, and deletes owned paragraph children.
- Read-only v1 documents still render their elements and are not migrated.
- Leftover `{ type: 'ydoc' }` / Unsupported ydoc `documentContent` is converted only when the Loro body is empty; `import('yjs')` is deferred until then.

## Tests

- Vitest: Yjs `XmlFragment` walker, `{ type: 'ydoc' }` detection, v1 element assembly.
- E2E: create a v1 document via `window.store`, open it, expect the rich-text editor and no upgrade button.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30b26261-8131-4414-a3cb-1586cc97bd9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30b26261-8131-4414-a3cb-1586cc97bd9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

