### PR TITLE
fix(ai): save a sidebar chat when the question is asked

### DIFF
--- a/browser/data-browser/src/chunks/AI/AISidebar.tsx
+++ b/browser/data-browser/src/chunks/AI/AISidebar.tsx
@@ -19,114 +19,24 @@ import {
   useStore,
   type Ai,
   type Resource,
-  type Store,
 } from '@tomic/react';
 import { useGenerativeData } from './useGenerativeData';
 import {
-  addMessageToChatResource,
   messageResourcesToDisplayMessages,
-  persistMessageResourceToServer,
   removeFollowingMessagesFromChatResource,
   removeMessageFromChatResource,
 } from './chatConversionUtils';
 import { findLatestAiChatAbout } from './findLatestAiChatAbout';
+import {
+  persistSidebarMessage,
+  type TitlePromise,
+} from './persistSidebarMessage';
 import { getOrCreateAiChatsFolder } from '@helpers/standardLocations';
 import { RealAIChat } from './RealAIChat';
 import { useAISettings } from '@components/AI/AISettingsContext';
 import { DEFAULT_AICHAT_NAME } from '@components/AI/aiContstants';
 import { usePersonalDrive } from '@hooks/usePersonalDrive';
 import toast from 'react-hot-toast';
-
-type DraftChatResource = Resource<Ai.AiChat>;
-type TitlePromise = Promise<string | undefined>;
-
-type PersistSidebarMessageArgs = {
-  message: AtomicUIMessage;
-  newMessages: AtomicUIMessage[];
-  store: Store;
-  getOrCreateDraftChatResource: () => Promise<DraftChatResource | undefined>;
-  isChatSavedRef: React.MutableRefObject<boolean>;
-  titlePromiseRef: React.MutableRefObject<TitlePromise | undefined>;
-  setMessageToResourceMap: React.Dispatch<
-    React.SetStateAction<Map<AtomicUIMessage, Resource>>
-  >;
-  messageToResourceMapRef: React.MutableRefObject<
-    Map<AtomicUIMessage, Resource>
-  >;
-  setIsChatSaved: React.Dispatch<React.SetStateAction<boolean>>;
-};
-
-const shouldFinalizeDraftChat = (
-  newMessages: AtomicUIMessage[],
-  message: AtomicUIMessage,
-) => newMessages.length >= 2 && message.role === 'assistant';
-
-// This logic was extracted from the component because the logic inside
-const persistSidebarMessage = async ({
-  message,
-  newMessages,
-  store,
-  getOrCreateDraftChatResource,
-  isChatSavedRef,
-  titlePromiseRef,
-  setMessageToResourceMap,
-  messageToResourceMapRef,
-  setIsChatSaved,
-}: PersistSidebarMessageArgs) => {
-  const resource = await getOrCreateDraftChatResource();
-
-  if (!resource) {
-    return;
-  }
-
-  const messageResource = await addMessageToChatResource(
-    message,
-    resource,
-    store,
-    {
-      saveChat: isChatSavedRef.current,
-      persistToServer: isChatSavedRef.current,
-    },
-  );
-
-  setMessageToResourceMap(prev => {
-    const next = new Map(prev);
-    next.set(message, messageResource);
-    messageToResourceMapRef.current = next;
-
-    return next;
-  });
-
-  // The sidebar chat stays as an unsaved draft until there is a real
-  // user/assistant exchange, avoiding empty chat resources.
-  if (shouldFinalizeDraftChat(newMessages, message)) {
-    if (titlePromiseRef.current) {
-      const name = await titlePromiseRef.current;
-
-      if (name) {
-        await resource.set(core.properties.name, name);
-      }
-
-      titlePromiseRef.current = undefined;
-    }
-
-    if (!isChatSavedRef.current) {
-      // Persist child messages (and their parts) before the chat resource
-      // references them on the server — matches AIChatPage / addMessageToChatResource.
-      for (const pendingMessageResource of messageToResourceMapRef.current.values()) {
-        await persistMessageResourceToServer(
-          pendingMessageResource as Resource<Ai.AiMessage>,
-          store,
-        );
-      }
-
-      await resource.save();
-
-      isChatSavedRef.current = true;
-      setIsChatSaved(true);
-    }
-  }
-};
 
 const handleSidebarMessageSaveError = (error: unknown) => {
   console.error(error);
@@ -288,6 +198,8 @@ const AISidebar: React.FC = () => {
       getOrCreateDraftChatResource,
       isChatSavedRef,
       titlePromiseRef,
+      shouldGenerateTitles,
+      generateTitle: generateTitleFromConversation,
       setMessageToResourceMap,
       messageToResourceMapRef,
       setIsChatSaved,
@@ -300,19 +212,6 @@ const AISidebar: React.FC = () => {
     messagesRef.current = newMessages;
     setMessages(newMessages);
 
-    // Start title generation as soon as the first assistant response completes,
-    // but save the resource even when title generation is disabled or fails.
-    if (
-      !isChatSavedRef.current &&
-      !titlePromiseRef.current &&
-      newMessages.length >= 2 &&
-      message.role === 'assistant'
-    ) {
-      titlePromiseRef.current = shouldGenerateTitles
-        ? generateTitleFromConversation(newMessages)
-        : Promise.resolve(undefined);
-    }
-
     persistSidebarMessage({
       message,
       newMessages,
@@ -323,6 +222,8 @@ const AISidebar: React.FC = () => {
       setMessageToResourceMap,
       messageToResourceMapRef,
       setIsChatSaved,
+      shouldGenerateTitles,
+      generateTitle: generateTitleFromConversation,
     }).catch(handleSidebarMessageSaveError);
   };
 

--- a/browser/data-browser/src/chunks/AI/persistSidebarMessage.test.ts
+++ b/browser/data-browser/src/chunks/AI/persistSidebarMessage.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AtomicUIMessage } from './types';
+import type { PersistSidebarMessageArgs } from './persistSidebarMessage';
+
+const saved: string[] = [];
+const serverPersisted: string[] = [];
+
+vi.mock('./chatConversionUtils', () => ({
+  addMessageToChatResource: vi.fn(async (added, chat, _store, opts) => {
+    if (opts?.saveChat) saved.push(chat.subject);
+
+    return { subject: `message-${added.role}`, props: { parts: [] } };
+  }),
+  persistMessageResourceToServer: vi.fn(
+    async (resource: { subject: string }) => {
+      serverPersisted.push(resource.subject);
+    },
+  ),
+}));
+
+const { persistSidebarMessage } = await import('./persistSidebarMessage');
+
+const NAME = 'https://atomicdata.dev/properties/name';
+
+function fakeChat(name = 'Untitled Chat') {
+  const props: Record<string, unknown> = { [NAME]: name };
+
+  return {
+    subject: 'chat-1',
+    get: (property: string) => props[property],
+    set: async (property: string, value: unknown) => {
+      props[property] = value;
+    },
+    save: async () => {
+      saved.push('chat-1');
+    },
+    props,
+  };
+}
+
+function message(role: 'user' | 'assistant'): AtomicUIMessage {
+  return { id: role, role, parts: [] } as unknown as AtomicUIMessage;
+}
+
+/** Everything the function needs, with the pieces a test cares about swappable. */
+function args(
+  chat: ReturnType<typeof fakeChat>,
+  overrides: Record<string, unknown> = {},
+): PersistSidebarMessageArgs {
+  return {
+    store: {},
+    getOrCreateDraftChatResource: async () => chat,
+    isChatSavedRef: { current: false },
+    titlePromiseRef: { current: undefined },
+    setMessageToResourceMap: () => undefined,
+    messageToResourceMapRef: { current: new Map() },
+    setIsChatSaved: () => undefined,
+    shouldGenerateTitles: true,
+    generateTitle: async () => 'A good title',
+    ...overrides,
+  } as unknown as PersistSidebarMessageArgs;
+}
+
+beforeEach(() => {
+  saved.length = 0;
+  serverPersisted.length = 0;
+});
+
+/**
+ * A sidebar chat used to live only in memory until the assistant's reply
+ * finished. Anything that ended the page in that window — a hot reload, a
+ * crash, a closed tab — took the question, the half-written answer and the
+ * chat resource with it, and because no resource had ever been created the
+ * conversation could not even be found afterwards.
+ *
+ * These tests are about the write, not the screen. The screen was never the
+ * problem: it showed the chat perfectly while nothing was being saved.
+ */
+describe('persistSidebarMessage', () => {
+  it('saves the chat when the question is asked, not when it is answered', async () => {
+    const chat = fakeChat();
+    const isChatSavedRef = { current: false };
+
+    await persistSidebarMessage({
+      ...args(chat, { isChatSavedRef }),
+      message: message('user'),
+      newMessages: [message('user')],
+    });
+
+    // Before any reply exists. This is the whole fix: the model may take
+    // minutes, and until now that was minutes of holding the only copy in a
+    // JavaScript variable.
+    expect(saved).toContain('chat-1');
+    expect(isChatSavedRef.current).toBe(true);
+  });
+
+  it('pushes the messages to the server before the chat points at them', async () => {
+    const chat = fakeChat();
+    const pending = new Map([
+      [message('user'), { subject: 'message-user', props: { parts: [] } }],
+    ]);
+
+    await persistSidebarMessage({
+      ...args(chat, { messageToResourceMapRef: { current: pending } }),
+      message: message('user'),
+      newMessages: [message('user')],
+    });
+
+    // A chat that references children the server has not seen is a commit that
+    // fails validation and gets dropped.
+    expect(serverPersisted).toContain('message-user');
+  });
+
+  it('still names the chat, even though it was saved a message earlier', async () => {
+    // The trap in this change: titling used to be gated on the chat NOT being
+    // saved yet. Finalising on the user's message makes that condition false
+    // by the time the reply lands, so a naive fix leaves every chat called
+    // "Untitled Chat" for ever.
+    const chat = fakeChat();
+
+    await persistSidebarMessage({
+      ...args(chat, { isChatSavedRef: { current: true } }),
+      message: message('assistant'),
+      newMessages: [message('user'), message('assistant')],
+    });
+
+    expect(chat.get(NAME)).toBe('A good title');
+  });
+
+  it('leaves a chat that already has a name alone', async () => {
+    const chat = fakeChat('Something the user typed');
+
+    await persistSidebarMessage({
+      ...args(chat, { isChatSavedRef: { current: true } }),
+      message: message('assistant'),
+      newMessages: [message('user'), message('assistant')],
+    });
+
+    expect(chat.get(NAME)).toBe('Something the user typed');
+  });
+
+  it('does not name a chat when the user has titles switched off', async () => {
+    const chat = fakeChat();
+
+    await persistSidebarMessage({
+      ...args(chat, {
+        isChatSavedRef: { current: true },
+        shouldGenerateTitles: false,
+      }),
+      message: message('assistant'),
+      newMessages: [message('user'), message('assistant')],
+    });
+
+    expect(chat.get(NAME)).toBe('Untitled Chat');
+  });
+});

--- a/browser/data-browser/src/chunks/AI/persistSidebarMessage.ts
+++ b/browser/data-browser/src/chunks/AI/persistSidebarMessage.ts
@@ -1,0 +1,134 @@
+import { core, type Resource, type Store, type Ai } from '@tomic/react';
+import type { AtomicUIMessage } from './types';
+import {
+  addMessageToChatResource,
+  persistMessageResourceToServer,
+} from './chatConversionUtils';
+import { DEFAULT_AICHAT_NAME } from '@components/AI/aiContstants';
+
+export type DraftChatResource = Resource<Ai.AiChat>;
+export type TitlePromise = Promise<string | undefined>;
+
+export type PersistSidebarMessageArgs = {
+  message: AtomicUIMessage;
+  newMessages: AtomicUIMessage[];
+  store: Store;
+  getOrCreateDraftChatResource: () => Promise<DraftChatResource | undefined>;
+  isChatSavedRef: React.MutableRefObject<boolean>;
+  titlePromiseRef: React.MutableRefObject<TitlePromise | undefined>;
+  setMessageToResourceMap: React.Dispatch<
+    React.SetStateAction<Map<AtomicUIMessage, Resource>>
+  >;
+  messageToResourceMapRef: React.MutableRefObject<
+    Map<AtomicUIMessage, Resource>
+  >;
+  setIsChatSaved: React.Dispatch<React.SetStateAction<boolean>>;
+  shouldGenerateTitles: boolean;
+  generateTitle: (messages: AtomicUIMessage[]) => TitlePromise;
+};
+
+/**
+ * When a sidebar chat stops being a draft and becomes a resource.
+ *
+ * On the user's message, not on the reply that follows it. The draft exists so
+ * that opening the panel and typing nothing leaves nothing behind — but once
+ * someone has actually asked something, there is nothing empty about the chat,
+ * and waiting for the answer means the whole exchange lives only in memory for
+ * as long as the model takes to produce one. A reload in that window used to
+ * take the question, the half-written answer and the chat itself, and since no
+ * resource had ever been created, the chat could not even be found afterwards.
+ */
+export const shouldFinalizeDraftChat = (message: AtomicUIMessage) =>
+  message.role === 'user';
+
+/**
+ * Whether this chat still needs a name.
+ *
+ * Asked of the resource rather than of `isChatSaved`, which used to stand in
+ * for it. Those were the same question only while a chat was saved at the
+ * moment it was first titled; now that it is saved a message earlier, a shared
+ * flag would report every chat as titled and none would ever get a name.
+ */
+export const needsTitle = (resource: DraftChatResource) =>
+  (resource.get(core.properties.name) ?? DEFAULT_AICHAT_NAME) ===
+  DEFAULT_AICHAT_NAME;
+
+export const persistSidebarMessage = async ({
+  message,
+  newMessages,
+  store,
+  getOrCreateDraftChatResource,
+  isChatSavedRef,
+  titlePromiseRef,
+  setMessageToResourceMap,
+  messageToResourceMapRef,
+  setIsChatSaved,
+  shouldGenerateTitles,
+  generateTitle,
+}: PersistSidebarMessageArgs) => {
+  const resource = await getOrCreateDraftChatResource();
+
+  if (!resource) {
+    return;
+  }
+
+  const messageResource = await addMessageToChatResource(
+    message,
+    resource,
+    store,
+    {
+      saveChat: isChatSavedRef.current,
+      persistToServer: isChatSavedRef.current,
+    },
+  );
+
+  setMessageToResourceMap(prev => {
+    const next = new Map(prev);
+    next.set(message, messageResource);
+    messageToResourceMapRef.current = next;
+
+    return next;
+  });
+
+  if (!isChatSavedRef.current && shouldFinalizeDraftChat(message)) {
+    // Persist child messages (and their parts) before the chat resource
+    // references them on the server — matches AIChatPage / addMessageToChatResource.
+    for (const pendingMessageResource of messageToResourceMapRef.current.values()) {
+      await persistMessageResourceToServer(
+        pendingMessageResource as Resource<Ai.AiMessage>,
+        store,
+      );
+    }
+
+    await resource.save();
+
+    isChatSavedRef.current = true;
+    setIsChatSaved(true);
+  }
+
+  // Naming happens on the reply, because a title wants both halves of the
+  // exchange to describe. Decided here, where the resource is already in hand,
+  // rather than in the component — the caller cannot know whether the chat has
+  // been created yet, and a title generated against a chat that does not exist
+  // is dropped without a word.
+  if (message.role === 'assistant' && newMessages.length >= 2) {
+    if (
+      !titlePromiseRef.current &&
+      shouldGenerateTitles &&
+      needsTitle(resource)
+    ) {
+      titlePromiseRef.current = generateTitle(newMessages);
+    }
+
+    if (titlePromiseRef.current) {
+      const name = await titlePromiseRef.current;
+
+      titlePromiseRef.current = undefined;
+
+      if (name) {
+        await resource.set(core.properties.name, name);
+        await resource.save();
+      }
+    }
+  }
+};


### PR DESCRIPTION
A sidebar chat stayed in memory until the assistant's reply finished. Anything that ended the page in that window — a hot reload, a crash, a closed tab — took the question, the half-written answer and the chat resource with it. And since no resource had ever been created, the conversation was not in the AI Chats panel either: there was nothing to list.

The window is exactly as long as the model takes to answer, which is why this showed up while generating code and never in ordinary chat.

Nothing was broken. The draft exists so that opening the panel and typing nothing leaves nothing behind, and that is worth keeping — but the boundary was drawn one message too late. A chat holding a real question is not empty. It is now saved when the user sends, so the prompt is on disk before the reply is even requested, and a reload restores it.

Titling had to be separated from saving to do this. It was gated on the chat NOT being saved yet, which was the same question as "not yet titled" only while the two happened together. Saving a message earlier would have left every chat called "Untitled Chat" for ever, silently. It now asks the resource whether it still has the default name — the rule AIChatPage already used — and does it where the resource is in hand rather than in the component, which cannot know whether the chat exists yet.

Lifted out of the component to be testable at all: the tests assert the write happened, not what the screen showed. The screen was never wrong here — it displayed the whole conversation perfectly while none of it was being saved, which is why this survived every existing test.

What is still lost is the in-flight reply, now recoverable with regenerate because the prompt survives. Persisting the stream as it arrives is the next rung and writes on a hot path, so it should be measured, not assumed.

## Related Issues

closes #number

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [ ] Update docs if needed
