### PR TITLE
fix(canvas): oxlint padding in undo bootstrap

### DIFF
--- a/browser/data-browser/src/views/Canvas/CanvasPage.tsx
+++ b/browser/data-browser/src/views/Canvas/CanvasPage.tsx
@@ -520,8 +520,10 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
    *  load. */
   const ensureUndoStack = useCallback(async () => {
     if (bootstrappedRef.current) return;
+
     if (bootstrappingPromiseRef.current) {
       await bootstrappingPromiseRef.current;
+
       return;
     }
 
@@ -539,8 +541,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
           resource.get(canvas.properties.strokeData),
         );
         const steps = bootstrapUndoSteps(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          versions.map((v: any) => v.propvals.get(canvas.properties.strokeData)),
+          versions.map(v => v.propvals.get(canvas.properties.strokeData)),
           current,
         );
 
@@ -551,8 +552,12 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
         // it twice.
         if (undoStackRef.current.length > 0) {
           const filtered = steps.filter(
-            step => !undoStackRef.current.some(existing => strokesEqual(existing, step)),
+            step =>
+              !undoStackRef.current.some(existing =>
+                strokesEqual(existing, step),
+              ),
           );
+
           undoStackRef.current = [...filtered, ...undoStackRef.current].slice(
             -UNDO_STACK_LIMIT,
           );

--- a/browser/data-browser/src/views/Canvas/CanvasPage.tsx
+++ b/browser/data-browser/src/views/Canvas/CanvasPage.tsx
@@ -511,13 +511,15 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
    *  hovering it, pressing it, or Ctrl+Z — rather than on open. Runs at most
    *  once per canvas per device; cheap to call on every interaction after.
    *
-   *  Synchronous: the undo control is only enabled once the mount effect has
-   *  awaited the Loro WASM, so by the time anything can call this the oplog
-   *  is readable. */
-  const ensureUndoStack = useCallback(() => {
+   *  Async: awaits Loro WASM readiness before reading the oplog, so it's
+   *  safe to call from the keyboard shortcut (Ctrl+Z) even on a cold page
+   *  load. */
+  const ensureUndoStack = useCallback(async () => {
     if (bootstrappedRef.current) return;
 
-    if (undoStackRef.current.length > 0 || redoStackRef.current.length > 0) {
+    try {
+      await enableLoro();
+    } catch {
       return;
     }
 
@@ -526,22 +528,31 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
       resource.get(canvas.properties.strokeData),
     );
     const steps = bootstrapUndoSteps(
-      versions.map(v => v.propvals.get(canvas.properties.strokeData)),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      versions.map((v: any) => v.propvals.get(canvas.properties.strokeData)),
       current,
     );
+
+    // If the user started drawing before this completed, prepend the Loro
+    // history (which is older) to the existing undo stack instead of
+    // discarding their edits.
+    if (undoStackRef.current.length > 0) {
+      undoStackRef.current = [...steps, ...undoStackRef.current].slice(
+        -UNDO_STACK_LIMIT,
+      );
+    } else {
+      undoStackRef.current = steps;
+    }
 
     // Record the attempt even when it found nothing, so a canvas with no
     // recoverable history doesn't pay for the walk again on the next open.
     bootstrappedRef.current = true;
-    undoStackRef.current = steps;
-    // Opening only counted version buckets. If every one of them holds the
-    // drawing as it looks right now, there is nothing to undo after all.
-    setCanUndo(steps.length > 0);
+    setCanUndo(undoStackRef.current.length > 0);
     persistHistory();
   }, [resource, persistHistory]);
 
   const handleUndo = useCallback(async () => {
-    ensureUndoStack();
+    await ensureUndoStack();
 
     if (undoStackRef.current.length === 0) return;
 
@@ -651,7 +662,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     (e: React.PointerEvent) => {
       if (!canUndo && !canRedo && branchesRef.current.length === 0) return;
 
-      ensureUndoStack();
+      void ensureUndoStack();
 
       e.preventDefault();
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
@@ -1589,7 +1600,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
             // Build the undo stack on hover, so the press that follows acts
             // on a stack that is already there. The press paths call this
             // too — touch and Ctrl+Z never hover.
-            onPointerEnter={ensureUndoStack}
+            onPointerEnter={() => void ensureUndoStack()}
             disabled={!canUndo && !canRedo && branches.length === 0}
             aria-pressed={previewStrokes !== null}
           >

--- a/browser/data-browser/src/views/Canvas/CanvasPage.tsx
+++ b/browser/data-browser/src/views/Canvas/CanvasPage.tsx
@@ -160,9 +160,9 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
   /** Whether the Loro-history bootstrap has already run for this canvas on
    *  this device. Persisted so it runs at most once — see the mount effect. */
   const bootstrappedRef = useRef(false);
-  /** In-flight guard: true while a bootstrap operation is running. Prevents
-   *  concurrent calls from duplicating history. */
-  const bootstrappingRef = useRef(false);
+  /** In-flight guard: holds a promise while a bootstrap operation is running.
+   *  Waiters join the in-flight work instead of bailing. */
+  const bootstrappingPromiseRef = useRef<Promise<void> | null>(null);
 
   // Discarded branch leaves — versions abandoned by editing after an undo,
   // recoverable from the overlay while holding the undo button. Kept in a
@@ -324,6 +324,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     redoStackRef.current = stored.redo;
     branchesRef.current = stored.branches;
     bootstrappedRef.current = stored.bootstrapped;
+    bootstrappingPromiseRef.current = null;
     setBranches(stored.branches);
     setCanUndo(stored.undo.length > 0);
     setCanRedo(stored.redo.length > 0);
@@ -519,57 +520,58 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
    *  load. */
   const ensureUndoStack = useCallback(async () => {
     if (bootstrappedRef.current) return;
-    if (bootstrappingRef.current) return;
-
-    bootstrappingRef.current = true;
-    const targetResource = resource;
-
-    try {
-      await enableLoro();
-    } catch {
-      bootstrappingRef.current = false;
-
+    if (bootstrappingPromiseRef.current) {
+      await bootstrappingPromiseRef.current;
       return;
     }
 
-    if (resource !== targetResource) {
-      bootstrappingRef.current = false;
+    const targetSubject = resource.subject;
+    const promise = (async () => {
+      try {
+        await enableLoro();
 
-      return;
-    }
+        if (resource.subject !== targetSubject) {
+          return;
+        }
 
-    const versions = resource.getLoroHistory();
-    const current = parseCanvasStrokes(
-      resource.get(canvas.properties.strokeData),
-    );
-    const steps = bootstrapUndoSteps(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      versions.map((v: any) => v.propvals.get(canvas.properties.strokeData)),
-      current,
-    );
+        const versions = resource.getLoroHistory();
+        const current = parseCanvasStrokes(
+          resource.get(canvas.properties.strokeData),
+        );
+        const steps = bootstrapUndoSteps(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          versions.map((v: any) => v.propvals.get(canvas.properties.strokeData)),
+          current,
+        );
 
-    // If the user started drawing before this completed, prepend the Loro
-    // history (which is older) to the existing undo stack instead of
-    // discarding their edits. Filter out duplicates: if pushUndoSnapshot
-    // already captured a state that's also in the Loro history, don't add
-    // it twice.
-    if (undoStackRef.current.length > 0) {
-      const filtered = steps.filter(
-        step => !undoStackRef.current.some(existing => strokesEqual(existing, step)),
-      );
-      undoStackRef.current = [...filtered, ...undoStackRef.current].slice(
-        -UNDO_STACK_LIMIT,
-      );
-    } else {
-      undoStackRef.current = steps;
-    }
+        // If the user started drawing before this completed, prepend the Loro
+        // history (which is older) to the existing undo stack instead of
+        // discarding their edits. Filter out duplicates: if pushUndoSnapshot
+        // already captured a state that's also in the Loro history, don't add
+        // it twice.
+        if (undoStackRef.current.length > 0) {
+          const filtered = steps.filter(
+            step => !undoStackRef.current.some(existing => strokesEqual(existing, step)),
+          );
+          undoStackRef.current = [...filtered, ...undoStackRef.current].slice(
+            -UNDO_STACK_LIMIT,
+          );
+        } else {
+          undoStackRef.current = steps;
+        }
 
-    // Record the attempt even when it found nothing, so a canvas with no
-    // recoverable history doesn't pay for the walk again on the next open.
-    bootstrappedRef.current = true;
-    bootstrappingRef.current = false;
-    setCanUndo(undoStackRef.current.length > 0);
-    persistHistory();
+        // Record the attempt even when it found nothing, so a canvas with no
+        // recoverable history doesn't pay for the walk again on the next open.
+        bootstrappedRef.current = true;
+        setCanUndo(undoStackRef.current.length > 0);
+        persistHistory();
+      } finally {
+        bootstrappingPromiseRef.current = null;
+      }
+    })();
+
+    bootstrappingPromiseRef.current = promise;
+    await promise;
   }, [resource, persistHistory]);
 
   const handleUndo = useCallback(async () => {
@@ -683,10 +685,10 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     async (e: React.PointerEvent) => {
       if (!canUndo && !canRedo && branchesRef.current.length === 0) return;
 
-      await ensureUndoStack();
-
       e.preventDefault();
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+
+      await ensureUndoStack();
 
       const timeline = timelineOf(
         { undo: undoStackRef.current, redo: redoStackRef.current },

--- a/browser/data-browser/src/views/Canvas/CanvasPage.tsx
+++ b/browser/data-browser/src/views/Canvas/CanvasPage.tsx
@@ -160,6 +160,9 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
   /** Whether the Loro-history bootstrap has already run for this canvas on
    *  this device. Persisted so it runs at most once — see the mount effect. */
   const bootstrappedRef = useRef(false);
+  /** In-flight guard: true while a bootstrap operation is running. Prevents
+   *  concurrent calls from duplicating history. */
+  const bootstrappingRef = useRef(false);
 
   // Discarded branch leaves — versions abandoned by editing after an undo,
   // recoverable from the overlay while holding the undo button. Kept in a
@@ -516,10 +519,22 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
    *  load. */
   const ensureUndoStack = useCallback(async () => {
     if (bootstrappedRef.current) return;
+    if (bootstrappingRef.current) return;
+
+    bootstrappingRef.current = true;
+    const targetResource = resource;
 
     try {
       await enableLoro();
     } catch {
+      bootstrappingRef.current = false;
+
+      return;
+    }
+
+    if (resource !== targetResource) {
+      bootstrappingRef.current = false;
+
       return;
     }
 
@@ -535,9 +550,14 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
 
     // If the user started drawing before this completed, prepend the Loro
     // history (which is older) to the existing undo stack instead of
-    // discarding their edits.
+    // discarding their edits. Filter out duplicates: if pushUndoSnapshot
+    // already captured a state that's also in the Loro history, don't add
+    // it twice.
     if (undoStackRef.current.length > 0) {
-      undoStackRef.current = [...steps, ...undoStackRef.current].slice(
+      const filtered = steps.filter(
+        step => !undoStackRef.current.some(existing => strokesEqual(existing, step)),
+      );
+      undoStackRef.current = [...filtered, ...undoStackRef.current].slice(
         -UNDO_STACK_LIMIT,
       );
     } else {
@@ -547,6 +567,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     // Record the attempt even when it found nothing, so a canvas with no
     // recoverable history doesn't pay for the walk again on the next open.
     bootstrappedRef.current = true;
+    bootstrappingRef.current = false;
     setCanUndo(undoStackRef.current.length > 0);
     persistHistory();
   }, [resource, persistHistory]);
@@ -659,10 +680,10 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
   );
 
   const onUndoPointerDown = useCallback(
-    (e: React.PointerEvent) => {
+    async (e: React.PointerEvent) => {
       if (!canUndo && !canRedo && branchesRef.current.length === 0) return;
 
-      void ensureUndoStack();
+      await ensureUndoStack();
 
       e.preventDefault();
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);

--- a/browser/data-browser/src/views/Canvas/CanvasPage.tsx
+++ b/browser/data-browser/src/views/Canvas/CanvasPage.tsx
@@ -157,6 +157,9 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
   // this device still has its full pre-existing history available.
   const undoStackRef = useRef<CanvasStroke[][]>([]);
   const redoStackRef = useRef<CanvasStroke[][]>([]);
+  /** Whether the Loro-history bootstrap has already run for this canvas on
+   *  this device. Persisted so it runs at most once — see the mount effect. */
+  const bootstrappedRef = useRef(false);
 
   // Discarded branch leaves — versions abandoned by editing after an undo,
   // recoverable from the overlay while holding the undo button. Kept in a
@@ -299,6 +302,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
       undo: undoStackRef.current,
       redo: redoStackRef.current,
       branches: branchesRef.current,
+      bootstrapped: bootstrappedRef.current,
     });
   }, [resource.subject]);
 
@@ -316,17 +320,28 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     undoStackRef.current = stored.undo;
     redoStackRef.current = stored.redo;
     branchesRef.current = stored.branches;
+    bootstrappedRef.current = stored.bootstrapped;
     setBranches(stored.branches);
     setCanUndo(stored.undo.length > 0);
     setCanRedo(stored.redo.length > 0);
 
     let cancelled = false;
 
-    if (stored.undo.length === 0 && stored.redo.length === 0) {
-      // First open on this device: bootstrap undo steps from the Loro
-      // history. `getLoroHistory()` returns [] until the Loro WASM has
-      // loaded, so await it — reading synchronously here left the undo
-      // button permanently disabled on a cold page load.
+    if (
+      !stored.bootstrapped &&
+      stored.undo.length === 0 &&
+      stored.redo.length === 0
+    ) {
+      // First open on this device: this canvas may still have undoable
+      // history in its Loro oplog. Reconstructing it means materializing
+      // every version, which is far too expensive to spend on opening a
+      // canvas nobody may ever undo — so only ask the cheap question here
+      // ("is there anything older than now?") and leave the reconstruction
+      // to `ensureUndoStack`, on the first undo or scrub.
+      //
+      // Still async: `hasPriorLoroVersions()` reads the oplog, which is
+      // empty until the Loro WASM has loaded. Reading it synchronously left
+      // the undo button permanently disabled on a cold page load.
       (async () => {
         try {
           await enableLoro();
@@ -336,7 +351,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
 
         if (cancelled) return;
 
-        // Don't clobber steps the user created while the WASM loaded.
+        // Don't override the state of steps made while the WASM loaded.
         if (
           undoStackRef.current.length > 0 ||
           redoStackRef.current.length > 0
@@ -344,19 +359,9 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
           return;
         }
 
-        const versions = resource.getLoroHistory();
-        const current = parseCanvasStrokes(
-          resource.get(canvas.properties.strokeData),
-        );
-        const steps = bootstrapUndoSteps(
-          versions.map(v => v.propvals.get(canvas.properties.strokeData)),
-          current,
-        );
-
-        if (cancelled || steps.length === 0) return;
-
-        undoStackRef.current = steps;
-        setCanUndo(true);
+        if (resource.hasPriorLoroVersions()) {
+          setCanUndo(true);
+        }
       })();
     }
 
@@ -500,7 +505,44 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     [resource],
   );
 
+  /** Reconstruct undo steps from this canvas's Loro history, for a canvas
+   *  whose history was made on another device. Materializing every version
+   *  is expensive, so it happens on first contact with the undo control —
+   *  hovering it, pressing it, or Ctrl+Z — rather than on open. Runs at most
+   *  once per canvas per device; cheap to call on every interaction after.
+   *
+   *  Synchronous: the undo control is only enabled once the mount effect has
+   *  awaited the Loro WASM, so by the time anything can call this the oplog
+   *  is readable. */
+  const ensureUndoStack = useCallback(() => {
+    if (bootstrappedRef.current) return;
+
+    if (undoStackRef.current.length > 0 || redoStackRef.current.length > 0) {
+      return;
+    }
+
+    const versions = resource.getLoroHistory();
+    const current = parseCanvasStrokes(
+      resource.get(canvas.properties.strokeData),
+    );
+    const steps = bootstrapUndoSteps(
+      versions.map(v => v.propvals.get(canvas.properties.strokeData)),
+      current,
+    );
+
+    // Record the attempt even when it found nothing, so a canvas with no
+    // recoverable history doesn't pay for the walk again on the next open.
+    bootstrappedRef.current = true;
+    undoStackRef.current = steps;
+    // Opening only counted version buckets. If every one of them holds the
+    // drawing as it looks right now, there is nothing to undo after all.
+    setCanUndo(steps.length > 0);
+    persistHistory();
+  }, [resource, persistHistory]);
+
   const handleUndo = useCallback(async () => {
+    ensureUndoStack();
+
     if (undoStackRef.current.length === 0) return;
 
     const target = undoStackRef.current.pop()!;
@@ -515,7 +557,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     setCanRedo(true);
 
     await applyHistoricalStrokes(target);
-  }, [applyHistoricalStrokes, persistHistory]);
+  }, [applyHistoricalStrokes, persistHistory, ensureUndoStack]);
 
   const handleRedo = useCallback(async () => {
     if (redoStackRef.current.length === 0) return;
@@ -609,6 +651,8 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
     (e: React.PointerEvent) => {
       if (!canUndo && !canRedo && branchesRef.current.length === 0) return;
 
+      ensureUndoStack();
+
       e.preventDefault();
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 
@@ -637,7 +681,7 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
       setScrubTotal(timeline.length);
       setOverlayMode('held');
     },
-    [canUndo, canRedo],
+    [canUndo, canRedo, ensureUndoStack],
   );
 
   const onUndoPointerMove = useCallback((e: React.PointerEvent) => {
@@ -1542,6 +1586,10 @@ export const CanvasPage: React.FC<ResourcePageProps> = ({ resource }) => {
             onPointerMove={onUndoPointerMove}
             onPointerUp={onUndoPointerUp}
             onPointerCancel={onUndoPointerCancel}
+            // Build the undo stack on hover, so the press that follows acts
+            // on a stack that is already there. The press paths call this
+            // too — touch and Ctrl+Z never hover.
+            onPointerEnter={ensureUndoStack}
             disabled={!canUndo && !canRedo && branches.length === 0}
             aria-pressed={previewStrokes !== null}
           >

--- a/browser/data-browser/src/views/Canvas/history-helpers.test.ts
+++ b/browser/data-browser/src/views/Canvas/history-helpers.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { CanvasStroke } from '@tomic/lib';
 import {
   archiveBranch,
   BRANCH_LIMIT,
   bootstrapUndoSteps,
+  loadCanvasHistory,
+  saveCanvasHistory,
   scrubIndexFor,
   SCRUB_PIXELS_PER_HISTORY,
   stacksAt,
@@ -152,5 +154,66 @@ describe('strokesEqual', () => {
     expect(strokesEqual(snap(1), snap(1))).toBe(true);
     expect(strokesEqual(snap(1), snap(2))).toBe(false);
     expect(strokesEqual([], [])).toBe(true);
+  });
+});
+
+// These tests run in node, which has no localStorage. An in-memory stand-in
+// keeps them dependency-free; the helpers only ever use these four.
+const storage = new Map<string, string>();
+globalThis.localStorage = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => void storage.set(k, v),
+  removeItem: (k: string) => void storage.delete(k),
+  clear: () => storage.clear(),
+} as unknown as Storage;
+
+describe('canvas history persistence', () => {
+  const subject = 'https://example.com/canvas-persist';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  /**
+   * Reconstructing undo steps from the Loro history is expensive, and it
+   * legitimately returns nothing for a canvas with no prior state. Without a
+   * recorded attempt, "no steps" is indistinguishable from "never ran", so
+   * every open paid for the walk again.
+   */
+  it('remembers that the bootstrap ran even when it found no steps', () => {
+    saveCanvasHistory(subject, {
+      undo: [],
+      redo: [],
+      branches: [],
+      bootstrapped: true,
+    });
+
+    const stored = loadCanvasHistory(subject);
+
+    expect(stored.bootstrapped).toBe(true);
+    expect(stored.undo).toEqual([]);
+  });
+
+  it('treats a canvas never seen on this device as un-bootstrapped', () => {
+    expect(loadCanvasHistory('https://example.com/canvas-unseen')).toEqual({
+      undo: [],
+      redo: [],
+      branches: [],
+      bootstrapped: false,
+    });
+  });
+
+  it('treats history saved before the flag existed as un-bootstrapped', () => {
+    // Entries written by an older build carry undo state but no flag; they
+    // must not be read as "already bootstrapped".
+    localStorage.setItem(
+      `canvas-undo:${subject}`,
+      JSON.stringify({ undo: [snap(1)], redo: [], branches: [] }),
+    );
+
+    const stored = loadCanvasHistory(subject);
+
+    expect(stored.bootstrapped).toBe(false);
+    expect(stored.undo).toEqual([snap(1)]);
   });
 });

--- a/browser/data-browser/src/views/Canvas/history-helpers.ts
+++ b/browser/data-browser/src/views/Canvas/history-helpers.ts
@@ -44,6 +44,13 @@ export type DiscardedBranch = {
 
 export type CanvasHistoryState = HistoryStacks & {
   branches: DiscardedBranch[];
+  /**
+   * Whether undo steps have already been reconstructed from the Loro
+   * history for this canvas on this device. That reconstruction is
+   * expensive, and it legitimately yields zero steps for a canvas with no
+   * prior state — without this flag those canvases re-run it on every open.
+   */
+  bootstrapped: boolean;
 };
 
 const historyStorageKey = (subject: string) => `canvas-undo:${subject}`;
@@ -52,7 +59,7 @@ export function loadCanvasHistory(subject: string): CanvasHistoryState {
   try {
     const raw = localStorage.getItem(historyStorageKey(subject));
 
-    if (!raw) return { undo: [], redo: [], branches: [] };
+    if (!raw) return { undo: [], redo: [], branches: [], bootstrapped: false };
 
     const parsed = JSON.parse(raw) as Partial<CanvasHistoryState>;
 
@@ -64,9 +71,10 @@ export function loadCanvasHistory(subject: string): CanvasHistoryState {
             b => b && typeof b.id === 'string' && Array.isArray(b.strokes),
           )
         : [],
+      bootstrapped: parsed.bootstrapped === true,
     };
   } catch {
-    return { undo: [], redo: [], branches: [] };
+    return { undo: [], redo: [], branches: [], bootstrapped: false };
   }
 }
 

--- a/browser/lib/src/resource.test.ts
+++ b/browser/lib/src/resource.test.ts
@@ -615,6 +615,173 @@ describe('getLoroHistory', () => {
   });
 
   /**
+   * The undo control needs to know whether anything older than "now" exists,
+   * and that question was answered by materializing the entire history —
+   * seconds of work on canvas open for a boolean nobody may ever act on.
+   * The probe reads only change metadata.
+   */
+  describe('hasPriorLoroVersions', () => {
+    it('is false for a resource whose only state is its current one', async ({
+      expect,
+    }) => {
+      const r = new Resource('https://example.com/prior-none');
+      await r.set(name, 'Canvas', false);
+      r.getLoroDoc()!.commit();
+
+      expect(r.hasPriorLoroVersions()).toBe(false);
+    });
+
+    it('is true once an edit leaves an older state behind', async ({
+      expect,
+    }) => {
+      const r = new Resource('https://example.com/prior-some');
+      await r.set(name, 'Canvas', false);
+      r.getLoroDoc()!.commit();
+      r.pushListItem(strokeData, { color: 1, width: 2, path: [[0, 0]] });
+
+      expect(r.hasPriorLoroVersions()).toBe(true);
+    });
+
+    it('agrees with getLoroHistory without materializing anything', async ({
+      expect,
+    }) => {
+      const r = new Resource('https://example.com/prior-agrees');
+      await r.set(name, 'Canvas', false);
+      r.getLoroDoc()!.commit();
+      r.pushListItem(strokeData, { color: 1, width: 2, path: [[0, 0]] });
+      r.pushListItem(strokeData, { color: 2, width: 2, path: [[1, 1]] });
+
+      const doc = r.getLoroDoc()!;
+      const fork = doc.fork.bind(doc);
+      let forked = 0;
+      vi.spyOn(doc, 'fork').mockImplementation(() => {
+        forked++;
+
+        return fork();
+      });
+
+      expect(r.hasPriorLoroVersions()).toBe(r.getLoroHistory().length > 1);
+      // getLoroHistory forks to time-travel; the probe must not.
+      expect(forked).toBe(1);
+    });
+
+    it('is false before the Loro WASM has produced a doc', ({ expect }) => {
+      const r = new Resource('https://example.com/prior-no-doc');
+      vi.spyOn(r, 'getLoroDoc').mockReturnValue(undefined);
+
+      expect(r.hasPriorLoroVersions()).toBe(false);
+    });
+  });
+
+  /**
+   * Regression: history materialized *every* op counter — a checkout plus a
+   * whole-document `toJSON()` each — then kept only the last one per bucket.
+   * A canvas stores one op per stroke point, so opening a drawing with a few
+   * thousand points spent seconds rebuilding states nothing ever read. Only
+   * the last step of a bucket is observable, so only those get materialized.
+   */
+  it('materializes one state per version, not one per op', async ({
+    expect,
+  }) => {
+    const r = new Resource('https://example.com/history-op-count');
+    await r.set(name, 'Canvas', false);
+    r.getLoroDoc()!.commit();
+
+    // One edit carrying many ops — a single stroke with a long path is one
+    // logical version but hundreds of Loro ops.
+    const longPath = Array.from(
+      { length: 400 },
+      (_, i) => [i, i] as [number, number],
+    );
+    r.pushListItem(strokeData, { color: 1, width: 2, path: longPath });
+    r.pushListItem(strokeData, { color: 2, width: 2, path: longPath });
+
+    let opCount = 0;
+
+    for (const changes of r.getLoroDoc()!.getAllChanges().values()) {
+      for (const change of changes) {
+        opCount += change.length;
+      }
+    }
+
+    const doc = r.getLoroDoc()!;
+    const fork = doc.fork.bind(doc);
+    let checkouts = 0;
+    vi.spyOn(doc, 'fork').mockImplementation(() => {
+      const forked = fork();
+      const checkout = forked.checkout.bind(forked);
+      vi.spyOn(forked, 'checkout').mockImplementation(frontiers => {
+        checkouts++;
+
+        return checkout(frontiers);
+      });
+
+      return forked;
+    });
+
+    const history = r.getLoroHistory();
+
+    expect(opCount).toBeGreaterThan(500);
+    expect(history.map(strokeCountOf)).toEqual([0, 1, 2]);
+    // One checkout per message bucket, independent of how many ops each
+    // bucket spans. The bucket count is what may grow, never the op count.
+    expect(checkouts).toBeLessThanOrEqual(history.length + 2);
+  });
+
+  /**
+   * Regression: versions were deduped on `JSON.stringify` of raw `toJSON()`
+   * output, whose map-key order depends on the path taken to reach the
+   * version — jumping straight to one yields `{color, path, width}` where
+   * replaying every op yields `{width, path, color}`. Identical states then
+   * compared unequal, so whether a duplicate version collapsed depended on
+   * how history happened to walk the doc. Key order is emitted by Loro, so
+   * reproduce it here by shuffling the keys `toJSON()` hands back.
+   */
+  it('dedupes identical states regardless of map key order', async ({
+    expect,
+  }) => {
+    const r = new Resource('https://example.com/history-key-order');
+    await r.set(name, 'Canvas', false);
+    r.getLoroDoc()!.commit();
+    r.pushListItem(strokeData, { color: 1, width: 2, path: [[0, 0]] });
+    r.replaceListItems(strokeData, [{ color: 1, width: 2, path: [[0, 0]] }]);
+
+    const doc = r.getLoroDoc()!;
+    const fork = doc.fork.bind(doc);
+    let call = 0;
+    vi.spyOn(doc, 'fork').mockImplementation(() => {
+      const forked = fork();
+      const toJSON = forked.toJSON.bind(forked);
+      vi.spyOn(forked, 'toJSON').mockImplementation(() => {
+        // Alternate key order per materialization without touching values.
+        const reorder = (value: unknown): unknown => {
+          if (!value || typeof value !== 'object') return value;
+
+          if (Array.isArray(value)) return value.map(reorder);
+
+          const keys = Object.keys(value as Record<string, unknown>);
+          const ordered = call % 2 === 0 ? keys : [...keys].reverse();
+
+          return Object.fromEntries(
+            ordered.map(k => [k, reorder((value as never)[k])]),
+          );
+        };
+
+        call++;
+
+        return reorder(toJSON()) as ReturnType<typeof toJSON>;
+      });
+
+      return forked;
+    });
+
+    // The push and the replace leave the canvas in the same observable
+    // state, so history must collapse them into one version — regardless of
+    // the key order each materialization happened to come back in.
+    expect(r.getLoroHistory().map(strokeCountOf)).toEqual([0, 1]);
+  });
+
+  /**
    * Regression: versions were sorted by (wall-clock timestamp, counter).
    * Second-resolution stamps tie for every edit in the same second and
    * counters are per-peer, so cross-peer order was arbitrary — a canvas

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -1863,6 +1863,39 @@ export class Resource<C extends OptionalClass = any> {
   }
 
   /**
+   * Whether the OpLog holds any state older than the current one — i.e.
+   * whether `getLoroHistory()` would return more than just "now".
+   *
+   * Counts version buckets the same way `getLoroHistory` groups them, but
+   * without materializing any of them: no `checkout()`, no `toJSON()`. Use
+   * this for "is there anything to undo?" and leave the (far more expensive)
+   * materialization until something actually reads a historical state.
+   */
+  public hasPriorLoroVersions(): boolean {
+    const doc = this.getLoroDoc();
+
+    if (!doc) {
+      return false;
+    }
+
+    const buckets = new Set<string>();
+
+    for (const changes of doc.getAllChanges().values()) {
+      for (const change of changes) {
+        buckets.add(change.message ?? '');
+
+        // The newest bucket is the current state, so two distinct buckets is
+        // already enough — no reason to walk the rest of the oplog.
+        if (buckets.size > 1) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Get the history of this resource from its Loro OpLog.
    * Returns an array of Versions, each with materialized property values
    * at that point in time. Uses Loro's `checkout()` for instant time-travel
@@ -1888,10 +1921,17 @@ export class Resource<C extends OptionalClass = any> {
     // Loro merges sequential same-peer ops into a single Change whose
     // `length` is the operation count. Iterating only over Changes therefore
     // collapses every edit between commits into one version. To recover one
-    // version per *commit* we walk every op counter inside each Change and
-    // group by the change message (see the bucketing below). The state
+    // version per *commit* we enumerate every op counter inside each Change
+    // and group by the change message (see the bucketing below). The state
     // captured for each bucket is the **last** op counter that carried its
     // message — the snapshot that was actually saved under that commit.
+    //
+    // Enumerating steps is cheap; *materializing* one is not (a checkout plus
+    // a whole-document toJSON). Since only the last step of each bucket is
+    // ever read, we resolve the winners first and materialize only those.
+    // Materializing every step instead made this O(total ops) — a canvas
+    // stores one op per stroke point, so opening a small drawing spent
+    // seconds doing 6000+ checkouts to produce 10 versions.
     type Step = {
       peer: string;
       counter: number;
@@ -1932,7 +1972,6 @@ export class Resource<C extends OptionalClass = any> {
 
     const lastCommitProp = 'https://atomicdata.dev/properties/lastCommit';
     type GroupedVersion = {
-      bucketKey: string;
       contentKey: string;
       step: Step;
       propvals: Map<string, JSONValue>;
@@ -1945,7 +1984,28 @@ export class Resource<C extends OptionalClass = any> {
      *  state arrived at from different peers (e.g. the same snapshot
      *  reimported during sync). Including containers is what lets body-only
      *  edits register as distinct versions instead of collapsing into the
-     *  previous propvals-identical bucket. */
+     *  previous propvals-identical bucket.
+     *
+     *  Nested object keys are sorted, because `doc.toJSON()` emits map keys in
+     *  an order that depends on how the doc reached that version: jumping
+     *  straight to a version can yield `{color, path, width}` where arriving
+     *  by replaying every op yields `{width, path, color}`. Same state, and a
+     *  plain `JSON.stringify` would call them different — which made dedup
+     *  depend on the checkout path taken to get there. */
+    const canonicalize = (_key: string, value: JSONValue): JSONValue => {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return value;
+      }
+
+      const record = value as Record<string, JSONValue>;
+
+      return Object.fromEntries(
+        Object.keys(record)
+          .sort()
+          .map(k => [k, record[k]]),
+      );
+    };
+
     const contentSignature = (
       pv: Map<string, JSONValue>,
       ct: Map<string, JSONValue>,
@@ -1957,10 +2017,44 @@ export class Resource<C extends OptionalClass = any> {
         a.localeCompare(b),
       );
 
-      return JSON.stringify([propEntries, containerEntries]);
+      return JSON.stringify([propEntries, containerEntries], canonicalize);
     };
 
+    // Bucket by the Loro Change message. Two token families exist:
+    // `e-<token>` written by the logical-edit mutation methods
+    // (pushListItem / replaceListItems / removeListItem / undo / redo —
+    // see `commitLoroEdit`), and `c-<ulid>` written by the drain for
+    // ops that were still pending at export time (property `set()`s).
+    // All ops of one edit/commit share a message and form one version.
+    // Ops with no message (the genesis/base change, and body edits made
+    // outside the runtime, e.g. loro-prosemirror) bucket under '' as the
+    // base version — intentionally collapsed so document typing doesn't
+    // spam a version per keystroke batch. The latest step per bucket
+    // wins — the final saved state under that commit.
+    //
+    // (Earlier this bucketed by the `lastCommit` propval, but under
+    // sign-at-drain `lastCommit` is server-assigned and never written into
+    // the Loro doc, so every op collapsed into the '' bucket and history
+    // showed only the latest state.)
+    //
+    // `steps` is in causal order, so the last write per key is the winner.
+    // Bucket order follows first appearance, which is what orders the
+    // resulting versions.
+    const bucketOrder: string[] = [];
+    const winners = new Map<string, Step>();
+
     for (const step of steps) {
+      const bucketKey = step.message ?? '';
+
+      if (!winners.has(bucketKey)) {
+        bucketOrder.push(bucketKey);
+      }
+
+      winners.set(bucketKey, step);
+    }
+
+    for (const bucketKey of bucketOrder) {
+      const step = winners.get(bucketKey)!;
       const frontiers = [
         { peer: step.peer as `${number}`, counter: step.counter },
       ];
@@ -2001,41 +2095,12 @@ export class Resource<C extends OptionalClass = any> {
         }
       }
 
-      // Bucket by the Loro Change message. Two token families exist:
-      // `e-<token>` written by the logical-edit mutation methods
-      // (pushListItem / replaceListItems / removeListItem / undo / redo —
-      // see `commitLoroEdit`), and `c-<ulid>` written by the drain for
-      // ops that were still pending at export time (property `set()`s).
-      // All ops of one edit/commit share a message and form one version.
-      // Ops with no message (the genesis/base change, and body edits made
-      // outside the runtime, e.g. loro-prosemirror) bucket under '' as the
-      // base version — intentionally collapsed so document typing doesn't
-      // spam a version per keystroke batch. The latest entry per bucket
-      // wins — the final saved state under that commit.
-      //
-      // (Earlier this bucketed by the `lastCommit` propval, but under
-      // sign-at-drain `lastCommit` is server-assigned and never written into
-      // the Loro doc, so every op collapsed into the '' bucket and history
-      // showed only the latest state.)
-      const bucketKey = step.message ?? '';
-      const cKey = contentSignature(propvals, containers);
-
-      const existing = grouped.find(g => g.bucketKey === bucketKey);
-
-      if (existing) {
-        existing.step = step;
-        existing.propvals = propvals;
-        existing.containers = containers;
-        existing.contentKey = cKey;
-      } else {
-        grouped.push({
-          bucketKey,
-          contentKey: cKey,
-          step,
-          propvals,
-          containers,
-        });
-      }
+      grouped.push({
+        contentKey: contentSignature(propvals, containers),
+        step,
+        propvals,
+        containers,
+      });
     }
 
     // Drop earlier buckets whose content signature matches a later one — they


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

CI fix for https://github.com/ontola/atomic-server/pull/1294. Same commit (`e39154ca`) is on `perf/canvas-history-open`.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

## Summary

#1294 CI failed in `data-browser lint` with **2 oxlint errors**:

```
x @stylistic(padding-line-between-statements)
  src/views/Canvas/CanvasPage.tsx:523  (blank line before multiline if)
x @stylistic(padding-line-between-statements)
  src/views/Canvas/CanvasPage.tsx:525  (blank line before return)
```

`ensureUndoStack` now has those blank lines. Also dropped the `any` cast — `getLoroHistory()` already returns `Version[]`.

No behavior change. The 237 data-browser lint warnings are pre-existing on develop.

## Verification

- data-browser `oxlint` (quiet/errors-only): exit 0
- data-browser `oxfmt --check ./src`: 960 files, correct format
- `@tomic/lib` oxlint: exit 0
- `history-helpers.test.ts`: 20 passed
- `lib` `resource.test.ts`: 33 passed

GitHub Actions on Mancave was still queued after this verification; the failing step was lint, which now passes locally with the same oxlint config CI uses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ab6612f-a49c-420c-96df-c8c63de5ec12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ab6612f-a49c-420c-96df-c8c63de5ec12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

