### PR TITLE
fix(ci): full Playwright suite must not echo grep="(full)"

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -113,6 +113,30 @@ function e2eRunKnobs(profile: HostProfile, mode: E2eMode): E2eRunKnobs {
 }
 
 /**
+ * `bash -c` payload for one Playwright shard.
+ *
+ * The log label must be safe inside a double-quoted `echo`. The previous
+ * `JSON.stringify(grep || '(full)')` wrote `grep="(full)"`, which closed
+ * the quote so bash treated `(full)` as a subshell and the shard never
+ * started. Light CI hid it because `@smoke` is not a metacharacter.
+ */
+function e2eShardRunScript(
+  grep: string,
+  shardIndex: number,
+  shardCount: number,
+): string {
+  const grepFlag = grep ? ` --grep ${JSON.stringify(grep)}` : '';
+  const grepLabel = grep || 'full';
+
+  return (
+    'set -o pipefail; ' +
+    `echo "e2e mode grep=${grepLabel} shard=${shardIndex}/${shardCount} workers=$PLAYWRIGHT_WORKERS retries=$PLAYWRIGHT_RETRIES"; ` +
+    `pnpm exec playwright test --config=./playwright.config.ts${grepFlag} --shard=${shardIndex}/${shardCount} 2>&1 | tee /test-output.log; ` +
+    'echo ${PIPESTATUS[0]} > /test-exit-code; exit 0'
+  );
+}
+
+/**
  * Trim a Playwright `error-context.md` to the part worth reading in a CI log.
  *
  * The file leads with ~2.5k characters of breadcrumbs, sidebar and app menu —
@@ -1600,9 +1624,6 @@ export class AtomicServer {
 
   /** One Playwright shard against its own atomic-server service. */
   private e2eShardContainer(base: Container, shardIndex: number): Container {
-    const grepFlag = this.e2eRun.grep
-      ? ` --grep ${JSON.stringify(this.e2eRun.grep)}`
-      : '';
     const shardCount = this.e2eRun.shardCount;
 
     return base
@@ -1615,10 +1636,7 @@ export class AtomicServer {
       .withExec([
         '/bin/bash',
         '-c',
-        'set -o pipefail; ' +
-          `echo "e2e mode grep=${JSON.stringify(this.e2eRun.grep || '(full)')} shard=${shardIndex}/${shardCount} workers=$PLAYWRIGHT_WORKERS retries=$PLAYWRIGHT_RETRIES"; ` +
-          `pnpm exec playwright test --config=./playwright.config.ts${grepFlag} --shard=${shardIndex}/${shardCount} 2>&1 | tee /test-output.log; ` +
-          'echo ${PIPESTATUS[0]} > /test-exit-code; exit 0',
+        e2eShardRunScript(this.e2eRun.grep, shardIndex, shardCount),
       ]);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Unbreaks develop CI after #1286 (and every develop push since the Playwright light/heavy split). The product change in #1286 is not the failure.

https://github.com/ontola/atomic-server/actions/runs/32510577920

## What failed

`develop` runs Playwright **full**. Dagger logged the mode with:

```
echo "e2e mode grep="(full)" shard=1/4 ..."
```

`JSON.stringify('(full)')` put quotes inside a double-quoted bash string, so `(full)` became a subshell:

```
syntax error near unexpected token `('
```

The suite never started. Feature-branch CI stayed green because light mode greps `@smoke`, which is not a bash metacharacter.

The same quoting bug has been failing develop since that split landed (including #1294 and #1295).

## Fix

Log `grep=full` without extra quotes or parentheses. `--grep` is still omitted for the unfiltered suite.

## Checklist
- [x] Add or update tests if needed — `bash -n` on the full and light shard scripts; the broken echo reproduces the CI error
- [ ] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa98d8e-b92a-4c72-88f9-128fcb4eb7ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa98d8e-b92a-4c72-88f9-128fcb4eb7ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

