### PR TITLE
ci: Playwright light on feature branches, full on develop and tags

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -63,6 +63,10 @@ const ATOMIC_DOMAIN = 'atomic';
 // invocation — pin `CARGO_BUILD_JOBS` on every cargo container too.
 type HostProfile = 'mancave' | 'hosted';
 
+/** Playwright gate. `light` is `--grep @smoke`; `full` is the unfiltered suite.
+ *  Default is `full` so a forgotten flag cannot silently shrink develop/tag CI. */
+type E2eMode = 'light' | 'full';
+
 type HostKnobs = {
   e2eShardCount: number;
   e2ePlaywrightWorkers: string;
@@ -73,6 +77,40 @@ type HostKnobs = {
   /** Caps rustc parallelism inside each container via CARGO_BUILD_JOBS. */
   cargoBuildJobs: string;
 };
+
+type E2eRunKnobs = {
+  shardCount: number;
+  workers: string;
+  retries: string;
+  /** Empty string = unfiltered. Otherwise passed as `--grep`. */
+  grep: string;
+};
+
+function resolveE2eMode(value: string): E2eMode {
+  return value === 'light' ? 'light' : 'full';
+}
+
+function e2eRunKnobs(profile: HostProfile, mode: E2eMode): E2eRunKnobs {
+  const host = HOST_PROFILES[profile];
+  if (mode === 'light') {
+    return {
+      // ~18 @smoke tests: two Mancave shards is plenty; hosted keeps one
+      // atomic-server. Do not mutate HostKnobs — rustTest reads those in
+      // parallel with endToEnd.
+      shardCount: profile === 'mancave' ? 2 : 1,
+      workers: host.e2ePlaywrightWorkers,
+      retries: '1',
+      grep: '@smoke',
+    };
+  }
+
+  return {
+    shardCount: host.e2eShardCount,
+    workers: host.e2ePlaywrightWorkers,
+    retries: host.e2ePlaywrightRetries,
+    grep: '',
+  };
+}
 
 /**
  * Trim a Playwright `error-context.md` to the part worth reading in a CI log.
@@ -147,6 +185,10 @@ export class AtomicServer {
   /** Active host knobs for this `ci()` invocation. Standalone func calls
    *  (rustTest/endToEnd alone) keep the conservative hosted defaults. */
   private hostKnobs: HostKnobs = HOST_PROFILES.hosted;
+  private hostProfile: HostProfile = 'hosted';
+  /** Playwright-only knobs for the in-flight `endToEnd` run. Isolated from
+   *  `hostKnobs` so a light E2E job cannot change nextest width mid-`ci()`. */
+  private e2eRun: E2eRunKnobs = e2eRunKnobs('hosted', 'full');
 
   constructor(
     @argument({
@@ -303,8 +345,15 @@ export class AtomicServer {
      * Passed from `.github/workflows/main.yml` per job.
      */
     @argument() hostProfile: string = 'hosted',
+    /**
+     * Playwright suite. `light` = `@smoke` first-hour journeys (feature
+     * branches). `full` = every spec (`develop`, `v*` tags, opt-in).
+     * Default `full` so omitting the flag cannot shrink a release gate.
+     */
+    @argument() e2eMode: string = 'full',
   ): Promise<string> {
-    this.hostKnobs = HOST_PROFILES[resolveHostProfile(hostProfile)];
+    this.hostProfile = resolveHostProfile(hostProfile);
+    this.hostKnobs = HOST_PROFILES[this.hostProfile];
 
     // Fail fast on cheap static checks. A store.ts oxfmt miss used to burn
     // ~20+ minutes of rust/e2e compile before jsLint surfaced it.
@@ -316,7 +365,7 @@ export class AtomicServer {
     await Promise.all([
       this.docsPublish(netlifyAuthToken, publishDocs),
       this.typedocPublish(netlifyAuthToken, publishDocs),
-      this.endToEnd(netlifyAuthToken),
+      this.endToEnd(netlifyAuthToken, e2eMode),
       this.jsTest(),
       this.jsTestIntegration(),
       this.flutterTest(),
@@ -1479,14 +1528,15 @@ export class AtomicServer {
     // `pnpm install` — see git history for ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
     return playwrightContainer
       .withEnvVariable('CI', 'true')
-      // Host-profile knobs — see HOST_PROFILES / `--host-profile`.
+      // Playwright-run knobs — see `e2eRunKnobs` / `--e2e-mode`. Isolated
+      // from `hostKnobs` so a light suite does not change nextest width.
       .withEnvVariable(
         'PLAYWRIGHT_WORKERS',
-        this.hostKnobs.e2ePlaywrightWorkers,
+        this.e2eRun.workers,
       )
       .withEnvVariable(
         'PLAYWRIGHT_RETRIES',
-        this.hostKnobs.e2ePlaywrightRetries,
+        this.e2eRun.retries,
       )
       .withFile('/app/package.json', browserContainer.file('/app/package.json'))
       .withFile(
@@ -1546,6 +1596,11 @@ export class AtomicServer {
 
   /** One Playwright shard against its own atomic-server service. */
   private e2eShardContainer(base: Container, shardIndex: number): Container {
+    const grepFlag = this.e2eRun.grep
+      ? ` --grep ${JSON.stringify(this.e2eRun.grep)}`
+      : '';
+    const shardCount = this.e2eRun.shardCount;
+
     return base
       .withServiceBinding('atomic', this.atomicService(true))
       .withExec([
@@ -1557,17 +1612,28 @@ export class AtomicServer {
         '/bin/bash',
         '-c',
         'set -o pipefail; ' +
-          `pnpm exec playwright test --config=./playwright.config.ts --shard=${shardIndex}/${this.hostKnobs.e2eShardCount} 2>&1 | tee /test-output.log; ` +
+          `echo "e2e mode grep=${JSON.stringify(this.e2eRun.grep || '(full)')} shard=${shardIndex}/${shardCount} workers=$PLAYWRIGHT_WORKERS retries=$PLAYWRIGHT_RETRIES"; ` +
+          `pnpm exec playwright test --config=./playwright.config.ts${grepFlag} --shard=${shardIndex}/${shardCount} 2>&1 | tee /test-output.log; ` +
           'echo ${PIPESTATUS[0]} > /test-exit-code; exit 0',
       ]);
   }
 
   @func()
-  async endToEnd(@argument() netlifyAuthToken: Secret): Promise<string> {
+  async endToEnd(
+    @argument() netlifyAuthToken: Secret,
+    /**
+     * `light` = `@smoke` only. `full` (default) = every spec, matching
+     * today's unfiltered suite. Workflow decides; this func does not
+     * guess the git ref.
+     */
+    @argument() e2eMode: string = 'full',
+  ): Promise<string> {
     // Shards × own atomic-server. Count comes from `--host-profile`
-    // (Mancave hot / hosted conservative). Dagger dedupes the shared
-    // debug `rustBuild(e2e)` / base-container graph.
-    const shardCount = this.hostKnobs.e2eShardCount;
+    // (Mancave hot / hosted conservative) plus `--e2e-mode` (light uses
+    // fewer shards). Dagger dedupes the shared debug `rustBuild(e2e)` /
+    // base-container graph.
+    this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(e2eMode));
+    const shardCount = this.e2eRun.shardCount;
     const base = this.e2eBaseContainer();
     const shardIndexes = Array.from({ length: shardCount }, (_, i) => i + 1);
     const shardContainers = shardIndexes.map(i =>

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -94,7 +94,7 @@ function e2eRunKnobs(profile: HostProfile, mode: E2eMode): E2eRunKnobs {
   const host = HOST_PROFILES[profile];
   if (mode === 'light') {
     return {
-      // ~18 @smoke tests: two Mancave shards is plenty; hosted keeps one
+      // ~17 @smoke tests: two Mancave shards is plenty; hosted keeps one
       // atomic-server. Do not mutate HostKnobs — rustTest reads those in
       // parallel with endToEnd.
       shardCount: profile === 'mancave' ? 2 : 1,

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -349,8 +349,12 @@ export class AtomicServer {
      * Playwright suite. `light` = `@smoke` first-hour journeys (feature
      * branches). `full` = every spec (`develop`, `v*` tags, opt-in).
      * Default `full` so omitting the flag cannot shrink a release gate.
+     *
+     * Named `playwrightMode` rather than `e2eMode`: Dagger's kebab-case
+     * parser maps `--e2e-mode` to `e2EMode` (capital after a digit) and
+     * then cannot find the argument.
      */
-    @argument() e2eMode: string = 'full',
+    @argument() playwrightMode: string = 'full',
   ): Promise<string> {
     this.hostProfile = resolveHostProfile(hostProfile);
     this.hostKnobs = HOST_PROFILES[this.hostProfile];
@@ -365,7 +369,7 @@ export class AtomicServer {
     await Promise.all([
       this.docsPublish(netlifyAuthToken, publishDocs),
       this.typedocPublish(netlifyAuthToken, publishDocs),
-      this.endToEnd(netlifyAuthToken, e2eMode),
+      this.endToEnd(netlifyAuthToken, playwrightMode),
       this.jsTest(),
       this.jsTestIntegration(),
       this.flutterTest(),
@@ -1528,7 +1532,7 @@ export class AtomicServer {
     // `pnpm install` — see git history for ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
     return playwrightContainer
       .withEnvVariable('CI', 'true')
-      // Playwright-run knobs — see `e2eRunKnobs` / `--e2e-mode`. Isolated
+      // Playwright-run knobs — see `e2eRunKnobs` / `--playwright-mode`. Isolated
       // from `hostKnobs` so a light suite does not change nextest width.
       .withEnvVariable(
         'PLAYWRIGHT_WORKERS',
@@ -1624,15 +1628,15 @@ export class AtomicServer {
     /**
      * `light` = `@smoke` only. `full` (default) = every spec, matching
      * today's unfiltered suite. Workflow decides; this func does not
-     * guess the git ref.
+     * guess the git ref. See `ci()` for why this is not named `e2eMode`.
      */
-    @argument() e2eMode: string = 'full',
+    @argument() playwrightMode: string = 'full',
   ): Promise<string> {
     // Shards × own atomic-server. Count comes from `--host-profile`
-    // (Mancave hot / hosted conservative) plus `--e2e-mode` (light uses
+    // (Mancave hot / hosted conservative) plus `--playwright-mode` (light uses
     // fewer shards). Dagger dedupes the shared debug `rustBuild(e2e)` /
     // base-container graph.
-    this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(e2eMode));
+    this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(playwrightMode));
     const shardCount = this.e2eRun.shardCount;
     const base = this.e2eBaseContainer();
     const shardIndexes = Array.from({ length: shardCount }, (_, i) => i + 1);

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -19,7 +19,7 @@ on:
         type: string
         required: true
       e2e-mode:
-        description: Dagger `--e2e-mode` — light (@smoke) or full (every spec)
+        description: Dagger `--playwright-mode` — light (@smoke) or full (every spec)
         type: string
         required: true
     secrets:
@@ -80,9 +80,11 @@ jobs:
           # republished the public docs and typedoc. `master` used to own live
           # docs while the app shipped from tags; both now follow the tag.
           # Every other ref gets a preview URL. `--host-profile` selects
-          # parallelism (mancave hot / hosted quiet). `--e2e-mode` is light
-          # (@smoke) on feature branches and full on develop/tags.
-          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} --e2e-mode ${{ inputs.e2e-mode }} ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && '--publish-docs' || '' }}
+          # parallelism (mancave hot / hosted quiet). `--playwright-mode` is
+          # light (@smoke) on feature branches and full on develop/tags.
+          # Not `--e2e-mode`: Dagger maps that kebab to `e2EMode` and misses
+          # the argument.
+          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} --playwright-mode ${{ inputs.e2e-mode }} ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && '--publish-docs' || '' }}
       - name: Dagger docker images (build images & publish)
         # Floating `:develop` image tracks the integration branch. There is no
         # `main` branch here — that clause could never fire, and left in place

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -18,6 +18,10 @@ on:
         description: Dagger `--host-profile` — mancave (hot) or hosted (conservative)
         type: string
         required: true
+      e2e-mode:
+        description: Dagger `--e2e-mode` — light (@smoke) or full (every spec)
+        type: string
+        required: true
     secrets:
       NETLIFY_TOKEN:
         required: true
@@ -64,7 +68,7 @@ jobs:
           # shell command instead.
           sep-tags: ","
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dagger CI (test, lint, build)
+      - name: Dagger CI (test, lint, build, e2e ${{ inputs.e2e-mode }})
         uses: dagger/dagger-for-github@8.0.0
         with:
           version: "latest"
@@ -76,8 +80,9 @@ jobs:
           # republished the public docs and typedoc. `master` used to own live
           # docs while the app shipped from tags; both now follow the tag.
           # Every other ref gets a preview URL. `--host-profile` selects
-          # parallelism (mancave hot / hosted quiet).
-          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && '--publish-docs' || '' }}
+          # parallelism (mancave hot / hosted quiet). `--e2e-mode` is light
+          # (@smoke) on feature branches and full on develop/tags.
+          args: ci --netlify-auth-token env://NETLIFY_TOKEN --host-profile ${{ inputs.host-profile }} --e2e-mode ${{ inputs.e2e-mode }} ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && '--publish-docs' || '' }}
       - name: Dagger docker images (build images & publish)
         # Floating `:develop` image tracks the integration branch. There is no
         # `main` branch here — that clause could never fire, and left in place

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,16 @@
-on: [push, workflow_dispatch]
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      e2e_mode:
+        description: Playwright suite. auto = light on feature branches, full on develop and v* tags.
+        type: choice
+        options:
+          - auto
+          - light
+          - full
+        default: auto
+
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.
 # GitHub-hosted runs ONLY when Mancave is unavailable — never as a retry
@@ -30,8 +42,12 @@ jobs:
   pick:
     name: Pick runner
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       host: ${{ steps.pick.outputs.host }}
+      e2e-mode: ${{ steps.e2e.outputs.mode }}
     steps:
       - id: pick
         env:
@@ -86,6 +102,39 @@ jobs:
             echo "host=hosted" >> "$GITHUB_OUTPUT"
           fi
 
+      - id: e2e
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          DISPATCH_MODE: ${{ github.event.inputs.e2e_mode }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Light = @smoke Playwright. Full = every spec.
+          # Default full on develop/tags so staging/production never ship on
+          # a subset. Feature-branch pushes are light unless opted in.
+          mode=light
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "${DISPATCH_MODE:-auto}" = "full" ]; then
+            mode=full
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "${DISPATCH_MODE:-auto}" = "light" ]; then
+            mode=light
+          elif [ "$REF" = "refs/heads/develop" ]; then
+            mode=full
+          elif [[ "$REF" == refs/tags/v* ]]; then
+            mode=full
+          elif printf '%s' "${COMMIT_MSG:-}" | grep -q '\[full-e2e\]'; then
+            mode=full
+          elif prs=$(gh api "repos/$REPO/commits/$SHA/pulls" -H "Accept: application/vnd.github+json" 2>/dev/null); then
+            if printf '%s' "$prs" | jq -e 'any(.[]; any(.labels[]; .name == "full-e2e"))' >/dev/null; then
+              mode=full
+            fi
+          fi
+          echo "e2e-mode=$mode (ref=$REF dispatch=${DISPATCH_MODE:-} event=$EVENT_NAME)"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
   mancave:
     name: Main (Mancave)
     needs: pick
@@ -101,6 +150,7 @@ jobs:
       runner: ${{ vars.CI_RUNNER || '["self-hosted", "Linux", "X64"]' }}
       artifact-name: build-artifacts-mancave
       host-profile: mancave
+      e2e-mode: ${{ needs.pick.outputs.e2e-mode }}
     secrets:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -120,6 +170,7 @@ jobs:
       runner: '["ubuntu-latest"]'
       artifact-name: build-artifacts-github
       host-profile: hosted
+      e2e-mode: ${{ needs.pick.outputs.e2e-mode }}
     secrets:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,12 @@ In E2E tests, most specs use `test.beforeEach(before)` from `test-utils.ts`, whi
 ## Debugging process
 
 1. Identify the bug, where it's coming from.
-2. Reproduce the bug in a test at the right abstraction level. E2E tests are the most expensive, so try to find a different level if possible.
+2. Reproduce the bug in a test at the cheapest layer that can fail: Rust /
+   vitest first, then `browser/lib` `*.integration.test.ts` (real server, no
+   UI), then one Playwright test. E2E is the most expensive. Tag `@smoke`
+   (`smoke` in `browser/e2e/tests/test-utils.ts`) only if a failure means the
+   first-hour demo is dead; extra operators and offline variants stay in the
+   full suite. See `planning/e2e-light-heavy.md`.
 3. After reproduction in a failing test, fix the bug until the test and all other tests are green again
 
 ## DevTools Console Helpers
@@ -238,7 +243,8 @@ cargo test -p atomic-server --test it iroh_pairing  # two servers pair via POST 
 cargo test --manifest-path flutter/rust/Cargo.toml  # Flutter bridge (workspace-excluded, needs --manifest-path)
 cd browser/lib && pnpm test                      # JS unit tests
 cd browser && pnpm run -r build                  # Full workspace build
-cd browser && pnpm run test-e2e                  # Full e2e test
+cd browser && pnpm run test-e2e:light            # Playwright @smoke (feature-branch CI)
+cd browser && pnpm run test-e2e                  # Full Playwright suite (develop / tags)
 ```
 
 `atomic_lib`'s unit tests need the `db` feature — `hierarchy.rs`'s test module

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ next release reintroduces the bug.
 - We try to test at every level, unit tests, integration tests, e2e tests (playwright).
 - When tests fail, first make sure the unit tests are green, then do integration tests, then to e2e.
 - If e2e tests fail, try walking through the steps 1 by 1 either with the playwright debugger, or by simply reproducing the steps in your browser of choice.
+- Feature-branch CI runs Playwright **light** (`@smoke`). `develop` and `v*` tags run the **full** suite. Opt in to full on a branch with a `full-e2e` PR label, `[full-e2e]` in the commit message, or `workflow_dispatch` `e2e_mode=full`. See `planning/e2e-light-heavy.md`.
 
 ```sh
 # Make sure nextest is installed
@@ -162,7 +163,9 @@ cargo nextest run test_name_substring
 # First, run the server
 cargo run
 # now, open new terminal window
-cd browser && pnpm i && pnpm test-e2e
+cd browser && pnpm i && pnpm test-e2e:light   # @smoke, matches feature-branch CI
+# full suite (develop / tags / before a release)
+pnpm test-e2e
 # if things go wrong, debug!
 pnpm run test-query {testname}
 ```
@@ -345,6 +348,11 @@ Two consequences worth knowing:
   unconditional `--prod`, which meant pushing any feature branch republished
   the public documentation, and later `master`-only, which left live docs on a
   branch that was not production.
+- Playwright is `--e2e-mode light` on feature-branch pushes (`@smoke` only)
+  and `full` on `develop` and `v*` tags. `dagger call ci` defaults to `full`
+  so omitting the flag cannot shrink a release gate. Opt in from a branch
+  with a `full-e2e` PR label, `[full-e2e]` in the commit message, or
+  `workflow_dispatch` `e2e_mode=full`.
 
 Every deploy then has to prove itself: the job polls `/server` on the target
 until it answers `200` (with enough patience for a store migration). A deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,11 +348,12 @@ Two consequences worth knowing:
   unconditional `--prod`, which meant pushing any feature branch republished
   the public documentation, and later `master`-only, which left live docs on a
   branch that was not production.
-- Playwright is `--e2e-mode light` on feature-branch pushes (`@smoke` only)
+- Playwright is `--playwright-mode light` on feature-branch pushes (`@smoke` only)
   and `full` on `develop` and `v*` tags. `dagger call ci` defaults to `full`
   so omitting the flag cannot shrink a release gate. Opt in from a branch
   with a `full-e2e` PR label, `[full-e2e]` in the commit message, or
-  `workflow_dispatch` `e2e_mode=full`.
+  `workflow_dispatch` `e2e_mode=full`. (Do not name the Dagger flag
+  `--e2e-mode`: the CLI camelCases it to `e2EMode` and the call fails.)
 
 Every deploy then has to prove itself: the job polls `/server` on the target
 until it answers `200` (with enough patience for a store migration). A deploy

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -26,6 +26,23 @@ and absent in another:
 
 A flow is only genuinely safe when all three are covered.
 
+### Playwright light vs full
+
+Only the browser suite splits. Lint, Rust, vitest, JS integration, and
+Flutter run on every CI job.
+
+| Trigger | Playwright |
+|---|---|
+| Feature-branch push | **light** (`@smoke`), required |
+| `develop` push | **full**, required (staging) |
+| stable `v*` tag | **full**, required (production) |
+| `workflow_dispatch` `e2e_mode=full`, `[full-e2e]` in the commit, or PR label `full-e2e` | **full** |
+
+Tag a new journey `@smoke` (`smoke` from `browser/e2e/tests/test-utils.ts`)
+only if a failure means the first-hour demo is dead. Extra operators,
+templates, and offline variants stay in the full suite. Policy:
+[`planning/e2e-light-heavy.md`](./planning/e2e-light-heavy.md).
+
 ---
 
 ## Where the suites live
@@ -35,7 +52,9 @@ A flow is only genuinely safe when all three are covered.
 | `atomic_lib` unit + integration | `cargo nextest run -p atomic_lib --features db-redb,iroh,ws` | `rustTest` |
 | Server integration | `cargo test -p atomic-server --test it <module>` | `rustTest` |
 | Browser unit (vitest) | `cd browser && pnpm run -r test` | `jsTest` |
-| Browser e2e (playwright) | `cd browser/e2e && pnpm run test-e2e` | `endToEnd` |
+| Browser integration (vitest + real server) | `cd browser/lib && pnpm run test:integration` | `jsTestIntegration` |
+| Browser e2e light (`@smoke`) | `cd browser && pnpm run test-e2e:light` | `endToEnd` on feature branches |
+| Browser e2e full | `cd browser && pnpm run test-e2e` | `endToEnd` on `develop` and `v*` tags |
 | Flutter Dart | `cd flutter && flutter test` | `flutterTest` |
 | Flutter Rust bridge | `cargo test --manifest-path flutter/rust/Cargo.toml` | `flutterTest` |
 

--- a/browser/e2e/README.md
+++ b/browser/e2e/README.md
@@ -63,11 +63,20 @@ pnpm playwright test some.spec.ts --project=chromium --workers=1
 
 Comparing failure _sets_ against a known baseline beats expecting all-green.
 
+## Light vs full
+
+Feature-branch CI runs **light**: `--grep @smoke`, about twenty first-hour
+journeys. `develop` and `v*` tags run the **full** suite. Tag a test with
+`smoke` from `./tests/test-utils.ts` only if a failure means the demo is
+dead. See [`planning/e2e-light-heavy.md`](../../planning/e2e-light-heavy.md).
+
 ```sh
 # install deps
 pnpm i
 # install chromium
 pnpm playwright-install
+# light suite (matches feature-branch CI)
+pnpm test-e2e:light
 # run all tests, creates a `playwright-report` folder with HTML files + images
 pnpm test-e2e
 # run all tests and updates snapshots

--- a/browser/e2e/package.json
+++ b/browser/e2e/package.json
@@ -22,6 +22,7 @@
     "test-server": "./scripts/e2e-server.sh",
     "test-server-fresh": "./scripts/e2e-server.sh --fresh",
     "test-e2e": "playwright test --config=./playwright.config.ts",
+    "test-e2e:light": "playwright test --config=./playwright.config.ts --grep @smoke",
     "test-debug": "PWDEBUG=1 playwright test",
     "test-update": "playwright test --update-snapshots",
     "test-new": "playwright codegen http://localhost:6747",

--- a/browser/e2e/playwright.config.ts
+++ b/browser/e2e/playwright.config.ts
@@ -148,6 +148,9 @@ const config: PlaywrightTestConfig = {
       : []),
   ],
   fullyParallel: true,
+  // Light vs full: tag `@smoke` (see `smoke` in tests/test-utils.ts).
+  // `pnpm test-e2e:light` / CI feature branches pass `--grep @smoke`.
+  // `pnpm test-e2e` and develop/tag CI run the unfiltered suite.
   // Worker count:
   // - local (no CI): 2
   // - CI without override: 1 (safe for 2-vCPU hosted runners)

--- a/browser/e2e/tests/dashboard.spec.ts
+++ b/browser/e2e/tests/dashboard.spec.ts
@@ -307,36 +307,42 @@ test.describe('dashboards', () => {
     await expect(page.getByRole('menuitem', { name: 'Button' })).toBeVisible();
   });
 
-  test('the four block kinds each show what they were configured to', smoke, async ({
-    page,
-  }) => {
-    const fixture = await createSpendingTable(page);
-    await createDashboard(page, fixture);
+  test(
+    'the four block kinds each show what they were configured to',
+    smoke,
+    async ({ page }) => {
+      const fixture = await createSpendingTable(page);
+      await createDashboard(page, fixture);
 
-    // The store computes the number over every matching row, so it is the real
-    // total rather than a sum of whatever page happened to load.
-    await expect(block(page, 'Total spent')).toContainText('946.5', {
-      timeout: 15_000,
-    });
-    await expect(block(page, 'Expenses')).toContainText('4', {
-      timeout: 15_000,
-    });
+      // The store computes the number over every matching row, so it is the real
+      // total rather than a sum of whatever page happened to load.
+      await expect(block(page, 'Total spent')).toContainText('946.5', {
+        timeout: 15_000,
+      });
+      await expect(block(page, 'Expenses')).toContainText('4', {
+        timeout: 15_000,
+      });
 
-    // One bar per category, largest first, each labelled by its tag name.
-    const chart = block(page, 'Per category');
-    await expect(chart).toContainText('900');
-    await expect(chart).toContainText('30');
-    // 4.5 + 12 — the two food rows, bucketed together.
-    await expect(chart).toContainText('16.5');
+      // One bar per category, largest first, each labelled by its tag name.
+      const chart = block(page, 'Per category');
+      await expect(chart).toContainText('900');
+      await expect(chart).toContainText('30');
+      // 4.5 + 12 — the two food rows, bucketed together.
+      await expect(chart).toContainText('16.5');
 
-    // Markdown, not the raw asterisks.
-    await expect(block(page, 'Notes')).toContainText('Watch the tools budget');
+      // Markdown, not the raw asterisks.
+      await expect(block(page, 'Notes')).toContainText(
+        'Watch the tools budget',
+      );
 
-    // The view block is the real grid: its rows are there and editable.
-    const list = block(page, 'All expenses');
-    await expect(list.getByRole('gridcell', { name: 'Laptop' })).toBeVisible();
-    await expect(list.getByRole('grid')).toBeVisible();
-  });
+      // The view block is the real grid: its rows are there and editable.
+      const list = block(page, 'All expenses');
+      await expect(
+        list.getByRole('gridcell', { name: 'Laptop' }),
+      ).toBeVisible();
+      await expect(list.getByRole('grid')).toBeVisible();
+    },
+  );
 
   test('a button block adds a row, and the numbers beside it follow', async ({
     page,

--- a/browser/e2e/tests/dashboard.spec.ts
+++ b/browser/e2e/tests/dashboard.spec.ts
@@ -6,6 +6,7 @@ import {
   newResource,
   pickFromMenu,
   waitForRowsMaterialized,
+  smoke,
 } from './test-utils';
 
 /**
@@ -306,7 +307,7 @@ test.describe('dashboards', () => {
     await expect(page.getByRole('menuitem', { name: 'Button' })).toBeVisible();
   });
 
-  test('the four block kinds each show what they were configured to', async ({
+  test('the four block kinds each show what they were configured to', smoke, async ({
     page,
   }) => {
     const fixture = await createSpendingTable(page);

--- a/browser/e2e/tests/documents.spec.ts
+++ b/browser/e2e/tests/documents.spec.ts
@@ -10,7 +10,6 @@ import {
   before,
   setTitle,
   waitForSearchIndex,
-  smoke,
 } from './test-utils';
 
 /**
@@ -37,148 +36,136 @@ test.describe('documents', async () => {
   // exceeds the loro broadcast budget under dagger CPU contention.
   // Investigate: bump the assertion to `waitForFunction` polling on the
   // store's loro-doc state instead of DOM text.
-  test(
-    'create document, edit, page title, websockets',
-    smoke,
-    async ({ page, browser }) => {
-      page.on('console', msg => {
-        console.log(`[page1-console] [${msg.type()}]`, msg.text());
-      });
-      // The multi-user flow opens a second context, signs in, syncs, edits,
-      // and waits for cross-tab WS propagation — frequently bumps past the
-      // 30s default under suite-wide load.
-      test.slow();
-      const folderTitle = 'SomeFolder';
+  // Full suite only — do not tag `@smoke`. Folder create is the light cover.
+  test('create document, edit, page title, websockets', async ({
+    page,
+    browser,
+  }) => {
+    page.on('console', msg => {
+      console.log(`[page1-console] [${msg.type()}]`, msg.text());
+    });
+    // The multi-user flow opens a second context, signs in, syncs, edits,
+    // and waits for cross-tab WS propagation — frequently bumps past the
+    // 30s default under suite-wide load.
+    test.slow();
+    const folderTitle = 'SomeFolder';
 
-      const secret = await getDevDriveSecret(page);
-      await makeDrivePublic(page);
-      await newResource('folder', page);
-      await setTitle(page, folderTitle);
-      await newResource('document', page);
-      const title = `Document ${timestamp()}`;
-      await editTitle(title, page);
+    const secret = await getDevDriveSecret(page);
+    await makeDrivePublic(page);
+    await newResource('folder', page);
+    await setTitle(page, folderTitle);
+    await newResource('document', page);
+    const title = `Document ${timestamp()}`;
+    await editTitle(title, page);
 
-      const teststring = `My test: ${timestamp()}`;
+    const teststring = `My test: ${timestamp()}`;
 
-      await expect(page.getByText('loading...')).not.toBeVisible();
+    await expect(page.getByText('loading...')).not.toBeVisible();
 
-      const editor = page.getByLabel('Rich Text Editor');
+    const editor = page.getByLabel('Rich Text Editor');
 
-      await editor.fill('/heading');
-      await expect(page.getByText('Heading 1')).toBeVisible();
-      await page.keyboard.press('Enter');
-      await page.keyboard.type(teststring);
+    await editor.fill('/heading');
+    await expect(page.getByText('Heading 1')).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.keyboard.type(teststring);
 
-      await expect(
-        page.getByRole('heading', { name: teststring }),
-      ).toBeVisible();
+    await expect(page.getByRole('heading', { name: teststring })).toBeVisible();
 
-      // multi-user
-      const currentSubject = await getCurrentSubject(page);
-      const page2 = await openNewSubjectWindow(
-        browser,
-        currentSubject!,
-        secret,
-      );
-      page2.on('console', msg => {
-        console.log(`[page2-console] [${msg.type()}]`, msg.text());
-      });
+    // multi-user
+    const currentSubject = await getCurrentSubject(page);
+    const page2 = await openNewSubjectWindow(browser, currentSubject!, secret);
+    page2.on('console', msg => {
+      console.log(`[page2-console] [${msg.type()}]`, msg.text());
+    });
 
-      // "Set Drive" historically appeared when opening a foreign-drive subject;
-      // proper sign-in already sets the drive, so the button often isn't there.
-      // Click only when present, ignore otherwise.
-      const setDriveButton = page2.getByRole('button', { name: 'Set Drive' });
+    // "Set Drive" historically appeared when opening a foreign-drive subject;
+    // proper sign-in already sets the drive, so the button often isn't there.
+    // Click only when present, ignore otherwise.
+    const setDriveButton = page2.getByRole('button', { name: 'Set Drive' });
 
-      if (
-        await setDriveButton.isVisible({ timeout: 1500 }).catch(() => false)
-      ) {
-        await setDriveButton.click();
-      }
+    if (await setDriveButton.isVisible({ timeout: 1500 }).catch(() => false)) {
+      await setDriveButton.click();
+    }
 
-      // Sidebar may still show loading placeholders for unrelated children;
-      // scope to `main` so we only wait for the document body to land. Bumped
-      // timeout because the second tab needs WS auth + initial sync.
-      await expect(
-        page2.getByRole('main').getByText(/^loading/i),
-      ).not.toBeVisible({ timeout: 15000 });
-      await expect(
-        page2.getByRole('heading', { name: teststring }),
-        'First paragraph title not visible in second tab. Not a websocket issue',
-      ).toBeVisible({ timeout: 15000 });
-      expect(await page2.title()).toEqual(title);
+    // Sidebar may still show loading placeholders for unrelated children;
+    // scope to `main` so we only wait for the document body to land. Bumped
+    // timeout because the second tab needs WS auth + initial sync.
+    await expect(
+      page2.getByRole('main').getByText(/^loading/i),
+    ).not.toBeVisible({ timeout: 15000 });
+    await expect(
+      page2.getByRole('heading', { name: teststring }),
+      'First paragraph title not visible in second tab. Not a websocket issue',
+    ).toBeVisible({ timeout: 15000 });
+    expect(await page2.title()).toEqual(title);
 
-      await page2.getByLabel('Rich Text Editor').focus();
-      await page2.keyboard.press('End');
-      await page2.keyboard.press('Enter');
-      const syncText = 'New paragraph';
-      await page2.keyboard.type(syncText);
+    await page2.getByLabel('Rich Text Editor').focus();
+    await page2.keyboard.press('End');
+    await page2.keyboard.press('Enter');
+    const syncText = 'New paragraph';
+    await page2.keyboard.type(syncText);
 
-      await expect(async () => {
-        expect(
-          await editorPlainText(page2),
-          'New paragraph not found after typing. Something is wrong with rendering the text / handling the keyboard.',
-        ).toContain(syncText);
-      }).toPass({ timeout: 10_000 });
+    await expect(async () => {
+      expect(
+        await editorPlainText(page2),
+        'New paragraph not found after typing. Something is wrong with rendering the text / handling the keyboard.',
+      ).toContain(syncText);
+    }).toPass({ timeout: 10_000 });
 
-      await expect(async () => {
-        expect(
-          await editorPlainText(page),
-          'New paragraph not found in first window. Sync might not be working.',
-        ).toContain(syncText);
-      }).toPass({ timeout: 15_000 });
+    await expect(async () => {
+      expect(
+        await editorPlainText(page),
+        'New paragraph not found in first window. Sync might not be working.',
+      ).toContain(syncText);
+    }).toPass({ timeout: 15_000 });
 
-      // Delete the typed text. `Alt+Backspace` only deletes-word on macOS;
-      // headless chromium on Linux (dagger CI) treats it as a no-op, so the
-      // paragraph stayed and the cross-tab "not visible" assertion timed
-      // out. Re-select-then-Backspace deletes the selection deterministically
-      // on every platform. Select the paragraph node instead of locating it by
-      // text: a remote cursor decoration can split "New paragraph" across text
-      // nodes and make Playwright's text locator miss visibly rendered content.
-      await page2
-        .getByLabel('Rich Text Editor')
-        .locator('p')
-        .last()
-        .selectText();
-      await page2.keyboard.press('Backspace');
+    // Delete the typed text. `Alt+Backspace` only deletes-word on macOS;
+    // headless chromium on Linux (dagger CI) treats it as a no-op, so the
+    // paragraph stayed and the cross-tab "not visible" assertion timed
+    // out. Re-select-then-Backspace deletes the selection deterministically
+    // on every platform. Select the paragraph node instead of locating it by
+    // text: a remote cursor decoration can split "New paragraph" across text
+    // nodes and make Playwright's text locator miss visibly rendered content.
+    await page2.getByLabel('Rich Text Editor').locator('p').last().selectText();
+    await page2.keyboard.press('Backspace');
 
-      // Loro CRDT sync between two browser contexts goes through the server's
-      // WS hub, so propagation can take several seconds under suite-wide load.
-      // Verify the local deletion first, then poll for the cross-tab sync.
-      await expect(async () => {
-        expect(
-          await editorPlainText(page2),
-          'Paragraph not deleted in second window',
-        ).not.toContain(syncText);
-      }).toPass({ timeout: 15_000 });
-      await expect(async () => {
-        expect(
-          await editorPlainText(page),
-          'Paragraph not deleted in first window.',
-        ).not.toContain(syncText);
-      }).toPass({ timeout: 15_000 });
+    // Loro CRDT sync between two browser contexts goes through the server's
+    // WS hub, so propagation can take several seconds under suite-wide load.
+    // Verify the local deletion first, then poll for the cross-tab sync.
+    await expect(async () => {
+      expect(
+        await editorPlainText(page2),
+        'Paragraph not deleted in second window',
+      ).not.toContain(syncText);
+    }).toPass({ timeout: 15_000 });
+    await expect(async () => {
+      expect(
+        await editorPlainText(page),
+        'Paragraph not deleted in first window.',
+      ).not.toContain(syncText);
+    }).toPass({ timeout: 15_000 });
 
-      // Wait for AtomicServer to index the folder so the @-mention can find it.
-      await waitForSearchIndex(page2, folderTitle);
-      // Add a link to a folder via @ mention
-      await page2.keyboard.press('Space');
-      await page2.keyboard.type('@');
-      // The RTE command list mounts asynchronously after `@` is typed.
-      // Wait for it instead of guessing a fixed delay.
-      await expect(page2.getByTestId('rte-command-list')).toBeVisible({
-        timeout: 10000,
-      });
-      await page2.keyboard.type(folderTitle, { delay: 50 });
-      await expect(
-        page2.getByTestId('rte-command-list').getByText(folderTitle),
-      ).toBeVisible();
-      await page2.keyboard.press('Enter');
+    // Wait for AtomicServer to index the folder so the @-mention can find it.
+    await waitForSearchIndex(page2, folderTitle);
+    // Add a link to a folder via @ mention
+    await page2.keyboard.press('Space');
+    await page2.keyboard.type('@');
+    // The RTE command list mounts asynchronously after `@` is typed.
+    // Wait for it instead of guessing a fixed delay.
+    await expect(page2.getByTestId('rte-command-list')).toBeVisible({
+      timeout: 10000,
+    });
+    await page2.keyboard.type(folderTitle, { delay: 50 });
+    await expect(
+      page2.getByTestId('rte-command-list').getByText(folderTitle),
+    ).toBeVisible();
+    await page2.keyboard.press('Enter');
 
-      // Cross-tab CRDT sync of the @-mention link can take a few seconds.
-      await expect(
-        page.getByLabel('Rich Text Editor').locator('a:has-text("SomeFolder")'),
-      ).toBeVisible({ timeout: 15000 });
-    },
-  );
+    // Cross-tab CRDT sync of the @-mention link can take a few seconds.
+    await expect(
+      page.getByLabel('Rich Text Editor').locator('a:has-text("SomeFolder")'),
+    ).toBeVisible({ timeout: 15000 });
+  });
 
   // Ephemeral Loro cursor (presence): a collaborator's caret position is
   // broadcast over the WS hub as a `LORO_EPHEMERAL_UPDATE` frame (not

--- a/browser/e2e/tests/documents.spec.ts
+++ b/browser/e2e/tests/documents.spec.ts
@@ -37,135 +37,148 @@ test.describe('documents', async () => {
   // exceeds the loro broadcast budget under dagger CPU contention.
   // Investigate: bump the assertion to `waitForFunction` polling on the
   // store's loro-doc state instead of DOM text.
-  test('create document, edit, page title, websockets', smoke, async ({
-    page,
-    browser,
-  }) => {
-    page.on('console', msg => {
-      console.log(`[page1-console] [${msg.type()}]`, msg.text());
-    });
-    // The multi-user flow opens a second context, signs in, syncs, edits,
-    // and waits for cross-tab WS propagation — frequently bumps past the
-    // 30s default under suite-wide load.
-    test.slow();
-    const folderTitle = 'SomeFolder';
+  test(
+    'create document, edit, page title, websockets',
+    smoke,
+    async ({ page, browser }) => {
+      page.on('console', msg => {
+        console.log(`[page1-console] [${msg.type()}]`, msg.text());
+      });
+      // The multi-user flow opens a second context, signs in, syncs, edits,
+      // and waits for cross-tab WS propagation — frequently bumps past the
+      // 30s default under suite-wide load.
+      test.slow();
+      const folderTitle = 'SomeFolder';
 
-    const secret = await getDevDriveSecret(page);
-    await makeDrivePublic(page);
-    await newResource('folder', page);
-    await setTitle(page, folderTitle);
-    await newResource('document', page);
-    const title = `Document ${timestamp()}`;
-    await editTitle(title, page);
+      const secret = await getDevDriveSecret(page);
+      await makeDrivePublic(page);
+      await newResource('folder', page);
+      await setTitle(page, folderTitle);
+      await newResource('document', page);
+      const title = `Document ${timestamp()}`;
+      await editTitle(title, page);
 
-    const teststring = `My test: ${timestamp()}`;
+      const teststring = `My test: ${timestamp()}`;
 
-    await expect(page.getByText('loading...')).not.toBeVisible();
+      await expect(page.getByText('loading...')).not.toBeVisible();
 
-    const editor = page.getByLabel('Rich Text Editor');
+      const editor = page.getByLabel('Rich Text Editor');
 
-    await editor.fill('/heading');
-    await expect(page.getByText('Heading 1')).toBeVisible();
-    await page.keyboard.press('Enter');
-    await page.keyboard.type(teststring);
+      await editor.fill('/heading');
+      await expect(page.getByText('Heading 1')).toBeVisible();
+      await page.keyboard.press('Enter');
+      await page.keyboard.type(teststring);
 
-    await expect(page.getByRole('heading', { name: teststring })).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: teststring }),
+      ).toBeVisible();
 
-    // multi-user
-    const currentSubject = await getCurrentSubject(page);
-    const page2 = await openNewSubjectWindow(browser, currentSubject!, secret);
-    page2.on('console', msg => {
-      console.log(`[page2-console] [${msg.type()}]`, msg.text());
-    });
+      // multi-user
+      const currentSubject = await getCurrentSubject(page);
+      const page2 = await openNewSubjectWindow(
+        browser,
+        currentSubject!,
+        secret,
+      );
+      page2.on('console', msg => {
+        console.log(`[page2-console] [${msg.type()}]`, msg.text());
+      });
 
-    // "Set Drive" historically appeared when opening a foreign-drive subject;
-    // proper sign-in already sets the drive, so the button often isn't there.
-    // Click only when present, ignore otherwise.
-    const setDriveButton = page2.getByRole('button', { name: 'Set Drive' });
+      // "Set Drive" historically appeared when opening a foreign-drive subject;
+      // proper sign-in already sets the drive, so the button often isn't there.
+      // Click only when present, ignore otherwise.
+      const setDriveButton = page2.getByRole('button', { name: 'Set Drive' });
 
-    if (await setDriveButton.isVisible({ timeout: 1500 }).catch(() => false)) {
-      await setDriveButton.click();
-    }
+      if (
+        await setDriveButton.isVisible({ timeout: 1500 }).catch(() => false)
+      ) {
+        await setDriveButton.click();
+      }
 
-    // Sidebar may still show loading placeholders for unrelated children;
-    // scope to `main` so we only wait for the document body to land. Bumped
-    // timeout because the second tab needs WS auth + initial sync.
-    await expect(
-      page2.getByRole('main').getByText(/^loading/i),
-    ).not.toBeVisible({ timeout: 15000 });
-    await expect(
-      page2.getByRole('heading', { name: teststring }),
-      'First paragraph title not visible in second tab. Not a websocket issue',
-    ).toBeVisible({ timeout: 15000 });
-    expect(await page2.title()).toEqual(title);
+      // Sidebar may still show loading placeholders for unrelated children;
+      // scope to `main` so we only wait for the document body to land. Bumped
+      // timeout because the second tab needs WS auth + initial sync.
+      await expect(
+        page2.getByRole('main').getByText(/^loading/i),
+      ).not.toBeVisible({ timeout: 15000 });
+      await expect(
+        page2.getByRole('heading', { name: teststring }),
+        'First paragraph title not visible in second tab. Not a websocket issue',
+      ).toBeVisible({ timeout: 15000 });
+      expect(await page2.title()).toEqual(title);
 
-    await page2.getByLabel('Rich Text Editor').focus();
-    await page2.keyboard.press('End');
-    await page2.keyboard.press('Enter');
-    const syncText = 'New paragraph';
-    await page2.keyboard.type(syncText);
+      await page2.getByLabel('Rich Text Editor').focus();
+      await page2.keyboard.press('End');
+      await page2.keyboard.press('Enter');
+      const syncText = 'New paragraph';
+      await page2.keyboard.type(syncText);
 
-    await expect(async () => {
-      expect(
-        await editorPlainText(page2),
-        'New paragraph not found after typing. Something is wrong with rendering the text / handling the keyboard.',
-      ).toContain(syncText);
-    }).toPass({ timeout: 10_000 });
+      await expect(async () => {
+        expect(
+          await editorPlainText(page2),
+          'New paragraph not found after typing. Something is wrong with rendering the text / handling the keyboard.',
+        ).toContain(syncText);
+      }).toPass({ timeout: 10_000 });
 
-    await expect(async () => {
-      expect(
-        await editorPlainText(page),
-        'New paragraph not found in first window. Sync might not be working.',
-      ).toContain(syncText);
-    }).toPass({ timeout: 15_000 });
+      await expect(async () => {
+        expect(
+          await editorPlainText(page),
+          'New paragraph not found in first window. Sync might not be working.',
+        ).toContain(syncText);
+      }).toPass({ timeout: 15_000 });
 
-    // Delete the typed text. `Alt+Backspace` only deletes-word on macOS;
-    // headless chromium on Linux (dagger CI) treats it as a no-op, so the
-    // paragraph stayed and the cross-tab "not visible" assertion timed
-    // out. Re-select-then-Backspace deletes the selection deterministically
-    // on every platform. Select the paragraph node instead of locating it by
-    // text: a remote cursor decoration can split "New paragraph" across text
-    // nodes and make Playwright's text locator miss visibly rendered content.
-    await page2.getByLabel('Rich Text Editor').locator('p').last().selectText();
-    await page2.keyboard.press('Backspace');
+      // Delete the typed text. `Alt+Backspace` only deletes-word on macOS;
+      // headless chromium on Linux (dagger CI) treats it as a no-op, so the
+      // paragraph stayed and the cross-tab "not visible" assertion timed
+      // out. Re-select-then-Backspace deletes the selection deterministically
+      // on every platform. Select the paragraph node instead of locating it by
+      // text: a remote cursor decoration can split "New paragraph" across text
+      // nodes and make Playwright's text locator miss visibly rendered content.
+      await page2
+        .getByLabel('Rich Text Editor')
+        .locator('p')
+        .last()
+        .selectText();
+      await page2.keyboard.press('Backspace');
 
-    // Loro CRDT sync between two browser contexts goes through the server's
-    // WS hub, so propagation can take several seconds under suite-wide load.
-    // Verify the local deletion first, then poll for the cross-tab sync.
-    await expect(async () => {
-      expect(
-        await editorPlainText(page2),
-        'Paragraph not deleted in second window',
-      ).not.toContain(syncText);
-    }).toPass({ timeout: 15_000 });
-    await expect(async () => {
-      expect(
-        await editorPlainText(page),
-        'Paragraph not deleted in first window.',
-      ).not.toContain(syncText);
-    }).toPass({ timeout: 15_000 });
+      // Loro CRDT sync between two browser contexts goes through the server's
+      // WS hub, so propagation can take several seconds under suite-wide load.
+      // Verify the local deletion first, then poll for the cross-tab sync.
+      await expect(async () => {
+        expect(
+          await editorPlainText(page2),
+          'Paragraph not deleted in second window',
+        ).not.toContain(syncText);
+      }).toPass({ timeout: 15_000 });
+      await expect(async () => {
+        expect(
+          await editorPlainText(page),
+          'Paragraph not deleted in first window.',
+        ).not.toContain(syncText);
+      }).toPass({ timeout: 15_000 });
 
-    // Wait for AtomicServer to index the folder so the @-mention can find it.
-    await waitForSearchIndex(page2, folderTitle);
-    // Add a link to a folder via @ mention
-    await page2.keyboard.press('Space');
-    await page2.keyboard.type('@');
-    // The RTE command list mounts asynchronously after `@` is typed.
-    // Wait for it instead of guessing a fixed delay.
-    await expect(page2.getByTestId('rte-command-list')).toBeVisible({
-      timeout: 10000,
-    });
-    await page2.keyboard.type(folderTitle, { delay: 50 });
-    await expect(
-      page2.getByTestId('rte-command-list').getByText(folderTitle),
-    ).toBeVisible();
-    await page2.keyboard.press('Enter');
+      // Wait for AtomicServer to index the folder so the @-mention can find it.
+      await waitForSearchIndex(page2, folderTitle);
+      // Add a link to a folder via @ mention
+      await page2.keyboard.press('Space');
+      await page2.keyboard.type('@');
+      // The RTE command list mounts asynchronously after `@` is typed.
+      // Wait for it instead of guessing a fixed delay.
+      await expect(page2.getByTestId('rte-command-list')).toBeVisible({
+        timeout: 10000,
+      });
+      await page2.keyboard.type(folderTitle, { delay: 50 });
+      await expect(
+        page2.getByTestId('rte-command-list').getByText(folderTitle),
+      ).toBeVisible();
+      await page2.keyboard.press('Enter');
 
-    // Cross-tab CRDT sync of the @-mention link can take a few seconds.
-    await expect(
-      page.getByLabel('Rich Text Editor').locator('a:has-text("SomeFolder")'),
-    ).toBeVisible({ timeout: 15000 });
-  });
+      // Cross-tab CRDT sync of the @-mention link can take a few seconds.
+      await expect(
+        page.getByLabel('Rich Text Editor').locator('a:has-text("SomeFolder")'),
+      ).toBeVisible({ timeout: 15000 });
+    },
+  );
 
   // Ephemeral Loro cursor (presence): a collaborator's caret position is
   // broadcast over the WS hub as a `LORO_EPHEMERAL_UPDATE` frame (not

--- a/browser/e2e/tests/documents.spec.ts
+++ b/browser/e2e/tests/documents.spec.ts
@@ -10,6 +10,7 @@ import {
   before,
   setTitle,
   waitForSearchIndex,
+  smoke,
 } from './test-utils';
 
 /**
@@ -36,7 +37,7 @@ test.describe('documents', async () => {
   // exceeds the loro broadcast budget under dagger CPU contention.
   // Investigate: bump the assertion to `waitForFunction` polling on the
   // store's loro-doc state instead of DOM text.
-  test('create document, edit, page title, websockets', async ({
+  test('create document, edit, page title, websockets', smoke, async ({
     page,
     browser,
   }) => {

--- a/browser/e2e/tests/drive-deeplink.spec.ts
+++ b/browser/e2e/tests/drive-deeplink.spec.ts
@@ -13,65 +13,66 @@ import {
 test.describe('drive deep link', () => {
   test.beforeEach(before);
 
-  test('opening a share link to a NON-DRIVE child resource adopts the PARENT drive as the session drive', smoke, async ({
-    page,
-    browser,
-  }) => {
-    // Context 1: create a dev drive and make it publicly readable so an
-    // anonymous session can resolve it and its contents.
-    await devDrive(page);
-    const driveSubject = await getCurrentSubject(page);
-    const driveTitle = await currentDriveTitle(page).textContent();
-    expect(driveTitle).toBeTruthy();
-    await makeDrivePublic(page);
+  test(
+    'opening a share link to a NON-DRIVE child resource adopts the PARENT drive as the session drive',
+    smoke,
+    async ({ page, browser }) => {
+      // Context 1: create a dev drive and make it publicly readable so an
+      // anonymous session can resolve it and its contents.
+      await devDrive(page);
+      const driveSubject = await getCurrentSubject(page);
+      const driveTitle = await currentDriveTitle(page).textContent();
+      expect(driveTitle).toBeTruthy();
+      await makeDrivePublic(page);
 
-    // Create a NON-DRIVE child resource inside the drive. This is the
-    // resource the deep link will point at — it is NOT itself a drive, so
-    // the old buggy fallback (walking an unresolvable ancestry) would adopt
-    // the child as its own drive instead of its parent.
-    await newResource('folder', page);
-    const childSubject = await getCurrentSubject(page);
+      // Create a NON-DRIVE child resource inside the drive. This is the
+      // resource the deep link will point at — it is NOT itself a drive, so
+      // the old buggy fallback (walking an unresolvable ancestry) would adopt
+      // the child as its own drive instead of its parent.
+      await newResource('folder', page);
+      const childSubject = await getCurrentSubject(page);
 
-    // Sanity check: the test is meaningless if the child happens to be the
-    // drive itself.
-    expect(childSubject).not.toBe(driveSubject);
+      // Sanity check: the test is meaningless if the child happens to be the
+      // drive itself.
+      expect(childSubject).not.toBe(driveSubject);
 
-    // Context 2: a fresh browser profile with no stored drive, whose ENTRY
-    // URL is a share deep link to the CHILD resource. The session must start
-    // in the child's PARENT DRIVE, not in the child resource itself.
-    const context2 = await browser.newContext();
-    const page2 = await context2.newPage();
-    await page2.goto(
-      `${FRONTEND_URL}/app/share?subject=${encodeURIComponent(childSubject)}`,
-    );
+      // Context 2: a fresh browser profile with no stored drive, whose ENTRY
+      // URL is a share deep link to the CHILD resource. The session must start
+      // in the child's PARENT DRIVE, not in the child resource itself.
+      const context2 = await browser.newContext();
+      const page2 = await context2.newPage();
+      await page2.goto(
+        `${FRONTEND_URL}/app/share?subject=${encodeURIComponent(childSubject)}`,
+      );
 
-    await expect(currentDriveTitle(page2)).toHaveText(driveTitle!, {
-      timeout: 20000,
-    });
+      await expect(currentDriveTitle(page2)).toHaveText(driveTitle!, {
+        timeout: 20000,
+      });
 
-    // The adoption must be persisted as the session's default drive, not just
-    // rendered: store.setDrive writes the localStorage entry AppSettings reads.
-    // Assert it is the DRIVE subject — and explicitly NOT the child subject,
-    // which is exactly what the old ancestry-fallback bug produced.
-    await expect
-      .poll(async () =>
-        page2.evaluate(() => {
-          const raw = localStorage.getItem('drive');
+      // The adoption must be persisted as the session's default drive, not just
+      // rendered: store.setDrive writes the localStorage entry AppSettings reads.
+      // Assert it is the DRIVE subject — and explicitly NOT the child subject,
+      // which is exactly what the old ancestry-fallback bug produced.
+      await expect
+        .poll(async () =>
+          page2.evaluate(() => {
+            const raw = localStorage.getItem('drive');
 
-          return raw ? JSON.parse(raw) : undefined;
-        }),
-      )
-      .toBe(driveSubject);
+            return raw ? JSON.parse(raw) : undefined;
+          }),
+        )
+        .toBe(driveSubject);
 
-    const adoptedDrive = await page2.evaluate(() => {
-      const raw = localStorage.getItem('drive');
+      const adoptedDrive = await page2.evaluate(() => {
+        const raw = localStorage.getItem('drive');
 
-      return raw ? JSON.parse(raw) : undefined;
-    });
-    expect(adoptedDrive).not.toBe(childSubject);
+        return raw ? JSON.parse(raw) : undefined;
+      });
+      expect(adoptedDrive).not.toBe(childSubject);
 
-    await context2.close();
-  });
+      await context2.close();
+    },
+  );
 
   test('opening a share link to a DRIVE itself adopts that drive as the session drive', async ({
     page,

--- a/browser/e2e/tests/drive-deeplink.spec.ts
+++ b/browser/e2e/tests/drive-deeplink.spec.ts
@@ -7,12 +7,13 @@ import {
   makeDrivePublic,
   newResource,
   FRONTEND_URL,
+  smoke,
 } from './test-utils';
 
 test.describe('drive deep link', () => {
   test.beforeEach(before);
 
-  test('opening a share link to a NON-DRIVE child resource adopts the PARENT drive as the session drive', async ({
+  test('opening a share link to a NON-DRIVE child resource adopts the PARENT drive as the session drive', smoke, async ({
     page,
     browser,
   }) => {

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -37,6 +37,7 @@ import {
   acceptInvite,
   topBarShareButton,
   SEARCHBOX_PROPERTY_PLACEHOLDER,
+  smoke,
 } from './test-utils';
 
 test.describe('data-browser', async () => {
@@ -54,7 +55,9 @@ test.describe('data-browser', async () => {
     await expect(currentDriveTitle(page)).toContainText('atomicdata.dev');
   });
 
-  test('sign in with secret, edit profile, sign out', async ({ page }) => {
+  test('sign in with secret, edit profile, sign out', smoke, async ({
+    page,
+  }) => {
     await signIn(page);
     await editProfileAndCommit(page);
 
@@ -80,7 +83,7 @@ test.describe('data-browser', async () => {
    * We remove public read rights from drive, create an invite, open that
    * invite, and add the public read right again.
    */
-  test('authorization, invite, share menu', async ({
+  test('authorization, invite, share menu', smoke, async ({
     page,
     browser,
     context,
@@ -155,7 +158,7 @@ test.describe('data-browser', async () => {
     );
   });
 
-  test('chatroom', async ({ page, browser, context }) => {
+  test('chatroom', smoke, async ({ page, browser, context }) => {
     // This test also goes through `acceptInvite`'s two-round-trip agent
     // creation flow (see that call site) partway through, on top of its own
     // multi-round-trip chat/reload/invite steps — give it the same wider
@@ -417,7 +420,7 @@ test.describe('data-browser', async () => {
   // Likely a children-collection invalidation race after the `newResource`
   // commit. Investigate: subscribe directly to the folder's `useChildren`
   // collection ready state instead of waiting for the DOM.
-  test('folder', async ({ page }) => {
+  test('folder', smoke, async ({ page }) => {
     await newResource('folder', page);
     const folderTitle = 'TestFolder-uniqueName';
     await setTitle(page, folderTitle);
@@ -530,7 +533,7 @@ test.describe('data-browser', async () => {
     await expect(page.locator('text=Resource Saved')).toBeVisible();
   });
 
-  test('delete resource', async ({ page }) => {
+  test('delete resource', smoke, async ({ page }) => {
     await newResource('folder', page);
     const parentResource = await getCurrentSubject(page);
     // Empty-folder quick-create now renders dedicated "New Folder" / "New
@@ -751,7 +754,7 @@ test.describe('data-browser', async () => {
     ).toBeVisible();
   });
 
-  test('history page', async ({ page }) => {
+  test('history page', smoke, async ({ page }) => {
     await newResource('document', page);
 
     const firstTitleCommit = waitForCommit(page, {

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -55,108 +55,112 @@ test.describe('data-browser', async () => {
     await expect(currentDriveTitle(page)).toContainText('atomicdata.dev');
   });
 
-  test('sign in with secret, edit profile, sign out', smoke, async ({
-    page,
-  }) => {
-    await signIn(page);
-    await editProfileAndCommit(page);
+  test(
+    'sign in with secret, edit profile, sign out',
+    smoke,
+    async ({ page }) => {
+      await signIn(page);
+      await editProfileAndCommit(page);
 
-    page.on('dialog', d => {
-      d.accept();
-    });
+      page.on('dialog', d => {
+        d.accept();
+      });
 
-    await openAgentPage(page);
-    await page.click('[data-test="sign-out"]');
-    await expect(
-      page.getByRole('button', { name: 'Create account' }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Sign in', exact: true }),
-    ).toBeVisible();
-    await page.reload();
-    await expect(
-      page.getByRole('button', { name: 'Create account' }),
-    ).toBeVisible();
-  });
+      await openAgentPage(page);
+      await page.click('[data-test="sign-out"]');
+      await expect(
+        page.getByRole('button', { name: 'Create account' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Sign in', exact: true }),
+      ).toBeVisible();
+      await page.reload();
+      await expect(
+        page.getByRole('button', { name: 'Create account' }),
+      ).toBeVisible();
+    },
+  );
 
   /**
    * We remove public read rights from drive, create an invite, open that
    * invite, and add the public read right again.
    */
-  test('authorization, invite, share menu', smoke, async ({
-    page,
-    browser,
-    context,
-  }) => {
-    // `acceptInvite` (test-utils.ts) waits through two sequential server
-    // round trips (new agent genesis commit save, then invite accept POST)
-    // before its dialog opens — see the comment at that call site. Give the
-    // whole test a wider budget to match, same as plugin.spec.ts's install
-    // flow.
-    test.slow();
+  test(
+    'authorization, invite, share menu',
+    smoke,
+    async ({ page, browser, context }) => {
+      // `acceptInvite` (test-utils.ts) waits through two sequential server
+      // round trips (new agent genesis commit save, then invite accept POST)
+      // before its dialog opens — see the comment at that call site. Give the
+      // whole test a wider budget to match, same as plugin.spec.ts's install
+      // flow.
+      test.slow();
 
-    await signIn(page);
-    const { driveURL, driveTitle } = await newDrive(page);
-    await currentDriveTitle(page).click();
-    await contextMenuClick('share', page);
-    expect(publicReadRightLocator(page)).not.toBeChecked();
+      await signIn(page);
+      const { driveURL, driveTitle } = await newDrive(page);
+      await currentDriveTitle(page).click();
+      await contextMenuClick('share', page);
+      expect(publicReadRightLocator(page)).not.toBeChecked();
 
-    // Initialize unauthorized page for reader. An anonymous user landing on a
-    // private drive is redirected to the welcome flow (ErrorPage redirects on
-    // unauthorized when no agent), so check for the sign-in card buttons that
-    // GettingStartedFlow renders instead of a literal "Unauthorized" string.
-    const context2 = await browser.newContext();
-    const page2 = await context2.newPage();
-    await page2.setViewportSize({ width: 1000, height: 400 });
-    // Navigate straight to the private drive. Do NOT use `openSubject` here:
-    // it waits for `main[about=drive]`, but an unauthorized anonymous user is
-    // redirected to /welcome — `main[about]` only renders as a sub-second
-    // flash (ResourcePage wraps ErrorPage in <Main> before the redirect
-    // effect fires). Dev is slow enough to catch that flash; on a production
-    // bundle the redirect wins the race. The correct readiness signal is the
-    // welcome card itself, asserted below.
-    await page2.goto(
-      `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(driveURL)}`,
-    );
-    await expect(
-      page2.getByRole('button', { name: 'Create account' }),
-    ).toBeVisible({ timeout: 15000 });
+      // Initialize unauthorized page for reader. An anonymous user landing on a
+      // private drive is redirected to the welcome flow (ErrorPage redirects on
+      // unauthorized when no agent), so check for the sign-in card buttons that
+      // GettingStartedFlow renders instead of a literal "Unauthorized" string.
+      const context2 = await browser.newContext();
+      const page2 = await context2.newPage();
+      await page2.setViewportSize({ width: 1000, height: 400 });
+      // Navigate straight to the private drive. Do NOT use `openSubject` here:
+      // it waits for `main[about=drive]`, but an unauthorized anonymous user is
+      // redirected to /welcome — `main[about]` only renders as a sub-second
+      // flash (ResourcePage wraps ErrorPage in <Main> before the redirect
+      // effect fires). Dev is slow enough to catch that flash; on a production
+      // bundle the redirect wins the race. The correct readiness signal is the
+      // welcome card itself, asserted below.
+      await page2.goto(
+        `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(driveURL)}`,
+      );
+      await expect(
+        page2.getByRole('button', { name: 'Create account' }),
+      ).toBeVisible({ timeout: 15000 });
 
-    // Create invite
-    await page.click('button:has-text("Create Invite")');
-    context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.click('button:has-text("Create")');
-    await expect(page.locator('text=Invite created and copied ')).toBeVisible();
-    const inviteUrl = await page.evaluate(() =>
-      document
-        ?.querySelector('[data-code-content]')
-        ?.getAttribute('data-code-content'),
-    );
-    expect(inviteUrl).not.toBeFalsy();
+      // Create invite
+      await page.click('button:has-text("Create Invite")');
+      context.grantPermissions(['clipboard-read', 'clipboard-write']);
+      await page.click('button:has-text("Create")');
+      await expect(
+        page.locator('text=Invite created and copied '),
+      ).toBeVisible();
+      const inviteUrl = await page.evaluate(() =>
+        document
+          ?.querySelector('[data-code-content]')
+          ?.getAttribute('data-code-content'),
+      );
+      expect(inviteUrl).not.toBeFalsy();
 
-    // The invite resource needs to be persisted server-side before the
-    // invitee opens its URL — otherwise the server returns 404. Wait for
-    // the dirty queue to drain rather than guessing a fixed 200ms.
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+      // The invite resource needs to be persisted server-side before the
+      // invitee opens its URL — otherwise the server returns 404. Wait for
+      // the dirty queue to drain rather than guessing a fixed 200ms.
+      await page.waitForFunction(
+        () => window.store?.getSyncStatus().pendingDirtyCount === 0,
+        undefined,
+        { timeout: 10000 },
+      );
 
-    // Open invite
-    const page3 = await openNewSubjectWindow(browser, inviteUrl as string);
-    await acceptInvite(page3);
-    await page3.waitForURL(/\/app\/show/, { timeout: 15000 });
-    await page3.reload();
-    await expect(page3.getByText(driveTitle).first()).toBeVisible();
-    // Accepting must also make the invited drive the ACTIVE one. Showing the
-    // resource while the sidebar still points at the invitee's own drive is
-    // the failure this guards: the sidebar lists the wrong children and the
-    // drive-wide subscription goes to a drive nobody is looking at.
-    await expect(page3.getByTestId('current-drive-title')).toHaveText(
-      driveTitle,
-    );
-  });
+      // Open invite
+      const page3 = await openNewSubjectWindow(browser, inviteUrl as string);
+      await acceptInvite(page3);
+      await page3.waitForURL(/\/app\/show/, { timeout: 15000 });
+      await page3.reload();
+      await expect(page3.getByText(driveTitle).first()).toBeVisible();
+      // Accepting must also make the invited drive the ACTIVE one. Showing the
+      // resource while the sidebar still points at the invitee's own drive is
+      // the failure this guards: the sidebar lists the wrong children and the
+      // drive-wide subscription goes to a drive nobody is looking at.
+      await expect(page3.getByTestId('current-drive-title')).toHaveText(
+        driveTitle,
+      );
+    },
+  );
 
   test('chatroom', smoke, async ({ page, browser, context }) => {
     // This test also goes through `acceptInvite`'s two-round-trip agent

--- a/browser/e2e/tests/filePicker.spec.ts
+++ b/browser/e2e/tests/filePicker.spec.ts
@@ -94,116 +94,122 @@ const createModel = async (page: Page) => {
 test.describe('File Picker', () => {
   test.beforeEach(before);
 
-  test('select file and upload using the filepicker', smoke, async ({
-    page,
-  }) => {
-    const SEARCH_BAR_PLACEHOLDER = 'Search or enter a URL...';
+  test(
+    'select file and upload using the filepicker',
+    smoke,
+    async ({ page }) => {
+      const SEARCH_BAR_PLACEHOLDER = 'Search or enter a URL...';
 
-    await signIn(page);
-    await newDrive(page);
+      await signIn(page);
+      await newDrive(page);
 
-    await uploadFile(page, 'testFile1.txt');
-    await uploadFile(page, 'testFile2.md');
+      await uploadFile(page, 'testFile1.txt');
+      await uploadFile(page, 'testFile2.md');
 
-    await createModel(page);
+      await createModel(page);
 
-    // `/app/new` lists classes by searching for ONTOLOGIES and rendering each
-    // one's `classes` — so wait for that, not for `robot` to be findable by
-    // name. The two are not the same signal, and the difference is what made
-    // this test fail under suite load while passing on its own.
-    await waitForOntologyClass(page, 'robot');
+      // `/app/new` lists classes by searching for ONTOLOGIES and rendering each
+      // one's `classes` — so wait for that, not for `robot` to be findable by
+      // name. The two are not the same signal, and the difference is what made
+      // this test fail under suite load while passing on its own.
+      await waitForOntologyClass(page, 'robot');
 
-    {
-      // Test selecting an existing file.
-      await newResource('robot', page);
-
-      await expect(
-        page.getByRole('heading', { name: 'new robot' }),
-      ).toBeVisible();
-
-      await expect(
-        page.getByRole('button', { name: 'Select File' }),
-      ).toBeVisible();
-
-      await page.getByRole('button', { name: 'Select File' }).click();
-
-      await inDialog(page, async dialog => {
-        await expect(
-          dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER),
-        ).toBeVisible();
-        await expect(dialog.getByText('Contents of test file 1')).toBeVisible();
-        await expect(dialog.getByText('testFile2.md')).toBeVisible();
-
-        await dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER).fill('.md');
+      {
+        // Test selecting an existing file.
+        await newResource('robot', page);
 
         await expect(
-          dialog.getByText('Contents of test file 1'),
-        ).not.toBeVisible();
-
-        await dialog.getByRole('button', { name: 'testFile2.md' }).click();
-
-        await expect(
-          dialog.getByRole('heading', {
-            name: 'first step in understanding recursion?',
-          }),
-        ).not.toBeVisible();
-      });
-
-      await expect(
-        page
-          .getByRole('region', { name: 'testFile2.md preview' })
-          .getByRole('heading', {
-            name: 'first step in understanding recursion?',
-          }),
-      ).toBeVisible();
-
-      await page.getByRole('button', { name: 'Save' }).click();
-      await expect(page.getByText('New robot')).not.toBeVisible();
-    }
-
-    {
-      // Test uploading a new file.
-      await newResource('robot', page);
-
-      await expect(
-        page.getByRole('heading', { name: 'new robot' }),
-      ).toBeVisible();
-
-      await page.getByRole('button', { name: 'Select File' }).click();
-
-      await inDialog(page, async dialog => {
-        await expect(
-          dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER),
+          page.getByRole('heading', { name: 'new robot' }),
         ).toBeVisible();
 
-        await dialog
-          .getByLabel('Upload')
-          .setInputFiles(testFilePath('testFile3.txt'));
-      });
+        await expect(
+          page.getByRole('button', { name: 'Select File' }),
+        ).toBeVisible();
 
-      await expect(
-        page
-          .getByRole('region', { name: 'testFile3.txt preview' })
-          .getByText('File preview not available at this time'),
-      ).toBeVisible();
+        await page.getByRole('button', { name: 'Select File' }).click();
 
-      await page.getByRole('button', { name: 'Save' }).click();
-      await expect(page.getByText('New robot')).not.toBeVisible();
-      // Read the file resource's subject from the value link in main and
-      // navigate to it directly. Clicking the inline link doesn't reliably
-      // trigger SPA navigation under Playwright (the browser tries to handle
-      // the `did:ad:...` href as a real URL and lands on `about:blank#`).
-      const fileSubject = await page
-        .getByRole('main')
-        .getByRole('link', { name: 'testFile3.txt' })
-        .getAttribute('href');
-      expect(fileSubject).toBeTruthy();
-      await page.goto(
-        `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(fileSubject!)}`,
-      );
+        await inDialog(page, async dialog => {
+          await expect(
+            dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER),
+          ).toBeVisible();
+          await expect(
+            dialog.getByText('Contents of test file 1'),
+          ).toBeVisible();
+          await expect(dialog.getByText('testFile2.md')).toBeVisible();
 
-      // For some reason playwright will only find text with quotes in them when using a regex instead of string.
-      await expect(page.getByText(/It's a secret to everybody/)).toBeVisible();
-    }
-  });
+          await dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER).fill('.md');
+
+          await expect(
+            dialog.getByText('Contents of test file 1'),
+          ).not.toBeVisible();
+
+          await dialog.getByRole('button', { name: 'testFile2.md' }).click();
+
+          await expect(
+            dialog.getByRole('heading', {
+              name: 'first step in understanding recursion?',
+            }),
+          ).not.toBeVisible();
+        });
+
+        await expect(
+          page
+            .getByRole('region', { name: 'testFile2.md preview' })
+            .getByRole('heading', {
+              name: 'first step in understanding recursion?',
+            }),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: 'Save' }).click();
+        await expect(page.getByText('New robot')).not.toBeVisible();
+      }
+
+      {
+        // Test uploading a new file.
+        await newResource('robot', page);
+
+        await expect(
+          page.getByRole('heading', { name: 'new robot' }),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: 'Select File' }).click();
+
+        await inDialog(page, async dialog => {
+          await expect(
+            dialog.getByPlaceholder(SEARCH_BAR_PLACEHOLDER),
+          ).toBeVisible();
+
+          await dialog
+            .getByLabel('Upload')
+            .setInputFiles(testFilePath('testFile3.txt'));
+        });
+
+        await expect(
+          page
+            .getByRole('region', { name: 'testFile3.txt preview' })
+            .getByText('File preview not available at this time'),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: 'Save' }).click();
+        await expect(page.getByText('New robot')).not.toBeVisible();
+        // Read the file resource's subject from the value link in main and
+        // navigate to it directly. Clicking the inline link doesn't reliably
+        // trigger SPA navigation under Playwright (the browser tries to handle
+        // the `did:ad:...` href as a real URL and lands on `about:blank#`).
+        const fileSubject = await page
+          .getByRole('main')
+          .getByRole('link', { name: 'testFile3.txt' })
+          .getAttribute('href');
+        expect(fileSubject).toBeTruthy();
+        await page.goto(
+          `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(fileSubject!)}`,
+        );
+
+        // For some reason playwright will only find text with quotes in them when using a regex instead of string.
+        await expect(
+          page.getByText(/It's a secret to everybody/),
+        ).toBeVisible();
+      }
+    },
+  );
 });

--- a/browser/e2e/tests/filePicker.spec.ts
+++ b/browser/e2e/tests/filePicker.spec.ts
@@ -13,6 +13,7 @@ import {
   signIn,
   testFilePath,
   waitForOntologyClass,
+  smoke,
 } from './test-utils';
 
 const ONTOLOGY_NAME = 'filepicker-test';
@@ -93,7 +94,9 @@ const createModel = async (page: Page) => {
 test.describe('File Picker', () => {
   test.beforeEach(before);
 
-  test('select file and upload using the filepicker', async ({ page }) => {
+  test('select file and upload using the filepicker', smoke, async ({
+    page,
+  }) => {
     const SEARCH_BAR_PLACEHOLDER = 'Search or enter a URL...';
 
     await signIn(page);

--- a/browser/e2e/tests/kanban.spec.ts
+++ b/browser/e2e/tests/kanban.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
-import { before, createTableFromDialog, reloadReconnected, smoke } from './test-utils';
+import {
+  before,
+  createTableFromDialog,
+  reloadReconnected,
+  smoke,
+} from './test-utils';
 
 /**
  * Drag `source` onto `target` in a way that satisfies @dnd-kit's MouseSensor,
@@ -156,42 +161,44 @@ test.describe('kanban', () => {
     await expect(column(page, 'No status')).not.toBeVisible();
   });
 
-  test('add a card, drag it between columns, and it persists', smoke, async ({
-    page,
-  }) => {
-    await createIssueTracker(page, 'Bugs');
+  test(
+    'add a card, drag it between columns, and it persists',
+    smoke,
+    async ({ page }) => {
+      await createIssueTracker(page, 'Bugs');
 
-    const todo = column(page, 'todo');
-    const doing = column(page, 'doing');
+      const todo = column(page, 'todo');
+      const doing = column(page, 'doing');
 
-    await addCard(page, todo, 'Login button misaligned');
+      await addCard(page, todo, 'Login button misaligned');
 
-    // Starts in todo, not doing.
-    await expect(cardIn(todo, 'Login button misaligned')).toBeVisible();
-    await expect(cardIn(doing, 'Login button misaligned')).toHaveCount(0);
+      // Starts in todo, not doing.
+      await expect(cardIn(todo, 'Login button misaligned')).toBeVisible();
+      await expect(cardIn(doing, 'Login button misaligned')).toHaveCount(0);
 
-    // Drag from todo onto the doing column's card list.
-    await dndDrag(
-      page,
-      cardIn(todo, 'Login button misaligned'),
-      doing.getByTestId('kanban-column-body'),
-    );
+      // Drag from todo onto the doing column's card list.
+      await dndDrag(
+        page,
+        cardIn(todo, 'Login button misaligned'),
+        doing.getByTestId('kanban-column-body'),
+      );
 
-    // Now in doing, gone from todo.
-    await expect(cardIn(doing, 'Login button misaligned')).toBeVisible();
-    await expect(cardIn(todo, 'Login button misaligned')).toHaveCount(0);
+      // Now in doing, gone from todo.
+      await expect(cardIn(doing, 'Login button misaligned')).toBeVisible();
+      await expect(cardIn(todo, 'Login button misaligned')).toHaveCount(0);
 
-    // Survives a reload (the status change was persisted to the resource).
-    await reloadReconnected(page);
-    await expect(page.getByTestId('kanban-board')).toBeVisible({
-      timeout: 30_000,
-    });
-    await expect(
-      column(page, 'doing').getByTestId('kanban-card').filter({
-        hasText: 'Login button misaligned',
-      }),
-    ).toBeVisible();
-  });
+      // Survives a reload (the status change was persisted to the resource).
+      await reloadReconnected(page);
+      await expect(page.getByTestId('kanban-board')).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(
+        column(page, 'doing').getByTestId('kanban-card').filter({
+          hasText: 'Login button misaligned',
+        }),
+      ).toBeVisible();
+    },
+  );
 
   test('clicking a card opens it in the expanded modal (not full-screen)', async ({
     page,

--- a/browser/e2e/tests/kanban.spec.ts
+++ b/browser/e2e/tests/kanban.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
-import { before, createTableFromDialog, reloadReconnected } from './test-utils';
+import { before, createTableFromDialog, reloadReconnected, smoke } from './test-utils';
 
 /**
  * Drag `source` onto `target` in a way that satisfies @dnd-kit's MouseSensor,
@@ -156,7 +156,7 @@ test.describe('kanban', () => {
     await expect(column(page, 'No status')).not.toBeVisible();
   });
 
-  test('add a card, drag it between columns, and it persists', async ({
+  test('add a card, drag it between columns, and it persists', smoke, async ({
     page,
   }) => {
     await createIssueTracker(page, 'Bugs');

--- a/browser/e2e/tests/meetings.spec.ts
+++ b/browser/e2e/tests/meetings.spec.ts
@@ -55,54 +55,60 @@ test('top bar offers no Meet control when no meeting is live', async ({
   await expect(page.getByTestId('menu-item-newDraft')).toHaveCount(0);
 });
 
-test('prepare an agenda, start it, and preserve minutes', smoke, async ({
-  page,
-}) => {
-  test.setTimeout(90_000);
-  await before({ page });
-  await page.waitForLoadState('load');
+test(
+  'prepare an agenda, start it, and preserve minutes',
+  smoke,
+  async ({ page }) => {
+    test.setTimeout(90_000);
+    await before({ page });
+    await page.waitForLoadState('load');
 
-  await page.getByRole('button', { name: 'New Meeting' }).first().click();
-  await expect(page.getByText('agenda', { exact: true }).first()).toBeVisible({
-    timeout: 30_000,
-  });
+    await page.getByRole('button', { name: 'New Meeting' }).first().click();
+    await expect(page.getByText('agenda', { exact: true }).first()).toBeVisible(
+      {
+        timeout: 30_000,
+      },
+    );
 
-  const meeting = await getCurrentSubject(page);
-  expect(meeting).toBeTruthy();
-  const agendaText = 'Approve launch plan';
-  await page.getByLabel('Rich Text Editor').fill(agendaText);
-  await expect(page.getByText(agendaText)).toBeVisible();
+    const meeting = await getCurrentSubject(page);
+    expect(meeting).toBeTruthy();
+    const agendaText = 'Approve launch plan';
+    await page.getByLabel('Rich Text Editor').fill(agendaText);
+    await expect(page.getByText(agendaText)).toBeVisible();
 
-  expect(
-    await page.evaluate(subject => {
-      const store = window.store;
-      const drive = store.getDrive();
+    expect(
+      await page.evaluate(subject => {
+        const store = window.store;
+        const drive = store.getDrive();
 
-      if (!drive) return false;
+        if (!drive) return false;
 
-      const resource = store.getResourceLoading(drive);
-      const live = (resource.get(
-        'https://atomicdata.dev/properties/currentMeetings',
-      ) ?? []) as string[];
+        const resource = store.getResourceLoading(drive);
+        const live = (resource.get(
+          'https://atomicdata.dev/properties/currentMeetings',
+        ) ?? []) as string[];
 
-      return live.includes(subject!);
-    }, meeting),
-  ).toBe(false);
+        return live.includes(subject!);
+      }, meeting),
+    ).toBe(false);
 
-  await page.getByRole('button', { name: 'Start meeting' }).click();
-  await expect(page.getByText('notes', { exact: true }).first()).toBeVisible();
-  await expect(page.getByTestId('follow-session-panel')).toHaveAttribute(
-    'data-open',
-    '',
-  );
-  await expect(page.getByText(agendaText)).toBeVisible();
+    await page.getByRole('button', { name: 'Start meeting' }).click();
+    await expect(
+      page.getByText('notes', { exact: true }).first(),
+    ).toBeVisible();
+    await expect(page.getByTestId('follow-session-panel')).toHaveAttribute(
+      'data-open',
+      '',
+    );
+    await expect(page.getByText(agendaText)).toBeVisible();
 
-  await page.getByRole('button', { name: 'End meeting' }).click();
-  await expect(
-    page.getByText('minutes', { exact: true }).first(),
-  ).toBeVisible();
-  await expect(page.getByText(agendaText)).toBeVisible();
-});
+    await page.getByRole('button', { name: 'End meeting' }).click();
+    await expect(
+      page.getByText('minutes', { exact: true }).first(),
+    ).toBeVisible();
+    await expect(page.getByText(agendaText)).toBeVisible();
+  },
+);
 
 test('start a meeting, join it, follow along, and end it', async ({
   browser,

--- a/browser/e2e/tests/meetings.spec.ts
+++ b/browser/e2e/tests/meetings.spec.ts
@@ -5,6 +5,7 @@ import {
   getDevDriveSecret,
   signIn,
   FRONTEND_URL,
+  smoke,
 } from './test-utils';
 
 /**
@@ -54,7 +55,9 @@ test('top bar offers no Meet control when no meeting is live', async ({
   await expect(page.getByTestId('menu-item-newDraft')).toHaveCount(0);
 });
 
-test('prepare an agenda, start it, and preserve minutes', async ({ page }) => {
+test('prepare an agenda, start it, and preserve minutes', smoke, async ({
+  page,
+}) => {
   test.setTimeout(90_000);
   await before({ page });
   await page.waitForLoadState('load');

--- a/browser/e2e/tests/ontology.spec.ts
+++ b/browser/e2e/tests/ontology.spec.ts
@@ -10,6 +10,7 @@ import {
   waitForSearchIndex,
   waitForClassInstanceSearchable,
   waitForOntologyClass,
+  smoke,
 } from './test-utils';
 
 test.describe('Ontology', async () => {
@@ -20,7 +21,7 @@ test.describe('Ontology', async () => {
   // probably too short under contention. Investigate: replace the
   // `waitForTimeout(100)` in `pickOption` with an explicit visibility
   // wait on the dropdown's option list.
-  test('Create and edit ontology', async ({ page }) => {
+  test('Create and edit ontology', smoke, async ({ page }) => {
     test.slow();
 
     const pickOption = async (query: Locator, keyboardSteps?: number) => {

--- a/browser/e2e/tests/pairing-dialog.spec.ts
+++ b/browser/e2e/tests/pairing-dialog.spec.ts
@@ -4,6 +4,7 @@ import {
   FRONTEND_URL,
   nodeReachableServerUrl,
   SERVER_URL,
+  smoke,
 } from './test-utils';
 
 /**
@@ -156,7 +157,7 @@ test.describe('pairing by pasting a code', () => {
     ).toBeVisible();
   });
 
-  test('a successful pairing reports what synced, and with whom', async ({
+  test('a successful pairing reports what synced, and with whom', smoke, async ({
     page,
   }) => {
     await pretendToBeTheApp(page);

--- a/browser/e2e/tests/pairing-dialog.spec.ts
+++ b/browser/e2e/tests/pairing-dialog.spec.ts
@@ -157,23 +157,25 @@ test.describe('pairing by pasting a code', () => {
     ).toBeVisible();
   });
 
-  test('a successful pairing reports what synced, and with whom', smoke, async ({
-    page,
-  }) => {
-    await pretendToBeTheApp(page);
-    const calls = await stubIrohSync(page, {
-      count: 3,
-      peerName: 'Joep’s phone',
-    });
-    await gotoSync(page);
+  test(
+    'a successful pairing reports what synced, and with whom',
+    smoke,
+    async ({ page }) => {
+      await pretendToBeTheApp(page);
+      const calls = await stubIrohSync(page, {
+        count: 3,
+        peerName: 'Joep’s phone',
+      });
+      await gotoSync(page);
 
-    await pasteCode(page, VALID_CODE);
+      await pasteCode(page, VALID_CODE);
 
-    await expect(
-      page.getByText('Synced 3 resources with Joep’s phone'),
-    ).toBeVisible();
-    expect(calls.count).toBe(1);
-  });
+      await expect(
+        page.getByText('Synced 3 resources with Joep’s phone'),
+      ).toBeVisible();
+      expect(calls.count).toBe(1);
+    },
+  );
 
   test('the paired device is remembered for next time', async ({ page }) => {
     await pretendToBeTheApp(page);

--- a/browser/e2e/tests/search.spec.ts
+++ b/browser/e2e/tests/search.spec.ts
@@ -11,6 +11,7 @@ import {
   getCurrentSubject,
   openSubject,
   waitForSearchIndex,
+  smoke,
 } from './test-utils';
 
 const SEARCH_RESULTS = 'https://atomicdata.dev/properties/search/results';
@@ -100,7 +101,7 @@ async function waitForFilteredServerSearch(
 test.describe('search', async () => {
   test.beforeEach(before);
 
-  test('text search', async ({ page }) => {
+  test('text search', smoke, async ({ page }) => {
     // Seed content: dev-drive starts empty, so we create the thing we intend
     // to find. Previously the test relied on onboarding content ("Welcome to
     // your drive…") that no longer ships with dev-drive. Avoid colons in the

--- a/browser/e2e/tests/second-device-load.spec.ts
+++ b/browser/e2e/tests/second-device-load.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { before, getDevDriveSecret, signIn, FRONTEND_URL } from './test-utils';
+import { before, getDevDriveSecret, signIn, FRONTEND_URL, smoke } from './test-utils';
 
 /**
  * A second device (or a fresh/cleared OPFS) must load an existing drive's
@@ -9,7 +9,7 @@ import { before, getDevDriveSecret, signIn, FRONTEND_URL } from './test-utils';
  * fallback). Guards the cold-load path that the OPFS durability fix and the
  * collection server-fallback depend on.
  */
-test('a fresh-OPFS second device loads an existing drive’s contents', async ({
+test('a fresh-OPFS second device loads an existing drive’s contents', smoke, async ({
   browser,
 }) => {
   const ctx1 = await browser.newContext();

--- a/browser/e2e/tests/second-device-load.spec.ts
+++ b/browser/e2e/tests/second-device-load.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { before, getDevDriveSecret, signIn, FRONTEND_URL, smoke } from './test-utils';
+import {
+  before,
+  getDevDriveSecret,
+  signIn,
+  FRONTEND_URL,
+  smoke,
+} from './test-utils';
 
 /**
  * A second device (or a fresh/cleared OPFS) must load an existing drive's
@@ -9,59 +15,61 @@ import { before, getDevDriveSecret, signIn, FRONTEND_URL, smoke } from './test-u
  * fallback). Guards the cold-load path that the OPFS durability fix and the
  * collection server-fallback depend on.
  */
-test('a fresh-OPFS second device loads an existing drive’s contents', smoke, async ({
-  browser,
-}) => {
-  const ctx1 = await browser.newContext();
-  const p1 = await ctx1.newPage();
-  await before({ page: p1 });
-  const drive = await p1.evaluate(async () => {
-    const s = window.store;
-    const d = s.getDrive();
+test(
+  'a fresh-OPFS second device loads an existing drive’s contents',
+  smoke,
+  async ({ browser }) => {
+    const ctx1 = await browser.newContext();
+    const p1 = await ctx1.newPage();
+    await before({ page: p1 });
+    const drive = await p1.evaluate(async () => {
+      const s = window.store;
+      const d = s.getDrive();
 
-    if (!d) throw new Error('no drive');
+      if (!d) throw new Error('no drive');
 
-    const tmp = await s.createSubject('sd');
-    const f = await s.newResource({
-      subject: tmp,
-      parent: d,
-      isA: 'https://atomicdata.dev/classes/Folder',
+      const tmp = await s.createSubject('sd');
+      const f = await s.newResource({
+        subject: tmp,
+        parent: d,
+        isA: 'https://atomicdata.dev/classes/Folder',
+      });
+      await f.set(
+        'https://atomicdata.dev/properties/name',
+        'SecondDeviceChild',
+        false,
+      );
+      await f.save();
+
+      return d;
     });
-    await f.set(
-      'https://atomicdata.dev/properties/name',
-      'SecondDeviceChild',
-      false,
+    const secret = await getDevDriveSecret(p1);
+
+    // Device 1 is about to be closed, so the folder has to have reached the
+    // server before that — device 2 has an empty OPFS and can only load it from
+    // there. This was a flat 2s sleep, which is a guess at how long a commit
+    // takes and was simply wrong on a loaded CI runner: the context closed with
+    // the commit still queued, and the failure landed on device 2 as "the drive
+    // is missing its contents", pointing at the cold-load path this test exists
+    // to check rather than at the setup that never completed.
+    await p1.waitForFunction(
+      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
+      undefined,
+      { timeout: 30_000 },
     );
-    await f.save();
+    await ctx1.close();
 
-    return d;
-  });
-  const secret = await getDevDriveSecret(p1);
+    const ctx2 = await browser.newContext(); // brand-new context ⇒ empty OPFS
+    const p2 = await ctx2.newPage();
+    await p2.goto(FRONTEND_URL);
+    await signIn(p2, secret);
+    await p2.goto(
+      `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(drive)}`,
+    );
 
-  // Device 1 is about to be closed, so the folder has to have reached the
-  // server before that — device 2 has an empty OPFS and can only load it from
-  // there. This was a flat 2s sleep, which is a guess at how long a commit
-  // takes and was simply wrong on a loaded CI runner: the context closed with
-  // the commit still queued, and the failure landed on device 2 as "the drive
-  // is missing its contents", pointing at the cold-load path this test exists
-  // to check rather than at the setup that never completed.
-  await p1.waitForFunction(
-    () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-    undefined,
-    { timeout: 30_000 },
-  );
-  await ctx1.close();
-
-  const ctx2 = await browser.newContext(); // brand-new context ⇒ empty OPFS
-  const p2 = await ctx2.newPage();
-  await p2.goto(FRONTEND_URL);
-  await signIn(p2, secret);
-  await p2.goto(
-    `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(drive)}`,
-  );
-
-  await expect(p2.getByText('SecondDeviceChild').first()).toBeVisible({
-    timeout: 12000,
-  });
-  await ctx2.close();
-});
+    await expect(p2.getByText('SecondDeviceChild').first()).toBeVisible({
+      timeout: 12000,
+    });
+    await ctx2.close();
+  },
+);

--- a/browser/e2e/tests/sync.spec.ts
+++ b/browser/e2e/tests/sync.spec.ts
@@ -16,44 +16,48 @@ import {
 test.describe('sync', () => {
   test.beforeEach(before);
 
-  test('create resource online, edit title, verify it persists across reload', smoke, async ({
-    page,
-  }) => {
-    // 1. Create a document in the drive (online)
-    await page
-      .getByTestId('sidebar')
-      .getByRole('button', { name: 'New Document' })
-      .click();
+  test(
+    'create resource online, edit title, verify it persists across reload',
+    smoke,
+    async ({ page }) => {
+      // 1. Create a document in the drive (online)
+      await page
+        .getByTestId('sidebar')
+        .getByRole('button', { name: 'New Document' })
+        .click();
 
-    await expect(editableTitle(page)).toBeVisible({ timeout: 10000 });
+      await expect(editableTitle(page)).toBeVisible({ timeout: 10000 });
 
-    // Set title
-    await editableTitle(page).click();
-    await expect(editableTitle(page)).toHaveRole('textbox');
-    await editableTitle(page).fill('Sync Test Doc');
-    await page.keyboard.press('Escape');
+      // Set title
+      await editableTitle(page).click();
+      await expect(editableTitle(page)).toHaveRole('textbox');
+      await editableTitle(page).fill('Sync Test Doc');
+      await page.keyboard.press('Escape');
 
-    // Wait for the title to be committed to the server
-    await expect(
-      page.getByTestId('sidebar').getByText('Sync Test Doc'),
-    ).toBeVisible({ timeout: 10000 });
+      // Wait for the title to be committed to the server
+      await expect(
+        page.getByTestId('sidebar').getByText('Sync Test Doc'),
+      ).toBeVisible({ timeout: 10000 });
 
-    // Wait for server to process the commit and rebuild index
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 10000 },
-    );
+      // Wait for server to process the commit and rebuild index
+      await page.waitForFunction(
+        () => window.store?.getSyncStatus().pendingDirtyCount === 0,
+        undefined,
+        { timeout: 10000 },
+      );
 
-    // 2. Reload and verify persistence
-    await page.reload({ waitUntil: 'domcontentloaded' });
-    await expect(currentDriveTitle(page)).toBeVisible({ timeout: 15000 });
+      // 2. Reload and verify persistence
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(currentDriveTitle(page)).toBeVisible({ timeout: 15000 });
 
-    // The document should be accessible (not unauthorized)
-    await expect(page.getByTestId('sidebar').locator('a').first()).toBeVisible({
-      timeout: 15000,
-    });
-  });
+      // The document should be accessible (not unauthorized)
+      await expect(
+        page.getByTestId('sidebar').locator('a').first(),
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    },
+  );
 
   test('edits made offline persist across reload', async ({ page }) => {
     test.slow();

--- a/browser/e2e/tests/sync.spec.ts
+++ b/browser/e2e/tests/sync.spec.ts
@@ -10,12 +10,13 @@ import {
   waitForSearchIndex,
   waitForServerConnected,
   waitForSynced,
+  smoke,
 } from './test-utils';
 
 test.describe('sync', () => {
   test.beforeEach(before);
 
-  test('create resource online, edit title, verify it persists across reload', async ({
+  test('create resource online, edit title, verify it persists across reload', smoke, async ({
     page,
   }) => {
     // 1. Create a document in the drive (online)

--- a/browser/e2e/tests/tables.spec.ts
+++ b/browser/e2e/tests/tables.spec.ts
@@ -12,6 +12,7 @@ import {
   waitForGridMounted,
   waitForSynced,
   waitForTableBuild,
+  smoke,
 } from './test-utils';
 
 /**
@@ -59,7 +60,7 @@ test.describe('tables', async () => {
   // races, leaving the cell-input not focused. Investigate: replace the
   // double-click pattern with a single-click + explicit Edit-mode
   // assertion, or use the keyboard-driven flow exclusively.
-  test('create and fill', async ({ page }) => {
+  test('create and fill', smoke, async ({ page }) => {
     test.slow();
 
     const newColumn = async (type: string) => {

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -5,6 +5,9 @@ import {
   registerPerfPage,
 } from './perf-attach';
 
+/** Playwright tag for the light CI gate (`pnpm test-e2e:light` / `--grep @smoke`). */
+export const smoke = { tag: '@smoke' } as const;
+
 export const PROPERTIES = {
   isA: 'https://atomicdata.dev/properties/isA',
   set: 'https://atomicdata.dev/properties/set',

--- a/browser/package.json
+++ b/browser/package.json
@@ -27,6 +27,7 @@
     "build": "pnpm --filter \"@tomic/lib\" run build && pnpm --filter=!./lib run -r build ",
     "test": "pnpm run -r test",
     "test-e2e": "pnpm run --filter @tomic/e2e test-e2e",
+    "test-e2e:light": "pnpm run --filter @tomic/e2e test-e2e:light",
     "test-query": "pnpm run --filter @tomic/e2e test-query",
     "test-query-debug": "pnpm run --filter @tomic/e2e test-query-debug",
     "start": "pnpm run -r --parallel start",

--- a/planning/README.md
+++ b/planning/README.md
@@ -65,7 +65,7 @@ Remaining work, not "this file exists."
 | [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md) | **Proposal.** Local-first Chromium extension. |
 | [`tours.md`](./tours.md) | Design, not built. |
 | [`rust-dependency-upgrade-audit.md`](./rust-dependency-upgrade-audit.md) | Audit notes for a Rust dependency upgrade pass. |
-| [`e2e-light-heavy.md`](./e2e-light-heavy.md) | **Proposal.** Playwright light on feature branches; full on `develop` / tags / opt-in. Non-E2E jobs always. Grow vitest + `jsTestIntegration` before shrinking heavy. |
+| [`e2e-light-heavy.md`](./e2e-light-heavy.md) | **Landing.** Playwright light on feature branches; full on `develop` / tags / opt-in. Steps 1–3 shipped. Remaining: grow vitest + `jsTestIntegration` before shrinking heavy. |
 
 ## Slices and companions
 

--- a/planning/README.md
+++ b/planning/README.md
@@ -65,7 +65,7 @@ Remaining work, not "this file exists."
 | [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md) | **Proposal.** Local-first Chromium extension. |
 | [`tours.md`](./tours.md) | Design, not built. |
 | [`rust-dependency-upgrade-audit.md`](./rust-dependency-upgrade-audit.md) | Audit notes for a Rust dependency upgrade pass. |
-| [`e2e-light-heavy.md`](./e2e-light-heavy.md) | **Proposal.** Playwright light (`@smoke`) on PRs; full suite on `develop` / tags. Grow vitest + `jsTestIntegration` before shrinking heavy. |
+| [`e2e-light-heavy.md`](./e2e-light-heavy.md) | **Proposal.** Playwright light on feature branches; full on `develop` / tags / opt-in. Non-E2E jobs always. Grow vitest + `jsTestIntegration` before shrinking heavy. |
 
 ## Slices and companions
 

--- a/planning/README.md
+++ b/planning/README.md
@@ -65,6 +65,7 @@ Remaining work, not "this file exists."
 | [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md) | **Proposal.** Local-first Chromium extension. |
 | [`tours.md`](./tours.md) | Design, not built. |
 | [`rust-dependency-upgrade-audit.md`](./rust-dependency-upgrade-audit.md) | Audit notes for a Rust dependency upgrade pass. |
+| [`e2e-light-heavy.md`](./e2e-light-heavy.md) | **Proposal.** Playwright light (`@smoke`) on PRs; full suite on `develop` / tags. Grow vitest + `jsTestIntegration` before shrinking heavy. |
 
 ## Slices and companions
 

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -195,7 +195,8 @@ list — tag these, do not copy them into a new file:
 | Create identity / sign in / sign out | `e2e.spec.ts`, `onboarding.spec.ts` | 1–2 tests |
 | Invite + share + second context accepts | `e2e.spec.ts` authorization | 1 (this *is* a flow test; protocol coverage is not a substitute) |
 | Chatroom | `e2e.spec.ts` | 1 |
-| Folder + document edit | `e2e.spec.ts` / `documents.spec.ts` | 1 |
+| Folder | `e2e.spec.ts` | 1 |
+| Document CRDT (create + websockets) | `documents.spec.ts` | 0 — already marked FLAKY; folder covers create |
 | Table create + type a row | `tables.spec.ts` `create and fill` | 1 |
 | Search | `search.spec.ts` text search | 1 |
 | Offline edit survives reload + reconnect | `sync.spec.ts` | 1 |

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -2,9 +2,11 @@
 
 **Status: proposal, not built.** Analysis 2026-08-20.
 
-Yes: split Playwright into a **light** suite that gates everyday CI, and a
-**heavy** suite that gates `develop` / tags / releases. Also yes: that only
-works if the cases we drop from the PR gate already have a cheaper test at
+Yes: split Playwright into a **light** suite that gates feature-branch CI,
+and a **heavy** suite that gates `develop` / tags / releases. Lint, Rust,
+vitest, JS integration, and Flutter stay on **every** run — “partial” means
+fewer browsers, not a thinner backend net. The split only works if the
+cases we drop from the feature-branch gate already have a cheaper test at
 the right layer. Do not shrink E2E first and hope unit tests appear later.
 
 Companion: [`TESTING_COVERAGE.md`](../TESTING_COVERAGE.md) — protocol vs glue
@@ -111,40 +113,73 @@ integration tests.
 
 ## Proposed model
 
-Three layers, two E2E gates.
+Three layers. **Only Playwright splits.** Lint, Rust, vitest, JS integration,
+and Flutter stay on every run.
 
 ```
-unit (vitest / cargo)     always, PR + develop + tag
-integration (jsTestIntegration, server `it`, lib sync)
-                          always
-e2e light  (@smoke)       every PR, and local `pnpm test-e2e:light`
-e2e heavy  (full suite)   develop, v* tags, workflow_dispatch, nightly-optional
+always (any branch / tag / dispatch)
+  jsLint, rustFmt, rustClippy, rustTest, jsTest, jsTestIntegration, flutterTest
+
+e2e light  (@smoke)     feature-branch pushes (today's `on: push` to anything but develop)
+e2e heavy  (full suite) develop, v* tags, and opt-in
 ```
 
 Mechanism: Playwright **tags**, not two folders. A test can be `@smoke` and
 still run in heavy (heavy = unfiltered). Light is `--grep @smoke`. Optional
 later: `@perf` excluded from both default jobs and run on a schedule.
 
-### When each gate runs
+### CI policy: when full?
 
-| Trigger | Light | Heavy |
+**Partial by default. Full when we are about to ship, or when someone asks.**
+
+Today every origin push runs the full Playwright suite (`main.yml` is
+`on: [push, workflow_dispatch]`; there is no `pull_request` trigger). That
+is why Mancave queues: agent branches and feature branches compete with
+`develop` for the same box. The split only pays off if feature-branch
+pushes stop launching 8 browsers.
+
+| Trigger | Unit / integration / lint | Playwright |
 |---|---|---|
-| PR / feature-branch push | required | no |
-| `develop` push (staging) | included in heavy | required |
-| `v*` tag (production) | included in heavy | required |
-| Local default `pnpm test-e2e` | — | full (today's behavior) |
-| Local inner loop | `test-e2e:light` | on demand |
+| Push to a feature branch | always, required | **light**, required |
+| Push to `develop` | always, required | **full**, required (staging deploys from this green) |
+| Push of a stable `v*` tag | always, required | **full**, required (production deploys from this green) |
+| `workflow_dispatch` | always | **full** unless the input says light |
+| PR label / dispatch input `full-e2e` on a feature branch | always | **full** (opt-in, still required for that run) |
+| Local `pnpm test-e2e` | — | full (today) |
+| Local `pnpm test-e2e:light` | — | light |
 
-PRs stay mergeable without waiting for website-template applies and kanban
-operator matrices. `develop` still refuses to stage a build that broke an
-offline table reload.
+Never skip the non-Playwright jobs on a “partial” run. Those are the cheap
+net, already parallel with E2E, and they are where protocol bugs belong.
+“Partial CI” means **fewer browsers**, not “skip Rust.”
 
-Retries: light can run `retries=1` (or 0 locally). Heavy keeps `retries=2`
-on Mancave until the host is less contended. A smaller light job also *is*
-the contention fix: fewer browsers next to cargo.
+Do **not**:
 
-Shards: light likely needs **1–2 shards**, not 4. That frees CPU for
-clippy/nextest on the same box.
+- Run light on `develop`. Staging (`deploy_staging.yml`) follows a green
+  Main on `develop`. A subset gate would ship untested offline / table /
+  two-browser paths.
+- Run full E2E as a non-blocking extra job on every feature branch. That
+  keeps Mancave contended and undoes the split.
+- Infer the suite from changed paths (`tables.spec.ts` if `TablePage`
+  changed). Brittle, and agents will get it wrong. Opt-in full on the
+  branch if you touched a heavy-only flow and want the answer before merge.
+- Skip E2E entirely on docs-only commits as a first step. Dagger cache
+  already makes those ~2–12 min. A GHA path filter is an optional later
+  save, not the policy.
+
+**Merge tax.** A light-green feature branch can still turn `develop` red.
+That is the point of the `develop` gate: staging waits, the author (or
+whoever lands) pays the full suite once, not on every push. Use the
+`full-e2e` opt-in when the change is in a heavy-only area (offline tables,
+canvas, vault, website templates) so you find that before merge.
+
+Retries: light `retries=1` (0 locally). Heavy keeps `retries=2` on Mancave
+until the host is less contended. A smaller default job *is* the contention
+fix.
+
+Shards: light **1–2 shards**, not 4. Full keeps current 4 / 2.
+
+Nightly full-on-`develop` is optional later (retries=0, flake hunting). It
+is not required if every `develop` push already runs full.
 
 ---
 
@@ -268,28 +303,25 @@ that can fail.
 ## CI / Dagger shape (when building)
 
 Today `ci()` always calls `this.endToEnd(...)`, which shards the full
-suite. Change:
+suite. The workflow decides the mode; Dagger does not guess the branch.
 
-- `endToEnd(mode: 'light' | 'full')`.
-- `ci()` takes the same flag (or infers from git ref inside the workflow,
-  not inside Dagger — the workflow already knows branch vs tag).
+- `endToEnd(mode: 'light' | 'full')`, same flag on `ci()`.
+- `main.yml` passes `full` when `github.ref == develop` or the ref is a
+  stable `v*` tag, or when dispatch / a `full-e2e` label (or boolean
+  input) asks. Everything else passes `light`.
 - Light: `--grep @smoke`, 1–2 shards, `PLAYWRIGHT_RETRIES=1`,
   `PLAYWRIGHT_WORKERS=2` on Mancave.
 - Full: current command, current shards/retries.
 - `pnpm` scripts: `test-e2e:light` / keep `test-e2e` = full.
 - Do not grep-exclude by filename forever; tags survive file splits.
 
-`develop` and tags keep today's contract: staging/production only move
-when the heavy suite is green. Feature branches get the light gate plus
-the always-on unit/integration jobs (those are cheap and already
-parallel).
-
 Optional later, not required for the split to pay off:
 
-- Nightly heavy on `develop` even if a push already ran it (catches flake
-  that slipped a retry).
+- Nightly full on `develop` with `retries=0` (flake hunting).
 - `@perf` job, one shard, `workers=1`, no retries, fail on budget miss.
 - Firefox/WebKit projects stay heavy-only (locks + sign-out round-trip).
+- Docs-only path filter that skips Playwright entirely (Dagger cache
+  already makes these cheap).
 
 ---
 

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -1,6 +1,6 @@
 # Light vs heavy E2E, and where unit tests should grow
 
-**Status: landing.** Tags, `test-e2e:light`, Dagger `--e2e-mode`, and
+**Status: landing.** Tags, `test-e2e:light`, Dagger `--playwright-mode`, and
 `main.yml` gating are in. Remaining: grow `jsTestIntegration`, stop adding
 heavy-only variants as Playwright, then drop redundant heavy specs.
 
@@ -304,10 +304,11 @@ that can fail.
 
 ## CI / Dagger shape (when building)
 
-Today `ci()` takes `--e2e-mode light|full` and passes it to `endToEnd`.
+Today `ci()` takes `--playwright-mode light|full` and passes it to `endToEnd`.
 The workflow decides the mode; Dagger does not guess the branch.
 
-- `endToEnd(mode: 'light' | 'full')`, same flag on `ci()`.
+- `endToEnd` / `ci` take `--playwright-mode light|full` (not `--e2e-mode`:
+  Dagger camelCases that to `e2EMode` and the call fails).
 - `main.yml` passes `full` when `github.ref == develop` or the ref is a
   stable `v*` tag, or when dispatch / a `full-e2e` label (or boolean
   input) asks. Everything else passes `light`.

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -1,0 +1,325 @@
+# Light vs heavy E2E, and where unit tests should grow
+
+**Status: proposal, not built.** Analysis 2026-08-20.
+
+Yes: split Playwright into a **light** suite that gates everyday CI, and a
+**heavy** suite that gates `develop` / tags / releases. Also yes: that only
+works if the cases we drop from the PR gate already have a cheaper test at
+the right layer. Do not shrink E2E first and hope unit tests appear later.
+
+Companion: [`TESTING_COVERAGE.md`](../TESTING_COVERAGE.md) — protocol vs glue
+vs flow. This plan is about *which flow tests run when*, not about abandoning
+the flow layer.
+
+---
+
+## Verdict
+
+The suite is doing two jobs in one job:
+
+1. **Can a person still use the app?** Sign in, make a document, share it,
+   edit a table, survive reload. A few dozen browser tests.
+2. **Did this operator / template / offline path / regression still work?**
+   Combinatorics, serial specs, two-browser sessions, website scaffolding,
+   perf probes. Another ~140 tests, most of the wall time.
+
+Job 1 belongs on every PR. Job 2 belongs on `develop`, on `v*` tags, and
+whenever someone is about to ship. The missing piece is not more Playwright:
+it is using the layers we already have so job 2 does not have to live in a
+browser.
+
+---
+
+## What is expensive today
+
+Playwright is the slow lane. Counts from this tree (2026-08-20):
+
+| Layer | Size | CI job |
+|---|---|---|
+| Playwright | 68 spec files, ~172 `test()`s, ~13.5k lines | `endToEnd` |
+| Browser unit (vitest) | ~100 files (`@tomic/lib` + data-browser helpers) | `jsTest` |
+| Browser integration (vitest + real `atomic-server`, no UI) | 5 files under `browser/lib/tests/` | `jsTestIntegration` |
+| Rust | ~580 `#[test]` / `#[tokio::test]` | `rustTest` |
+
+There is **no React Testing Library**. UI is only asserted through Playwright.
+
+CI already shards E2E (Mancave: 4 shards × 2 workers, `retries=2`; hosted: 2
+shards × 1 worker). `ci()` runs those browsers **in parallel with** clippy,
+nextest, Flutter, and two vitest jobs. Dagger comments record the cost: at 3
+workers Chromium was killed outright ("Target page, context or browser has
+been closed") — starvation, not a race. Retries were dropped to 1 to save
+wall time, then raised back to 2 because remaining failures rotated run to
+run. The retries are buying headroom the host does not have.
+
+Wall-clock of a Main run is not the same as E2E runtime. Recent Mancave
+successes (2026-08-20):
+
+- Docs-only / cache hit: **~2–12 min** end to end.
+- Code changes: **~15–45 min** of actual `Main (Mancave) / CI` once the
+  runner starts. Queue time on a busy box can add another hour before that.
+- Playwright config still talks about a **~50 min e2e budget** as the reason
+  retries were cut.
+
+Every test that uses `before` (`test-utils.ts`) pays a full `/app/dev-drive`
+bootstrap: WASM ClientDb + OPFS + genesis agent + drive. ~50 specs do this
+per test. Setup tax scales with test count, not with assertion count.
+
+Other known drags, already documented in-tree:
+
+- `template.spec.ts` is serial and spawns Next.js / SvelteKit applies.
+- `table-refresh.spec.ts` is serial.
+- Two-browser specs (`e2e.spec.ts` invite/chatroom, `meetings`, `presence-follow`,
+  `second-device-load`, `drive-deeplink`, `vault-backup-restore`, `onboarding`,
+  `sync.spec.ts`) hold extra contexts.
+- Perf / profile specs (`first-paint-*`, `dev-drive-timing/profile`,
+  `opfs-init-perf`, `perf-budgets`, `perf-sidebar-reload`,
+  `table-create-perf`) are probes. Several already `test.skip` unless an env
+  var is set, but they still occupy the suite.
+- Staging deploys from `develop` only after Main is green
+  (`deploy_staging.yml`). Production follows a `v*` tag. The full suite is
+  load-bearing for those two gates; PRs do not have to share that cost.
+
+`e2e.spec.ts` already says this out loud: *these tests are relatively slow,
+try to utilize unit tests to catch bugs earlier.*
+
+---
+
+## The trap
+
+[`TESTING_COVERAGE.md`](../TESTING_COVERAGE.md) exists because **protocol is
+well tested and glue/flow is not**, and every production device-sync bug so
+far lived in an uncovered glue/flow row. A light suite that is just "delete
+half the specs" would recreate that imbalance in the browser.
+
+So:
+
+- Keep **one** Playwright test per user journey that can only fail in the
+  UI (click, dialog, drag, two tabs, reload with OPFS).
+- Move **combinatorics** (operators, templates, filter keys, row actions,
+  pairing envelope validation) down to vitest / Rust, where many already
+  live.
+- Prefer `jsTestIntegration` (real server, `Store` + `NodeClientDb`, no
+  browser) for "does the client actually persist / sync / upload" before
+  adding another Playwright file. That job exists and is underused: five
+  tests covering upload, genesis, wasm smoke.
+
+Do **not** introduce React Testing Library as the escape hatch. The cost of
+a third UI-test stack is higher than tagging Playwright and growing helper /
+integration tests.
+
+---
+
+## Proposed model
+
+Three layers, two E2E gates.
+
+```
+unit (vitest / cargo)     always, PR + develop + tag
+integration (jsTestIntegration, server `it`, lib sync)
+                          always
+e2e light  (@smoke)       every PR, and local `pnpm test-e2e:light`
+e2e heavy  (full suite)   develop, v* tags, workflow_dispatch, nightly-optional
+```
+
+Mechanism: Playwright **tags**, not two folders. A test can be `@smoke` and
+still run in heavy (heavy = unfiltered). Light is `--grep @smoke`. Optional
+later: `@perf` excluded from both default jobs and run on a schedule.
+
+### When each gate runs
+
+| Trigger | Light | Heavy |
+|---|---|---|
+| PR / feature-branch push | required | no |
+| `develop` push (staging) | included in heavy | required |
+| `v*` tag (production) | included in heavy | required |
+| Local default `pnpm test-e2e` | — | full (today's behavior) |
+| Local inner loop | `test-e2e:light` | on demand |
+
+PRs stay mergeable without waiting for website-template applies and kanban
+operator matrices. `develop` still refuses to stage a build that broke an
+offline table reload.
+
+Retries: light can run `retries=1` (or 0 locally). Heavy keeps `retries=2`
+on Mancave until the host is less contended. A smaller light job also *is*
+the contention fix: fewer browsers next to cargo.
+
+Shards: light likely needs **1–2 shards**, not 4. That frees CPU for
+clippy/nextest on the same box.
+
+---
+
+## What belongs in light (~25–35 tests)
+
+One happy path per product surface a user hits in the first hour. Draft
+list — tag these, do not copy them into a new file:
+
+| Journey | Source spec | Keep in light |
+|---|---|---|
+| Create identity / sign in / sign out | `e2e.spec.ts`, `onboarding.spec.ts` | 1–2 tests |
+| Invite + share + second context accepts | `e2e.spec.ts` authorization | 1 (this *is* a flow test; protocol coverage is not a substitute) |
+| Chatroom | `e2e.spec.ts` | 1 |
+| Folder + document edit | `e2e.spec.ts` / `documents.spec.ts` | 1 |
+| Table create + type a row | `tables.spec.ts` `create and fill` | 1 |
+| Search | `search.spec.ts` text search | 1 |
+| Offline edit survives reload + reconnect | `sync.spec.ts` | 1 |
+| Second device cold-loads a drive | `second-device-load.spec.ts` | 1 |
+| Drive deep link adopts the right drive | `drive-deeplink.spec.ts` | 1 |
+| Kanban: create board + drag persists | `kanban.spec.ts` | 1 |
+| Dashboard: one block with a real total | `dashboard.spec.ts` | 1 |
+| Meeting prepare → start | `meetings.spec.ts` | 1 |
+| File upload round-trip | `filePicker.spec.ts` or `file-upload-offline` online case | 1 |
+| Pairing: paste code success (Tauri-gated form) | `pairing-dialog.spec.ts` | 1 |
+| Ontology create/edit | `ontology.spec.ts` | 1 |
+| History page | `e2e.spec.ts` | 1 |
+| Delete resource | `e2e.spec.ts` | 1 |
+
+That is roughly 20 tests plus a small buffer. Everything else in those files
+stays in the repo and runs in heavy.
+
+Rule of thumb for adding a new `@smoke` tag: **would a broken test here
+mean we cannot demo the app?** If it is an operator, a template, a
+Firefox-only lock, or a perf budget, it is heavy.
+
+---
+
+## What belongs only in heavy
+
+Group by why they are expensive or redundant as a PR gate.
+
+**Combinatorics already unit-tested** — keep one smoke, run the rest in
+heavy until (or after) the unit tests are trusted as the regression net:
+
+- Table filters / views, derived columns, aggregates, row actions, quick
+  add, templates (`table-*.spec.ts`, `derived-columns`, `aggregates`,
+  `quick-add`, `row-actions`) — twins exist:
+  `tableFiltering.test.ts`, `derivedColumns.test.ts`,
+  `tableAggregates.test.ts`, `rowActions.test.ts`, `quickAdd.test.ts`,
+  `tableTemplates.test.ts`.
+- Forks (`forks.spec.ts` vs `browser/lib/src/forks.test.ts`).
+- Pairing malformed / remembered-peer cards (`pairing.test.ts`,
+  `knownPeers.test.ts`).
+- Dashboard block math (`dashboardBlocks.test.ts`).
+- Meeting lifecycle helpers (`meetingLifecycle.test.ts`).
+- Vault helpers (`helpers/managed/*.test.ts`).
+- AI compact / tool XML (`chunks/AI/*.test.ts`). The E2E file is fully
+  mock-routed; it tests chrome, not a model.
+
+**Multi-session / OPFS / server-only fallbacks** — these *are* flow tests
+and should stay Playwright, just not on every PR:
+
+- `offline-*`, `local-db-off-*`, `server-only-fallback`,
+  `clientdb-edit-persistence`, `signout-signin-data`,
+  `sign-in-without-data`, `client-db-locks` (incl. Firefox project),
+  `canvas-*`, `presence-follow`, `vault-backup-restore`.
+
+**Product surfaces that are not the first-hour path:**
+
+- `timer`, `calendar`, `plugin`, `template.spec.ts` (Next/Svelte apply),
+  `ai.spec.ts`, `localized-text`, `JSONProp`, `tags`, `discussion`,
+  `shortcuts`, `settings`, `default-ontology`, `query-drive-filter`,
+  `resource-context-menu`, `rename-regression`, `table-refresh` (serial),
+  `sync-devices` (QR copy / form gate — pairing success is the smoke).
+
+**Perf probes** — never a PR gate. Exclude with `@perf` (or keep today's
+`test.skip` + env). Run on a schedule or locally with
+`ATOMIC_TEST_CPU_THROTTLE`.
+
+---
+
+## Unit / integration gaps to fill *before* shrinking heavy
+
+Do not move a spec to heavy-only and then delete it later unless the row
+below exists.
+
+| Gap | Better layer than more E2E |
+|---|---|
+| Offline create → reconnect → server has the commit | `jsTestIntegration` (extend upload-offline-reconnect pattern) |
+| Collection query + AND filters without a grid | already Rust + `multi-property-filter`; UI stays one E2E |
+| Kanban group-by precedence (explicit > existing select > auto-create) | data-browser helper unit test; DnD stays E2E |
+| Table view config persist (filters/sort/columns) | helper unit + one E2E reload |
+| Search overlay parsing (`tag:`, scoped) | small parser unit; overlay E2E stays one test |
+| Document CRDT / cursor | keep E2E; no RTL |
+| Chatroom invite across contexts | keep E2E; this is the flow |
+| `/app/dev-drive` bootstrap timing | perf job, not unit |
+
+`@tomic/lib` is in good shape. data-browser unit tests cluster on **tables
+and managed-node helpers**. Thin spots are RTE/documents, search overlay,
+ontology editor, plugin loader, settings — those should keep Playwright
+until a helper is extracted, not a mock React tree.
+
+Policy for new tests (put this in `TESTING_COVERAGE.md` and
+`browser/e2e/README.md` when building):
+
+1. If the logic is a pure function or a Store method, write vitest / Rust
+   first.
+2. If it is "client talks to a real server, no UI", add
+   `*.integration.test.ts`.
+3. If it is a user journey, add **one** Playwright test. Tag `@smoke` only
+   if a failure means the demo is dead.
+4. Extra operators, templates, and "also works offline" variants go to
+   heavy, or to (1)/(2) instead.
+
+Debugging process in `AGENTS.md` currently pushes agents toward E2E
+("reproduce the bug in a test"). Amend it: reproduce at the cheapest layer
+that can fail.
+
+---
+
+## CI / Dagger shape (when building)
+
+Today `ci()` always calls `this.endToEnd(...)`, which shards the full
+suite. Change:
+
+- `endToEnd(mode: 'light' | 'full')`.
+- `ci()` takes the same flag (or infers from git ref inside the workflow,
+  not inside Dagger — the workflow already knows branch vs tag).
+- Light: `--grep @smoke`, 1–2 shards, `PLAYWRIGHT_RETRIES=1`,
+  `PLAYWRIGHT_WORKERS=2` on Mancave.
+- Full: current command, current shards/retries.
+- `pnpm` scripts: `test-e2e:light` / keep `test-e2e` = full.
+- Do not grep-exclude by filename forever; tags survive file splits.
+
+`develop` and tags keep today's contract: staging/production only move
+when the heavy suite is green. Feature branches get the light gate plus
+the always-on unit/integration jobs (those are cheap and already
+parallel).
+
+Optional later, not required for the split to pay off:
+
+- Nightly heavy on `develop` even if a push already ran it (catches flake
+  that slipped a retry).
+- `@perf` job, one shard, `workers=1`, no retries, fail on budget miss.
+- Firefox/WebKit projects stay heavy-only (locks + sign-out round-trip).
+
+---
+
+## What not to do
+
+- Two copies of each spec in `tests/light/` and `tests/heavy/`.
+- Light-only on `develop`. Staging would then ship on a subset.
+- Deleting heavy tests whose only coverage is Playwright, "to save CI",
+  before a unit/integration twin exists.
+- Treating mocked `ai.spec.ts` as a substitute for tool-unit tests, or
+  vice versa.
+- Raising Mancave workers again to make the full suite faster. The box is
+  already oversubscribed; a smaller default job is the fix.
+- A new component-test framework.
+
+---
+
+## Build order (not started)
+
+1. Tag the draft smoke list; add `test-e2e:light`. Measure locally:
+   count, wall time, failures vs full.
+2. Wire Dagger + `main.yml` so PRs run light, `develop`/tags run full.
+   Confirm staging still waits on the full job.
+3. Document the policy in `TESTING_COVERAGE.md`, `browser/e2e/README.md`,
+   `AGENTS.md` (cheapest layer first).
+4. For each heavy spec that duplicates a unit file, leave the E2E in heavy
+   and stop adding variants there. New variants go to vitest.
+5. Grow `jsTestIntegration` for offline/sync/upload paths that currently
+   exist only as Playwright.
+6. Only then drop individual heavy tests that have become redundant.
+
+Step 1–3 is the split. Step 4–6 is how the heavy suite stops growing
+faster than the product.

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -1,6 +1,8 @@
 # Light vs heavy E2E, and where unit tests should grow
 
-**Status: proposal, not built.** Analysis 2026-08-20.
+**Status: landing.** Tags, `test-e2e:light`, Dagger `--e2e-mode`, and
+`main.yml` gating are in. Remaining: grow `jsTestIntegration`, stop adding
+heavy-only variants as Playwright, then drop redundant heavy specs.
 
 Yes: split Playwright into a **light** suite that gates feature-branch CI,
 and a **heavy** suite that gates `develop` / tags / releases. Lint, Rust,
@@ -302,8 +304,8 @@ that can fail.
 
 ## CI / Dagger shape (when building)
 
-Today `ci()` always calls `this.endToEnd(...)`, which shards the full
-suite. The workflow decides the mode; Dagger does not guess the branch.
+Today `ci()` takes `--e2e-mode light|full` and passes it to `endToEnd`.
+The workflow decides the mode; Dagger does not guess the branch.
 
 - `endToEnd(mode: 'light' | 'full')`, same flag on `ci()`.
 - `main.yml` passes `full` when `github.ref == develop` or the ref is a
@@ -339,13 +341,11 @@ Optional later, not required for the split to pay off:
 
 ---
 
-## Build order (not started)
+## Build order
 
-1. Tag the draft smoke list; add `test-e2e:light`. Measure locally:
-   count, wall time, failures vs full.
-2. Wire Dagger + `main.yml` so PRs run light, `develop`/tags run full.
-   Confirm staging still waits on the full job.
-3. Document the policy in `TESTING_COVERAGE.md`, `browser/e2e/README.md`,
+1. [x] Tag the draft smoke list; add `test-e2e:light`.
+2. [x] Wire Dagger + `main.yml` so feature branches run light, `develop`/tags run full.
+3. [x] Document the policy in `TESTING_COVERAGE.md`, `browser/e2e/README.md`,
    `AGENTS.md` (cheapest layer first).
 4. For each heavy spec that duplicates a unit file, leave the E2E in heavy
    and stop adding variants there. New variants go to vitest.
@@ -353,5 +353,5 @@ Optional later, not required for the split to pay off:
    exist only as Playwright.
 6. Only then drop individual heavy tests that have become redundant.
 
-Step 1–3 is the split. Step 4–6 is how the heavy suite stops growing
+Step 1–3 is the split (landed). Step 4–6 is how the heavy suite stops growing
 faster than the product.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the light vs heavy Playwright split from `planning/e2e-light-heavy.md`.

## CI policy

Lint, Rust, vitest, JS integration, and Flutter still run on **every** job. Only Playwright splits.

| Trigger | Playwright |
|---|---|
| Feature-branch push | **light** (`@smoke`, 17 tests) |
| `develop` push | **full** (staging) |
| stable `v*` tag | **full** (production) |
| `workflow_dispatch` `e2e_mode=full`, `[full-e2e]` in the commit, or PR label `full-e2e` | **full** |

`dagger call ci --playwright-mode light|full` (default `full`). Do not use `--e2e-mode`: Dagger camelCases that to `e2EMode` and the call fails before tests start.

## Light suite (`@smoke`)

Sign-in, share/invite, chatroom, folder, table create-and-fill, search, persist-across-reload, second device, drive deep link, kanban drag, dashboard totals, meeting start, upload, pairing success, ontology create/edit, history, delete resource.

Document CRDT (`documents.spec.ts` create + websockets) stays **full-only**. It is already marked FLAKY for multi-context WS under Dagger contention; putting it on the feature-branch gate made CI red (`New paragraph not found after typing`). Folder create remains the first-hour cover.

Run locally: `cd browser && pnpm test-e2e:light`. Full suite remains `pnpm test-e2e`.

Light CI uses fewer shards and `retries=1`. Full keeps today's shards/retries.

## Not in this PR

Growing `jsTestIntegration` or deleting heavy specs. Those stay; they just no longer gate every feature-branch push.

## Related Issues

n/a

## Checklist
- [ ] Changelog — CI/test infra, no product API change
- [x] Tests tagged; `test-e2e:light` added
- [x] Docs: `TESTING_COVERAGE.md`, `browser/e2e/README.md`, `AGENTS.md`, `CONTRIBUTING.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-862d6197-9d49-43e6-844f-9baa917443da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-862d6197-9d49-43e6-844f-9baa917443da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

