### PR TITLE
Keep the Tauri boot splash until the server is up, and get there faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Desktop / Android: keep the boot splash up until the embedded server is
+  listening, and show the startup error on that splash if the node never comes
+  up (for example another atomic-server already has the data directory).
+
 - Git / CI: one integration branch (`develop`) plus stable `v*` tags. Staging
   follows `develop`; production and live docs follow a tagged release. `master`
   is no longer a deploy or docs trigger, and `main` is not introduced as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 - Desktop / Android: keep the boot splash up until the embedded server is
   listening, and show the startup error on that splash if the node never comes
-  up (for example another atomic-server already has the data directory).
+  up (for example another atomic-server already has the data directory). HTTP
+  now binds without waiting on the Iroh n0 relay (up to 10s), so first paint
+  no longer waits on a transport the webview does not need.
 
 - Git / CI: one integration branch (`develop`) plus stable `v*` tags. Staging
   follows `develop`; production and live docs follow a tagged release. `master`

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -183,10 +183,13 @@ Paired-peer cards are covered too, by seeding `atomic-peers` in an init script.
 
 The boot splash wait (`waitForEmbeddedServer`) is unit-tested in
 `browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts`: it no-ops in
-a browser, hides when `node_status` is ready, falls back to HTTP when invoke
-is missing (the e2e fake-Tauri case), and surfaces a startup error instead of
-spinning forever. The Tauri command itself (`node_status` in
-`desktop/src/lib.rs`) is not covered by a harness.
+a browser, hides when `node_status` is ready, falls back to HTTP HEAD when
+invoke is missing (the e2e fake-Tauri case), skips HTTP when IPC already
+answered `{ready:false}`, and surfaces a startup error instead of spinning
+forever. `hideBootSplash` keeps a failed splash up. The Tauri HTML transform
+(`stripUnusedTauriPreloads`) is tested against `index.html`. The Tauri
+command itself (`node_status` in `desktop/src/lib.rs`) is not covered by a
+harness.
 
 Still uncovered: `PairingLinkHandler`'s deep-link entry (the system camera
 launching the app) and `IdentityReconcileGate`. Anything that genuinely calls

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -175,10 +175,18 @@ replacement for `/iroh-node-id`.
 
 `ConnectToDeviceForm` (paste a code) and the pairing dialog are now covered —
 `isRunningInTauri()` only checks for `window.__TAURI_INTERNALS__`, so
-`page.addInitScript` reaching it is enough, and nothing on that path calls
-`invoke`. See `pairing-dialog.spec.ts`.
+`page.addInitScript` reaching it is enough. Boot now calls `node_status`
+(invoke) and falls back to HTTP when invoke is missing, so the empty
+stand-in still works. See `pairing-dialog.spec.ts`.
 
 Paired-peer cards are covered too, by seeding `atomic-peers` in an init script.
+
+The boot splash wait (`waitForEmbeddedServer`) is unit-tested in
+`browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts`: it no-ops in
+a browser, hides when `node_status` is ready, falls back to HTTP when invoke
+is missing (the e2e fake-Tauri case), and surfaces a startup error instead of
+spinning forever. The Tauri command itself (`node_status` in
+`desktop/src/lib.rs`) is not covered by a harness.
 
 Still uncovered: `PairingLinkHandler`'s deep-link entry (the system camera
 launching the app) and `IdentityReconcileGate`. Anything that genuinely calls

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -8,7 +8,10 @@ This changelog covers all five packages, as they are (for now) updated as a whol
   accepting connections, instead of rendering the app against a port that is
   not listening yet (and landing on "Could not reach the server"). A node that
   fails to start (for example another atomic-server holding the data directory)
-  shows the reason on the splash rather than spinning forever.
+  shows the reason on the splash rather than spinning forever. First paint is
+  faster: HTTP binds without waiting on the Iroh relay, the splash lives
+  outside `#root` so React does not blank it, unused WASM preloads are omitted
+  from the Tauri shell, and readiness uses IPC (HEAD only as the e2e fallback).
 
 - Fix: opening a v1 document no longer shows a read-only page with an "Update Document" button that throws. Writable v1 documents migrate silently to the Loro-backed editor. Leftover Yjs-era V2 bodies still convert, but `yjs` is loaded only when those bytes are present.
 - Fix: opening an adopted HTTP drive no longer moves the home server. A bare origin (`https://host`) is still a server switch; an HTTP subject with a path is a workspace and is fetched cross-origin, so a pre-DID drive on `atomicdata.dev` cannot take the session with it (websocket, DID auth, every later fetch).

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Desktop / Android: the boot splash stays up until the embedded server is
+  accepting connections, instead of rendering the app against a port that is
+  not listening yet (and landing on "Could not reach the server"). A node that
+  fails to start (for example another atomic-server holding the data directory)
+  shows the reason on the splash rather than spinning forever.
+
 - Fix: opening a v1 document no longer shows a read-only page with an "Update Document" button that throws. Writable v1 documents migrate silently to the Loro-backed editor. Leftover Yjs-era V2 bodies still convert, but `yjs` is loaded only when those bytes are present.
 - Fix: opening an adopted HTTP drive no longer moves the home server. A bare origin (`https://host`) is still a server switch; an HTTP subject with a path is a workspace and is fetched cross-origin, so a pre-DID drive on `atomicdata.dev` cannot take the session with it (websocket, DID auth, every later fetch).
 - Fix: opening a filled table no longer flashes rows (or sidebar children) in the wrong order. Local queries are unsorted; hydrating each member used to optimistic-add them in arrival order before the client-side sort landed. The sidebar also listed every table row until the resource's class arrived. OPFS cold-load could shuffle array properties the same way by merging a JSON-AD-seeded LoroList with the stored snapshot. Reloading a table after a cell edit no longer leaves the page stuck loading: an OPFS snapshot replace was importing the same bytes twice and could drop `isA`. Table totals now re-query after the edit is queued to OPFS, so a sum follows a cell change without a reload.

