### PR TITLE
fix(lib): genesis-only offline save must not rewind the outbox forever

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -324,6 +324,7 @@ Not covered: leftover Yjs-era DocumentV2 bodies end-to-end (needs a stored `{ ty
 | `createDrive({ personal: true })` uses the derived DID | `browser/lib/src/store.personal-drive.test.ts` |
 | Two stores with the same key mint the same subject | `store.personal-drive.test.ts` |
 | Extra drives are listed on the derived personal drive | `store.personal-drive.test.ts` |
+| Extra drive created offline drains on reconnect (genesis must not set a rewind baseline) | `browser/lib/src/offline-create-drain.test.ts` |
 | Lists from a previous random-DID home are unioned onto the derived drive | `store.personal-drive.test.ts` |
 | `Agent.personalDriveSubject` matches the genesis helper | `agent.test.ts` |
 | `Db::setup` / `ensure_personal_drive` use the derived DID and are idempotent | `lib/src/db.rs::personal_drive_tests` |

--- a/browser/lib/src/offline-create-drain.test.ts
+++ b/browser/lib/src/offline-create-drain.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'vitest';
+import { server } from './ontologies/server.js';
+import { testStore } from './test-store.js';
+
+/**
+ * Reproduces the develop full-e2e failure of
+ * `offline-create-then-online`: an extra drive created while disconnected
+ * left its default ontology (genesis-only) with a rewind `baseVersion`
+ * equal to the genesis cursor. Reconnect POSTed genesis, then treated the
+ * empty follow-up export as "OPFS not ready" and retried forever —
+ * `pendingDirtyCount` stuck at 1, `hasSignedGenesis` false.
+ */
+describe('offline create drain', () => {
+  it('does not capture a rewind baseline on an unposted genesis', async ({
+    expect,
+  }) => {
+    const { store } = await testStore();
+    await store.createDrive('Home', { personal: true });
+    store.setServerConnected(false);
+
+    const extra = await store.createDrive('Offline-Created Drive', {
+      personal: false,
+    });
+    expect(extra.subject.startsWith('did:ad:')).toBe(true);
+
+    const pending = store.outbox.pending();
+    expect(pending.length).toBeGreaterThan(0);
+
+    for (const entry of pending) {
+      if (entry.signedGenesis) {
+        expect(entry.baseVersion).toBeUndefined();
+      }
+    }
+  });
+
+  it('reconnect drain clears a genesis-only extra drive and its ontology', async ({
+    expect,
+  }) => {
+    const { store } = await testStore();
+    await store.createDrive('Home', { personal: true });
+    store.setServerConnected(false);
+
+    const extra = await store.createDrive('Offline-Created Drive', {
+      personal: false,
+    });
+    const ontology = extra.get(server.properties.defaultOntology) as string;
+    expect(ontology).toBeTruthy();
+
+    store.setServerConnected(true);
+    await store.syncDirtyResources();
+
+    expect(store.getSyncStatus().pendingDirtyCount).toBe(0);
+    expect(store.outbox.getEntry(extra.subject)).toBeUndefined();
+    expect(store.outbox.getEntry(ontology)).toBeUndefined();
+  });
+
+  it('drain does not strand a genesis that wrongly had a baseline', async ({
+    expect,
+  }) => {
+    const { store } = await testStore();
+    await store.createDrive('Home', { personal: true });
+    store.setServerConnected(false);
+
+    const extra = await store.createDrive('Offline-Created Drive', {
+      personal: false,
+    });
+    const ontology = extra.get(server.properties.defaultOntology) as string;
+    const ontoEntry = store.outbox.getEntry(ontology);
+    expect(ontoEntry?.signedGenesis).toBeTruthy();
+
+    const ontoResource = store.resources.get(ontology);
+    const cursor = ontoResource?.getEncodedSaveCursor();
+    expect(cursor).toBeTruthy();
+
+    // The pre-fix saveOffline shape: genesis cursor stored as rewind
+    // baseline. Drain must still clear after POSTing genesis.
+    store.outbox.setBaseVersion(ontology, cursor!);
+
+    store.setServerConnected(true);
+    await store.syncDirtyResources();
+
+    expect(store.outbox.getEntry(ontology)).toBeUndefined();
+    expect(store.getSyncStatus().pendingDirtyCount).toBe(0);
+  });
+});

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -3297,12 +3297,18 @@ export class Resource<C extends OptionalClass = any> {
     // past it — that's why the subject is dirty), so this is exactly the
     // baseline the reconnect drain must export from. `setBaseVersion` keeps
     // only the first offline baseline, so a run of offline edits all rebase
-    // on the same synced version. (Skipped when nothing synced yet — the
-    // drain then sends a first-commit snapshot.)
-    const baseVersion = this.getEncodedSaveCursor();
+    // on the same synced version.
+    //
+    // Skip when the only commit is an unposted genesis. `signChanges` already
+    // advanced the local cursor to that snapshot; treating it as a rewind
+    // baseline makes the post-genesis empty export look like "OPFS not ready"
+    // and the drain retries forever (`offline-create-then-online`).
+    if (!signedGenesis) {
+      const baseVersion = this.getEncodedSaveCursor();
 
-    if (baseVersion) {
-      this.store.outbox.setBaseVersion(this.subject, baseVersion);
+      if (baseVersion) {
+        this.store.outbox.setBaseVersion(this.subject, baseVersion);
+      }
     }
 
     await this.persistToClientDb();

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1287,6 +1287,8 @@ export class Store {
     // `setGenesisCommit` and this drain pass (they're past the
     // genesis's captured version but would be marked "saved" by an
     // overzealous `markLoroSaved()`). Step 2 below picks those up.
+    const postedGenesis = !!entry.signedGenesis;
+
     if (entry.signedGenesis) {
       const genesis = entry.signedGenesis;
       const created = await this.postCommit(genesis, endpoint);
@@ -1445,6 +1447,18 @@ export class Store {
     let exported = resource.exportLoroDeltaForDrain(isFirstCommit, commitToken);
 
     if (!exported) {
+      if (entry.baseVersion && postedGenesis) {
+        // Genesis already captured the doc. An empty follow-up is "caught
+        // up", not "OPFS not ready" — leaving dirty here is what stranded
+        // `offline-create-then-online` (pendingDirtyCount stuck at 1,
+        // hasSignedGenesis false, drain spinning).
+        this.outbox.clearBaseVersion(subject);
+        this.outbox.clearDirty(subject);
+        this.emitSyncStatus();
+
+        return;
+      }
+
       if (entry.baseVersion) {
         console.warn(
           `[Outbox] empty Loro export for ${subject} with offline baseVersion; leaving dirty for retry`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Unbreaks develop full Playwright after #1301. The quoting fix let the suite run; this is the actual test failure:

https://github.com/ontola/atomic-server/actions/runs/32518361794

`offline-create-then-online` failed all 3 attempts:

```
waitForSynced timed out. pendingDirtyCount: 1, syncInProgress: true, hasSignedGenesis: false
```

## Cause

`saveOffline` stored the local **genesis** cursor as a rewind `baseVersion`. The comment already said to skip that when nothing had been server-acked; the code did not.

On reconnect the drain POSTed genesis, then the empty follow-up export looked like "OPFS not ready" and the outbox retried forever. The default ontology of an extra drive is genesis-only, so it was the stranded entry.

## Fix

- Do not set `baseVersion` when a `signedGenesis` is still unposted.
- If this drain pass POSTed genesis and the follow-up export is empty, clear the dirty bit.

Covered by `browser/lib/src/offline-create-drain.test.ts`. Commit is tagged `[full-e2e]` so this PR runs the same suite that failed on develop.

## Checklist
- [x] Add or update tests if needed
- [x] Update docs if needed (`TESTING_COVERAGE.md`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa98d8e-b92a-4c72-88f9-128fcb4eb7ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa98d8e-b92a-4c72-88f9-128fcb4eb7ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

