### PR TITLE
Fix @tomic/cli ontology codegen for did:ad subjects

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -791,3 +791,13 @@ page, never payload contents. A real local WebSocket exercises this collection.
 - `save-status-coordinator.test.ts` exercises narrow injected dependencies without a
   Store: overlapping owners, idempotent observer disposal, resource renaming, cached
   immutable snapshots, current outbox/connection state and failure accounting.
+## Ontology codegen (`@tomic/cli`) and DID fetch
+
+| Flow | Where |
+|---|---|
+| HTTP path `https://host/did:ad:…` and `/did?subject=` extract the same DID | `browser/lib/src/subject.test.ts` |
+| JSON-AD parse accepts `@id: did:ad:…` when the request used the HTTP path alias | `browser/lib/src/parse.test.ts` |
+| `Client.fetchResourceHTTP` resolves DIDs via `/did?subject=` and does not touch `window` in Node | `browser/lib/src/client.fetch.test.ts` |
+| Store fetch by HTTP path alias returns the resource stored under the DID | `browser/lib/src/store.test.ts` |
+
+Not covered: `ad-generate ontologies` end-to-end against a live server (no CLI test runner).

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: `@tomic/cli` `ad-generate ontologies` works with `did:ad:` ontology subjects. A DID is not an HTTP URL: the CLI needs `serverUrl` (the Atomic Server origin) and fetches `GET {serverUrl}/did?subject=…`. Pasting the address-bar form `https://host/did:ad:…` no longer fails with `Resource has wrong subject in @id` — that URL is an alias, and the resource's `@id` is the DID. `ad-generate init` writes `serverUrl`.
 - Add peer rooms for up to eight simultaneous browsers on the Sync page with WebRTC collaboration, OPFS reconciliation and attachment sync without a Cloud subscription. Discovery defaults to shared Atomic SaaS signaling, independent of the drive’s data node. Export `BrowserPeerSync`, `WebRtcPeer` and `WebRtcTransport` from `@tomic/lib` ([#1396](https://github.com/ontola/atomic-server/issues/1396)).
 - Portal Open links select their workspace; ordinary resource links keep the current drive.
 - Sync distinguishes remote node data from Cloud Server enrollment, explains drive-specific plans, and refreshes account/recovery status after portal sign-in.

--- a/browser/cli/src/commands/init.ts
+++ b/browser/cli/src/commands/init.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 const TEMPLATE_CONFIG_FILE = {
   outputFolder: './src/ontologies',
   moduleAlias: '@tomic/lib',
+  serverUrl: 'http://localhost:9883',
   ontologies: [],
 };
 
@@ -32,7 +33,7 @@ export const initCommand = async (args: string[]) => {
   console.log(chalk.green('Done!'));
   console.log(
     chalk.cyan(
-      'Next add your ontologies to your atomic.config.json file. You can find more info on how to do this here: https://docs.atomicdata.dev/js-cli',
+      'Set "serverUrl" to your Atomic Server origin, then add ontology subjects (did:ad:… identifiers, not the https://host/did:ad:… address-bar URL). More info: https://docs.atomicdata.dev/js-cli',
     ),
   );
 };

--- a/browser/cli/src/config.ts
+++ b/browser/cli/src/config.ts
@@ -20,7 +20,7 @@ export interface AtomicConfig {
    * If left empty the public agent is used.
    */
   agentSecret?: string;
-  /** HTTP(S) origin used to retrieve ontology subjects, including DIDs. */
+  /** HTTP(S) origin used to fetch `did:ad:` ontology subjects via `/did?subject=`. */
   serverUrl?: string;
   /** The list of subjects of your ontologies */
 

--- a/browser/cli/src/store.ts
+++ b/browser/cli/src/store.ts
@@ -1,6 +1,39 @@
 import { Agent, Store, type OptionalClass, type Resource } from '@tomic/lib';
 import { atomicConfig } from './config.js';
 
+const stripTrailingSlash = (url: string): string => url.replace(/\/$/, '');
+
+const originFromHttpSubject = (subject: string): string | undefined => {
+  if (!subject.startsWith('http://') && !subject.startsWith('https://')) {
+    return undefined;
+  }
+
+  try {
+    return new URL(subject).origin;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Configured origin, or the host of the first HTTP ontology subject. */
+const resolveServerUrl = (): string | undefined => {
+  const configured = atomicConfig.serverUrl?.trim();
+
+  if (configured) {
+    return stripTrailingSlash(configured);
+  }
+
+  for (const subject of atomicConfig.ontologies) {
+    const origin = originFromHttpSubject(subject);
+
+    if (origin) {
+      return origin;
+    }
+  }
+
+  return undefined;
+};
+
 const getCommandIndex = (): number | undefined => {
   const agentIndex = process.argv.indexOf('--agent');
   if (agentIndex !== -1) return agentIndex;
@@ -26,12 +59,27 @@ const getAgent = async (): Promise<Agent | undefined> => {
   return Agent.fromSecret(secret, 'js');
 };
 
-export const store = new Store({ serverUrl: atomicConfig.serverUrl });
+const serverUrl = resolveServerUrl();
+
+export const store = new Store(serverUrl ? { serverUrl } : {});
 
 // CLI reads are ordinary HTTP requests. Do not make them wait for the
 // background WebSocket handshake or Store will classify the first ontology
 // fetch as an offline-only read and fail before it reaches the server.
 store.setServerConnected(true);
+
+/**
+ * Point the store at the origin of an HTTP ontology URL so nested DID
+ * subjects (classes, properties) resolve against the server that served
+ * it, even if `atomic.config.json` still has the init default of localhost.
+ */
+export const ensureServerUrlForSubject = (subject: string): void => {
+  const origin = originFromHttpSubject(subject);
+
+  if (origin && origin !== store.getServerUrl()) {
+    store.setServerUrl(origin);
+  }
+};
 
 /**
  * The CLI is a finite batch process, so always perform complete HTTP reads.
@@ -41,8 +89,11 @@ store.setServerConnected(true);
  */
 export const fetchResource = <C extends OptionalClass>(
   subject: string,
-): Promise<Resource<C>> =>
-  store.fetchResourceFromServer<C>(subject, { noWebSocket: true });
+): Promise<Resource<C>> => {
+  ensureServerUrlForSubject(subject);
+
+  return store.fetchResourceFromServer<C>(subject, { noWebSocket: true });
+};
 
 /**
  * Resolves once the agent (from `--agent` / `-a` or the config file) has been

--- a/browser/cli/src/validateOntologies.ts
+++ b/browser/cli/src/validateOntologies.ts
@@ -1,5 +1,5 @@
 import { core } from '@tomic/lib';
-import { fetchResource } from './store.js';
+import { fetchResource, store } from './store.js';
 import chalk from 'chalk';
 
 export const validateOntologies = async (
@@ -32,7 +32,15 @@ export const validateOntologies = async (
       }
     } catch (e) {
       isValid = false;
-      report += `Could not fetch ontology at ${subject}\n`;
+      const message = e instanceof Error ? e.message : String(e);
+      report += `Could not fetch ontology at ${subject}\n  ${message}\n`;
+
+      if (/ECONNREFUSED|Could not reach|no server URL/i.test(message)) {
+        const hint = store.getServerUrl()
+          ? `Check that ${chalk.cyan('serverUrl')} (${store.getServerUrl()}) is the Atomic Server that hosts this ontology.`
+          : `Set ${chalk.cyan('serverUrl')} in ${chalk.cyan('atomic.config.json')} to your Atomic Server origin (the CLI cannot fetch a did:ad: subject without one).`;
+        report += `  ${hint}\n`;
+      }
     }
   }
 

--- a/browser/lib/src/client.fetch.test.ts
+++ b/browser/lib/src/client.fetch.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, vi } from 'vitest';
+import { Client } from './client.js';
+import { core } from './ontologies/core.js';
+
+const DID = 'did:ad:ontology123';
+const JSON_AD = {
+  '@id': DID,
+  [core.properties.name]: 'My ontology',
+};
+
+const jsonResponse = () =>
+  new Response(JSON.stringify(JSON_AD), {
+    status: 200,
+    headers: { 'Content-Type': 'application/ad+json' },
+  });
+
+describe('Client.fetchResourceHTTP DID subjects', () => {
+  it('resolves a DID via /did?subject= when given a serverURL', async ({
+    expect,
+  }) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        `https://example.com/did?subject=${encodeURIComponent(DID)}`,
+      );
+
+      return jsonResponse();
+    });
+    const client = new Client(fetchMock);
+    const { resource } = await client.fetchResourceHTTP(DID, {
+      serverURL: 'https://example.com',
+    });
+
+    expect(resource.error).toBeUndefined();
+    expect(resource.subject).toBe(DID);
+    expect(resource.get(core.properties.name)).toBe('My ontology');
+  });
+
+  it('rewrites https://host/did:ad:… to the /did endpoint and accepts the DID @id', async ({
+    expect,
+  }) => {
+    const httpAlias = `https://example.com/${DID}`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        `https://example.com/did?subject=${encodeURIComponent(DID)}`,
+      );
+
+      return jsonResponse();
+    });
+    const client = new Client(fetchMock);
+    const { resource } = await client.fetchResourceHTTP(httpAlias);
+
+    expect(resource.error).toBeUndefined();
+    expect(resource.subject).toBe(DID);
+    expect(resource.get(core.properties.name)).toBe('My ontology');
+  });
+
+  it('does not touch window when resolving a DID without a server URL in Node', async ({
+    expect,
+  }) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    const client = new Client(fetchMock);
+    const { resource } = await client.fetchResourceHTTP(DID);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(resource.error).toBeDefined();
+    expect(resource.error?.message).toMatch(/no server URL/);
+    errorSpy.mockRestore();
+  });
+
+  it('does not rewrite ordinary HTTP resource URLs', async ({ expect }) => {
+    const httpSubject = 'https://atomicdata.dev/ontology/core';
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(httpSubject);
+
+      return new Response(
+        JSON.stringify({
+          '@id': httpSubject,
+          [core.properties.name]: 'core',
+        }),
+        { status: 200 },
+      );
+    });
+    const client = new Client(fetchMock);
+    const { resource } = await client.fetchResourceHTTP(httpSubject);
+
+    expect(resource.error).toBeUndefined();
+    expect(resource.subject).toBe(httpSubject);
+  });
+});

--- a/browser/lib/src/client.ts
+++ b/browser/lib/src/client.ts
@@ -21,6 +21,7 @@ import {
 } from './commit.js';
 import { JSONADParser } from './parse.js';
 import { Resource } from './resource.js';
+import { extractDidSubject } from './subject.js';
 import {
   recordServerVersionFromResponse,
   shouldSkipDidAuthForLegacyServer,
@@ -219,16 +220,26 @@ export class Client {
       }
 
       let url = subject;
+      const wrappedDid = extractDidSubject(subject);
 
       if (subject.startsWith('did:')) {
         // We can't fetch DIDs directly, so we use the server's /did endpoint.
-        const baseUrl =
-          signInfo?.serverURL ||
-          serverURL ||
-          (window as unknown as Record<'atomicServerUrl', string>)
-            .atomicServerUrl ||
-          window.location.origin;
+        const baseUrl = didResolutionBaseUrl(signInfo?.serverURL, serverURL);
+
+        if (!baseUrl) {
+          throw new AtomicError(
+            `Cannot fetch ${subject}: no server URL to resolve this DID against. ` +
+              `Pass serverURL to fetchResourceHTTP, call store.setServerUrl(), ` +
+              `or (for @tomic/cli) set "serverUrl" in atomic.config.json.`,
+          );
+        }
+
         url = `${baseUrl}/did?subject=${encodeURIComponent(subject)}`;
+      } else if (wrappedDid && wrappedDid !== subject) {
+        // `https://host/did:ad:…` is an HTTP alias, not the resource's
+        // identity. Fetch via the host's /did endpoint so the response
+        // `@id` (the DID) matches what JSON-AD actually contains.
+        url = `${new URL(subject).origin}/did?subject=${encodeURIComponent(wrappedDid)}`;
       }
 
       // Sign the request with the actual URL being fetched (not the raw DID
@@ -304,10 +315,15 @@ export class Client {
               );
             }
 
-            // For array responses, find the resource matching the requested subject.
-            // Falls back to the last item (the convention for non-array responses).
+            // For array responses, find the resource matching the requested
+            // subject (or its DID, when the request used an HTTP alias).
+            // Falls back to the last item (the convention for non-array
+            // responses).
             resource =
               resources.find(r => r.subject === subject) ??
+              (wrappedDid
+                ? resources.find(r => r.subject === wrappedDid)
+                : undefined) ??
               (resources.at(-1) as Resource);
             createdResources.push(...resources);
           }
@@ -429,4 +445,24 @@ export class Client {
 
     return fetch(...params);
   }
+}
+
+/** Origin used to turn a `did:ad:…` subject into `GET {origin}/did?subject=`. */
+function didResolutionBaseUrl(
+  ...candidates: Array<string | undefined>
+): string | undefined {
+  for (const candidate of candidates) {
+    if (candidate) {
+      return candidate.replace(/\/$/, '');
+    }
+  }
+
+  if (hasBrowserAPI()) {
+    const fromWindow = (window as unknown as Record<'atomicServerUrl', string>)
+      .atomicServerUrl;
+
+    return fromWindow || window.location.origin;
+  }
+
+  return undefined;
 }

--- a/browser/lib/src/parse.test.ts
+++ b/browser/lib/src/parse.test.ts
@@ -219,4 +219,41 @@ describe('parse.ts', () => {
     ]);
     expect(commit.get(core.properties.description)).toBeUndefined();
   });
+
+  /**
+   * Regression: `@tomic/cli` users copy `https://host/did:ad:…` from the
+   * address bar. The server returns `@id: did:ad:…` (the resource's
+   * identity). Treating that as a mismatch made `ad-generate ontologies`
+   * fail after a successful fetch.
+   */
+  it('accepts a DID @id when the requested subject is the HTTP path alias', ({
+    expect,
+  }) => {
+    const did = 'did:ad:ontology123';
+    const httpAlias = `https://myserver.example/${did}`;
+    const jsonObject = {
+      '@id': did,
+      [STRING_PROPERTY]: 'My ontology',
+    };
+
+    const parser = new JSONADParser();
+    const [resource] = parser.parse(jsonObject, httpAlias);
+
+    expect(resource.error).toBeUndefined();
+    expect(resource.subject).toBe(did);
+    expect(resource.get(STRING_PROPERTY)).toBe('My ontology');
+  });
+
+  it('still rejects a genuine @id mismatch', ({ expect }) => {
+    const jsonObject = {
+      '@id': 'https://example.com/other',
+      [STRING_PROPERTY]: 'Hoi',
+    };
+
+    const parser = new JSONADParser();
+
+    expect(() => parser.parse(jsonObject, EXAMPLE_SUBJECT)).toThrow(
+      /wrong subject in @id/,
+    );
+  });
 });

--- a/browser/lib/src/parse.ts
+++ b/browser/lib/src/parse.ts
@@ -1,7 +1,7 @@
 import { AtomicError } from './error.js';
-import { Client } from './index.js';
 import { server } from './ontologies/server.js';
 import { Resource, unknownSubject } from './resource.js';
+import { subjectsReferToSameResource } from './subject.js';
 import { type JSONObject, type AtomicValue, isJSONObject } from './value.js';
 import { decodeB64 } from './base64.js';
 
@@ -53,16 +53,18 @@ export class JSONADParser {
             throw new Error('Expected @id to be a string');
           }
 
-          // Only enforce subject match when a specific subject was requested
-          if (subject && subject !== unknownSubject && value !== subject) {
-            const subjectNoParams = Client.removeQueryParamsFromURL(subject);
-            const valueNoParams = Client.removeQueryParamsFromURL(value);
-
-            if (subjectNoParams !== valueNoParams) {
-              throw new Error(
-                `Resource has wrong subject in @id. Received subject was ${value}, expected ${resource.subject}.`,
-              );
-            }
+          // Only enforce subject match when a specific subject was requested.
+          // HTTP aliases of a DID (`https://host/did:ad:…`) are the same
+          // resource as `@id: did:ad:…` — the server keeps the DID as
+          // identity even when the resource was fetched by URL.
+          if (
+            subject &&
+            subject !== unknownSubject &&
+            !subjectsReferToSameResource(subject, value)
+          ) {
+            throw new Error(
+              `Resource has wrong subject in @id. Received subject was ${value}, expected ${resource.subject}.`,
+            );
           }
 
           resource.setSubject(value as string);

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -711,6 +711,35 @@ describe('Store', () => {
     expect(gotByAlias).toBe(gotByDID);
   });
 
+  it('returns a DID resource fetched by its HTTP path alias', async ({
+    expect,
+  }) => {
+    const did = 'did:ad:ontology123';
+    const httpAlias = `https://example.com/${did}`;
+    const store = new Store({ serverUrl: 'https://example.com' });
+    store.setServerConnected(true);
+    store.injectFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            '@id': did,
+            [core.properties.name]: 'My ontology',
+          }),
+          { status: 200 },
+        ),
+    );
+
+    const resource = await store.fetchResourceFromServer(httpAlias, {
+      noWebSocket: true,
+    });
+
+    expect(resource).toBeDefined();
+    expect(resource.error).toBeUndefined();
+    expect(resource.subject).toBe(did);
+    expect(resource.get(core.properties.name)).toBe('My ontology');
+    expect(store.getResourceLoading(httpAlias).subject).toBe(did);
+  });
+
   it('normalizes relative subjects to full URLs', async ({ expect }) => {
     const store = new Store({ serverUrl: 'https://myserver.dev' });
 

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -3489,7 +3489,10 @@ export class Store {
       });
     }
 
