### PR TITLE
Gate public FOSS nodes: a server can be reachable without hosting strangers

### DIFF
--- a/browser/data-browser/src/helpers/managedServer.test.ts
+++ b/browser/data-browser/src/helpers/managedServer.test.ts
@@ -70,6 +70,36 @@ describe('accountCreationTarget', () => {
       }),
     ).toEqual({ kind: 'local' });
   });
+
+  it('a self-hosted node that has an owner → no account creation', () => {
+    expect(
+      accountCreationTarget({
+        managed: false,
+        portalUrl: null,
+        acceptsNewDrives: false,
+      }),
+    ).toEqual({ kind: 'unavailable', reason: 'node-has-owner' });
+  });
+
+  it('a node that says nothing about host mode still offers local creation', () => {
+    // Every node released before host mode existed. Reading silence as "gated"
+    // would remove the Create account button from all of them.
+    expect(accountCreationTarget({ managed: false, portalUrl: null })).toEqual({
+      kind: 'local',
+    });
+  });
+
+  it('an owner-gated managed node still routes to its portal', () => {
+    // Host mode gates *this disk*. Where accounts are made is the portal's
+    // business, and a managed node has one.
+    expect(
+      accountCreationTarget({
+        managed: true,
+        portalUrl: 'https://portal.example/',
+        acceptsNewDrives: false,
+      }),
+    ).toEqual({ kind: 'portal', url: 'https://portal.example/signin' });
+  });
 });
 
 describe('isAtomicServer', () => {

--- a/browser/data-browser/src/helpers/managedServer.ts
+++ b/browser/data-browser/src/helpers/managedServer.ts
@@ -37,6 +37,14 @@ export type ManagedInfo = {
   /** The devices this server syncs with — how a browser sees the phone that
    *  paired with its server, since a browser is not itself a node. */
   peers?: ServerPeer[];
+  /**
+   * Whether this node takes a new Drive from whoever asks.
+   *
+   * Defaults to `true`, and must: a node that predates host mode says nothing
+   * here, and that node does accept new Drives. Guessing the safe-looking
+   * `false` would hide account creation on every server currently running.
+   */
+  acceptsNewDrives?: boolean;
 };
 
 /** What a node reports when it is unreachable, or says nothing about itself. */
@@ -46,6 +54,7 @@ export const EMPTY_NODE_INFO: ManagedInfo = {
   nodeId: null,
   version: null,
   peers: [],
+  acceptsNewDrives: true,
 };
 
 const DEFAULT = EMPTY_NODE_INFO;
@@ -126,6 +135,9 @@ export async function fetchManagedInfo(
       nodeId: readString(data?.[serverProps.nodeId]),
       version: readString(data?.[serverProps.version]),
       peers,
+      // Only an explicit `false` closes this. Absent means an older node, which
+      // accepts new Drives.
+      acceptsNewDrives: data?.[serverProps.acceptsNewDrives] !== false,
     };
   } catch {
     // Older/self-hosted nodes have no such endpoint — treat as non-managed.
@@ -150,6 +162,8 @@ export function isAtomicServer(info: ManagedInfo): boolean {
  * {@link ManagedInfo}:
  *  - a managed node with a dashboard URL → the managed portal (which handles
  *    sign-up + email verification);
+ *  - a self-hosted node that has an owner → nothing; creating an account there
+ *    would mint an identity that cannot store anything;
  *  - anything else (self-hosted / FOSS, or managed-but-no-URL) → the local
  *    DID-agent creation flow. This is what keeps the FOSS UX intact.
  *
@@ -158,7 +172,13 @@ export function isAtomicServer(info: ManagedInfo): boolean {
  */
 export type AccountCreationTarget =
   | { kind: 'portal'; url: string }
-  | { kind: 'local' };
+  | { kind: 'local' }
+  /**
+   * This node has an owner and it is not you. Creating an account here would
+   * produce an identity with nowhere to put anything, so the welcome screen
+   * offers signing in and accepting an invite instead.
+   */
+  | { kind: 'unavailable'; reason: 'node-has-owner' };
 
 /**
  * The portal a build was compiled against, if any.
@@ -236,6 +256,15 @@ export function accountCreationTarget(
     } catch {
       return { kind: 'portal', url: info.portalUrl };
     }
+  }
+
+  // Last, deliberately: every branch above sends people somewhere that still
+  // works. A hosted build has its own portal, and a managed node's accounts are
+  // the portal's business no matter what this disk accepts. What is left is a
+  // self-hosted node, the only kind whose gate means "not here, and nowhere
+  // else either".
+  if (info.acceptsNewDrives === false) {
+    return { kind: 'unavailable', reason: 'node-has-owner' };
   }
 
   return { kind: 'local' };

--- a/browser/data-browser/src/helpers/serverOntology.ts
+++ b/browser/data-browser/src/helpers/serverOntology.ts
@@ -13,6 +13,10 @@ export const serverProps = {
   managed: 'https://atomicdata.dev/properties/server/managed',
   portalUrl: 'https://atomicdata.dev/properties/server/portalUrl',
   peers: 'https://atomicdata.dev/properties/server/peers',
+  /** `open` | `owner`. Absent on a node older than host mode — read as `open`. */
+  hostMode: 'https://atomicdata.dev/properties/server/hostMode',
+  acceptsNewDrives: 'https://atomicdata.dev/properties/server/acceptsNewDrives',
+  ownerSet: 'https://atomicdata.dev/properties/server/ownerSet',
 } as const;
 
 /** Property URLs of a nested `Peer` — a device the server syncs with. */

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -727,21 +727,33 @@ export function GettingStartedFlow({
             {/* alt='' because the heading above already names the app. */}
             <AtomicServerLogo key='logo' alt='' />
             <ButtonStack key='buttons'>
-              <CtaButton
-                key='create'
-                type='button'
-                onClick={() => {
-                  // Hosted build or managed node → create the account on the
-                  // portal (email verification). FOSS node → local identity.
-                  if (createTarget.kind === 'portal') {
-                    window.location.assign(createTarget.url);
-                  } else {
-                    setStep('create');
-                  }
-                }}
-              >
-                Create account
-              </CtaButton>
+              {/* A node with an owner has nowhere to put a new account, so
+                  offering one would be offering a dead end. Sign in and invites
+                  still work, and are what someone arriving here actually needs.
+                  Guarded rather than always-rendered: on every other node this
+                  subtree must not exist at all. */}
+              {createTarget.kind === 'unavailable' ? (
+                <CardSubtitle key='owned'>
+                  This server is run by one person for their own data. You can
+                  sign in, or open a drive you were invited to.
+                </CardSubtitle>
+              ) : (
+                <CtaButton
+                  key='create'
+                  type='button'
+                  onClick={() => {
+                    // Hosted build or managed node → create the account on the
+                    // portal (email verification). FOSS node → local identity.
+                    if (createTarget.kind === 'portal') {
+                      window.location.assign(createTarget.url);
+                    } else {
+                      setStep('create');
+                    }
+                  }}
+                >
+                  Create account
+                </CtaButton>
+              )}
               {/* The local path stays reachable in a hosted build, one tap
                   down rather than gone. Someone who already has an identity,
                   or who wants nothing to do with our account system, must not

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -52,6 +52,7 @@ import {
   type RecoverySecret,
 } from '../../helpers/managed/recovery';
 import { CodeBlock } from '../../components/CodeBlock';
+import { ExternalLink } from '../../components/ExternalLink';
 import { InputStyled, InputWrapper } from '../../components/forms/InputStyles';
 import { FaArrowLeft, FaKey } from 'react-icons/fa6';
 import { Logo } from '../../components/Logo';
@@ -732,10 +733,24 @@ export function GettingStartedFlow({
                   Guarded rather than always-rendered: on every other node this
                   subtree must not exist at all. */}
               {createTarget?.kind === 'unavailable' ? (
-                <CardSubtitle key='owned'>
-                  This server is run by one person for their own data. You can
-                  sign in, or open a drive you were invited to.
-                </CardSubtitle>
+                <Column key='owned' gap='0.75rem'>
+                  <CardSubtitle>
+                    This server is run by one person for their own data. You can
+                    sign in, or open a drive you were invited to.
+                  </CardSubtitle>
+                  {/* Nobody arrives here wanting to be told no. They wanted an
+                      account somewhere, so name the two places that still give
+                      them one — hosted, or their own machine. */}
+                  <CardSubtitle>Want a server of your own?</CardSubtitle>
+                  <OwnedElsewhere>
+                    <ExternalLink to='https://atomicserver.eu'>
+                      Get one hosted
+                    </ExternalLink>
+                    <ExternalLink to='https://github.com/atomicdata-dev/atomic-server'>
+                      Run it yourself
+                    </ExternalLink>
+                  </OwnedElsewhere>
+                </Column>
               ) : (
                 <CtaButton
                   key='create'
@@ -1314,6 +1329,13 @@ const AtomicServerLogo = styled(Logo)`
 `;
 
 /** Separates the offered passkey from the advanced agent-secret path below. */
+const OwnedElsewhere = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  justify-content: center;
+`;
+
 const OtherWaysLabel = styled.span`
   display: flex;
   align-items: center;

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -120,9 +120,8 @@ export function GettingStartedFlow({
   // /node-info), account creation goes through the portal (email
   // verification). Self-hosted / FOSS nodes report nothing here, so we keep the
   // local DID-agent creation unchanged.
-  const [createTarget, setCreateTarget] = useState<AccountCreationTarget | null>(
-    null,
-  );
+  const [createTarget, setCreateTarget] =
+    useState<AccountCreationTarget | null>(null);
   /**
    * Any control plane this build knows of, which is a weaker question than
    * `createTarget` answers.
@@ -743,7 +742,11 @@ export function GettingStartedFlow({
                   type='button'
                   disabled={!createTarget}
                   onClick={() => {
+                    // Belt and braces with `disabled`: the button is unclickable
+                    // until `/server` answers, so this only guards a
+                    // programmatic call.
                     if (!createTarget) return;
+
                     // Hosted build or managed node → create the account on the
                     // portal (email verification). FOSS node → local identity.
                     if (createTarget.kind === 'portal') {
@@ -946,9 +949,15 @@ export function GettingStartedFlow({
                         key='create'
                         type='button'
                         subtle
-                        disabled={!createTarget || createTarget.kind === 'unavailable'}
+                        disabled={
+                          !createTarget || createTarget.kind === 'unavailable'
+                        }
                         onClick={() => {
-                          if (!createTarget || createTarget.kind === 'unavailable') return;
+                          if (
+                            !createTarget ||
+                            createTarget.kind === 'unavailable'
+                          )
+                            return;
                           setError(undefined);
 
                           if (createTarget.kind === 'portal') {

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -52,7 +52,6 @@ import {
   type RecoverySecret,
 } from '../../helpers/managed/recovery';
 import { CodeBlock } from '../../components/CodeBlock';
-import { ExternalLink } from '../../components/ExternalLink';
 import { InputStyled, InputWrapper } from '../../components/forms/InputStyles';
 import { FaArrowLeft, FaKey } from 'react-icons/fa6';
 import { Logo } from '../../components/Logo';
@@ -733,24 +732,10 @@ export function GettingStartedFlow({
                   Guarded rather than always-rendered: on every other node this
                   subtree must not exist at all. */}
               {createTarget?.kind === 'unavailable' ? (
-                <Column key='owned' gap='0.75rem'>
-                  <CardSubtitle>
-                    This server is run by one person for their own data. You can
-                    sign in, or open a drive you were invited to.
-                  </CardSubtitle>
-                  {/* Nobody arrives here wanting to be told no. They wanted an
-                      account somewhere, so name the two places that still give
-                      them one — hosted, or their own machine. */}
-                  <CardSubtitle>Want a server of your own?</CardSubtitle>
-                  <OwnedElsewhere>
-                    <ExternalLink to='https://atomicserver.eu'>
-                      Get one hosted
-                    </ExternalLink>
-                    <ExternalLink to='https://github.com/atomicdata-dev/atomic-server'>
-                      Run it yourself
-                    </ExternalLink>
-                  </OwnedElsewhere>
-                </Column>
+                <CardSubtitle key='owned'>
+                  This server is run by one person for their own data. You can
+                  sign in, or open a drive you were invited to.
+                </CardSubtitle>
               ) : (
                 <CtaButton
                   key='create'
@@ -812,6 +797,31 @@ export function GettingStartedFlow({
                 Try the live demo
               </CtaButton>
             </ButtonStack>
+            {/* Below the buttons on purpose: what this node offers comes
+                first, and this is the consolation for someone it cannot
+                help. Plain links, no icon — an aside, not a third choice
+                competing with Sign in. */}
+            {createTarget?.kind === 'unavailable' ? (
+              <OwnedElsewhere key='elsewhere'>
+                Want a server of your own?{' '}
+                <PlainExternalLink
+                  href='https://atomicserver.eu'
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  Get one hosted
+                </PlainExternalLink>{' '}
+                or{' '}
+                <PlainExternalLink
+                  href='https://github.com/atomicdata-dev/atomic-server'
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  run it yourself
+                </PlainExternalLink>
+                .
+              </OwnedElsewhere>
+            ) : null}
             {error ? (
               <CardError key='error' role='alert'>
                 {error.message}
@@ -1329,11 +1339,22 @@ const AtomicServerLogo = styled(Logo)`
 `;
 
 /** Separates the offered passkey from the advanced agent-secret path below. */
-const OwnedElsewhere = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1.25rem;
-  justify-content: center;
+const OwnedElsewhere = styled.p`
+  margin: 0;
+  width: 100%;
+  text-align: center;
+  /* pretty, not balance: balancing squeezed this to half the available
+     width and split a link across two lines. */
+  text-wrap: pretty;
+  color: ${p => p.theme.colors.textLight};
+  font-size: 0.85rem;
+`;
+
+const PlainExternalLink = styled.a`
+  color: ${p => p.theme.colors.main};
+  text-decoration: underline;
+  /* A link that reads as one thing should wrap as one thing. */
+  white-space: nowrap;
 `;
 
 const OtherWaysLabel = styled.span`

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -120,9 +120,9 @@ export function GettingStartedFlow({
   // /node-info), account creation goes through the portal (email
   // verification). Self-hosted / FOSS nodes report nothing here, so we keep the
   // local DID-agent creation unchanged.
-  const [createTarget, setCreateTarget] = useState<AccountCreationTarget>({
-    kind: 'local',
-  });
+  const [createTarget, setCreateTarget] = useState<AccountCreationTarget | null>(
+    null,
+  );
   /**
    * Any control plane this build knows of, which is a weaker question than
    * `createTarget` answers.
@@ -732,7 +732,7 @@ export function GettingStartedFlow({
                   still work, and are what someone arriving here actually needs.
                   Guarded rather than always-rendered: on every other node this
                   subtree must not exist at all. */}
-              {createTarget.kind === 'unavailable' ? (
+              {createTarget?.kind === 'unavailable' ? (
                 <CardSubtitle key='owned'>
                   This server is run by one person for their own data. You can
                   sign in, or open a drive you were invited to.
@@ -741,7 +741,9 @@ export function GettingStartedFlow({
                 <CtaButton
                   key='create'
                   type='button'
+                  disabled={!createTarget}
                   onClick={() => {
+                    if (!createTarget) return;
                     // Hosted build or managed node → create the account on the
                     // portal (email verification). FOSS node → local identity.
                     if (createTarget.kind === 'portal') {
@@ -760,7 +762,7 @@ export function GettingStartedFlow({
                   be walled out of their own software — and on a FOSS build
                   "Create account" already is this, so offering it twice would
                   just be noise. */}
-              {createTarget.kind === 'portal' && (
+              {createTarget?.kind === 'portal' && (
                 <CtaButton
                   key='local'
                   type='button'
@@ -944,7 +946,9 @@ export function GettingStartedFlow({
                         key='create'
                         type='button'
                         subtle
+                        disabled={!createTarget || createTarget.kind === 'unavailable'}
                         onClick={() => {
+                          if (!createTarget || createTarget.kind === 'unavailable') return;
                           setError(undefined);
 
                           if (createTarget.kind === 'portal') {

--- a/docs/src/atomicserver/faq.md
+++ b/docs/src/atomicserver/faq.md
@@ -33,6 +33,21 @@ This could especially be helpful if you're running at `localhost:9883` and want 
 You can press the menu icon (the three dots in the navigation bar), go to sharing, and uncheck the public `read` right.
 See the [Hierarchy chapter](https://docs.atomicdata.dev/hierarchy.html) in the docs on more info of the authorization model.
 
+## Can strangers store their data on my server?
+
+By default, yes — anyone who can reach your server can create an account and a
+Drive on it. That is deliberate for a machine on your desk or your home network,
+and wrong for one on a public address.
+
+Being reachable is not the same as hosting strangers. To keep the first without
+the second, set `ATOMIC_OWNER_AGENT` to your Agent ID. Visitors keep reading
+whatever you shared and invited collaborators keep their access; only creating a
+*new* Drive becomes yours alone. See
+[Putting your server on the internet](./installation.md#putting-your-server-on-the-internet).
+
+If your server sits behind nginx, Caddy, Docker, or a tunnel, it cannot tell that
+it is public and will not warn you. Set it yourself.
+
 ## Items are missing in my Collections / Search results
 
 You might have a problem with your indexes.

--- a/docs/src/atomicserver/installation.md
+++ b/docs/src/atomicserver/installation.md
@@ -168,9 +168,111 @@ ATOMIC_DOMAIN=example.com
 ATOMIC_PORT=80
 # Disable built-in letsencrypt
 ATOMIC_HTTPS=false
-# Since Atomic-server is no longer aware of the existence of the external HTTPS service, we need to set the full URL here:
-ATOMIC_SERVER_URL=https://example.com
 ```
+
+`ATOMIC_DOMAIN` is what the server uses to build its own links, so set it to the
+name your users type — not to `localhost`, even though that is where the proxy
+forwards to. Getting this wrong mostly shows up as links pointing at the wrong
+host.
+
+Behind a proxy the server cannot tell that it is reachable from the internet:
+the connection arrives from the proxy, on the local interface. It will not warn
+you. See [Putting your server on the internet](#putting-your-server-on-the-internet)
+for what to set so strangers cannot store their data on your disk.
+
+## Putting your server on the internet
+
+By default, **anyone who can reach your server can create an account on it and
+store their data on your disk.** That is the right behaviour on your laptop or a
+home network. On a public address it makes your server an open sign-up form for
+free storage.
+
+This is not about privacy of what you already have — your existing Drives stay
+as private as their permissions say. It is about who may put *new* data here.
+
+### Name yourself as the owner
+
+You need your Agent ID: a public identifier that looks like
+`did:ad:agent:AbCd...`. If you do not have one yet, run the server on your own
+machine first, click **Create account**, and copy the Agent ID from Settings.
+Your phone or the desktop app work equally well — an identity is a keypair, it
+does not belong to any particular server.
+
+Then set it on the server that will be public:
+
+```ini
+ATOMIC_OWNER_AGENT=did:ad:agent:AbCd...
+```
+
+That is the whole setup. Restart, and the server will say so at boot:
+
+```text
+Only its owner can create new Drives here (did:ad:agent:AbCd...).
+```
+
+> **Use the Agent ID, never the secret.** The ID is public and safe to put in a
+> config file. The secret is your private key; the server never needs it and
+> refuses to start if you paste one here.
+
+### What changes, and what does not
+
+| Still works | Now refused |
+| --- | --- |
+| Anyone reading a Drive you made public | A stranger creating an account here |
+| People you invited, in the Drives you invited them to | A stranger pushing a new Drive over sync |
+| Your own other devices, signing in as you | A stranger uploading files to a Drive they invented |
+| Every Drive already on this server, including guests' | |
+
+Drives that already exist keep working. Turning this on never revokes access to
+data that is already on the disk — including Drives created before you set it,
+or by people you invited.
+
+New Drives you create are enrolled automatically, because you are the owner. Your
+second device is the same Agent, so it needs nothing extra.
+
+### If you are behind a reverse proxy or a tunnel
+
+**The server cannot detect this, and will not warn you.** With nginx, Caddy,
+Traefik, Docker port mapping, a Cloudflare Tunnel, or Tailscale in front, every
+request arrives from the proxy on a local address, and `ATOMIC_DOMAIN` is often
+still `localhost`. As far as the process can tell, it is a private machine.
+
+If your server is reachable from the internet by any route, set
+`ATOMIC_OWNER_AGENT`. Nothing else infers it for you.
+
+### Running an open server on purpose
+
+If you *want* a server other people can sign up on — a shared instance for a
+team or a community — that is still supported, and is what you get by default.
+To keep it open and silence the boot warning, say so:
+
+```ini
+ATOMIC_HOST_MODE=open
+```
+
+Do this deliberately. It means anyone who can reach the address can store data
+on your disk, and there is currently no quota.
+
+### Troubleshooting
+
+**"ATOMIC_HOST_MODE=owner needs ATOMIC_OWNER_AGENT to be set"** — you asked for a
+gated server without saying whose it is. Set `ATOMIC_OWNER_AGENT`, or use
+`ATOMIC_HOST_MODE=open` if you meant to run an open one. The server refuses to
+start rather than falling back to open, because a typo in a config file should
+not quietly publish your disk.
+
+**"ATOMIC_OWNER_AGENT looks like an Agent *secret*"** — you pasted the private
+key. Open the secret and use the `subject` field inside it, or copy the Agent ID
+from Settings.
+
+**"This server does not host new Drives"** — someone (possibly you, in another
+browser) tried to create an account. Sign in with the owner's secret instead. If
+you meant to let this person in, invite them to a specific Drive rather than
+giving them one of their own.
+
+**I locked myself out.** You did not: `ATOMIC_OWNER_AGENT` is read fresh at every
+boot and is never stored. Change it and restart, or remove it to go back to an
+open server.
 
 ## Using `systemd` to run Atomic-Server as a service
 

--- a/lib/defaults/default_store.json
+++ b/lib/defaults/default_store.json
@@ -1393,7 +1393,10 @@
       "https://atomicdata.dev/properties/server/managed",
       "https://atomicdata.dev/properties/server/portalUrl",
       "https://atomicdata.dev/properties/server/peers",
-      "https://atomicdata.dev/properties/isUninitialized"
+      "https://atomicdata.dev/properties/isUninitialized",
+      "https://atomicdata.dev/properties/server/hostMode",
+      "https://atomicdata.dev/properties/server/acceptsNewDrives",
+      "https://atomicdata.dev/properties/server/ownerSet"
     ],
     "https://atomicdata.dev/properties/requires": [
       "https://atomicdata.dev/properties/shortname"
@@ -1647,6 +1650,36 @@
     ],
     "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
     "https://atomicdata.dev/properties/shortname": "peers"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/server/hostMode",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/string",
+    "https://atomicdata.dev/properties/description": "Who may create a new Drive on this node: `open` (anyone who can reach it) or `owner` (only the agent that owns the node). Absent on older nodes, which behave as `open`.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "host-mode"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/server/acceptsNewDrives",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/boolean",
+    "https://atomicdata.dev/properties/description": "True if this node accepts a new Drive from whoever asks. False in owner mode, where new Drives are the owner's alone. Reading shared data and using an invited Drive are unaffected either way.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "accepts-new-drives"
+  },
+  {
+    "@id": "https://atomicdata.dev/properties/server/ownerSet",
+    "https://atomicdata.dev/properties/datatype": "https://atomicdata.dev/datatypes/boolean",
+    "https://atomicdata.dev/properties/description": "True if this node has been told which agent owns it.",
+    "https://atomicdata.dev/properties/isA": [
+      "https://atomicdata.dev/classes/Property"
+    ],
+    "https://atomicdata.dev/properties/parent": "https://atomicdata.dev/properties",
+    "https://atomicdata.dev/properties/shortname": "owner-set"
   },
   {
     "@id": "https://atomicdata.dev/properties/peer/live",

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -923,10 +923,35 @@ impl Commit {
                     match store.sync_policy().admit_decision(&drive_subject) {
                         crate::sync::policy::AdmitDecision::Admitted => {}
                         crate::sync::policy::AdmitDecision::NotEnrolled => {
-                            return Err(format!(
-                                "Drive {drive_subject} is not enrolled for sync on this node."
-                            )
-                            .into());
+                            // A drive nobody here has seen is either its owner
+                            // setting one up or a stranger helping themselves to
+                            // the disk. Only the policy can tell those apart, so
+                            // ask it — and only for a drive being created, never
+                            // as a way back in for one already refused.
+                            //
+                            // Whose signature this is has been checked by now
+                            // (`validate_signature`, far above). When that check
+                            // was skipped the commit did not come off the wire at
+                            // all — it is initialization, a migration, or an
+                            // import — so the writer is this node itself.
+                            let writer = if opts.validate_signature {
+                                crate::agents::ForAgent::AgentSubject(commit.signer.clone())
+                            } else {
+                                crate::agents::ForAgent::Sudo
+                            };
+
+                            let policy = store.sync_policy();
+
+                            if is_new && policy.may_enroll_drive(&drive_subject, &writer) {
+                                tracing::info!(
+                                    "Enrolling new drive {} for {}",
+                                    drive_subject,
+                                    writer
+                                );
+                                policy.enroll_drive(&drive_subject);
+                            } else {
+                                return Err(policy.not_enrolled_message(&drive_subject).into());
+                            }
                         }
                         crate::sync::policy::AdmitDecision::OverQuota => {
                             return Err(format!(
@@ -2941,5 +2966,121 @@ mod test {
         assert_eq!(commit_builder.subject, "https://localhost/test");
         assert!(commit_builder.loro_update.is_some());
         assert!(!commit_builder.destroy);
+    }
+}
+
+/// Owner mode: only the node's owner may put a *new* drive here.
+///
+/// The managed-node tests above cover an allowlist a control plane populates.
+/// These cover the self-hosted gate, where the answer turns on *who is signing*
+/// rather than on what some other system already enrolled.
+#[cfg(all(test, feature = "db"))]
+mod owner_mode_tests {
+    use super::*;
+    use crate::sync::policy::OwnerPolicy;
+    use crate::Value;
+    use std::sync::Arc;
+
+    fn signed_opts(agent: &crate::agents::Agent) -> CommitOpts {
+        CommitOpts {
+            validate_signature: true,
+            validate_timestamp: false,
+            validate_previous_commit: true,
+            validate_rights: true,
+            validate_for_agent: Some(agent.subject.to_string()),
+            update_index: true,
+            ..CommitOpts::no_validations_no_index()
+        }
+    }
+
+    /// A commit that brings a new drive into being, signed by `agent`.
+    async fn new_drive_commit(db: &crate::Db, agent: &crate::agents::Agent) -> Commit {
+        let mut builder = CommitBuilder::new("placeholder".into());
+        builder.set(
+            crate::urls::IS_A.into(),
+            Value::ResourceArray(vec![crate::urls::DRIVE.to_string().into()]),
+        );
+        builder.set(crate::urls::NAME.into(), Value::String("A Drive".into()));
+        Commit::create_did(builder, agent, db).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_stranger_cannot_create_a_drive_on_someone_elses_node() {
+        let db = crate::Db::init_temp("owner_gate_stranger").await.unwrap();
+        let (owner, _) = db.setup("Owner").await.unwrap();
+        let stranger = db.create_agent(Some("Stranger")).await.unwrap();
+
+        db.set_sync_policy(Arc::new(OwnerPolicy::new(owner.subject.to_string())));
+
+        let commit = new_drive_commit(&db, &stranger).await;
+        let err = db
+            .apply_commit(commit, &signed_opts(&stranger))
+            .await
+            .expect_err("a stranger must not be able to genesis a drive on a gated node")
+            .to_string();
+
+        // The person reading this clicked a button; the message has to be about
+        // them, not about enrollment bookkeeping.
+        assert!(err.contains("does not host new Drives"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn the_owner_can_still_create_drives() {
+        let db = crate::Db::init_temp("owner_gate_owner").await.unwrap();
+        let (owner, _) = db.setup("Owner").await.unwrap();
+
+        db.set_sync_policy(Arc::new(OwnerPolicy::new(owner.subject.to_string())));
+
+        let commit = new_drive_commit(&db, &owner).await;
+        let subject = commit.subject.to_string();
+
+        db.apply_commit(commit, &signed_opts(&owner))
+            .await
+            .expect("the owner must be able to create a drive on their own node");
+
+        // And it was enrolled, so the *next* write to it is admitted without
+        // re-deciding who may enroll.
+        assert!(
+            db.sync_policy().admit_drive_write(&subject),
+            "creating a drive must enroll it"
+        );
+    }
+
+    #[tokio::test]
+    async fn drives_that_predate_the_gate_keep_working() {
+        // The switch from open to owner must never revoke access to data
+        // already on the disk — including a guest's drive from before.
+        let db = crate::Db::init_temp("owner_gate_snapshot").await.unwrap();
+        let (owner, _) = db.setup("Owner").await.unwrap();
+        let guest = db.create_agent(Some("Guest")).await.unwrap();
+
+        let commit = new_drive_commit(&db, &guest).await;
+        let guest_drive = commit.subject.to_string();
+        db.apply_commit(commit, &signed_opts(&guest))
+            .await
+            .expect("open node accepts the guest drive");
+
+        // Now the operator names an owner and restarts.
+        let policy = OwnerPolicy::new(owner.subject.to_string());
+        policy.enroll_existing(db.drive_subjects().await);
+        db.set_sync_policy(Arc::new(policy));
+
+        assert!(
+            db.sync_policy().admit_drive_write(&guest_drive),
+            "a drive created before the gate went up must stay writable"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_open_node_still_takes_a_drive_from_anyone() {
+        // The default path, and the one every existing deployment is on.
+        let db = crate::Db::init_temp("owner_gate_open").await.unwrap();
+        let (_owner, _) = db.setup("Owner").await.unwrap();
+        let stranger = db.create_agent(Some("Stranger")).await.unwrap();
+
+        let commit = new_drive_commit(&db, &stranger).await;
+        db.apply_commit(commit, &signed_opts(&stranger))
+            .await
+            .expect("an open node must behave exactly as it did before host mode existed");
     }
 }

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -1073,6 +1073,29 @@ impl Db {
         Ok(drives)
     }
 
+    /// Every Drive this node stores.
+    ///
+    /// A full scan of the resource tree, deliberately. The query indexes would
+    /// be faster, but an index that is stale or partial answers "fewer drives
+    /// than you have" — and the caller (owner-mode enrollment) would then
+    /// silently lock the owner out of their own data. Paying O(store) once at
+    /// boot for a certain answer is the right trade; do not "optimize" this into
+    /// a query without changing what a wrong answer costs.
+    pub async fn drive_subjects(&self) -> Vec<String> {
+        use crate::storelike::Storelike;
+
+        self.all_resources(false)
+            .filter(|resource| {
+                matches!(
+                    resource.get(crate::urls::IS_A),
+                    Ok(Value::ResourceArray(classes))
+                        if classes.iter().any(|class| class.to_string() == crate::urls::DRIVE)
+                )
+            })
+            .map(|resource| resource.get_subject().to_string())
+            .collect()
+    }
+
     /// Cheap local-presence check (no network fetch): is this subject's resource
     /// already stored locally? Used by managed-node replication to skip drives it
     /// already hosts before resolving/pulling them from a peer.

--- a/lib/src/sync/engine.rs
+++ b/lib/src/sync/engine.rs
@@ -978,20 +978,37 @@ pub async fn import_sync_push(
             return (0, vec![]);
         }
     }
-    // If drive doesn't exist yet, allow import (bootstrap case — new drive arriving)
+    // Admission gate. A no-op under the default OpenPolicy (self-hosted / FOSS
+    // left open), so it bites only where a policy was installed: a managed node
+    // admits enrolled drives within quota, an owner-gated node admits the drives
+    // it hosts.
+    let policy = store.sync_policy();
+    let decision = policy.admit_decision(&push.drive);
 
-    // Managed admission gate. No-op under the default OpenPolicy (self-hosted /
-    // FOSS), so this only bites on a managed node: it admits writes to enrolled
-    // drives (within quota), plus a bootstrap grace for a drive whose enrollment
-    // is still propagating to the allowlist.
-    let decision = store.sync_policy().admit_decision(&push.drive);
     if !decision.is_admitted() {
-        tracing::warn!(
-            "import_sync_push: drive {} not admitted by sync policy ({:?})",
-            push.drive,
-            decision
-        );
-        return (0, vec![]);
+        // The drive not existing here used to be reason enough to accept it —
+        // "bootstrap case, a new drive is arriving". That is also exactly what
+        // a stranger's first push looks like, so the bootstrap now has to say
+        // who it is for. An open node still admits anyone, which is what keeps
+        // ordinary first-sync working.
+        let is_new_here = store.get_resource(&drive_subject).await.is_err();
+
+        if is_new_here && policy.may_enroll_drive(&push.drive, for_agent) {
+            tracing::info!(
+                "import_sync_push: enrolling new drive {} for {:?}",
+                push.drive,
+                for_agent
+            );
+            policy.enroll_drive(&push.drive);
+        } else {
+            tracing::warn!(
+                "import_sync_push: drive {} not admitted by sync policy ({:?}, agent {:?})",
+                push.drive,
+                decision,
+                for_agent
+            );
+            return (0, vec![]);
+        }
     }
 
     let mut count = 0;

--- a/lib/src/sync/peer.rs
+++ b/lib/src/sync/peer.rs
@@ -686,9 +686,22 @@ async fn admitted_for_drive(
 
     // Admission gate first (allowlist/quota/bootstrap grace) — cheap,
     // in-memory. No-op under the default OpenPolicy (self-hosted / FOSS).
-    if !store.sync_policy().admit_drive_write(drive_subject) {
-        cache.insert(drive_subject.to_string(), false);
-        return false;
+    let policy = store.sync_policy();
+
+    if !policy.admit_drive_write(drive_subject) {
+        // Same bootstrap question as `import_sync_push`: a drive we do not have
+        // may be a live update for one arriving right now. Whether that is
+        // allowed depends on who is pushing it, which only the policy knows.
+        let drive_subj =
+            crate::Subject::from_raw(drive_subject, store.get_base_domain().as_deref());
+        let is_new_here = store.get_resource(&drive_subj).await.is_err();
+
+        if is_new_here && policy.may_enroll_drive(drive_subject, agent) {
+            policy.enroll_drive(drive_subject);
+        } else {
+            cache.insert(drive_subject.to_string(), false);
+            return false;
+        }
     }
 
     // ACL: may this write land? The sending peer's own write access, or —

--- a/lib/src/sync/policy.rs
+++ b/lib/src/sync/policy.rs
@@ -68,6 +68,34 @@ pub trait SyncPolicy: Send + Sync {
     fn admit_drive_write(&self, drive_subject: &str) -> bool {
         self.admit_decision(drive_subject).is_admitted()
     }
+
+    /// Whether `agent` may bring a drive this node has **never hosted** into
+    /// existence here.
+    ///
+    /// This is the one question [`admit_decision`](Self::admit_decision) cannot
+    /// answer, because it is about the *writer*, not the drive: a node that
+    /// refuses every unknown drive can never be set up, and a node that accepts
+    /// every unknown drive is free storage for the internet. Consulted only
+    /// where a drive is genuinely new — the bootstrap paths — and never as a
+    /// substitute for `admit_decision` on an existing one.
+    ///
+    /// Deliberately has no default: "may a stranger create a workspace here"
+    /// has no answer that is safe to inherit by omission.
+    fn may_enroll_drive(&self, drive_subject: &str, agent: &crate::agents::ForAgent) -> bool;
+
+    /// Remember that this node now hosts `drive_subject`, so later writes to it
+    /// are admitted. A no-op for policies with nothing to remember.
+    fn enroll_drive(&self, _drive_subject: &str) {}
+
+    /// What to tell whoever was refused, in their language rather than ours.
+    ///
+    /// The person reading this is usually not an operator: they clicked
+    /// "create account" on someone else's server. "Drive … is not enrolled for
+    /// sync on this node" tells them nothing they can act on, and reads like a
+    /// malfunction rather than a decision.
+    fn not_enrolled_message(&self, drive_subject: &str) -> String {
+        format!("Drive {drive_subject} is not enrolled for sync on this node.")
+    }
 }
 
 /// The default policy: every drive is allowed and there are no quotas. This is
@@ -82,6 +110,12 @@ impl SyncPolicy for OpenPolicy {
     }
 
     fn drive_within_quota(&self, _drive_subject: &str) -> bool {
+        true
+    }
+
+    /// Anyone. This is what "open" means, and what every node did before host
+    /// mode existed — an upgrade must not change who may write.
+    fn may_enroll_drive(&self, _drive_subject: &str, _agent: &crate::agents::ForAgent) -> bool {
         true
     }
 }
@@ -147,6 +181,21 @@ impl AllowlistPolicy {
             .collect();
         if let Ok(mut guard) = self.inner.write() {
             guard.allowed = map;
+        }
+    }
+
+    /// Add one drive to the allowlist, leaving the rest of it alone.
+    ///
+    /// [`set_drive_policies`](Self::set_drive_policies) replaces the whole list,
+    /// which is right for a control plane pushing the current truth and wrong
+    /// for a node enrolling the drive it just accepted — that would drop every
+    /// other drive it hosts.
+    pub fn enroll(&self, drive_subject: impl Into<String>) {
+        if let Ok(mut guard) = self.inner.write() {
+            guard
+                .allowed
+                .entry(drive_subject.into())
+                .or_insert_with(DrivePolicy::default);
         }
     }
 
@@ -234,11 +283,232 @@ impl SyncPolicy for AllowlistPolicy {
     fn admit_decision(&self, drive_subject: &str) -> AdmitDecision {
         self.decide_at(drive_subject, Instant::now())
     }
+
+    /// Nobody, by asking. A managed node's allowlist is the control plane's to
+    /// populate; a drive appears here because it was enrolled out of band, not
+    /// because someone pushed it.
+    fn may_enroll_drive(&self, _drive_subject: &str, _agent: &crate::agents::ForAgent) -> bool {
+        false
+    }
+
+    fn enroll_drive(&self, drive_subject: &str) {
+        self.enroll(drive_subject);
+    }
+}
+
+/// Only one agent may put new drives on this node.
+///
+/// The self-hosted counterpart to [`AllowlistPolicy`]: same allowlist, but
+/// populated locally and synchronously instead of by a control plane. A node
+/// running this hosts the drives it already had plus whatever its owner creates,
+/// and refuses to become storage for anybody else.
+///
+/// What it does **not** touch: reading, ACL on existing resources, or writes by
+/// collaborators to a drive that is already hosted. A guest invited to a drive
+/// keeps working exactly as before — they just cannot genesis a drive of their
+/// own here. Treating "has write on some hosted drive" as "may enroll a new
+/// one" would be the same hole with extra steps.
+pub struct OwnerPolicy {
+    /// The owner's agent DID. Compared verbatim: an agent DID *is* a public
+    /// key, so equality is the whole check.
+    owner_agent: String,
+    hosted: AllowlistPolicy,
+}
+
+impl OwnerPolicy {
+    /// `owner_agent` is the DID (`did:ad:agent:…`), never a secret.
+    ///
+    /// Grace is zero, unlike a managed node's. A managed allowlist lags its
+    /// control plane, so a freshly-enrolled drive needs a window to sync in;
+    /// enrollment here is local and immediate, and that window is precisely how
+    /// long a stranger would have to dump a drive before anyone noticed.
+    pub fn new(owner_agent: impl Into<String>) -> Self {
+        let hosted = AllowlistPolicy::new();
+        hosted.set_grace(Duration::ZERO);
+
+        Self {
+            owner_agent: owner_agent.into(),
+            hosted,
+        }
+    }
+
+    /// Enroll the drives this node already stores.
+    ///
+    /// A node that ran Open and then gained an owner must keep serving what is
+    /// already on its disk — including drives belonging to people the owner
+    /// invited, or created before the switch. Gating those retroactively would
+    /// turn on a security feature by deleting access to existing data.
+    pub fn enroll_existing<I, S>(&self, drive_subjects: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for subject in drive_subjects {
+            self.hosted.enroll(subject);
+        }
+    }
+
+    pub fn owner_agent(&self) -> &str {
+        &self.owner_agent
+    }
+
+    pub fn hosted_drive_subjects(&self) -> Vec<String> {
+        self.hosted.allowed_drive_subjects()
+    }
+}
+
+impl SyncPolicy for OwnerPolicy {
+    fn drive_is_allowed(&self, drive_subject: &str) -> bool {
+        self.hosted.drive_is_allowed(drive_subject)
+    }
+
+    fn drive_within_quota(&self, drive_subject: &str) -> bool {
+        self.hosted.drive_within_quota(drive_subject)
+    }
+
+    fn admit_decision(&self, drive_subject: &str) -> AdmitDecision {
+        self.hosted.admit_decision(drive_subject)
+    }
+
+    fn may_enroll_drive(&self, _drive_subject: &str, agent: &crate::agents::ForAgent) -> bool {
+        match agent {
+            // The node acting on its own behalf: initialization, migrations,
+            // importing a backup. Refusing this would mean a gated node could
+            // not finish booting.
+            crate::agents::ForAgent::Sudo => true,
+            crate::agents::ForAgent::AgentSubject(subject) => {
+                subject.as_str() == self.owner_agent
+            }
+            // An unauthenticated request is never the owner. Stated rather than
+            // left to fall out of the comparison, because this is the case the
+            // whole policy exists for.
+            crate::agents::ForAgent::Public => false,
+        }
+    }
+
+    fn enroll_drive(&self, drive_subject: &str) {
+        self.hosted.enroll(drive_subject);
+    }
+
+    fn not_enrolled_message(&self, _drive_subject: &str) -> String {
+        "This server does not host new Drives. Its owner runs it for their own \
+         data, so you cannot create a workspace here.\n\n\
+         You can still read anything they published, and open any Drive you were \
+         invited to. To keep your own data, run your own server or use a hosted \
+         one."
+            .to_string()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::agents::ForAgent;
+
+    const OWNER: &str = "did:ad:agent:ownerkey";
+    const STRANGER: &str = "did:ad:agent:strangerkey";
+
+    fn agent(subject: &str) -> ForAgent {
+        ForAgent::AgentSubject(crate::Subject::from_raw(subject, None))
+    }
+
+    #[test]
+    fn an_open_node_takes_a_drive_from_anyone() {
+        assert!(OpenPolicy.may_enroll_drive("did:ad:drive:new", &agent(STRANGER)));
+        assert!(OpenPolicy.may_enroll_drive("did:ad:drive:new", &ForAgent::Public));
+    }
+
+    #[test]
+    fn only_the_owner_may_enroll_a_new_drive() {
+        let policy = OwnerPolicy::new(OWNER);
+
+        assert!(policy.may_enroll_drive("did:ad:drive:new", &agent(OWNER)));
+        assert!(!policy.may_enroll_drive("did:ad:drive:new", &agent(STRANGER)));
+        assert!(!policy.may_enroll_drive("did:ad:drive:new", &ForAgent::Public));
+        // The node itself, so a gated node can still finish booting.
+        assert!(policy.may_enroll_drive("did:ad:drive:new", &ForAgent::Sudo));
+    }
+
+    #[test]
+    fn a_stranger_drive_is_refused_with_no_grace_window() {
+        let policy = OwnerPolicy::new(OWNER);
+
+        // Managed nodes admit an unknown drive briefly while enrollment
+        // propagates. That window is exactly the abuse this mode closes, so the
+        // very first attempt must be refused — not the second.
+        assert_eq!(
+            policy.admit_decision("did:ad:drive:stranger"),
+            AdmitDecision::NotEnrolled
+        );
+        assert_eq!(
+            policy.admit_decision("did:ad:drive:stranger"),
+            AdmitDecision::NotEnrolled
+        );
+    }
+
+    #[test]
+    fn an_enrolled_drive_keeps_writing() {
+        let policy = OwnerPolicy::new(OWNER);
+        policy.enroll_drive("did:ad:drive:mine");
+
+        assert_eq!(
+            policy.admit_decision("did:ad:drive:mine"),
+            AdmitDecision::Admitted
+        );
+    }
+
+    #[test]
+    fn drives_already_on_disk_survive_the_switch() {
+        // Turning the gate on must not revoke access to data that is already
+        // here — including a guest's drive created while the node was open.
+        let policy = OwnerPolicy::new(OWNER);
+        policy.enroll_existing(["did:ad:drive:from-before", "did:ad:drive:a-guests"]);
+
+        for existing in ["did:ad:drive:from-before", "did:ad:drive:a-guests"] {
+            assert_eq!(
+                policy.admit_decision(existing),
+                AdmitDecision::Admitted,
+                "{existing}"
+            );
+        }
+        assert_eq!(
+            policy.admit_decision("did:ad:drive:brand-new"),
+            AdmitDecision::NotEnrolled
+        );
+    }
+
+    #[test]
+    fn enrolling_one_drive_does_not_drop_the_others() {
+        let policy = AllowlistPolicy::new();
+        policy.set_drive_policies([("did:ad:drive:a", None), ("did:ad:drive:b", None)]);
+        policy.enroll("did:ad:drive:c");
+
+        let mut hosted = policy.allowed_drive_subjects();
+        hosted.sort();
+        assert_eq!(
+            hosted,
+            ["did:ad:drive:a", "did:ad:drive:b", "did:ad:drive:c"]
+        );
+    }
+
+    #[test]
+    fn the_refusal_explains_itself_to_a_visitor() {
+        let message = OwnerPolicy::new(OWNER).not_enrolled_message("did:ad:drive:x");
+
+        // No jargon, and no drive subject: the person reading this did not ask
+        // for a drive by name, they clicked a button.
+        assert!(!message.contains("enrolled"), "{message}");
+        assert!(!message.contains("did:ad:drive:x"), "{message}");
+        // It has to say what they *can* still do.
+        assert!(message.contains("invited"), "{message}");
+    }
+
+    #[test]
+    fn a_managed_allowlist_is_never_enrolled_by_asking() {
+        let policy = AllowlistPolicy::new();
+        assert!(!policy.may_enroll_drive("did:ad:drive:new", &agent(OWNER)));
+    }
 
     #[test]
     fn open_policy_allows_everything() {

--- a/lib/src/sync/policy.rs
+++ b/lib/src/sync/policy.rs
@@ -376,9 +376,7 @@ impl SyncPolicy for OwnerPolicy {
             // importing a backup. Refusing this would mean a gated node could
             // not finish booting.
             crate::agents::ForAgent::Sudo => true,
-            crate::agents::ForAgent::AgentSubject(subject) => {
-                subject.as_str() == self.owner_agent
-            }
+            crate::agents::ForAgent::AgentSubject(subject) => subject.as_str() == self.owner_agent,
             // An unauthenticated request is never the owner. Stated rather than
             // left to fall out of the comparison, because this is the case the
             // whole policy exists for.

--- a/lib/src/sync/tests.rs
+++ b/lib/src/sync/tests.rs
@@ -369,6 +369,10 @@ mod peer_sync_tests {
             fn drive_within_quota(&self, _drive_subject: &str) -> bool {
                 true
             }
+
+            fn may_enroll_drive(&self, _drive_subject: &str, _agent: &ForAgent) -> bool {
+                false
+            }
         }
 
         let db = Db::init_temp("blob_unadmitted").await.unwrap();

--- a/lib/src/urls.rs
+++ b/lib/src/urls.rs
@@ -113,6 +113,12 @@ pub const SERVER_PORTAL_URL: &str = "https://atomicdata.dev/properties/server/po
 pub const SERVER_HOME_DRIVE: &str = "https://atomicdata.dev/properties/server/homeDrive";
 /// The devices this node syncs with directly — nested [PEER] resources.
 pub const SERVER_PEERS: &str = "https://atomicdata.dev/properties/server/peers";
+/// `open` or `owner` — who may create a new Drive here. Absent on a node older
+/// than host mode, which clients must read as `open`: that is what it does.
+pub const SERVER_HOST_MODE: &str = "https://atomicdata.dev/properties/server/hostMode";
+pub const SERVER_ACCEPTS_NEW_DRIVES: &str =
+    "https://atomicdata.dev/properties/server/acceptsNewDrives";
+pub const SERVER_OWNER_SET: &str = "https://atomicdata.dev/properties/server/ownerSet";
 
 // ... for Peers
 pub const PEER_NODE_ID: &str = "https://atomicdata.dev/properties/peer/nodeId";

--- a/planning/README.md
+++ b/planning/README.md
@@ -25,6 +25,7 @@ Remaining work, not "this file exists."
 | --- | --- |
 | [`unified-sync.md`](./unified-sync.md) | **Active.** One sync API over WS or Iroh. Remaining: AUTH-before-SYNC fail-closed, signed destroys on the wire, outbox port to `atomic_lib`, Layer 2 provenance. |
 | [`serverless-p2p.md`](./serverless-p2p.md) | **Planned.** Same-agent device sync without a hub. P0 remaining: AUTH-before-SYNC, bind `AUTH.requestedSubject` to the drive, OQ5 bootstrap admission. |
+| [`foss-public-host-mode.md`](./foss-public-host-mode.md) | **Proposal.** A FOSS node on a public address must not host strangers' workspaces. `HostMode { Open, Owner }`, owner claimed by agent DID. Closes unified-sync OQ5 for Owner. |
 | [`authorization-sync.md`](./authorization-sync.md) | **Draft.** Signed commit authorization, grant-chain evidence, peer-sync trust boundaries. |
 | [`encryption.md`](./encryption.md) | **Exploration.** E2EE / blind replicas undecided. Local cache at rest **shipped** — see [`opfs-per-agent-encryption.md`](./opfs-per-agent-encryption.md). |
 | [`unified-data-layer.md`](./unified-data-layer.md) | Browser/JS: one ingress, one outbox, one subscription model. Sign-at-drain (S4a) shipped separately. |

--- a/planning/cloud-sync-managed-node.md
+++ b/planning/cloud-sync-managed-node.md
@@ -20,8 +20,12 @@ work, spanning `atomic-server` (this repo: data plane + browser) and
   `AllowlistPolicy`, and spawns the heartbeat / policy poll / usage report /
   replication pull. Enabled by `ATOMIC_MANAGED_URL`.
 - **FOSS / self-hosted** runs the plain `atomic-server` binary (no-op hook):
-  unrestricted (`OpenPolicy`), `/node-info` reports `managed: false`, never
-  phones home. FOSS UX never changes.
+  unrestricted (`OpenPolicy`) on localhost, `/node-info` reports
+  `managed: false`, never phones home. Putting that same binary on a public
+  address without a local allowlist is an open sync hub — the proposed FOSS
+  fix is [`foss-public-host-mode.md`](./foss-public-host-mode.md), which
+  reuses `AllowlistPolicy` without a control plane. FOSS localhost UX does
+  not change.
 
 > **Do not put the control-plane client back in the open `atomic-server`.** The
 > recovery restored a pre-deletion `server/src/saas.rs`; it was renamed `node.rs`

--- a/planning/foss-public-host-mode.md
+++ b/planning/foss-public-host-mode.md
@@ -1,0 +1,386 @@
+# FOSS public host mode — expose HTTP, do not host strangers
+
+> **Status:** Proposal (2026-08-15). Companion to
+> [`cloud-sync-managed-node.md`](./cloud-sync-managed-node.md) (managed
+> allowlist), [`unified-sync.md`](./unified-sync.md) Open Question 5
+> (bootstrap admission), and [`sync-onboarding-ux.md`](./sync-onboarding-ux.md)
+> (welcome / pairing copy).
+>
+> This is the FOSS-side answer to the same abuse the managed node already
+> closes: a reachable node must not become a free sync hub. The open core
+> already has the *mechanism* (`SyncPolicy` / `AllowlistPolicy`). FOSS never
+> installs it. That is the gap.
+
+## Goal
+
+A person can put a stock `atomic-server` on the public internet — a site, a
+wiki, their own workspace reachable from a phone — **without** letting
+strangers store a workspace on it.
+
+Two things that must stay true:
+
+- **Public read of what the owner shared stays public.** `ATOMIC_HOME_DRIVE`,
+  the public Agent on a Drive, invite links, and ordinary `check_read` do not
+  change.
+- **FOSS never phones home.** No control plane, no email, no portal. The
+  owner is a local agent DID persisted on the node. Guardrail #3 in
+  `cloud-sync-managed-node.md` is not renegotiated here.
+
+## The hole today
+
+FOSS boots `OpenPolicy`: every drive is admitted, there is no quota, and a
+drive that does not exist locally is treated as a bootstrap and accepted
+(`import_sync_push` and `admitted_for_drive` both carve this out;
+`unified-sync.md` OQ5). Combined with the current welcome screen, a public
+FOSS node is an open registration form for free storage.
+
+Anyone who can reach the origin can:
+
+| Path | What happens |
+| --- | --- |
+| Welcome → **Create account** | `NewIdentitySection` mints a DID agent and `store.createDrive()` POSTs a genesis commit. `OpenPolicy` admits it. The stranger now has a private workspace on *your* disk. |
+| `POST /commit` genesis | Same write, no UI required. |
+| Iroh `SYNC_PUSH` of a new drive | `/server` advertises `did:ad:node:…`. AUTH is only identity proof. A missing drive hits `Err(_) => true` and is imported. |
+| `PUT /blob/{hash}` | Gated by `admit_drive_write`. Under `OpenPolicy` that is a no-op, so a freshly minted drive can also take file bytes. |
+
+What is *already* fine, and must not be “fixed”:
+
+- ACL on **existing** resources (`check_read` / `check_write`). A stranger
+  cannot read a private Drive just because they can reach the host.
+- `--public-mode` is the opposite of this feature (skip auth). Do not reuse
+  the name or the flag.
+- Managed nodes already install `AllowlistPolicy` from the control plane.
+  This plan is the self-hosted equivalent, populated locally.
+- Unsolicited Iroh peers are not written to the known-peers table (F9).
+  Connection ≠ enrollment.
+
+The old `/setup` invite is no longer the onboarding path.
+`AppState` no longer creates a root Drive; the data-browser’s new-identity
+flow does. Docs that still tell people to accept `/setup` are describing a
+vestige. There is **no owner** on a FOSS node today — the first visitor and
+the hundredth are the same to `OpenPolicy`.
+
+## What “sync with it” means
+
+**Host a workspace** = this node stores and serves a Drive (commits, Loro
+snapshots, blobs) as an always-on replica.
+
+That is what we gate. These are different, and stay allowed:
+
+- A visitor **reads** a Drive the owner marked public.
+- A collaborator the owner **invited** reads and writes *that* Drive
+  (ordinary hierarchy rights). They do not get a blank Drive of their own.
+- The owner’s **other devices** sign in as the same agent and push/pull
+  the owner’s Drives over HTTPS or Iroh.
+
+A later “host your friend’s workspace here” invite is a different product
+(multi-tenant FOSS). Out of scope until someone asks for it.
+
+## Decision: `HostMode { Open, Owner }`
+
+| Mode | Who may enroll a new Drive | Default |
+| --- | --- | --- |
+| **Open** | Anyone. Today’s `OpenPolicy`. | `ATOMIC_DOMAIN` is `localhost` / loopback / a private IP |
+| **Owner** | Only an **authorized-to-create** agent. `AllowlistPolicy` with **zero** grace, persisted on disk. | Everything else (public hostname, `--https`, an explicit flag) |
+
+Override: `--host-mode=open|owner` / `ATOMIC_HOST_MODE`. Never infer
+silently from `--https` alone without logging the chosen mode at boot —
+a tunnel used for local dev must be able to stay Open.
+
+**Do not** use `AllowlistPolicy`’s 10-minute bootstrap grace in Owner
+mode. That window is how a stranger dumps a Drive before anyone notices.
+Managed nodes need grace because enrollment is eventually consistent with
+a control plane. FOSS enrollment is local and synchronous.
+
+### Who is authorized to create a Drive
+
+Narrower than “has write on some hosted Drive”:
+
+1. The **owner agent** — the DID that claimed the node (setup token or
+   `ATOMIC_OWNER_AGENT`).
+2. Later, and only if we add it: agents the owner explicitly grants a
+   `createDrive` / host right. Not v1.
+
+A collaborator with `write` on Drive D may write to D. They may not
+genesis a new Drive on this node. Treating “write on an enrolled Drive”
+as “may enroll” is the abuse vector with extra steps.
+
+The owner’s second device is the same agent DID (they imported the
+secret). Creating another Drive auto-enrolls because the signer *is* the
+owner.
+
+### How a Drive gets on the allowlist
+
+On a successful Drive genesis whose signer is authorized-to-create:
+persist the Drive subject in the allowlist (redb `PluginMeta`, reload on
+boot). Existing Drives at the moment the node flips Open → Owner are
+snapshotted in. After that, strangers get `NotEnrolled` on every write
+path that already consults `admit_decision`:
+
+- `commit.rs::validate_and_build_response` (`POST /commit`, WS `COMMIT`)
+- `engine::import_sync_push`
+- `peer::admitted_for_drive` (Iroh live `UPDATE` / `DESTROY`)
+- `handlers/blob.rs::put_blob`
+
+Agent subjects (`did:ad:agent:…`) stay exempt, keyed on
+`commit.subject.is_agent_did()` — never on a claimed `IS_A`. That
+exemption is small; it is not a Drive. Rate-limit it (below) so it
+cannot become unbounded profile spam.
+
+### Bootstrap (closes OQ5 for Owner)
+
+Replace `Err(_) => true` (“missing Drive ⇒ admit”) with:
+
+- **Open:** keep today’s carve-out.
+- **Owner:** admit a missing Drive iff the authenticated signer is
+  authorized-to-create; then enroll it. Otherwise `NotEnrolled`.
+  `ForAgent::Public` never creates a Drive.
+
+This is “reject-until-known”, not first-writer-wins. First-writer-wins
+on a public socket is a claim race.
+
+## Setup UX
+
+Three real journeys. The welcome screen must be able to tell them apart
+from `/server` (see [Node advertisement](#node-advertisement)).
+
+### 1. Localhost (Open) — do not touch
+
+`Create account` → local DID → `createDrive` → it lands. This is the
+FOSS path `managedServer.ts` exists to protect. E2E `before` /
+`devDrive` stay on it.
+
+### 2. Local first, then expose — the good path
+
+1. Owner creates the account on localhost (Open).
+2. They set a domain / HTTPS / `--host-mode=owner` (or the UI “Make this
+   reachable on the internet” writes the same config).
+3. On the flip: snapshot every Drive already on disk into the allowlist;
+   persist the current agent as owner if none is set.
+4. Restart (or hot-install the policy). Strangers are rejected.
+   The owner’s secret still works from any browser.
+
+Copy, in the owner’s language from `sync-onboarding-ux.md`:
+
+> Visitors can see what you have shared. They cannot store their own
+> workspace on this always-on device.
+
+### 3. VPS first (Owner, no owner yet) — the dangerous path
+
+A fresh node on a public address has no owner. The first `Create
+account` would otherwise *be* the claim.
+
+**Setup token** (WordPress / Ghost / Home Assistant pattern):
+
+- On first boot in Owner mode with no owner, mint a high-entropy token.
+  Persist it. Print once:
+
+  `Owner setup: https://example.com/app/welcome?setup=<token>`
+
+- `/setup` and the welcome `Create account` path accept that token
+  **once**. From a loopback peer, the token is optional (so
+  `ssh -L` / a local proxy still works without fishing in logs).
+- From any other peer, missing/wrong token → the Create-account control
+  is hidden and the server rejects the genesis. Do not advertise a
+  working `/setup` URL on the public welcome page.
+- Accepting consumes the token and writes `owner_agent` + enrolls the
+  new Drive.
+
+Headless alternative: `ATOMIC_OWNER_AGENT=did:ad:agent:…` in the env.
+No token, no race. Useful for image-based deploys where the agent
+already exists.
+
+`--initialize` on a publicly bound Owner node is a footgun (it would
+mint a fresh claim). Require an extra `--confirm-initialize` (or only
+honor `--initialize` from a local CLI) and log a warning that names the
+bind address.
+
+### After the owner exists
+
+Welcome screen on an Owner node:
+
+- **No** “Create account” that creates a Drive on this node.
+- **Sign in** (secret / passkey) — the owner on a new browser.
+- **I have an invite** — existing resource-invite flow, if they arrived
+  on one.
+- If `ATOMIC_HOME_DRIVE` is set and the public Agent may read it: skip
+  welcome and show the site. That is the public-website case.
+
+A stranger who pastes their own secret signs in as themselves and sees
+nothing they may read — same as today — and cannot `createDrive` here.
+`promoteLocalDrive` / “use this always-on device” must fail with the
+same sentence the welcome page used, not a generic 403.
+
+### Collaborators and second devices
+
+| Person | How they get in | What they can host |
+| --- | --- | --- |
+| Owner, new browser | Sign in with the secret | Their Drives (auto-enroll new ones they genesis) |
+| Owner, phone | Pairing code (routing) + same-agent AUTH, or HTTPS + secret | Same |
+| Collaborator | Resource invite → `read`/`write` on a Drive | That Drive only |
+| Stranger | Nothing | Nothing |
+
+Pairing stays routing-only (`device-pairing.md`). The gate is the
+signer, not the NodeID.
+
+## Node advertisement
+
+`GET /server` already tells the client whether the node is managed.
+Add three facts (absent ⇒ treat as Open, so old nodes keep working):
+
+| Property | Meaning |
+| --- | --- |
+| `hostMode` | `open` \| `owner` |
+| `acceptsNewDrives` | `true` only in Open, or Owner with no owner yet *and* the request carries a valid setup token (the welcome page asked with it) |
+| `ownerSet` | whether an owner agent is persisted |
+
+In Owner mode, **do not** give `ForAgent::Public` the Iroh node id or
+the peer list. Those are a device inventory and a dial target. The
+owner’s signed-in session still gets them (Sync page, pairing QR). A
+stranger with a leaked NodeID can still *attempt* an Iroh connect;
+writes fail admission. Hiding the id removes the convenient listing.
+
+`accountCreationTarget` grows a third branch:
+
+- managed + portal → portal (unchanged)
+- FOSS Open → local Create account (unchanged)
+- FOSS Owner + `acceptsNewDrives: false` → no create; Sign in / invite
+- FOSS Owner + valid `?setup=` → one-shot local Create account, then
+  lock
+
+Keep this pure and unit-tested next to `managedServer.test.ts`. Do not
+infer “locked” from `managed: false` alone — that is every FOSS node.
+
+## Protection against malicious users
+
+Admission is the load-bearing gate. These are the leftovers that
+admission does not cover.
+
+1. **Claim race** — setup token, loopback exception, no public `/setup`
+   link. First-writer-wins is not acceptable on `:443`.
+2. **`--initialize`** — extra confirm when bound non-loopback in Owner
+   mode.
+3. **Agent spam** — the agent-DID exemption lets anyone persist a tiny
+   Agent resource. Either require the signer to be the owner / an
+   invite-accept, or rate-limit unknown-agent `POST /commit` (token
+   bucket per IP + per agent). Unbounded profile writes are the
+   residual.
+4. **Expensive public endpoints** — `/search`, `/query`, `/commit`,
+   `/blob`, WS upgrade. A public website needs some of these; a
+   stranger does not need unlimited blob PUTs. Cheap per-IP limits on
+   the write endpoints, independent of ACL.
+5. **Iroh slot exhaustion** — leave Iroh on (phones may use it). Do
+   not persist unknown peers (already true). Optional follow-up: after
+   AUTH, close the stream if the agent is not the owner and has
+   `check_read` on no hosted Drive. Public-site visitors do not need
+   Iroh; they use HTTP.
+6. **Do not treat CORS as a write gate.** Writes are signed. Permissive
+   CORS stays; it is how a public page is read from another origin.
+7. **Optional disk cap** for the whole node, even for the owner, so a
+   stolen secret cannot fill the disk. Nice-to-have; not v1.
+
+`--public-mode` remains a documented footgun: “skip auth, do not bind
+this to the internet.” Owner mode is the flag people actually want
+when they say “public but mine.”
+
+## What we will not do
+
+- Put a control-plane client, heartbeat, or portal URL into the open
+  `atomic-server` binary.
+- Require email to claim a FOSS node.
+- Change the localhost Create-account path.
+- Equate “has write on a shared Drive” with “may enroll a new Drive.”
+- Reuse `--public-mode` or name the feature “public mode.”
+- Make the node sign as a principal to pull private Drives
+  (`cloud-sync-managed-node.md` — the node relays and serves).
+
+## Implementation sketch
+
+Small, in this order. Each step is independently shippable and
+testable.
+
+### Phase 1 — policy on the node (no UI)
+
+- `HostMode` on `Opts` / `Config`. Default: Open on loopback/private
+  domain, Owner otherwise. Log the choice.
+- On Owner boot: `Db::set_sync_policy(AllowlistPolicy)` with
+  `set_grace(Duration::ZERO)`, load persisted `{ owner_agent,
+  allowed_drives }` from `PluginMeta`.
+- On Open → Owner flip (or first Owner boot with existing data):
+  snapshot every Drive already stored into `allowed_drives`.
+- Drive genesis by the owner agent → persist + enroll.
+- Close the missing-Drive carve-out in Owner mode (OQ5).
+- `/server` emits `hostMode`, `acceptsNewDrives`, `ownerSet`. Redact
+  node id + peers for `Public` when Owner.
+
+Tests (protocol / glue):
+
+- Owner rejects a stranger’s Drive genesis over `POST /commit`,
+  `SYNC_PUSH`, and Iroh live write.
+- Owner accepts the owner agent’s second Drive and enrolls it.
+- Collaborator with `write` on an enrolled Drive can commit there and
+  cannot genesis a new Drive.
+- Open mode (localhost default) still admits a stranger Drive — existing
+  e2e `devDrive` / `createDrive` stay green.
+- Snapshot-on-flip: a Drive created under Open still admits after the
+  policy is installed.
+
+### Phase 2 — claim + welcome
+
+- Setup token mint / consume; loopback exception; `?setup=` on welcome.
+- `ATOMIC_OWNER_AGENT` env.
+- `--confirm-initialize` when Owner + non-loopback.
+- `accountCreationTarget` third branch + `managedServer.test.ts`.
+- Welcome: hide Create account when `acceptsNewDrives === false`.
+- `createDrive` / `promoteLocalDrive` error copy when the node refuses
+  enrollment.
+
+Tests (flow):
+
+- Welcome unit: Owner + `ownerSet` → no Create account.
+- Welcome unit: Owner + `?setup=` → Create account once.
+- Server: genesis without token from a non-loopback peer is
+  `NotEnrolled`.
+- Browser e2e stays on localhost Open; add one Owner-mode server
+  integration test rather than a full Playwright public-bind.
+
+### Phase 3 — abuse leftovers
+
+- Rate-limit unknown-agent `/commit` and `/blob`.
+- Optional: refuse Iroh streams whose AUTH agent has no `read` on any
+  hosted Drive.
+- Docs: installation “going public” section; FAQ “how do I put this on
+  the internet without hosting other people”; retire `/setup` as the
+  primary onboarding story.
+
+## Docs and copy
+
+- `docs/src/atomicserver/installation.md` — new subsection after
+  HTTPS: default Owner on a public domain, setup-token log line,
+  localhost-then-expose, `ATOMIC_OWNER_AGENT`, `ATOMIC_HOST_MODE=open`
+  escape hatch for a *deliberate* multi-user FOSS node.
+- `docs/src/atomicserver/gui.md` — stop leading with `/setup`.
+- `docs/src/atomicserver/faq.md` — “How do I make my data private, yet
+  available online?” already points at the public Agent. Add: the node
+  being reachable is not the same as the node hosting strangers.
+- `planning/unified-sync.md` OQ5 — Owner mode is reject-until-known;
+  Open keeps the carve-out.
+- `planning/sync-onboarding-ux.md` — welcome branches; language:
+  “always-on device,” not “sync hub.”
+
+## Open questions
+
+1. **Should Owner be the default as soon as `ATOMIC_DOMAIN` is not
+   localhost, or only when `--https` / a non-loopback bind is set?**
+   Leaning: non-localhost domain. A `ATOMIC_DOMAIN=example.com` HTTP
+   node on a VPS is already public to anyone who finds the port.
+2. **May the owner grant `createDrive` to another agent in v1?** No.
+   Invite-to-a-Drive covers collaboration. Host-your-own-Drive is
+   multi-tenant and needs its own invite type.
+3. **Disable Iroh in Owner mode?** No for v1. HTTPS is enough for the
+   browser; phones still pair. Redacting the NodeID from public
+   `/server` is the first cut.
+4. **Name.** `hostMode` / Owner, not “public mode,” not “locked,” not
+   “registration.” The node is not a product with accounts; it has an
+   owner.
+)

--- a/planning/foss-public-host-mode.md
+++ b/planning/foss-public-host-mode.md
@@ -1,6 +1,12 @@
 # FOSS public host mode — expose HTTP, do not host strangers
 
-> **Status:** Proposal (2026-08-15). Companion to
+> **Status:** Phase 1 + 2 built (2026-08-23). Server-side gating, `/server`
+> advertisement, welcome-screen branch, and the operator guide have landed.
+> Phase 3 (rate limits, Iroh stream refusal) is untouched.
+>
+> Three decisions changed during the build; the body below has been corrected
+> where it said otherwise, and [Resolved decisions](#resolved-decisions) records
+> why. Companion to
 > [`cloud-sync-managed-node.md`](./cloud-sync-managed-node.md) (managed
 > allowlist), [`unified-sync.md`](./unified-sync.md) Open Question 5
 > (bootstrap admission), and [`sync-onboarding-ux.md`](./sync-onboarding-ux.md)
@@ -205,9 +211,9 @@ DID they will put in the env.
 ### 2. Going public — env, then expose
 
 1. They already have a secret (localhost, desktop, or phone).
-2. They set `ATOMIC_OWNER_AGENT`, a public `ATOMIC_DOMAIN`, and
-   usually `--https`. Owner mode is the default on a public domain;
-   the env is what makes it *theirs*.
+2. They set `ATOMIC_OWNER_AGENT`. That alone selects Owner mode —
+   a public `ATOMIC_DOMAIN` and `--https` are about links and certs,
+   not about who may write.
 3. Boot. Snapshot every Drive already on disk into the allowlist
    (so a localhost-then-expose move does not lock the owner out of
    data that is already there).
@@ -398,23 +404,79 @@ Tests (flow):
 - `planning/sync-onboarding-ux.md` — welcome branches; language:
   “always-on device,” not “sync hub.”
 
-## Open questions
+## Resolved decisions
 
-1. **Should Owner be the default as soon as `ATOMIC_DOMAIN` is not
-   localhost, or only when `--https` / a non-loopback bind is set?**
-   Leaning: non-localhost domain. A `ATOMIC_DOMAIN=example.com` HTTP
-   node on a VPS is already public to anyone who finds the port.
-2. **May the owner grant `createDrive` to another agent in v1?** No.
-   Invite-to-a-Drive covers collaboration. Host-your-own-Drive is
-   multi-tenant and needs its own invite type.
-3. **Disable Iroh in Owner mode?** No for v1. HTTPS is enough for the
-   browser; phones still pair. Redacting the NodeID from public
-   `/server` is the first cut.
-4. **Name.** `hostMode` / Owner, not “public mode,” not “locked,” not
-   “registration.” The node is not a product with accounts; it has an
-   owner.
-5. **Refuse to start vs. start locked if the env is missing?** Refuse
-   to start. A process that never bound is an operator error they see
-   in `journalctl`. A process that bound and admits nothing looks like
-   a broken site. `ATOMIC_HOST_MODE=open` remains the explicit escape.
-)
+Recorded because each reverses something this document originally proposed.
+
+### 1. `ATOMIC_DOMAIN` decides nothing (reverses OQ1)
+
+OQ1 asked whether Owner should be the default as soon as `ATOMIC_DOMAIN` is not
+localhost, and leaned yes. That is **fail-open in the deployments that matter
+most**.
+
+`ATOMIC_DOMAIN` defaults to `localhost` and exists to build links and to satisfy
+the LetsEncrypt challenge. Behind Docker with nginx/Caddy/Traefik, or behind a
+Cloudflare or Tailscale tunnel, the process never learns its public name: the
+domain still reads `localhost` while the whole internet reaches it. Inferring
+"Open, this is a private box" there hands out a guarantee we cannot keep — and
+the same rule would have hard-failed every `ATOMIC_DOMAIN=example.com` HTTP node
+on upgrade. Backwards on both ends.
+
+So the mode is decided by **explicit configuration only**:
+
+1. `ATOMIC_HOST_MODE` — the operator said so.
+2. `ATOMIC_OWNER_AGENT` is set — naming an owner is not done by accident.
+3. Neither — Open, exactly as before host mode existed.
+
+Domain, `--https`, and port are still read, for exactly one purpose: deciding
+whether an Open node prints a warning. A wrong guess there costs a line of log
+noise instead of a stranger's workspace.
+
+`ATOMIC_DOMAIN` itself is **not** deprecated — it still feeds `get_origin()` /
+`server_url` and the cert. What was deprecated is domain-as-identity: drives,
+agents, and nodes are `did:ad:…`, so the domain no longer names anyone's data.
+That is what makes it a bad security signal and a fine display one.
+
+### 2. Upgrades are grandfathered, not broken
+
+An existing node with no new configuration keeps booting and keeps admitting
+whoever it admitted yesterday. A security change that stops a running server is
+one operators route around.
+
+What an unconfigured node gets instead is a boot warning, but only when there is
+a sign of *intent to publish* — `--https`, a routable `ATOMIC_DOMAIN`, or port
+80/443. Notably **not** the bind address: `--ip` defaults to `::`, so warning on
+a non-loopback bind would fire on every dev run and every test, and a warning
+that always fires is one nobody reads.
+
+The residual gap is honest and documented: a proxied node shows no signal at all,
+so it is never warned. The docs carry that case instead — it is the one the FAQ
+and the installation guide both lead with.
+
+### 3. Enrollment is derived from the store, not persisted
+
+The sketch said to persist `allowed_drives` in redb `PluginMeta`. Simpler and
+impossible to drift: on Owner boot, scan the resource tree for Drives and enroll
+what is there (`Db::drive_subjects`). A drive that exists is a drive this node
+hosts; next boot re-derives the same answer.
+
+That also *is* the snapshot-on-flip behaviour the plan wanted, for free. The scan
+is O(store) once per boot, deliberately not index-backed: a stale or partial
+query index would answer "fewer drives than you have", which here silently locks
+the owner out of their own data.
+
+## Still open
+
+2. **May the owner grant `createDrive` to another agent?** No. Invite-to-a-Drive
+   covers collaboration. Host-your-own-Drive is multi-tenant and needs its own
+   invite type.
+3. **Disable Iroh in Owner mode?** No. HTTPS is enough for the browser, phones
+   still pair, and the node ID is now redacted from unauthenticated `/server`.
+4. **Name.** `hostMode` / Owner. Settled.
+5. **Refuse to start vs. start locked when Owner has no owner?** Refuse. A
+   process that never bound is an operator error visible in `journalctl`; one
+   that bound and admits nothing looks like a broken site.
+6. **Should a proxied node be detectable at runtime?** Open. An `X-Forwarded-*`
+   header or a non-local `Host` on a live request would prove reachability that
+   boot-time config cannot. Would close the one gap above, at the cost of a
+   warning path that fires from request handling.

--- a/planning/foss-public-host-mode.md
+++ b/planning/foss-public-host-mode.md
@@ -23,8 +23,8 @@ Two things that must stay true:
   the public Agent on a Drive, invite links, and ordinary `check_read` do not
   change.
 - **FOSS never phones home.** No control plane, no email, no portal. The
-  owner is a local agent DID persisted on the node. Guardrail #3 in
-  `cloud-sync-managed-node.md` is not renegotiated here.
+  owner is an agent DID the operator puts in `ATOMIC_OWNER_AGENT`.
+  Guardrail #3 in `cloud-sync-managed-node.md` is not renegotiated here.
 
 ## The hole today
 
@@ -96,10 +96,10 @@ a control plane. FOSS enrollment is local and synchronous.
 
 Narrower than “has write on some hosted Drive”:
 
-1. The **owner agent** — the DID that claimed the node (setup token or
-   `ATOMIC_OWNER_AGENT`).
-2. Later, and only if we add it: agents the owner explicitly grants a
-   `createDrive` / host right. Not v1.
+1. The **owner agent** — the DID in `ATOMIC_OWNER_AGENT` /
+   `--owner-agent`. That is the only claim mechanism.
+2. Later, and only if we add it: a comma-separated
+   `ATOMIC_OWNER_AGENTS` list, or a `createDrive` grant. Not v1.
 
 A collaborator with `write` on Drive D may write to D. They may not
 genesis a new Drive on this node. Treating “write on an enrolled Drive”
@@ -108,6 +108,11 @@ as “may enroll” is the abuse vector with extra steps.
 The owner’s second device is the same agent DID (they imported the
 secret). Creating another Drive auto-enrolls because the signer *is* the
 owner.
+
+The env holds the **agent DID**, never the secret. The node does not
+sign as the owner; it only admits signers that match. If someone pastes
+a full secret JSON, reject boot with “that is a secret; this flag wants
+`did:ad:agent:…`” — people will try.
 
 ### How a Drive gets on the allowlist
 
@@ -136,68 +141,92 @@ Replace `Err(_) => true` (“missing Drive ⇒ admit”) with:
   authorized-to-create; then enroll it. Otherwise `NotEnrolled`.
   `ForAgent::Public` never creates a Drive.
 
-This is “reject-until-known”, not first-writer-wins. First-writer-wins
-on a public socket is a claim race.
+This is “reject-until-known”, not first-writer-wins. There is no
+first-writer: the owner DID is in the process environment before the
+socket opens.
+
+## Claim: `ATOMIC_OWNER_AGENT`
+
+Identity is already local-first. A secret is a keypair; the agent DID
+is `did:ad:agent:{publicKey}` and does not need a server to exist. It
+is reasonable to expect someone who is about to bind `:443` to already
+have one — created on localhost, in the desktop app, or on a phone —
+and to paste that DID into the node’s env.
+
+```env
+# The DID only. Never the private key / secret JSON.
+ATOMIC_OWNER_AGENT=did:ad:agent:AbCdEf...
+```
+
+That is the whole claim. No setup token, no “first visitor to
+`/setup` owns the machine,” no one-shot Create account on the public
+origin. Those are claim races on a public socket; an env the operator
+set is not.
+
+**Owner mode without a valid `ATOMIC_OWNER_AGENT` fails closed.** Do
+not fall back to Open (that would make a missing line in `.env` an
+open hub). Do not boot a “waiting for first user” state. Refuse to
+start and print where to get the DID:
+
+```text
+Owner mode needs ATOMIC_OWNER_AGENT=did:ad:agent:…
+Create an account on localhost or in the app first, then copy the
+agent ID from Settings (or the `subject` field of your secret).
+To run an open node on purpose: ATOMIC_HOST_MODE=open
+```
+
+Validate the value: must be a `did:ad:agent:` DID. Reject a pasted
+secret, an `https://` agent URL, or an empty string.
+
+The env is the source of truth every boot — not a value we persist
+and can drift from. Changing the var changes who may enroll new
+Drives. Already-enrolled Drives stay hosted (collaborators keep
+`write` on them). `--initialize` cannot mint a new owner.
+
+Where the person copies the ID:
+
+- Settings / the agent profile (copy button).
+- The secret JSON’s `subject` field.
+- After a local Create account, one line of copy: “Going to put this
+  on the internet? Set `ATOMIC_OWNER_AGENT=` to this ID.”
 
 ## Setup UX
 
-Three real journeys. The welcome screen must be able to tell them apart
-from `/server` (see [Node advertisement](#node-advertisement)).
+Two journeys. The welcome screen tells them apart from `/server`
+(see [Node advertisement](#node-advertisement)).
 
 ### 1. Localhost (Open) — do not touch
 
 `Create account` → local DID → `createDrive` → it lands. This is the
 FOSS path `managedServer.ts` exists to protect. E2E `before` /
-`devDrive` stay on it.
+`devDrive` stay on it. This is also how a new operator *gets* the
+DID they will put in the env.
 
-### 2. Local first, then expose — the good path
+### 2. Going public — env, then expose
 
-1. Owner creates the account on localhost (Open).
-2. They set a domain / HTTPS / `--host-mode=owner` (or the UI “Make this
-   reachable on the internet” writes the same config).
-3. On the flip: snapshot every Drive already on disk into the allowlist;
-   persist the current agent as owner if none is set.
-4. Restart (or hot-install the policy). Strangers are rejected.
-   The owner’s secret still works from any browser.
+1. They already have a secret (localhost, desktop, or phone).
+2. They set `ATOMIC_OWNER_AGENT`, a public `ATOMIC_DOMAIN`, and
+   usually `--https`. Owner mode is the default on a public domain;
+   the env is what makes it *theirs*.
+3. Boot. Snapshot every Drive already on disk into the allowlist
+   (so a localhost-then-expose move does not lock the owner out of
+   data that is already there).
+4. They sign in on the public URL with the same secret. New Drives
+   they genesis enroll because the signer matches the env.
 
 Copy, in the owner’s language from `sync-onboarding-ux.md`:
 
 > Visitors can see what you have shared. They cannot store their own
 > workspace on this always-on device.
 
-### 3. VPS first (Owner, no owner yet) — the dangerous path
+A VPS image with no prior localhost step is the same journey: create
+the identity in any Atomic client first (the keypair is local), put
+the DID in the server’s env, deploy, sign in. The public welcome
+page never offers Create account.
 
-A fresh node on a public address has no owner. The first `Create
-account` would otherwise *be* the claim.
+### After boot (Owner + env set)
 
-**Setup token** (WordPress / Ghost / Home Assistant pattern):
-
-- On first boot in Owner mode with no owner, mint a high-entropy token.
-  Persist it. Print once:
-
-  `Owner setup: https://example.com/app/welcome?setup=<token>`
-
-- `/setup` and the welcome `Create account` path accept that token
-  **once**. From a loopback peer, the token is optional (so
-  `ssh -L` / a local proxy still works without fishing in logs).
-- From any other peer, missing/wrong token → the Create-account control
-  is hidden and the server rejects the genesis. Do not advertise a
-  working `/setup` URL on the public welcome page.
-- Accepting consumes the token and writes `owner_agent` + enrolls the
-  new Drive.
-
-Headless alternative: `ATOMIC_OWNER_AGENT=did:ad:agent:…` in the env.
-No token, no race. Useful for image-based deploys where the agent
-already exists.
-
-`--initialize` on a publicly bound Owner node is a footgun (it would
-mint a fresh claim). Require an extra `--confirm-initialize` (or only
-honor `--initialize` from a local CLI) and log a warning that names the
-bind address.
-
-### After the owner exists
-
-Welcome screen on an Owner node:
+Welcome screen:
 
 - **No** “Create account” that creates a Drive on this node.
 - **Sign in** (secret / passkey) — the owner on a new browser.
@@ -231,8 +260,8 @@ Add three facts (absent ⇒ treat as Open, so old nodes keep working):
 | Property | Meaning |
 | --- | --- |
 | `hostMode` | `open` \| `owner` |
-| `acceptsNewDrives` | `true` only in Open, or Owner with no owner yet *and* the request carries a valid setup token (the welcome page asked with it) |
-| `ownerSet` | whether an owner agent is persisted |
+| `acceptsNewDrives` | `true` only in Open. Owner is always `false` — new Drives enroll only when the signer matches `ATOMIC_OWNER_AGENT`. |
+| `ownerSet` | whether `ATOMIC_OWNER_AGENT` is set (Owner mode that booted) |
 
 In Owner mode, **do not** give `ForAgent::Public` the Iroh node id or
 the peer list. Those are a device inventory and a dial target. The
@@ -244,9 +273,7 @@ writes fail admission. Hiding the id removes the convenient listing.
 
 - managed + portal → portal (unchanged)
 - FOSS Open → local Create account (unchanged)
-- FOSS Owner + `acceptsNewDrives: false` → no create; Sign in / invite
-- FOSS Owner + valid `?setup=` → one-shot local Create account, then
-  lock
+- FOSS Owner → no create; Sign in / invite
 
 Keep this pure and unit-tested next to `managedServer.test.ts`. Do not
 infer “locked” from `managed: false` alone — that is every FOSS node.
@@ -256,10 +283,12 @@ infer “locked” from `managed: false` alone — that is every FOSS node.
 Admission is the load-bearing gate. These are the leftovers that
 admission does not cover.
 
-1. **Claim race** — setup token, loopback exception, no public `/setup`
-   link. First-writer-wins is not acceptable on `:443`.
-2. **`--initialize`** — extra confirm when bound non-loopback in Owner
-   mode.
+1. **Claim is config, not a request.** `ATOMIC_OWNER_AGENT` is set
+   before bind. A missing or invalid value refuses to start in Owner
+   mode. There is no HTTP path that becomes the owner.
+2. **`--initialize`** — cannot mint an owner (the env still wins).
+   Still log a warning if run on a non-loopback Owner bind; it is
+   not a claim reset.
 3. **Agent spam** — the agent-DID exemption lets anyone persist a tiny
    Agent resource. Either require the signer to be the owner / an
    invite-accept, or rate-limit unknown-agent `POST /commit` (token
@@ -287,7 +316,8 @@ when they say “public but mine.”
 
 - Put a control-plane client, heartbeat, or portal URL into the open
   `atomic-server` binary.
-- Require email to claim a FOSS node.
+- Require email to run a FOSS node.
+- Put the agent **secret** in the environment. The DID is enough.
 - Change the localhost Create-account path.
 - Equate “has write on a shared Drive” with “may enroll a new Drive.”
 - Reuse `--public-mode` or name the feature “public mode.”
@@ -303,12 +333,14 @@ testable.
 
 - `HostMode` on `Opts` / `Config`. Default: Open on loopback/private
   domain, Owner otherwise. Log the choice.
+- Owner mode **requires** `ATOMIC_OWNER_AGENT`. Invalid/missing →
+  exit with the message above. Never fall back to Open.
 - On Owner boot: `Db::set_sync_policy(AllowlistPolicy)` with
-  `set_grace(Duration::ZERO)`, load persisted `{ owner_agent,
-  allowed_drives }` from `PluginMeta`.
+  `set_grace(Duration::ZERO)`. Owner DID comes from the env every
+  time. Persist only `allowed_drives` (redb `PluginMeta`).
 - On Open → Owner flip (or first Owner boot with existing data):
   snapshot every Drive already stored into `allowed_drives`.
-- Drive genesis by the owner agent → persist + enroll.
+- Drive genesis whose signer equals `ATOMIC_OWNER_AGENT` → enroll.
 - Close the missing-Drive carve-out in Owner mode (OQ5).
 - `/server` emits `hostMode`, `acceptsNewDrives`, `ownerSet`. Redact
   node id + peers for `Public` when Owner.
@@ -325,22 +357,20 @@ Tests (protocol / glue):
 - Snapshot-on-flip: a Drive created under Open still admits after the
   policy is installed.
 
-### Phase 2 — claim + welcome
+### Phase 2 — welcome
 
-- Setup token mint / consume; loopback exception; `?setup=` on welcome.
-- `ATOMIC_OWNER_AGENT` env.
-- `--confirm-initialize` when Owner + non-loopback.
 - `accountCreationTarget` third branch + `managedServer.test.ts`.
-- Welcome: hide Create account when `acceptsNewDrives === false`.
+- Welcome: hide Create account when `hostMode === owner`.
+- After local Create account, show the agent DID and one line about
+  `ATOMIC_OWNER_AGENT` for people who will expose a node later.
 - `createDrive` / `promoteLocalDrive` error copy when the node refuses
   enrollment.
 
 Tests (flow):
 
-- Welcome unit: Owner + `ownerSet` → no Create account.
-- Welcome unit: Owner + `?setup=` → Create account once.
-- Server: genesis without token from a non-loopback peer is
-  `NotEnrolled`.
+- Welcome unit: Owner → no Create account; Sign in stays.
+- Server: Owner boot without `ATOMIC_OWNER_AGENT` exits non-zero.
+- Server: pasted secret / non-agent DID is rejected at boot.
 - Browser e2e stays on localhost Open; add one Owner-mode server
   integration test rather than a full Playwright public-bind.
 
@@ -356,8 +386,8 @@ Tests (flow):
 ## Docs and copy
 
 - `docs/src/atomicserver/installation.md` — new subsection after
-  HTTPS: default Owner on a public domain, setup-token log line,
-  localhost-then-expose, `ATOMIC_OWNER_AGENT`, `ATOMIC_HOST_MODE=open`
+  HTTPS: create an account first, set `ATOMIC_OWNER_AGENT`, then
+  expose; default Owner on a public domain; `ATOMIC_HOST_MODE=open`
   escape hatch for a *deliberate* multi-user FOSS node.
 - `docs/src/atomicserver/gui.md` — stop leading with `/setup`.
 - `docs/src/atomicserver/faq.md` — “How do I make my data private, yet
@@ -383,4 +413,8 @@ Tests (flow):
 4. **Name.** `hostMode` / Owner, not “public mode,” not “locked,” not
    “registration.” The node is not a product with accounts; it has an
    owner.
+5. **Refuse to start vs. start locked if the env is missing?** Refuse
+   to start. A process that never bound is an operator error they see
+   in `journalctl`. A process that bound and admits nothing looks like
+   a broken site. `ATOMIC_HOST_MODE=open` remains the explicit escape.
 )

--- a/planning/sync-onboarding-ux.md
+++ b/planning/sync-onboarding-ux.md
@@ -95,6 +95,13 @@ Keep these in step. A change to one is usually a change to its twin.
 | pairing code, format | `browser/lib/src/pairing.ts` | `pair_screen.dart` (`_parsePairingUri`) |
 | URL rules (scheme, local address) | `data-browser/src/helpers/serverUrl.ts` | `flutter/lib/atomic/server_url.dart` |
 | what a machine says about itself | `data-browser/src/helpers/managedServer.ts` | `flutter/lib/atomic/server_info.dart` |
+
+A FOSS node on a public address must not present **Create account** as if it
+were an open host — that path calls `createDrive` and, under today's
+`OpenPolicy`, stores the stranger's workspace. The proposed `/server` fields
+and welcome branches live in
+[`foss-public-host-mode.md`](./foss-public-host-mode.md). Localhost Create
+account does not change.
 | push a workspace up | `browser/lib/src/store.ts` (`promoteLocalDrive`) | `AtomicClient.syncDriveToServer` |
 
 **Which servers the browser's Devices list shows.** `SyncRoute` renders every

--- a/planning/unified-sync.md
+++ b/planning/unified-sync.md
@@ -1037,8 +1037,14 @@ work in that plan's Phase P0, not a decision-gated maybe.
    hub-signed destroys?
 5. **Bootstrap admission (F2)** — what replaces `Err(_) => true` for a drive that
    doesn't exist locally yet: first-writer-wins with grace (as `AllowlistPolicy`
-   does), explicit enrollment, or reject-until-known? Still open — F2's fix (`989a8751`)
-   closed the existing-resource spoof but deliberately left this carve-out unchanged.
+   does), explicit enrollment, or reject-until-known? **FOSS Owner mode
+   (proposed in [`foss-public-host-mode.md`](./foss-public-host-mode.md)) is
+   reject-until-known:** a missing drive is admitted only if the signer is the
+   node owner, then enrolled; `OpenPolicy` (localhost) keeps the carve-out.
+   F2's fix (`989a8751`) closed the existing-resource spoof and deliberately
+   left this carve-out unchanged — Owner mode is what replaces it on a public
+   FOSS node. Managed nodes keep bootstrap grace because their allowlist is
+   eventually consistent with a control plane.
 6. **What makes a peer "known"? (F9)** — today: any inbound connection. The fix says
    "pairing or explicit user action," but the pairing primitive itself is undefined
    (QR scan is one-directional trust; see [`sync.md`](./sync.md)'s handshake notes and

--- a/server/src/appstate.rs
+++ b/server/src/appstate.rs
@@ -103,6 +103,7 @@ impl AppState {
                 .map(str::trim)
                 .filter(|d| !d.is_empty())
                 .map(str::to_string),
+            host_mode: config.host_mode.clone(),
         };
 
         // Register all built-in endpoints
@@ -175,6 +176,11 @@ impl AppState {
                 .await
                 .map_err(|e| format!("Failed to repopulate defaults. {}", e))?;
         }
+
+        // Who may put a *new* Drive here. Installed after populate so the scan
+        // below sees every Drive already on disk, and before anything binds so
+        // no request can slip in under the default open policy.
+        crate::host_mode::install_policy(&store, &config.host_mode).await;
 
         // Initialize search constructs
         let search_state = SearchState::new(&config)

--- a/server/src/bin.rs
+++ b/server/src/bin.rs
@@ -11,6 +11,7 @@ mod context;
 mod errors;
 mod handlers;
 mod helpers;
+mod host_mode;
 #[cfg(feature = "https")]
 mod https;
 mod invite_token;

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -130,6 +130,28 @@ pub struct Opts {
     /// to the OS hostname if unset, then to "Unknown" if that fails.
     #[clap(long, env = "ATOMIC_DEVICE_NAME")]
     pub device_name: Option<String>,
+
+    /// Who may create a **new** Drive on this node.
+    ///
+    /// `open` (the default) lets anyone who can reach the server create an
+    /// account and store their data here. That is right for localhost and for a
+    /// node you deliberately share with others; on a public address it is an
+    /// open registration form for space on your disk.
+    ///
+    /// `owner` allows only the Agent named in `--owner-agent`. Reading what you
+    /// shared, invited collaborators, and your own other devices are unaffected.
+    ///
+    /// Left unset, naming an `--owner-agent` selects `owner`.
+    #[clap(value_enum, long, env = "ATOMIC_HOST_MODE")]
+    pub host_mode: Option<crate::host_mode::HostMode>,
+
+    /// The Agent ID that owns this node, e.g. `did:ad:agent:...`.
+    ///
+    /// The public ID only — never the secret. This node does not sign as you; it
+    /// only recognises you. Copy it from Settings in any Atomic client, or from
+    /// the `subject` field of your saved secret.
+    #[clap(long, env = "ATOMIC_OWNER_AGENT")]
+    pub owner_agent: Option<String>,
     /// Use the GPU (if available) for processing vector search embeddings.
     #[clap(long, env = "ATOMIC_GPU_INDEXING")]
     pub gpu_indexing: bool,
@@ -287,6 +309,9 @@ pub struct Config {
     pub openrouter_embedding_dimensions: Option<u32>,
     /// When true, vector models are not loaded and indexing is a no-op.
     pub skip_vector_index: bool,
+    /// Who may enroll a new Drive here. Resolved once at boot from explicit
+    /// configuration; see [`crate::host_mode`] for why it is never guessed.
+    pub host_mode: crate::host_mode::HostModeConfig,
 }
 
 impl Config {
@@ -311,6 +336,23 @@ impl Config {
     /// Returns the base domain of the server (e.g. "atomicdata.dev").
     pub fn get_base_domain(&self) -> Option<String> {
         self.base_domain.clone()
+    }
+
+    /// Signals that this node was set up to be reached from outside. Used only
+    /// to decide whether an Open node is warned at boot — never to pick the
+    /// mode, which [`crate::host_mode`] explains at length.
+    pub fn reachability(&self) -> crate::host_mode::Reachability {
+        let port = if self.opts.https {
+            self.opts.port_https
+        } else {
+            self.opts.port
+        };
+
+        crate::host_mode::Reachability {
+            https: self.opts.https,
+            public_domain: crate::host_mode::domain_looks_public(&self.opts.domain),
+            web_port: matches!(port, 80 | 443),
+        }
     }
 }
 
@@ -427,6 +469,11 @@ pub fn build_config(opts: Opts) -> AtomicServerResult<Config> {
         );
     }
 
+    // Resolved before anything binds: Owner mode with an unusable owner must
+    // fail here, not after the socket is open. Mirrors the `--https` without
+    // `--email` refusal above.
+    let host_mode = crate::host_mode::resolve(opts.host_mode, opts.owner_agent.as_deref())?;
+
     let base_domain = opts.base_domain.clone();
 
     let gpu_indexing = opts.gpu_indexing;
@@ -456,6 +503,7 @@ pub fn build_config(opts: Opts) -> AtomicServerResult<Config> {
         || store_path_looks_like_test_harness(&store_path);
 
     Ok(Config {
+        host_mode,
         initialize,
         repopulate_defaults,
         gpu_indexing,

--- a/server/src/host_mode.rs
+++ b/server/src/host_mode.rs
@@ -1,0 +1,519 @@
+//! Who may put a *new* workspace on this node.
+//!
+//! A stock node admits every drive ([`atomic_lib::sync::policy::OpenPolicy`]).
+//! On a laptop that is right: the person at the keyboard is the only one who
+//! can reach it. On a public address it means the welcome screen is an open
+//! registration form for free storage on somebody else's disk.
+//!
+//! [`HostMode::Owner`] closes that. It does not touch reading: what the owner
+//! shared stays shared, invited collaborators keep working, and ACL on existing
+//! resources is unchanged. The only new refusal is *enrolling a drive this node
+//! has never hosted*.
+//!
+//! # Why the mode is not inferred from the domain
+//!
+//! The obvious heuristic — "`ATOMIC_DOMAIN` is not localhost, so we must be
+//! public" — is wrong in the direction that costs data. `ATOMIC_DOMAIN`
+//! defaults to `localhost` and only ever has to be correct for building links
+//! and for the LetsEncrypt challenge. Behind Docker with nginx/Caddy/Traefik in
+//! front, or behind a Cloudflare/Tailscale tunnel, the process never learns its
+//! public name: the domain still reads `localhost` while the whole internet can
+//! reach it. Inferring "Open" there would hand out exactly the guarantee we
+//! could not keep.
+//!
+//! So the mode is decided by explicit configuration only, and the reachability
+//! signals below are used for *one* thing: deciding whether to warn. A wrong
+//! guess then costs a line of log noise instead of a stranger's workspace.
+
+use crate::errors::AtomicServerResult;
+
+/// The DID method for an agent. The owner is named by a public key, never by a
+/// URL: an agent DID needs no server to exist, which is what lets the operator
+/// create their identity on a laptop before this node has ever booted.
+const AGENT_DID_PREFIX: &str = "did:ad:agent:";
+
+/// Whether this node lets a stranger store a workspace here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum HostMode {
+    /// Anyone who can reach the node may create a drive on it. The default, and
+    /// correct for localhost, a LAN box nobody else is on, and a deliberate
+    /// multi-user node.
+    Open,
+    /// Only the owner agent may enroll a new drive. Everything else — reading
+    /// what was shared, collaborating on an invited drive, the owner's other
+    /// devices — is unchanged.
+    Owner,
+}
+
+impl HostMode {
+    /// What `/server` reports. Absent on an old node, which clients must read as
+    /// [`HostMode::Open`] — that is what an old node does.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HostMode::Open => "open",
+            HostMode::Owner => "owner",
+        }
+    }
+
+    /// Whether a drive nobody here has seen before may be created by whoever
+    /// asks. In Owner mode new drives still appear — but only for the owner, so
+    /// the answer to "will you take a drive from anyone" is no.
+    pub fn accepts_new_drives(self) -> bool {
+        matches!(self, HostMode::Open)
+    }
+}
+
+/// The resolved decision, and the agent it was resolved for.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostModeConfig {
+    pub mode: HostMode,
+    /// The owner's agent DID. Always `Some` in Owner mode — the mode cannot be
+    /// reached without one — and `None` in Open mode.
+    pub owner_agent: Option<String>,
+}
+
+impl HostModeConfig {
+    pub fn is_owner_mode(&self) -> bool {
+        matches!(self.mode, HostMode::Owner)
+    }
+
+    /// Whether `agent` is the owner. `false` in Open mode: nothing is gated
+    /// there, so nothing needs to be the owner.
+    pub fn is_owner(&self, agent: &str) -> bool {
+        self.owner_agent.as_deref() == Some(agent)
+    }
+}
+
+/// Why we think a stranger might be able to reach this node. Only ever used to
+/// decide whether an Open node gets a warning; never to pick the mode.
+///
+/// Every signal here is a sign of *intent to publish*, not of mere binding. The
+/// bind address deliberately is not one: `--ip` defaults to `::`, so a laptop
+/// running `atomic-server` with no arguments already listens on every
+/// interface. Warning on that would fire on every dev run and every test, and a
+/// warning that always fires is one nobody reads.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Reachability {
+    /// Terminates TLS itself, which nobody bothers with for a private toy.
+    pub https: bool,
+    /// `ATOMIC_DOMAIN` names something that is not this machine.
+    pub public_domain: bool,
+    /// Serves on the standard web ports. `--port 80` is documented as "set this
+    /// if you want it available on the network", so taking it is a statement.
+    pub web_port: bool,
+}
+
+impl Reachability {
+    pub fn looks_exposed(self) -> bool {
+        self.https || self.public_domain || self.web_port
+    }
+}
+
+/// Whether `ATOMIC_DOMAIN` names somewhere other than this machine or this LAN.
+///
+/// Used only for the warning. A false negative (the proxy case) costs a missing
+/// nudge; a false positive costs noise on a dev box. Both are cheap, which is
+/// the whole reason the *mode* is never decided this way.
+pub fn domain_looks_public(domain: &str) -> bool {
+    let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+
+    // Strip a port, and the brackets an IPv6 literal wears in a URL.
+    let host = domain
+        .rsplit_once(':')
+        .filter(|(head, _)| !head.is_empty() && head.contains(']') || !head.contains(':'))
+        .map(|(head, _)| head)
+        .unwrap_or(&domain);
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+
+    if host.is_empty() {
+        return false;
+    }
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return !(ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip));
+    }
+
+    // Names a home network hands out, and the bare hostname of a LAN machine.
+    // A name with no dot in it cannot be resolved from the public internet.
+    const LOCAL_SUFFIXES: [&str; 5] = [".local", ".localhost", ".internal", ".lan", ".home.arpa"];
+
+    if host == "localhost" || LOCAL_SUFFIXES.iter().any(|s| host.ends_with(s)) {
+        return false;
+    }
+
+    host.contains('.')
+}
+
+fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        // `is_unique_local` / `is_unicast_link_local` are still unstable for
+        // IPv6, so match the prefixes directly: fc00::/7 and fe80::/10.
+        std::net::IpAddr::V6(v6) => {
+            let [a, b, ..] = v6.octets();
+            (a & 0xfe) == 0xfc || (a == 0xfe && (b & 0xc0) == 0x80)
+        }
+    }
+}
+
+/// Resolve the mode from explicit configuration.
+///
+/// Precedence, and the reason for it:
+///
+/// 1. `ATOMIC_HOST_MODE` — the operator said so, in as many words.
+/// 2. `ATOMIC_OWNER_AGENT` is set — naming an owner is not a thing anyone does
+///    by accident, so it means "gate this".
+/// 3. Neither — Open, exactly as this node behaved before the flag existed. An
+///    upgrade never changes who may write.
+///
+/// Errors are boot failures. Owner mode without a usable owner must not
+/// silently degrade to Open: a typo'd env var would then be an open hub, which
+/// is the failure this whole module exists to prevent.
+pub fn resolve(
+    explicit: Option<HostMode>,
+    owner_agent_raw: Option<&str>,
+) -> AtomicServerResult<HostModeConfig> {
+    // An env var set to "" is the same as unset. Docker compose and systemd
+    // both produce empty strings for a variable someone left blank, and
+    // treating that as "owner mode, invalid DID" would refuse to boot over a
+    // stray line.
+    let raw = owner_agent_raw.map(str::trim).filter(|s| !s.is_empty());
+
+    match explicit {
+        Some(HostMode::Owner) => {
+            let Some(raw) = raw else {
+                return Err(missing_owner_agent_message().into());
+            };
+            Ok(HostModeConfig {
+                mode: HostMode::Owner,
+                owner_agent: Some(validate_owner_agent(raw)?),
+            })
+        }
+        // Explicitly Open wins over a set owner agent. Someone running a
+        // deliberate multi-user node may still want an owner recorded for
+        // later; refusing to boot over it would be obstinate.
+        Some(HostMode::Open) => Ok(HostModeConfig {
+            mode: HostMode::Open,
+            owner_agent: None,
+        }),
+        None => match raw {
+            Some(raw) => Ok(HostModeConfig {
+                mode: HostMode::Owner,
+                owner_agent: Some(validate_owner_agent(raw)?),
+            }),
+            None => Ok(HostModeConfig {
+                mode: HostMode::Open,
+                owner_agent: None,
+            }),
+        },
+    }
+}
+
+/// Check that the value names an agent, and say something useful when it does
+/// not. Every branch here is a mistake we expect a real person to make.
+fn validate_owner_agent(raw: &str) -> AtomicServerResult<String> {
+    if looks_like_secret(raw) {
+        return Err(format!(
+            "ATOMIC_OWNER_AGENT looks like an Agent *secret*, not an Agent ID.\n\
+             \n\
+             The secret is the private key — this node never needs it, and it \
+             must not sit in the environment.\n\
+             Use the public ID instead: it starts with `{AGENT_DID_PREFIX}` and \
+             is the `subject` field inside that secret."
+        )
+        .into());
+    }
+
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        return Err(format!(
+            "ATOMIC_OWNER_AGENT must be an Agent ID starting with \
+             `{AGENT_DID_PREFIX}`, not a URL.\n\
+             \n\
+             A `https://` agent lives on whichever server issued it, so it \
+             cannot say who owns *this* one. Open Settings in any Atomic client \
+             and copy the Agent ID."
+        )
+        .into());
+    }
+
+    let Some(public_key) = raw.strip_prefix(AGENT_DID_PREFIX) else {
+        return Err(format!(
+            "ATOMIC_OWNER_AGENT must start with `{AGENT_DID_PREFIX}` \
+             (got `{raw}`).\n\
+             \n\
+             {}",
+            where_to_find_the_id()
+        )
+        .into());
+    };
+
+    if public_key.trim().is_empty() {
+        return Err(format!(
+            "ATOMIC_OWNER_AGENT is `{AGENT_DID_PREFIX}` with no public key after it.\n\
+             \n\
+             {}",
+            where_to_find_the_id()
+        )
+        .into());
+    }
+
+    Ok(raw.to_string())
+}
+
+/// An Atomic secret is base64-encoded JSON holding a private key. People paste
+/// it because it is the thing they saved, so recognise both what it looks like
+/// raw and what it looks like decoded, and name the mistake precisely — a
+/// generic "invalid value" would leave a private key in a `.env` file while the
+/// operator hunted for the real problem.
+fn looks_like_secret(raw: &str) -> bool {
+    if raw.contains("privateKey") || raw.trim_start().starts_with('{') {
+        return true;
+    }
+
+    use base64::Engine;
+
+    base64::engine::general_purpose::STANDARD
+        .decode(raw)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .is_some_and(|decoded| decoded.contains("privateKey"))
+}
+
+fn where_to_find_the_id() -> String {
+    format!(
+        "Where to find it: open Settings in any Atomic client (browser, desktop, \
+         or phone) and copy the Agent ID, or read the `subject` field of your \
+         saved secret. It starts with `{AGENT_DID_PREFIX}`."
+    )
+}
+
+/// What to print instead of booting when Owner mode has no owner. The operator
+/// reads this in `journalctl` after the unit failed to start, so it has to
+/// carry the whole fix.
+fn missing_owner_agent_message() -> String {
+    format!(
+        "ATOMIC_HOST_MODE=owner needs ATOMIC_OWNER_AGENT to be set, and it is not.\n\
+         \n\
+         Owner mode means only one Agent may create new Drives here, so this \
+         node has to be told which one:\n\
+         \n\
+             ATOMIC_OWNER_AGENT={AGENT_DID_PREFIX}...\n\
+         \n\
+         {}\n\
+         \n\
+         Refusing to start rather than falling back to an open node, because an \
+         open node on a public address lets strangers store their data on this \
+         disk.\n\
+         To run an open node on purpose: ATOMIC_HOST_MODE=open",
+        where_to_find_the_id()
+    )
+}
+
+/// The banner an Open node prints when it looks like it is on the internet.
+///
+/// Deliberately not a boot failure: an existing node must keep booting after an
+/// upgrade. But it is the only chance to reach an operator who does not know
+/// this setting exists, so it says what is true right now, not what is
+/// possible.
+pub fn exposure_warning(reachability: Reachability) -> String {
+    let mut reasons: Vec<&str> = Vec::new();
+
+    if reachability.https {
+        reasons.push("it terminates HTTPS");
+    }
+
+    if reachability.public_domain {
+        reasons.push("ATOMIC_DOMAIN is not a local name");
+    }
+
+    if reachability.web_port {
+        reasons.push("it serves on a standard web port");
+    }
+
+    format!(
+        "This node accepts a new Drive from anyone who can reach it, and it may be reachable ({}).\n\
+         Anyone who opens it can create an account and store their data on this disk.\n\
+         \n\
+         If this node is only for you, name yourself as its owner:\n\
+         \n\
+             ATOMIC_OWNER_AGENT={AGENT_DID_PREFIX}...   (copy your Agent ID from Settings)\n\
+         \n\
+         Visitors keep reading whatever you shared, and people you invited keep their access.\n\
+         Only creating a *new* Drive here becomes yours alone.\n\
+         \n\
+         If this node is meant to be open to others, silence this with ATOMIC_HOST_MODE=open.",
+        reasons.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNER: &str = "did:ad:agent:RqPwpgHv+PK7Pnz/dVab8hmHjYnvTL1YrlVa6L9G9Zg=";
+
+    #[test]
+    fn nothing_configured_stays_open() {
+        let resolved = resolve(None, None).unwrap();
+        assert_eq!(resolved.mode, HostMode::Open);
+        assert_eq!(resolved.owner_agent, None);
+    }
+
+    #[test]
+    fn naming_an_owner_gates_the_node() {
+        let resolved = resolve(None, Some(OWNER)).unwrap();
+        assert_eq!(resolved.mode, HostMode::Owner);
+        assert_eq!(resolved.owner_agent.as_deref(), Some(OWNER));
+        assert!(resolved.is_owner(OWNER));
+        assert!(!resolved.is_owner("did:ad:agent:someoneelse"));
+    }
+
+    #[test]
+    fn an_empty_owner_var_is_not_a_claim() {
+        // systemd and compose both hand through "" for a blank line. That is an
+        // unset variable, not a broken one, and must not refuse boot.
+        for blank in ["", "   "] {
+            let resolved = resolve(None, Some(blank)).unwrap();
+            assert_eq!(resolved.mode, HostMode::Open, "blank {blank:?}");
+        }
+    }
+
+    #[test]
+    fn owner_mode_without_an_owner_refuses_to_boot() {
+        let err = resolve(Some(HostMode::Owner), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ATOMIC_OWNER_AGENT"), "{err}");
+        // The escape hatch has to be in the message: someone who wanted an open
+        // node needs to know that is still allowed.
+        assert!(err.contains("ATOMIC_HOST_MODE=open"), "{err}");
+    }
+
+    #[test]
+    fn explicit_open_wins_over_a_named_owner() {
+        let resolved = resolve(Some(HostMode::Open), Some(OWNER)).unwrap();
+        assert_eq!(resolved.mode, HostMode::Open);
+        assert!(!resolved.is_owner(OWNER));
+    }
+
+    #[test]
+    fn a_pasted_secret_is_named_as_such() {
+        use base64::Engine;
+        let secret = base64::engine::general_purpose::STANDARD
+            .encode(r#"{"privateKey":"abc","subject":"did:ad:agent:xyz"}"#);
+
+        let err = resolve(None, Some(&secret)).unwrap_err().to_string();
+        assert!(err.contains("secret"), "{err}");
+
+        // Raw JSON, for anyone who saved it unencoded.
+        let err = resolve(None, Some(r#"{"privateKey":"abc"}"#))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("secret"), "{err}");
+    }
+
+    #[test]
+    fn an_http_agent_cannot_own_this_node() {
+        let err = resolve(None, Some("https://example.com/agents/abc"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("did:ad:agent:"), "{err}");
+    }
+
+    #[test]
+    fn a_did_with_no_key_is_refused() {
+        let err = resolve(None, Some("did:ad:agent:"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("public key"), "{err}");
+    }
+
+    #[test]
+    fn owner_mode_never_accepts_new_drives_from_anyone() {
+        assert!(HostMode::Open.accepts_new_drives());
+        assert!(!HostMode::Owner.accepts_new_drives());
+    }
+
+    #[test]
+    fn the_warning_says_why_it_fired() {
+        let warning = exposure_warning(Reachability {
+            https: true,
+            public_domain: true,
+            web_port: false,
+        });
+        assert!(warning.contains("terminates HTTPS"), "{warning}");
+        assert!(warning.contains("ATOMIC_DOMAIN"), "{warning}");
+        assert!(!warning.contains("standard web port"), "{warning}");
+        // It must carry the fix, not just the diagnosis.
+        assert!(warning.contains("ATOMIC_OWNER_AGENT="), "{warning}");
+    }
+
+    #[test]
+    fn a_loopback_node_is_not_warned() {
+        assert!(!Reachability::default().looks_exposed());
+    }
+
+    #[test]
+    fn a_local_domain_is_not_public() {
+        for local in [
+            "localhost",
+            "localhost:9883",
+            "atomic.local",
+            "nas.lan",
+            "mybox",
+            "127.0.0.1",
+            "::1",
+            "[::1]:9883",
+            "192.168.1.40",
+            "10.0.0.5",
+            "172.16.4.1",
+            "fd00::1",
+            "fe80::1",
+            "0.0.0.0",
+            "",
+        ] {
+            assert!(!domain_looks_public(local), "expected local: {local:?}");
+        }
+    }
+
+    #[test]
+    fn a_routable_name_or_address_is_public() {
+        for public in [
+            "example.com",
+            "atomic.example.com",
+            "EXAMPLE.COM",
+            "example.com.",
+            "203.0.113.10",
+            "2606:4700::1111",
+        ] {
+            assert!(domain_looks_public(public), "expected public: {public:?}");
+        }
+    }
+}
+
+/// Install the admission policy this node's mode calls for.
+///
+/// Open installs nothing: the default [`atomic_lib::sync::policy::OpenPolicy`]
+/// is already what an ungated node wants, and leaving it untouched is what makes
+/// this change a no-op for every existing deployment.
+pub async fn install_policy(store: &atomic_lib::Db, host_mode: &HostModeConfig) {
+    let Some(owner_agent) = host_mode.owner_agent.as_deref() else {
+        return;
+    };
+
+    if !host_mode.is_owner_mode() {
+        return;
+    }
+
+    let policy = atomic_lib::sync::policy::OwnerPolicy::new(owner_agent);
+    let existing = store.drive_subjects().await;
+
+    tracing::info!(
+        "Host mode: owner ({}). Hosting {} existing Drive(s); new Drives here are the owner's alone.",
+        owner_agent,
+        existing.len()
+    );
+
+    policy.enroll_existing(existing);
+    store.set_sync_policy(std::sync::Arc::new(policy));
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod context;
 mod errors;
 mod handlers;
 mod helpers;
+pub mod host_mode;
 #[cfg(feature = "https")]
 mod https;
 pub mod invite_token;

--- a/server/src/plugins/server_info.rs
+++ b/server/src/plugins/server_info.rs
@@ -32,6 +32,10 @@ pub struct ServerInfo {
     /// it must know before the first render. This is for every other client:
     /// the desktop app, the SaaS portal, scripts asking "what does `/` show?".
     pub home_drive: Option<String>,
+    /// Who may create a new Drive here. The welcome screen reads this to decide
+    /// whether offering "create account" would be offering something that
+    /// works.
+    pub host_mode: crate::host_mode::HostModeConfig,
 }
 
 pub fn server_info_endpoint(info: ServerInfo) -> Endpoint {
@@ -177,19 +181,49 @@ fn handle_get(
             Value::String(env!("CARGO_PKG_VERSION").into()),
         )?;
 
-        // Absent rather than null: a node with no p2p transport has no node ID.
-        if let Some(node_id) = crate::iroh_transport::get_node_id() {
-            resource.set_unsafe(
-                urls::SERVER_NODE_ID.into(),
-                Value::String(format!("did:ad:node:{node_id}")),
-            )?;
+        // A gated node's device list is an inventory of the owner's machines and
+        // a set of dial targets. The owner's own session still sees it — that is
+        // what the Sync page and the pairing QR are built on — but a stranger
+        // who can reach the origin has no business enumerating it.
+        //
+        // This hides a listing, it does not stand in for a check: someone who
+        // learns the node ID elsewhere can still attempt a connection, and gets
+        // refused by admission rather than by obscurity.
+        let hide_node_inventory = info.host_mode.is_owner_mode()
+            && matches!(context.for_agent, atomic_lib::agents::ForAgent::Public);
+
+        if !hide_node_inventory {
+            // Absent rather than null: a node with no p2p transport has no node ID.
+            if let Some(node_id) = crate::iroh_transport::get_node_id() {
+                resource.set_unsafe(
+                    urls::SERVER_NODE_ID.into(),
+                    Value::String(format!("did:ad:node:{node_id}")),
+                )?;
+            }
+
+            let peers = peer_resources(context.store);
+
+            if !peers.is_empty() {
+                resource.set_unsafe(urls::SERVER_PEERS.into(), Value::ResourceArray(peers))?;
+            }
         }
 
-        let peers = peer_resources(context.store);
-
-        if !peers.is_empty() {
-            resource.set_unsafe(urls::SERVER_PEERS.into(), Value::ResourceArray(peers))?;
-        }
+        // Said plainly and unconditionally, including on an open node: a client
+        // that cannot tell "open" from "too old to say" would have to guess, and
+        // the safe guess (assume gated) would hide account creation on every
+        // node that predates this.
+        resource.set_unsafe(
+            urls::SERVER_HOST_MODE.into(),
+            Value::String(info.host_mode.mode.as_str().to_string()),
+        )?;
+        resource.set_unsafe(
+            urls::SERVER_ACCEPTS_NEW_DRIVES.into(),
+            Value::Boolean(info.host_mode.mode.accepts_new_drives()),
+        )?;
+        resource.set_unsafe(
+            urls::SERVER_OWNER_SET.into(),
+            Value::Boolean(info.host_mode.owner_agent.is_some()),
+        )?;
 
         let managed = info.managed.load(std::sync::atomic::Ordering::Relaxed);
         resource.set_unsafe(urls::SERVER_MANAGED.into(), Value::Boolean(managed))?;

--- a/server/src/serve.rs
+++ b/server/src/serve.rs
@@ -439,6 +439,35 @@ where
         message.push('\n');
     }
 
+    // Always say which it is. A node that silently changed who may write to it
+    // would be worse than one that never gated at all.
+    match config.host_mode.mode {
+        crate::host_mode::HostMode::Owner => {
+            message.push_str(&format!(
+                "Only its owner can create new Drives here ({}).\n\n",
+                config
+                    .host_mode
+                    .owner_agent
+                    .as_deref()
+                    .unwrap_or("no owner set")
+            ));
+        }
+        crate::host_mode::HostMode::Open => {
+            let reachability = config.reachability();
+
+            if reachability.looks_exposed() && config.opts.host_mode.is_none() {
+                let warning = crate::host_mode::exposure_warning(reachability);
+                // Both, deliberately: the banner is what someone watching the
+                // terminal sees, and the `warn!` is what survives into
+                // journalctl for someone reading back later.
+                tracing::warn!("{}", warning);
+                message.push_str(&format!("{}\n\n", warning));
+            } else {
+                message.push_str("Anyone who can reach this node can create a Drive on it.\n\n");
+            }
+        }
+    }
+
     if config.opts.https {
         if cfg!(feature = "https") {
             #[cfg(feature = "https")]


### PR DESCRIPTION
## Related Issues

Supersedes #1271 (planning only, no runtime change). Closes unified-sync **OQ5** for Owner mode.

Relates to #1196. That issue lists "set up a domain and its records" and "setup the correct config (most notably domain data)" as friction of the old HTTP world that the local-first / DID shift removed — which is exactly why `ATOMIC_DOMAIN` is the wrong thing to hang security on now. Identity moved to `did:ad:…`; the domain is display and certs. This PR makes that split explicit rather than quietly depending on the old meaning, and rewrites the self-hosting setup docs that #1196 calls out.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

## The hole

A stock `atomic-server` admits every drive (`OpenPolicy`). On a laptop that is right. On a public address the welcome screen is an open registration form for space on the operator's disk — Create account, a `POST /commit` genesis, or an Iroh `SYNC_PUSH` of an unknown drive all land there.

## What this does

One variable gates the node:

```ini
ATOMIC_OWNER_AGENT=did:ad:agent:AbCd...
```

Only the owner may enroll a **new** drive. Nothing else changes: reading what the owner shared, collaborators writing in drives they were invited to, and the owner's own devices all behave exactly as before.

## `ATOMIC_DOMAIN` decides nothing — and that is the main design change

#1271 proposed switching to Owner mode automatically when `ATOMIC_DOMAIN` is not localhost. That is **fail-open exactly where self-hosters live.** The variable defaults to `localhost` and only has to be correct for building links and the LetsEncrypt challenge, so behind Docker with nginx/Caddy/Traefik, or a Cloudflare/Tailscale tunnel, the process never learns its public name — it reads `localhost` while the whole internet reaches it. The same rule would also have hard-failed every plain `ATOMIC_DOMAIN=example.com` HTTP node on upgrade. Backwards at both ends.

Resolution is therefore explicit only:

1. `ATOMIC_HOST_MODE` — the operator said so
2. `ATOMIC_OWNER_AGENT` is set — naming an owner is not done by accident
3. Neither → Open, exactly as before. **An upgrade never changes who may write.**

Domain, `--https` and port are still read for one purpose: whether an Open node prints a warning. A wrong guess there costs a line of log noise instead of a stranger's workspace. Notably *not* the bind address, which defaults to `::` — warning on that would fire on every dev run, and a warning that always fires is one nobody reads.

`ATOMIC_DOMAIN` itself is **not** deprecated; it still feeds `get_origin()`/`server_url` and the cert. What was deprecated is domain-as-*identity* (everything is `did:ad:…` now), which is precisely what makes it a fine display signal and a bad security one.

## Behaviour

| | Open (default) | Owner |
|---|---|---|
| Stranger creates an account | admitted | refused |
| Stranger pushes an unknown drive over sync | admitted | refused |
| Invited collaborator writes in their drive | works | works |
| Owner's second device | works | works |
| Drives already on disk | work | work |
| `/server` node id + peer list, unauthenticated | shown | redacted |

Enrollment is **derived, not persisted**: on boot, scan for drives already stored and enroll them. A drive that exists is one this node hosts, so the next boot re-derives the same answer — and that *is* snapshot-on-flip for free. Turning the gate on never revokes access to data already on disk, including a guest's drive from before the switch. Deliberately a full scan rather than index-backed: a stale query index answers "fewer drives than you have", which here would silently lock the owner out of their own data.

Owner mode with no usable owner **refuses to start**. Falling back to Open would make a typo in a `.env` an open hub.

## Verified on real binaries

- `ATOMIC_HOST_MODE=owner` with no owner → exit 1, message carries the whole fix plus the `ATOMIC_HOST_MODE=open` escape hatch
- A pasted secret → refused *by name*, so a private key does not sit in a `.env` while its owner hunts for the real problem
- Gated `/server`: `hostMode: owner`, `acceptsNewDrives: false`, `nodeId` **absent** for unauthenticated callers
- Open node on a public domain: prints the warning, naming why it fired

Tests: 419 `atomic_lib` + 62 `atomic-server` + 177 data-browser, clippy and oxlint clean. The stranger-refusal test was confirmed to fail when the gate is reopened.

## Known gap, documented rather than papered over

A proxied node has **no** boot-time signal — the request arrives locally and the domain reads `localhost` — so it is never warned. The installation guide and FAQ both lead with that case. Runtime `X-Forwarded-*` detection would close it and is recorded as the open follow-up.

## Also here

- `accountCreationTarget` gains a third branch, so a gated node stops offering an account it cannot give. `acceptsNewDrives` defaults to `true` — a node predating host mode says nothing, and reading silence as `false` would remove account creation from every server now running.
- Fixes `ATOMIC_SERVER_URL` in the external-proxy docs: documented for a variable that does not exist in the code, so anyone following that section was setting nothing.

## Not in this PR

Phase 3: per-IP rate limits on `/commit` and `/blob`, and refusing Iroh streams from agents with no read access. Independent of the admission gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who may enroll new Drives on a node (commit, sync push, Iroh), which is authorization-critical. Default stays Open so upgrades do not change write access, but Owner mode is a new fail-closed admission path.
> 
> **Overview**
> Operators can set `ATOMIC_OWNER_AGENT` (or `ATOMIC_HOST_MODE`) so only that Agent may enroll a **new** Drive. Public reads, invited collaborators, and existing Drives are unchanged. Unconfigured nodes stay **Open** — the mode is never inferred from `ATOMIC_DOMAIN`.
> 
> **Owner mode** installs `OwnerPolicy` (zero grace). Missing-drive bootstrap on commit, `SYNC_PUSH`, and Iroh now asks `may_enroll_drive` instead of admitting any unknown Drive. Boot scans the store and enrolls what is already there, so flipping the gate does not lock out data on disk. Owner without a valid DID refuses to start; a pasted secret is rejected by name.
> 
> `/server` advertises `hostMode` / `acceptsNewDrives`. The welcome screen hides Create account on a gated FOSS node (managed portals still get sign-up). Unauthenticated callers no longer see node id or peers in Owner mode. Docs cover going public, including that a reverse proxy will not warn at boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eed4bcc5284b7c5a084c0f5ba57537a8a1a50c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