--- a/browser/data-browser/index.html
+++ b/browser/data-browser/index.html
@@ -182,6 +182,24 @@
           animation-duration: 3s;
         }
       }
+
+      .loader-status {
+        max-width: 28rem;
+        margin: 1.25rem auto 0;
+        padding: 0 1.5rem;
+        text-align: center;
+        color: var(--text-splash);
+        font-family: 'Open Sans', system-ui, sans-serif;
+        font-size: 0.95rem;
+        line-height: 1.45;
+        white-space: pre-wrap;
+      }
+
+      /* Boot failed: stop the spin so it does not read as still working. */
+      .loader.is-failed .loader-mark,
+      .loader.is-failed .loader-orb {
+        animation: none;
+      }
     </style>
     <!-- Meta tags and code added by Atomic-Server -->
     <!-- { inject_html_head } -->
@@ -220,6 +238,7 @@
           margin-top: 45vh;
         "
         class="loader"
+        aria-busy="true"
       >
         <path
           d="M9.06445 107L41.5125 34.2001H58.1525L90.7045 107H73.0245L46.4005 42.7281H53.0565L26.3285 107H9.06445ZM25.2885 91.4002L29.7605 78.6081H67.2005L71.7765 91.4002H25.2885Z"
@@ -497,6 +516,13 @@
           </linearGradient>
         </defs>
       </svg>
+      <p
+        id="loader-status"
+        class="loader-status"
+        role="status"
+        aria-live="polite"
+        hidden
+      ></p>
     </div>
 
     <script type="module" src="/src/index.tsx"></script>

--- a/browser/data-browser/index.html
+++ b/browser/data-browser/index.html
@@ -61,6 +61,8 @@
       `__WASM_VERSION__` is substituted at build time (vite.config.ts) and must
       stay in step with the urls the app itself requests, or these preloads
       warm a url nothing goes on to use.
+
+      The Tauri build strips these two links (ClientDb/OPFS is off there).
     -->
     <link
       rel="preload"
@@ -124,6 +126,33 @@
 
       body {
         background-color: var(--background-color);
+      }
+
+      /* Sibling of #root so React can mount without wiping the splash.
+         IdentityReconcileGate fades this once real children paint. */
+      #boot-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        background-color: var(--background-color);
+        opacity: 1;
+        transition: opacity 300ms ease-out;
+      }
+
+      #boot-splash.is-hidden {
+        opacity: 0;
+        pointer-events: none;
+        visibility: hidden;
+        transition:
+          opacity 300ms ease-out,
+          visibility 0s linear 300ms;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #boot-splash,
+        #boot-splash.is-hidden {
+          transition: none;
+        }
       }
 
       .loader {
@@ -223,7 +252,7 @@
         // Broken localStorage value: fall back to the OS preference.
       }
     </script>
-    <div id="root">
+    <div id="boot-splash" aria-busy="true">
       <svg
         viewBox="9.06 32.95 698.61 75.3"
         fill="none"
@@ -524,6 +553,7 @@
         hidden
       ></p>
     </div>
+    <div id="root"></div>
 
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/browser/data-browser/src/App.tsx
+++ b/browser/data-browser/src/App.tsx
@@ -8,6 +8,7 @@ import { registerCustomCreateActions } from './components/forms/NewForm/CustomCr
 import { serverURLStorage } from './helpers/serverURLStorage';
 import { driveStorage } from './helpers/driveStorage';
 import { isRunningInTauri } from './helpers/tauri';
+import { waitForEmbeddedServer } from './helpers/waitForEmbeddedServer';
 
 import { useEffect, type JSX } from 'react';
 import { RouterProvider } from '@tanstack/react-router';
@@ -109,7 +110,14 @@ enableLoro().catch(e =>
   console.warn('[Loro] init failed, edit/history features disabled:', e),
 );
 
-const storedAgent = await getAgentFromIDB();
+// The HTML splash stays up until this resolves. Creating the Store first
+// would fetch into a port the embed has not bound yet (webview is ready
+// before the server thread, especially on Android), and the page would
+// settle on "Could not reach the server". IndexedDB can load in parallel.
+const [storedAgent] = await Promise.all([
+  getAgentFromIDB(),
+  waitForEmbeddedServer(),
+]);
 
 // Device lock: withhold the stored agent when the gap since this app was
 // last open exceeds the user's policy (see `deviceLock.ts`). Enforced on the

--- a/browser/data-browser/src/components/IdentityReconcileGate.tsx
+++ b/browser/data-browser/src/components/IdentityReconcileGate.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useStore } from '@tomic/react';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useSettings } from '../helpers/AppSettings';
@@ -8,6 +14,7 @@ import {
   syncDeviceDirectory,
   writeManagedAccountBinding,
 } from '../helpers/managed';