-    return this.resources.get(normalizedSubject)!;
+    // Resolve HTTP aliases of a DID (`https://host/did:ad:…` → `did:ad:…`)
+    // so a fetch by the address-bar URL returns the resource stored under
+    // its canonical `@id`.
+    return this.resources.get(this.resolveSubject(normalizedSubject))!;
   }
 
   public getAllSubjects(): string[] {

--- a/browser/lib/src/subject.test.ts
+++ b/browser/lib/src/subject.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   asSubject,
+  extractDidSubject,
   InvalidSubjectError,
   isDidSubject,
   isHttpSubject,
   isValidSubject,
+  subjectsReferToSameResource,
   tryAsSubject,
   type Subject,
 } from './subject.js';
@@ -60,6 +62,63 @@ describe('subject', () => {
       expect(isHttpSubject(did)).toBe(false);
       expect(isDidSubject(http)).toBe(false);
       expect(isHttpSubject(http)).toBe(true);
+    });
+  });
+
+  describe('extractDidSubject / subjectsReferToSameResource', () => {
+    it('returns a DID unchanged, stripping query and fragment', () => {
+      expect(extractDidSubject('did:ad:abc')).toBe('did:ad:abc');
+      expect(extractDidSubject('did:ad:abc?drive=did:ad:drive')).toBe(
+        'did:ad:abc',
+      );
+    });
+
+    it('extracts a DID from the HTTP path form and the /did endpoint', () => {
+      expect(extractDidSubject('https://example.com/did:ad:abc')).toBe(
+        'did:ad:abc',
+      );
+      expect(
+        extractDidSubject(
+          'https://example.com/did?subject=' + encodeURIComponent('did:ad:abc'),
+        ),
+      ).toBe('did:ad:abc');
+    });
+
+    it('does not treat ordinary HTTP resources as DIDs', () => {
+      expect(
+        extractDidSubject('https://atomicdata.dev/ontology/core'),
+      ).toBeUndefined();
+      expect(extractDidSubject('/relative')).toBeUndefined();
+    });
+
+    it('treats https://host/did:ad:x and did:ad:x as the same resource', () => {
+      expect(
+        subjectsReferToSameResource(
+          'https://example.com/did:ad:abc',
+          'did:ad:abc',
+        ),
+      ).toBe(true);
+      expect(
+        subjectsReferToSameResource(
+          'did:ad:abc',
+          'https://example.com/did:ad:abc',
+        ),
+      ).toBe(true);
+    });
+
+    it('still rejects a genuine subject mismatch', () => {
+      expect(
+        subjectsReferToSameResource(
+          'https://example.com/did:ad:aaa',
+          'did:ad:bbb',
+        ),
+      ).toBe(false);
+      expect(
+        subjectsReferToSameResource(
+          'https://example.com/foo',
+          'https://example.com/bar',
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/browser/lib/src/subject.ts
+++ b/browser/lib/src/subject.ts
@@ -75,6 +75,81 @@ export function isHttpSubject(subject: Subject): boolean {
   return HTTP_RE.test(subject);
 }
 
+/**
+ * If `raw` is a `did:ad:` subject, return it with query/fragment stripped.
+ * If it is an HTTP(S) URL that *names* a DID resource — the path form
+ * `https://host/did:ad:…` (an address-bar / copy-paste URL) or the
+ * `/did` endpoint `https://host/did?subject=did:ad:…` — return that DID.
+ * Otherwise `undefined`.
+ *
+ * The server always serialises a DID resource's `@id` as the DID itself,
+ * even when the resource was fetched through one of these HTTP aliases.
+ * Callers comparing a requested subject against `@id` should use
+ * {@link subjectsReferToSameResource} rather than string equality.
+ */
+export function extractDidSubject(raw: string): string | undefined {
+  if (raw.startsWith(DID_PREFIX)) {
+    return raw.split(/[?#]/)[0];
+  }
+
+  if (!HTTP_RE.test(raw)) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(raw);
+    const path = url.pathname.replace(/\/$/, '') || '/';
+
+    // Path form: https://host/did:ad:…
+    if (path.startsWith(`/${DID_PREFIX}`) && !path.slice(1).includes('/')) {
+      return path.slice(1);
+    }
+
+    // Endpoint form: https://host/did?subject=did:ad:…
+    if (path === '/did') {
+      const subject = url.searchParams.get('subject');
+
+      if (subject?.startsWith(DID_PREFIX)) {
+        return subject.split(/[?#]/)[0];
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * True when `requested` and `received` name the same resource: exact
+ * match, same URL ignoring query params, or one is an HTTP alias of
+ * the other's DID (`https://host/did:ad:x` vs `did:ad:x`).
+ */
+export function subjectsReferToSameResource(
+  requested: string,
+  received: string,
+): boolean {
+  if (requested === received) {
+    return true;
+  }
+
+  const requestedNoParams = requested.split('?')[0];
+  const receivedNoParams = received.split('?')[0];
+
+  if (requestedNoParams === receivedNoParams) {
+    return true;
+  }
+
+  const requestedDid = extractDidSubject(requested);
+  const receivedDid = extractDidSubject(received);
+
+  return (
+    requestedDid !== undefined &&
+    receivedDid !== undefined &&
+    requestedDid === receivedDid
+  );
+}
+
 export class InvalidSubjectError extends Error {
   constructor(public readonly raw: string) {
     super(`Invalid subject: ${JSON.stringify(raw)}`);

--- a/docs/src/astro-guide/6-generating-types.md
+++ b/docs/src/astro-guide/6-generating-types.md
@@ -24,18 +24,22 @@ A config file called `atomic.config.json` has been generated, it should look som
 {
   "outputFolder": "./src/ontologies",
   "moduleAlias": "@tomic/lib",
+  "serverUrl": "http://localhost:9883",
   "ontologies": []
 }
 ```
 
 Now let's add the subject of our ontology to the `ontologies` list.
-To get the subject, go to your ontology in the browser and copy the URL from the address bar or the navigation/search bar at the bottom.
-Paste the URL as a string in the ontologies array like so:
+To get the subject, open the ontology in the Atomic Data browser and copy the `did:ad:…` identifier from the search bar at the bottom (or from `?subject=` in the address bar) — not the `https://…/did:ad:…` URL.
+Set `serverUrl` to the origin of your Atomic Server.
 
 ```json
-"ontologies": [
-	"<insert my-ontology url>"
-]
+{
+  "outputFolder": "./src/ontologies",
+  "moduleAlias": "@tomic/lib",
+  "serverUrl": "http://localhost:9883",
+  "ontologies": ["did:ad:<your-ontology-id>"]
+}
 ```
 
 We're ready to generate the types, Run the following command:

--- a/docs/src/js-cli.md
+++ b/docs/src/js-cli.md
@@ -68,6 +68,7 @@ There should now be a file called `atomic.config.json` in the folder where you r
 {
   "outputFolder": "./src/ontologies",
   "moduleAlias": "@tomic/lib",
+  "serverUrl": "http://localhost:9883",
   "ontologies": []
 }
 ```
@@ -75,6 +76,10 @@ There should now be a file called `atomic.config.json` in the folder where you r
 > If you want to change the location where the files are generated you can change the `outputFolder` field.
 
 Next add the subjects of your atomic ontologies to the `ontologies` array in the config.
+Use the ontology's `did:ad:…` identifier (shown in the app's address/search bar as `?subject=did:ad:…`), not the `https://your-server/did:ad:…` URL.
+Set `serverUrl` to the origin of the Atomic Server that hosts those ontologies (for local development that is usually `http://localhost:9883`).
+
+If you do paste an `https://your-server/did:ad:…` URL, the CLI treats it as an alias of the DID and takes the server origin from the URL.
 
 Now we will generate the ontology files. We do this by running the `ad-generate ontologies` command. If your ontologies don't have public read rights you will have to add an agent secret to the command that has access to these resources.
 
@@ -166,6 +171,13 @@ interface AtomicConfig {
    * If left empty the public agent is used.
    */
   agentSecret?: string;
+
+  /**
+   * Origin of the Atomic Server used to fetch ontology subjects,
+   * including `did:ad:…` identifiers (GET `/did?subject=`).
+   * Required when `ontologies` contains DID subjects.
+   */
+  serverUrl?: string;
 
   /** The list of subjects of your ontologies */
   ontologies: string[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Fixes `ad-generate ontologies` failing on DID ontologies.

## What was going on

A `did:ad:…` identifier is not an HTTP URL. Two config shapes both failed:

1. `"ontologies": ["did:ad:…"]` — the CLI fetched through `GET {serverUrl}/did?subject=…`. With no (or localhost) `serverUrl`, Node has no `window.location` to fall back to, so the request never reached the Atomic Server that actually hosts the ontology (connection refused).
2. `"ontologies": ["https://host/did:ad:…"]` — that URL is only a server-specific alias. The server still returns `@id: did:ad:…`. The JSON-AD parser required an exact subject match and threw `Resource has wrong subject in @id`.

## What changed

- Treat `https://host/did:ad:…` (and `/did?subject=`) as aliases of the DID. Parse, fetch, and store lookup all follow the canonical `@id`.
- Resolve raw DIDs through `/did?subject=` using `serverUrl`. In Node, missing `serverUrl` is a clear error instead of touching `window`.
- `@tomic/cli` writes `serverUrl` from `ad-generate init`, points the store at an HTTP ontology URL's origin so nested DID classes/properties resolve, and prints the real fetch error plus a `serverUrl` hint on connection refused.
- Docs: put `did:ad:…` in `ontologies` and set `serverUrl` to the Atomic Server origin.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f2dba46-b4c2-45af-adca-550d6d4f91eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f2dba46-b4c2-45af-adca-550d6d4f91eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




Rebase validation (2026-09-12): rebased onto develop `5c5d7794c`; preserved both coverage sections and placed the codegen fix in UNRELEASED. All 469 library tests, workspace type checks and full frontend lint pass. Real local AtomicServer acceptance created a DID ontology and successfully generated TypeScript from both its raw DID and its HTTP alias. This is a manual live-service check; a committed CLI integration runner remains a follow-up.