+import { hideBootSplash } from '../helpers/waitForEmbeddedServer';
 import { paths } from '../routes/paths';
 
 type GateProps = {
@@ -112,6 +119,14 @@ export function IdentityReconcileGate({
   useEffect(() => {
     void converge();
   }, [converge]);
+
+  // The HTML splash lives outside `#root` so this gate's empty first paint
+  // does not blank the screen. Fade it once we are about to show children.
+  useLayoutEffect(() => {
+    if (skip || !checking) {
+      hideBootSplash();
+    }
+  }, [skip, checking]);
 
   if (skip) {
     return <>{children}</>;

--- a/browser/data-browser/src/helpers/tauriHtml.test.ts
+++ b/browser/data-browser/src/helpers/tauriHtml.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { stripUnusedTauriPreloads } from './tauriHtml';
+
+const indexHtml = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), '../../index.html'),
+  'utf8',
+);
+
+describe('stripUnusedTauriPreloads', () => {
+  it('drops the WASM preloads and atomicdata.dev preconnect from index.html', () => {
+    expect(indexHtml).toContain('/wasm/atomic_wasm_bg.wasm');
+    expect(indexHtml).toContain('https://atomicdata.dev');
+
+    const stripped = stripUnusedTauriPreloads(indexHtml);
+
+    expect(stripped).not.toContain('/wasm/atomic_wasm_bg.wasm');
+    expect(stripped).not.toContain('/wasm/atomic_wasm.js');
+    expect(stripped).not.toContain('https://atomicdata.dev');
+    // Fonts still load — the app uses them; only unused boot fetches go.
+    expect(stripped).toContain('fonts.googleapis.com');
+    expect(stripped).toContain('id="boot-splash"');
+  });
+
+  it('leaves HTML that has nothing to strip unchanged in substance', () => {
+    const html = '<html><head></head><body><div id="root"></div></body></html>';
+
+    expect(stripUnusedTauriPreloads(html)).toBe(html);
+  });
+});

--- a/browser/data-browser/src/helpers/tauriHtml.test.ts
+++ b/browser/data-browser/src/helpers/tauriHtml.test.ts
@@ -16,9 +16,8 @@ describe('stripUnusedTauriPreloads', () => {
 
     const stripped = stripUnusedTauriPreloads(indexHtml);
 
-    expect(stripped).not.toContain('/wasm/atomic_wasm_bg.wasm');
-    expect(stripped).not.toContain('/wasm/atomic_wasm.js');
-    expect(stripped).not.toContain('https://atomicdata.dev');
+    expect(stripped).not.toMatch(/href="[^"]*\/wasm\//);
+    expect(stripped).not.toContain('href="https://atomicdata.dev"');
     // Fonts still load — the app uses them; only unused boot fetches go.
     expect(stripped).toContain('fonts.googleapis.com');
     expect(stripped).toContain('id="boot-splash"');

--- a/browser/data-browser/src/helpers/tauriHtml.ts
+++ b/browser/data-browser/src/helpers/tauriHtml.ts
@@ -1,0 +1,16 @@
+/**
+ * Drop fetches the Tauri app never uses from the HTML shell.
+ *
+ * The OPFS ClientDb is off under Tauri, so the ~6MB atomic-wasm preloads
+ * on the critical path are wasted work that delays first paint. The
+ * atomicdata.dev preconnect is the same: the embed talks to localhost.
+ * Called from `vite.config.ts` when `TAURI=1`.
+ */
+export function stripUnusedTauriPreloads(html: string): string {
+  return html
+    .replace(/[ \t]*<link\b[^>]*href="[^"]*\/wasm\/[^"]*"[^>]*\/?>\s*/gi, '')
+    .replace(
+      /[ \t]*<link\b[^>]*href="https:\/\/atomicdata\.dev"[^>]*\/?>\s*/gi,
+      '',
+    );
+}

--- a/browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts
+++ b/browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   waitForEmbeddedServer,
   showEmbeddedServerError,
+  hideBootSplash,
 } from './waitForEmbeddedServer';
 
 /**
@@ -69,6 +70,45 @@ describe('waitForEmbeddedServer', () => {
     );
 
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('probes HTTP with HEAD so it does not download the SPA', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 200 }));
+
+    await waitForEmbeddedServer(
+      deps({
+        fetchFn,
+        getStatus: async () => undefined,
+      }),
+    );
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'http://localhost:9883',
+      expect.objectContaining({ method: 'HEAD' }),
+    );
+  });
+
+  it('does not HTTP-poll when IPC reports that the node is not ready', async () => {
+    const fetchFn = vi.fn();
+    let now = 0;
+
+    await expect(
+      waitForEmbeddedServer(
+        deps({
+          fetchFn,
+          getStatus: async () => ({ ready: false }),
+          now: () => now,
+          sleep: async () => {
+            now += 500;
+          },
+          timeoutMs: 1_000,
+        }),
+      ),
+    ).rejects.toThrow(/did not start in time/);
+
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 
   it('treats any HTTP response as up, including 404', async () => {
@@ -140,27 +180,61 @@ describe('waitForEmbeddedServer', () => {
   });
 });
 
+function stubSplash(
+  overrides: {
+    splashFailed?: boolean;
+    splashHidden?: boolean;
+  } = {},
+) {
+  const classes = new Set<string>();
+  const attrs: Record<string, string> = {};
+  const status = { hidden: true, textContent: '' };
+  const loader = {
+    classList: {
+      add: (name: string) => {
+        classes.add(name);
+      },
+    },
+    setAttribute: (name: string, value: string) => {
+      attrs[name] = value;
+    },
+  };
+  const splash = {
+    classList: {
+      add: (name: string) => {
+        classes.add(name);
+      },
+      contains: (name: string) => {
+        if (name === 'is-failed') return !!overrides.splashFailed;
+        if (name === 'is-hidden') return !!overrides.splashHidden;
+
+        return classes.has(name);
+      },
+    },
+    setAttribute: (name: string, value: string) => {
+      attrs[name] = value;
+    },
+    querySelector: (selector: string) =>
+      selector === '.loader' ? loader : null,
+  };
+
+  vi.stubGlobal('document', {
+    getElementById: (id: string) => {
+      if (id === 'loader-status') return status;
+      if (id === 'boot-splash') return splash;
+
+      return null;
+    },
+    querySelector: (selector: string) =>
+      selector === '.loader' ? loader : null,
+  });
+
+  return { classes, attrs, status };
+}
+
 describe('showEmbeddedServerError', () => {
   it('unhides the splash status and stops the spinner', () => {
-    const classes = new Set<string>();
-    const attrs: Record<string, string> = {};
-    const status = { hidden: true, textContent: '' };
-    const loader = {
-      classList: {
-        add: (name: string) => {
-          classes.add(name);
-        },
-      },
-      setAttribute: (name: string, value: string) => {
-        attrs[name] = value;
-      },
-    };
-
-    vi.stubGlobal('document', {
-      getElementById: (id: string) => (id === 'loader-status' ? status : null),
-      querySelector: (selector: string) =>
-        selector === '.loader' ? loader : null,
-    });
+    const { classes, attrs, status } = stubSplash();
 
     showEmbeddedServerError('Database already open');
 
@@ -168,5 +242,33 @@ describe('showEmbeddedServerError', () => {
     expect(status.textContent).toBe('Database already open');
     expect(classes.has('is-failed')).toBe(true);
     expect(attrs['aria-busy']).toBe('false');
+  });
+});
+
+describe('hideBootSplash', () => {
+  it('fades the overlay so React can show the app', () => {
+    const { classes, attrs } = stubSplash();
+
+    hideBootSplash();
+
+    expect(classes.has('is-hidden')).toBe(true);
+    expect(attrs['aria-busy']).toBe('false');
+    expect(attrs['aria-hidden']).toBe('true');
+  });
+
+  it('leaves a failed splash up so the error stays readable', () => {
+    const { classes } = stubSplash({ splashFailed: true });
+
+    hideBootSplash();
+
+    expect(classes.has('is-hidden')).toBe(false);
+  });
+
+  it('is a no-op the second time', () => {
+    const { classes } = stubSplash({ splashHidden: true });
+
+    hideBootSplash();
+
+    expect(classes.has('is-hidden')).toBe(false);
   });
 });

--- a/browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts
+++ b/browser/data-browser/src/helpers/waitForEmbeddedServer.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  waitForEmbeddedServer,
+  showEmbeddedServerError,
+} from './waitForEmbeddedServer';
+
+/**
+ * The default vitest environment here is `node`, so there is no `document`.
+ * Splash DOM tests stub the two nodes the helper touches.
+ */
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function deps(overrides: Parameters<typeof waitForEmbeddedServer>[0] = {}) {
+  return {
+    isTauri: () => true,
+    origin: 'http://localhost:9883',
+    now: () => 0,
+    sleep: async () => undefined,
+    timeoutMs: 1_000,
+    intervalMs: 1,
+    showError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('waitForEmbeddedServer', () => {
+  it('does nothing in a regular browser', async () => {
+    const fetchFn = vi.fn();
+    const getStatus = vi.fn();
+
+    await waitForEmbeddedServer(
+      deps({
+        isTauri: () => false,
+        fetchFn,
+        getStatus,
+      }),
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('resolves as soon as node_status reports ready', async () => {
+    const fetchFn = vi.fn();
+
+    await waitForEmbeddedServer(
+      deps({
+        fetchFn,
+        getStatus: async () => ({ ready: true }),
+      }),
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to HTTP when invoke is missing, then resolves', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce(new Response('', { status: 200 }));
+
+    await waitForEmbeddedServer(
+      deps({
+        fetchFn,
+        getStatus: async () => undefined,
+      }),
+    );
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats any HTTP response as up, including 404', async () => {
+    await waitForEmbeddedServer(
+      deps({
+        fetchFn: vi.fn().mockResolvedValue(new Response('', { status: 404 })),
+        getStatus: async () => undefined,
+      }),
+    );
+  });
+
+  it('fails immediately when the node reports a startup error', async () => {
+    const showError = vi.fn();
+    const reason =
+      'The local node failed to start: Database already open\n\nAnother atomic-server is already using this data directory.';
+
+    await expect(
+      waitForEmbeddedServer(
+        deps({
+          fetchFn: vi.fn(),
+          getStatus: async () => ({ ready: false, error: reason }),
+          showError,
+        }),
+      ),
+    ).rejects.toThrow(reason);
+
+    expect(showError).toHaveBeenCalledWith(reason);
+  });
+
+  it('retries until the node is ready', async () => {
+    let calls = 0;
+
+    const getStatus = async () => {
+      calls += 1;
+
+      return { ready: calls >= 3 };
+    };
+
+    await waitForEmbeddedServer(
+      deps({
+        fetchFn: vi.fn().mockRejectedValue(new Error('refused')),
+        getStatus,
+      }),
+    );
+
+    expect(calls).toBe(3);
+  });
+
+  it('throws after the deadline and writes the error onto the splash', async () => {
+    let now = 0;
+    const showError = vi.fn();
+
+    await expect(
+      waitForEmbeddedServer(
+        deps({
+          fetchFn: vi.fn().mockRejectedValue(new Error('refused')),
+          getStatus: async () => ({ ready: false }),
+          now: () => now,
+          sleep: async () => {
+            now += 500;
+          },
+          timeoutMs: 1_000,
+          showError,
+        }),
+      ),
+    ).rejects.toThrow(/did not start in time/);
+
+    expect(showError).toHaveBeenCalledOnce();
+  });
+});
+
+describe('showEmbeddedServerError', () => {
+  it('unhides the splash status and stops the spinner', () => {
+    const classes = new Set<string>();
+    const attrs: Record<string, string> = {};
+    const status = { hidden: true, textContent: '' };
+    const loader = {
+      classList: {
+        add: (name: string) => {
+          classes.add(name);
+        },
+      },
+      setAttribute: (name: string, value: string) => {
+        attrs[name] = value;
+      },
+    };
+
+    vi.stubGlobal('document', {
+      getElementById: (id: string) => (id === 'loader-status' ? status : null),
+      querySelector: (selector: string) =>
+        selector === '.loader' ? loader : null,
+    });
+
+    showEmbeddedServerError('Database already open');
+
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toBe('Database already open');
+    expect(classes.has('is-failed')).toBe(true);
+    expect(attrs['aria-busy']).toBe('false');
+  });
+});

--- a/browser/data-browser/src/helpers/waitForEmbeddedServer.ts
+++ b/browser/data-browser/src/helpers/waitForEmbeddedServer.ts
@@ -9,9 +9,10 @@
 // - `node_status` (Tauri IPC) knows when *our* node failed (DB lock) and
 //   when its HTTP port is accepting. Invoke is the only check that works
 //   on an Android release build, where cleartext HTTP to localhost is off.
-// - HTTP GET is the fallback for e2e tests that fake `__TAURI_INTERNALS__`
+// - HTTP HEAD is the fallback for e2e tests that fake `__TAURI_INTERNALS__`
 //   without a real invoke (see pairing-dialog.spec.ts). Those point at a
 //   server that is already up, so the wait resolves on the first poll.
+//   HEAD rather than GET so a real fallback does not download the SPA HTML.
 
 import { getLocalServerOrigin, isRunningInTauri } from './tauri';
 
@@ -51,16 +52,54 @@ export function showEmbeddedServerError(message: string): void {
     status.textContent = message;
   }
 
+  const splash = document.getElementById('boot-splash');
+  splash?.classList.add('is-failed');
+  splash?.setAttribute('aria-busy', 'false');
+
   const loader = document.querySelector('.loader');
   loader?.classList.add('is-failed');
   loader?.setAttribute('aria-busy', 'false');
 }
 
+/**
+ * Fade out the HTML splash once real app chrome is on screen.
+ * No-op if the node failed to start — that message must stay up.
+ */
+export function hideBootSplash(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const splash = document.getElementById('boot-splash');
+
+  if (
+    !splash ||
+    splash.classList.contains('is-failed') ||
+    splash.classList.contains('is-hidden')
+  ) {
+    return;
+  }
+
+  splash.classList.add('is-hidden');
+  splash.setAttribute('aria-busy', 'false');
+  splash.setAttribute('aria-hidden', 'true');
+
+  const loader = splash.querySelector('.loader');
+  loader?.setAttribute('aria-busy', 'false');
+}
+
+// Cache the invoke binding across polls. Re-importing `@tauri-apps/api/core`
+// every 100ms was wasted work on the boot path; the module itself is stable.
+let invokeNodeStatus: (() => Promise<NodeStatus>) | undefined;
+
 async function defaultGetStatus(): Promise<NodeStatus | undefined> {
   try {
-    const { invoke } = await import('@tauri-apps/api/core');
+    if (!invokeNodeStatus) {
+      const { invoke } = await import('@tauri-apps/api/core');
+      invokeNodeStatus = () => invoke<NodeStatus>('node_status');
+    }
 
-    return await invoke<NodeStatus>('node_status');
+    return await invokeNodeStatus();
   } catch {
     // No invoke (e2e fake, or the runtime has not injected yet). HTTP below.
     return undefined;
@@ -79,10 +118,10 @@ async function httpIsUp(
   const timer = setTimeout(() => controller.abort(), 1000);
 
   try {
-    // Any HTTP response means the listener is up — 401/404 included.
+    // Any HTTP response means the listener is up — 401/404/405 included.
     // Connection refused / abort / CORS-as-network-error: not yet.
     await fetchFn(origin, {
-      method: 'GET',
+      method: 'HEAD',
       signal: controller.signal,
       cache: 'no-store',
     });
@@ -135,7 +174,10 @@ export async function waitForEmbeddedServer(
       return;
     }
 
-    if (await httpIsUp(origin, fetchFn)) {
+    // IPC answered: this is *our* node, and it is not listening yet.
+    // Don't also download the SPA — HTTP is only for the e2e fake where
+    // invoke is missing (`status === undefined`).
+    if (!status && (await httpIsUp(origin, fetchFn))) {
       return;
     }
 

--- a/browser/data-browser/src/helpers/waitForEmbeddedServer.ts
+++ b/browser/data-browser/src/helpers/waitForEmbeddedServer.ts
@@ -1,0 +1,162 @@
+// @wc-ignore-file
+// Keep the HTML splash up until this device's embedded atomic-server is
+// actually accepting connections. The webview is ready first — often by
+// seconds on a cold Android start, and on every `cargo tauri dev` rebuild —
+// and creating the Store in that window used to fetch into a port nothing
+// was listening on, then settle on "Could not reach the server".
+//
+// Two signals, because neither is enough on its own:
+// - `node_status` (Tauri IPC) knows when *our* node failed (DB lock) and
+//   when its HTTP port is accepting. Invoke is the only check that works
+//   on an Android release build, where cleartext HTTP to localhost is off.
+// - HTTP GET is the fallback for e2e tests that fake `__TAURI_INTERNALS__`
+//   without a real invoke (see pairing-dialog.spec.ts). Those point at a
+//   server that is already up, so the wait resolves on the first poll.
+
+import { getLocalServerOrigin, isRunningInTauri } from './tauri';
+
+export type NodeStatus = {
+  ready: boolean;
+  error?: string | null;
+};
+
+export type WaitForEmbeddedServerDeps = {
+  isTauri?: () => boolean;
+  origin?: string;
+  fetchFn?: typeof fetch;
+  getStatus?: () => Promise<NodeStatus | undefined>;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+  intervalMs?: number;
+  showError?: (message: string) => void;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_INTERVAL_MS = 100;
+
+const TIMEOUT_MESSAGE =
+  'The local node did not start in time. Restart the app. If this keeps happening, another atomic-server may already be using this data directory.';
+
+/** Write the failure onto the HTML splash so it is visible without React. */
+export function showEmbeddedServerError(message: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const status = document.getElementById('loader-status');
+
+  if (status) {
+    status.hidden = false;
+    status.textContent = message;
+  }
+
+  const loader = document.querySelector('.loader');
+  loader?.classList.add('is-failed');
+  loader?.setAttribute('aria-busy', 'false');
+}
+
+async function defaultGetStatus(): Promise<NodeStatus | undefined> {
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+
+    return await invoke<NodeStatus>('node_status');
+  } catch {
+    // No invoke (e2e fake, or the runtime has not injected yet). HTTP below.
+    return undefined;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function httpIsUp(
+  origin: string,
+  fetchFn: typeof fetch,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1000);
+
+  try {
+    // Any HTTP response means the listener is up — 401/404 included.
+    // Connection refused / abort / CORS-as-network-error: not yet.
+    await fetchFn(origin, {
+      method: 'GET',
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolves once the embedded node is accepting connections.
+ * No-op in a regular browser. Throws after showing the error on the splash
+ * if the node failed to start or the deadline passed — and does not resolve,
+ * so `App.tsx` never creates a Store against a dead port.
+ */
+export async function waitForEmbeddedServer(
+  deps: WaitForEmbeddedServerDeps = {},
+): Promise<void> {
+  const isTauri = deps.isTauri ?? isRunningInTauri;
+
+  if (!isTauri()) {
+    return;
+  }
+
+  const origin = deps.origin ?? getLocalServerOrigin();
+  const fetchFn = deps.fetchFn ?? fetch;
+  const getStatus = deps.getStatus ?? defaultGetStatus;
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? defaultSleep;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const showError = deps.showError ?? showEmbeddedServerError;
+
+  const started = now();
+
+  showStarting();
+
+  while (now() - started < timeoutMs) {
+    const status = await getStatus();
+
+    if (status?.error) {
+      showError(status.error);
+      throw new Error(status.error);
+    }
+
+    if (status?.ready) {
+      return;
+    }
+
+    if (await httpIsUp(origin, fetchFn)) {
+      return;
+    }
+
+    await sleep(intervalMs);
+  }
+
+  showError(TIMEOUT_MESSAGE);
+  throw new Error(TIMEOUT_MESSAGE);
+}
+
+function showStarting(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const status = document.getElementById('loader-status');
+
+  if (!status || status.textContent) {
+    return;
+  }
+
+  status.hidden = false;
+  status.textContent = 'Starting…';
+}

--- a/browser/data-browser/vite.config.ts
+++ b/browser/data-browser/vite.config.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
+import { stripUnusedTauriPreloads } from './src/helpers/tauriHtml';
 
 // TAURI=1 produces a Tauri-compatible bundle: no CSP nonces (Tauri serves
 // HTML verbatim, so the server's runtime ATOMICSERVER_NONCE substitution
@@ -140,7 +141,13 @@ export default defineConfig({
       transformIndexHtml: (html: string) =>
         html.replaceAll('__WASM_VERSION__', wasmVersionHash),
     },
-    !isVitest && webfontDownload(),
+    !isVitest && webfontDownload(isTauri ? { async: true } : undefined),
+    isTauri && {
+      // WASM preloads (~6MB) and atomicdata.dev preconnect are unused in
+      // the embed: ClientDb/OPFS is off, and the node is localhost.
+      name: 'atomic-tauri-html',
+      transformIndexHtml: stripUnusedTauriPreloads,
+    },
     !isVitest && wuchale(),
     // Native React Compiler (oxc-transform-react). Must run before JSX
     // transforms; this plugin does compiler + TS + JSX + Fast Refresh in one

--- a/browser/e2e/tests/pairing-dialog.spec.ts
+++ b/browser/e2e/tests/pairing-dialog.spec.ts
@@ -19,7 +19,7 @@ import {
  * `pretendToBeTheApp` proxies that origin to `SERVER_URL` when they differ
  * (dagger CI). Boot now calls `node_status` (invoke) and falls back to HTTP
  * if invoke is missing, so an empty stand-in object is still sufficient —
- * the test server is already up, the splash wait resolves on the first GET.
+ * the test server is already up, the splash wait resolves on the first HEAD.
  *
  * `/iroh-sync` is intercepted rather than dialled for real: what is under test
  * is how the UI reports an outcome, and the endpoint itself is covered against

--- a/browser/e2e/tests/pairing-dialog.spec.ts
+++ b/browser/e2e/tests/pairing-dialog.spec.ts
@@ -17,8 +17,9 @@ import {
  * `isRunningInTauri()` only checks for `window.__TAURI_INTERNALS__`. The page
  * then also resolves its embedded server as `localhost:9883`, so
  * `pretendToBeTheApp` proxies that origin to `SERVER_URL` when they differ
- * (dagger CI). Nothing here calls `invoke`, so an empty stand-in object is
- * sufficient.
+ * (dagger CI). Boot now calls `node_status` (invoke) and falls back to HTTP
+ * if invoke is missing, so an empty stand-in object is still sufficient —
+ * the test server is already up, the splash wait resolves on the first GET.
  *
  * `/iroh-sync` is intercepted rather than dialled for real: what is under test
  * is how the UI reports an outcome, and the endpoint itself is covered against

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -97,6 +97,10 @@ struct EmbeddedNode {
   /// reported "still starting up" forever. Recording the reason lets the UI say
   /// what actually went wrong.
   startup_error: std::sync::OnceLock<String>,
+  /// HTTP port the embed is supposed to bind. Used by `node_status` to tell
+  /// the splash when the server is actually accepting connections — `on_ready`
+  /// fires before `bind()`, so the store being set is not enough.
+  port: std::sync::OnceLock<u16>,
 }
 
 impl EmbeddedNode {
@@ -127,6 +131,53 @@ fn explain_startup_failure(error: &str) -> String {
   } else {
     error.to_string()
   }
+}
+
+/// Whether something is accepting TCP on this device at `port`.
+///
+/// Dual-stack: the server defaults to `[::]` which may or may not also
+/// listen on IPv4, so try both loopbacks. A 50ms timeout keeps the splash's
+/// poll snappy; a refused connection returns immediately anyway.
+fn is_http_listening(port: u16) -> bool {
+  let timeout = std::time::Duration::from_millis(50);
+  let v4 = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+  if std::net::TcpStream::connect_timeout(&v4, timeout).is_ok() {
+    return true;
+  }
+  let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
+  std::net::TcpStream::connect_timeout(&v6, timeout).is_ok()
+}
+
+/// What the boot splash asks: is the local node up yet, and if it will never
+/// be, why. `ready` is the HTTP listener, not merely the store — see `port`.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NodeStatus {
+  ready: bool,
+  error: Option<String>,
+}
+
+#[tauri::command]
+fn node_status(node: tauri::State<'_, std::sync::Arc<EmbeddedNode>>) -> NodeStatus {
+  if let Some(error) = node.startup_error.get() {
+    return NodeStatus {
+      ready: false,
+      error: Some(error.clone()),
+    };
+  }
+
+  // Store set (past init) AND the port accepting: `on_ready` runs before
+  // `bind()`, so either flag alone would hide the splash too early or — if
+  // something else already holds 9883 — too eagerly.
+  let ready = node.store.get().is_some()
+    && node
+      .port
+      .get()
+      .copied()
+      .map(is_http_listening)
+      .unwrap_or(false);
+
+  NodeStatus { ready, error: None }
 }
 
 /// Make this device's node act as the signed-in user, rather than as the
@@ -487,6 +538,7 @@ pub fn run() {
   let builder = builder
     .manage(std::sync::Arc::new(vfs::VfsController::default()))
     .invoke_handler(tauri::generate_handler![
+      node_status,
       adopt_agent,
       vault_export,
       vault_commit_segment,
@@ -498,6 +550,7 @@ pub fn run() {
     ]);
   #[cfg(not(all(desktop, unix)))]
   let builder = builder.invoke_handler(tauri::generate_handler![
+    node_status,
     adopt_agent,
     vault_export,
     vault_commit_segment,
@@ -608,6 +661,7 @@ pub fn run() {
       let _ = node_for_server
         .config_file
         .set(config.config_file_path.clone());
+      let _ = node_for_server.port.set(config.opts.port as u16);
       // This is not the cleanest solution, but running actix inside the tauri / tokio runtime is not
       std::thread::spawn(move || {
         #[cfg(target_os = "android")]

--- a/lib/src/sync/peer.rs
+++ b/lib/src/sync/peer.rs
@@ -131,8 +131,9 @@ fn load_or_create_secret_key(store: &Db) -> iroh::SecretKey {
 /// Start the Iroh peer node. Returns the NodeID and a Router that must be kept alive.
 ///
 /// The NodeID is persistent — derived from a secret key stored in the DB.
-/// Waits for the relay connection to be established before returning,
-/// so that other peers can discover and connect to us immediately.
+/// Relay connection happens in the background so HTTP / first paint is not
+/// blocked on the n0 relay (up to 10s on a slow or offline network). Same-LAN
+/// mDNS does not use the relay; WAN discovery still completes after return.
 pub async fn start(store: Db) -> anyhow::Result<(NodeId, Router)> {
     let secret_key = load_or_create_secret_key(&store);
     let endpoint: Endpoint = Endpoint::builder()
@@ -152,16 +153,22 @@ pub async fn start(store: Db) -> anyhow::Result<(NodeId, Router)> {
     NODE_ID.set(node_id.to_string()).ok();
     ENDPOINT.set(endpoint.clone()).ok();
 
-    // Wait for relay connection so discovery_n0 can find us
+    // Don't block boot on the n0 relay. `serve` used to await this before
+    // binding HTTP, so the Tauri splash sat for up to 10s on a slow or
+    // offline network — first contentful paint of the app, waiting on a
+    // transport the webview does not need. Same-LAN mDNS does not use the
+    // relay; WAN discovery still completes in the background.
     let relay = endpoint.home_relay();
-    tracing::info!("Iroh NodeID: {node_id}, waiting for relay...");
-    let relay_url =
-        tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_relay(relay)).await;
-    match relay_url {
-        Ok(Some(url)) => tracing::info!("Iroh relay connected: {url}"),
-        Ok(None) => tracing::warn!("Iroh relay: none (direct connections only)"),
-        Err(_) => tracing::warn!("Iroh relay: timed out after 10s (connections may fail)"),
-    }
+    tokio::spawn(async move {
+        tracing::info!("Iroh NodeID: {node_id}, connecting to relay…");
+        let relay_url =
+            tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_relay(relay)).await;
+        match relay_url {
+            Ok(Some(url)) => tracing::info!("Iroh relay connected: {url}"),
+            Ok(None) => tracing::warn!("Iroh relay: none (direct connections only)"),
+            Err(_) => tracing::warn!("Iroh relay: timed out after 10s (connections may fail)"),
+        }
+    });
 
     let bg_store = store.clone();
     let router = Router::builder(endpoint)

--- a/server/src/serve.rs
+++ b/server/src/serve.rs
@@ -202,11 +202,12 @@ pub async fn serve(config: crate::config::Config) -> AtomicServerResult<()> {
     serve_with_hook(config, |_appstate| {}).await
 }
 
-/// Like [`serve`], but invokes `on_ready(&AppState)` once the store, indexes and
-/// transports are up but before the HTTP server begins accepting connections.
-/// Embedders (e.g. a managed-node wrapper) use this to install a sync policy and
-/// spawn background tasks without forking the server. Self-hosted use goes
-/// through [`serve`] with a no-op hook.
+/// Like [`serve`], but invokes `on_ready(&AppState)` once the store and indexes
+/// are up but before the HTTP server begins accepting connections.
+/// Iroh starts in the background after this hook — it is not a "transports
+/// are up" barrier. Embedders (e.g. a managed-node wrapper) use this to install
+/// a sync policy and spawn background tasks without forking the server.
+/// Self-hosted use goes through [`serve`] with a no-op hook.
 pub async fn serve_with_hook<F>(
     config: crate::config::Config,
     on_ready: F,
@@ -344,35 +345,34 @@ where
             .expect("spawn durable-flush thread");
     }
 
-    // Start Iroh peer-to-peer transport
-    let _iroh_router = {
+    // Iroh + pkarr in the background so HTTP can bind as soon as the store
+    // is up. `peer::start` used to wait for the n0 relay here (up to 10s),
+    // which delayed first paint of the desktop/Android app on a slow network
+    // for a transport the webview does not need. The Router is kept alive by
+    // the `ROUTER` static inside `start`.
+    {
         let store = appstate.store.clone();
-        match crate::iroh_transport::start(store.clone()).await {
-            Ok((node_id, router)) => {
-                tracing::info!(
-                    "Iroh transport ready as \"{}\". Connect with: did:ad:node:{node_id}",
-                    atomic_lib::sync::peer::effective_device_name(&store)
-                );
+        let appstate_for_pkarr = appstate.clone();
+        actix_web::rt::spawn(async move {
+            match crate::iroh_transport::start(store.clone()).await {
+                Ok((node_id, _router)) => {
+                    tracing::info!(
+                        "Iroh transport ready as \"{}\". Connect with: did:ad:node:{node_id}",
+                        atomic_lib::sync::peer::effective_device_name(&store)
+                    );
 
-                // Announce this server's NodeID via pkarr relay, one record per
-                // drive (see `announce_drives_pkarr`).
-                let appstate_clone = appstate.clone();
-                actix_web::rt::spawn(async move {
                     if let Err(e) =
-                        announce_drives_pkarr(&appstate_clone, &node_id.to_string()).await
+                        announce_drives_pkarr(&appstate_for_pkarr, &node_id.to_string()).await
                     {
                         tracing::warn!("Pkarr announcement failed: {e}");
                     }
-                });
-
-                Some(router)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to start Iroh transport: {e}");
+                }
             }
-            Err(e) => {
-                tracing::warn!("Failed to start Iroh transport: {e}");
-                None
-            }
-        }
-    };
+        });
+    }
 
     // Catch up any drive the user asked us to replicate elsewhere. A target is
     // standing config, not a one-shot command, so anything committed while the
@@ -384,11 +384,12 @@ where
         crate::plugins::replicate::reconcile_replication_targets(&replication_store).await;
     });
 
-    // Embedder hook: the store, indexes and transports are up, but the HTTP
-    // server hasn't started accepting connections yet. A managed-node wrapper
-    // (atomic-saas/managed-node) uses this to flip the `managed` flag, install
-    // its sync admission policy, and spawn its control-plane tasks. The open
-    // server passes a no-op (see `serve`), so it never phones home.
+    // Embedder hook: the store and indexes are up, but the HTTP server hasn't
+    // started accepting connections yet. Iroh starts in the background (see
+    // above) so this is not a "transports are up" barrier. A managed-node
+    // wrapper (atomic-saas/managed-node) uses this to flip the `managed` flag,
+    // install its sync admission policy, and spawn its control-plane tasks.
+    // The open server passes a no-op (see `serve`), so it never phones home.
     on_ready(&appstate);
 
     let server = HttpServer::new(move || {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

The desktop and Android apps open the webview before the embedded atomic-server binds. The HTML splash disappeared as soon as React started, the Store fetched into a dead port, and the page settled on "Could not reach the server" — for a node that was about to answer in milliseconds. On a failed start (another `atomic-server` holding the data directory) the splash also spun forever with no reason.

First contentful paint of the real app was then delayed further: HTTP bind waited on the Iroh n0 relay (up to 10s on a slow or offline network), React wiped the splash for `IdentityReconcileGate`'s empty first paint, and unused boot fetches sat on the Tauri shell.

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

## What changed

The existing boot splash (spinning AtomicServer lockup in `index.html`) now stays up until the embedded node is actually accepting connections. The Store is not created until then, so the first fetch cannot race the bind.

Readiness is `node_status`, a new Tauri command: our store is up **and** the HTTP port is accepting (the embedder hook fires before `bind()`, so the store alone is too early). A startup error — the usual "Database already open" case — is written onto the splash instead of spinning forever.

HTTP HEAD is the fallback when invoke is missing, so e2e tests that fake `__TAURI_INTERNALS__` without a real shell still resolve against the already-running test server. When IPC answers `{ready:false}`, we do not also download the SPA.

To get real content on screen sooner:

- Iroh's n0 relay wait (up to 10s) no longer blocks HTTP bind. Same-LAN mDNS does not use the relay; WAN discovery still completes in the background.
- The splash lives outside `#root` (`#boot-splash`) so React mount and `IdentityReconcileGate` cannot blank it. The gate fades it once children are about to paint.
- The Tauri HTML transform drops leftover `/wasm/` preloads and the atomicdata.dev preconnect. Fonts load asynchronously in the Tauri build.

## Tests

- `waitForEmbeddedServer.test.ts`: no-op in a browser, ready via `node_status`, HTTP HEAD fallback, skip HTTP when IPC already answered, fail-fast on startup error, retries, timeout, splash error DOM, `hideBootSplash`.
- `tauriHtml.test.ts`: the Tauri transform strips unused boot fetches (fixture + real `index.html`). Develop already removed document-level WASM preloads; the test no longer assumes they are still in the shell.
- `convertFileToDocument.test.ts`: first Markdown conversion gets 15s so its WASM/schema import does not miss the default 5s on a loaded CI runner.
- `tauri.test.ts` still covers origin detection.

`cargo check -p atomic_lib --features db-redb,iroh --lib` and `cargo check -p atomic-server --lib` succeeded earlier. `cargo check -p atomic-server-tauri` could not run in this environment (no `gdk-3.0`). The Tauri GUI cannot be launched here.

## Notes

Pairing over Iroh is unchanged: `POST /iroh-sync` already polls until a node id is advertised, because HTTP being up never meant the transport was dialable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9197002-6728-4951-983d-79e2ec85f03d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9197002-6728-4951-983d-79e2ec85f03d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

