### PR TITLE
fix(sync): a cascade-deleted child says which drive it left

### DIFF
--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -542,12 +542,23 @@ test.describe('data-browser', async () => {
     const parentResource = await getCurrentSubject(page);
     // Empty-folder quick-create now renders dedicated "New Folder" / "New
     // Document" buttons instead of a generic "New Resource" + class picker.
+    const parentUrl = page.url();
     await page
       .getByRole('main')
       .getByRole('button', { name: 'New Folder' })
       .first()
       .click();
+    // QuickCreateRow's onClick fires createNewResource without awaiting, so
+    // the click returns before the navigation. Reading the subject here
+    // without waiting gives the PARENT's — which this test then destroyed and
+    // asserted was gone, passing without once exercising the cascade it
+    // exists to cover. Whether the navigation had landed depended on load,
+    // which is what made it look flaky.
+    await page.waitForURL(url => url.toString() !== parentUrl, {
+      timeout: 10000,
+    });
     const nestedResource = await getCurrentSubject(page);
+    expect(nestedResource).not.toBe(parentResource);
     await openSubject(page, parentResource);
     await contextMenuClick('delete', page);
     // Confirm the destroy in the dialog. Scoping to `dialog[open]` is needed
@@ -584,11 +595,22 @@ test.describe('data-browser', async () => {
       )
       .toBe(true);
 
-    // Neither signal above proves durability: the toast fires when the destroy
-    // is applied locally, and the sidebar drops the row on the same optimistic
-    // update. The reload then abandons anything still in flight — which this
-    // test knows, and which is exactly what made it fail under suite load.
-    // `pendingDirtyCount === 0` is the app's own "safe to reload" signal.
+    // Neither signal above says anything about the child. `destroy()` posts the
+    // parent's commit and awaits it, so the toast means the server applied
+    // THAT; the child is removed by the server's cascade, and this client only
+    // learns of it when that removal arrives over its drive subscription.
+    // Until then the child is still in the store, still in the local database,
+    // and a reload brings it back.
+    await page.waitForFunction(
+      nested => !window.store.resources?.get?.(nested),
+      nestedResource,
+      { timeout: 15000 },
+    );
+
+    // And then for that removal to be durable: tombstoning the child in the
+    // local database is queued work, and a reload before it lands resurrects
+    // it from OPFS. `pendingDirtyCount === 0` is the app's own "safe to
+    // reload" signal, and it covers that write.
     await waitForSynced(page);
 
     await page.reload();

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -124,6 +124,14 @@ pub enum DbEvent {
     /// Resource destroyed.
     Destroyed {
         subject: Subject,
+        /// The drive this resource belonged to, read before it was removed.
+        ///
+        /// Carried rather than looked up: by the time a listener reacts, the
+        /// resource is gone from the store, so the drive is unrecoverable. It
+        /// is what routes the removal to the drive's subscribers — and since
+        /// clients subscribe per drive and not per resource, a `None` here
+        /// means no client is ever told.
+        drive: Option<Subject>,
         /// Optional transport/source identity for echo suppression.
         source_id: Option<String>,
         /// See [`DbEvent::Changed::from_commit`].
@@ -2653,11 +2661,16 @@ impl Db {
     /// Recursively removes a resource and its children from the database.
     /// `removed` collects the `pure_id()` of every deleted subject so the
     /// caller can tombstone them after the transaction is applied.
+    /// `inherited_drive` is the drive of the resource whose cascade brought us
+    /// here. A child that carries no `drive` of its own — anything created
+    /// before the server stamped it — is still in its parent's drive, and the
+    /// removal has to name one or it reaches no subscriber.
     async fn recursive_remove(
         &self,
         subject: &Subject,
         transaction: &mut Transaction,
         removed: &mut Vec<String>,
+        inherited_drive: Option<Subject>,
     ) -> AtomicResult<()> {
         // Key by `pure_id()` — that is how resources and Loro snapshots are
         // stored (`add_resource_tx`, `apply_commit`). Looking up by the raw
@@ -2672,6 +2685,7 @@ impl Db {
             // forever — only the WS/Iroh DESTROY path cleaned it before.
             transaction.push(Operation::remove_loro_snapshot(&subject_str));
             removed.push(subject_str.clone());
+            let drive = resource.get_drive().or(inherited_drive);
             let mut children = resource.get_children(self).await?;
             for child in children.iter_mut() {
                 // Notify subscribers so clients evict the cascade-deleted
@@ -2681,11 +2695,18 @@ impl Db {
                 // rendering them.
                 let _ = self.db_events.send(DbEvent::Destroyed {
                     subject: child.get_subject().without_params(),
+                    drive: child.get_drive().or_else(|| drive.clone()),
                     source_id: None,
                     from_commit: false,
                 });
                 // Because the function is async we need to box it to use recursion.
-                Box::pin(self.recursive_remove(child.get_subject(), transaction, removed)).await?;
+                Box::pin(self.recursive_remove(
+                    child.get_subject(),
+                    transaction,
+                    removed,
+                    drive.clone(),
+                ))
+                .await?;
             }
             for (prop, val) in resource.get_propvals() {
                 let remove_atom = crate::Atom::new(subject.clone(), prop.clone(), val.clone());
@@ -3144,6 +3165,10 @@ impl Storelike for Db {
         let event = if is_destroy {
             DbEvent::Destroyed {
                 subject,
+                drive: commit_response
+                    .resource_old
+                    .as_ref()
+                    .and_then(|old| old.get_drive()),
                 source_id: commit_response.source_id.clone(),
                 from_commit: true,
             }
@@ -3612,7 +3637,7 @@ impl Storelike for Db {
     async fn remove_resource(&self, subject: &Subject) -> AtomicResult<()> {
         let mut transaction = Transaction::new();
         let mut removed = Vec::new();
-        self.recursive_remove(subject, &mut transaction, &mut removed)
+        self.recursive_remove(subject, &mut transaction, &mut removed, None)
             .await?;
         self.apply_transaction(&mut transaction)?;
         // Tombstone every removed subject so bulk sync (Iroh / WS `SYNC`)

--- a/lib/src/db/test.rs
+++ b/lib/src/db/test.rs
@@ -1817,6 +1817,101 @@ async fn db_events_say_whether_a_commit_produced_the_change() {
     );
 }
 
+/// A cascade-deleted child must say which drive it belonged to.
+///
+/// Destroying a folder removes its contents server-side, and the only way an
+/// open client hears about that is the removal event. Clients subscribe per
+/// drive — the per-resource subscribe is a no-op in the v2 protocol — so an
+/// event with no drive on it is routed to nobody: every other tab keeps
+/// rendering children that no longer exist, and the tab that issued the
+/// destroy keeps them in its local database, where a reload brings them back.
+///
+/// The drive has to be read here, while the resource still exists. A listener
+/// reacting to the event cannot look it up: by then the resource is gone.
+#[tokio::test]
+#[timeout(120000)]
+async fn a_cascade_deleted_child_names_its_drive() {
+    use crate::DbEvent;
+
+    let store = Db::init_temp("cascade_child_names_its_drive")
+        .await
+        .unwrap();
+    store.populate().await.unwrap();
+    let drive = crate::test_utils::create_test_drive(&store).await.unwrap();
+    let agent = store.get_default_agent().unwrap();
+
+    // Genesis commits with rights validation on, because that is the path that
+    // stamps `drive` onto a resource — and the drive is what this is about.
+    // A plain `save` skips the stamp, so the fanout would look broken here for
+    // a reason the app never hits.
+    let create_under = |parent: Subject| {
+        let store = &store;
+        let agent = agent.clone();
+        async move {
+            let mut resource = crate::Resource::new("did:ad:placeholder".into());
+            resource
+                .set(urls::PARENT.into(), Value::AtomicUrl(parent), store)
+                .await
+                .unwrap();
+
+            let mut commit_builder = resource.get_commit_builder().clone();
+            commit_builder.is_genesis = true;
+            let commit = commit_builder.sign(&agent, store, &resource).await.unwrap();
+            let signature = commit.signature.clone().unwrap();
+            let mut genesis_commit = commit;
+            genesis_commit.subject = Subject::from_raw(&format!("did:ad:{signature}"), None);
+
+            let opts = crate::commit::CommitOpts {
+                validate_schema: true,
+                validate_signature: true,
+                validate_timestamp: false,
+                validate_rights: true,
+                validate_previous_commit: false,
+                validate_loro_causality: false,
+                validate_for_agent: Some(agent.subject.to_string()),
+                update_index: true,
+                source_id: None,
+            };
+
+            store
+                .apply_commit(genesis_commit, &opts)
+                .await
+                .unwrap()
+                .resource_new
+                .unwrap()
+                .get_subject()
+                .clone()
+        }
+    };
+
+    let parent_subject = create_under(drive.clone()).await;
+    let child_subject = create_under(parent_subject.clone()).await.without_params();
+
+    let mut events = store.subscribe_events();
+
+    let mut doomed = store.get_resource(&parent_subject).await.unwrap();
+    doomed.destroy(&store).await.unwrap();
+
+    let child_drive = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        loop {
+            match events.recv().await.unwrap() {
+                DbEvent::Destroyed { subject, drive, .. } if subject == child_subject => {
+                    break drive;
+                }
+                _ => continue,
+            }
+        }
+    })
+    .await
+    .expect("the cascade never announced the child at all");
+
+    assert_eq!(
+        child_drive.map(|d| d.to_string()),
+        Some(drive.to_string()),
+        "a removal with no drive on it reaches no subscriber"
+    );
+}
+
 /// A resource created under a drive must be findable by that drive.
 ///
 /// `drive` is stamped onto the resource by the server (`commit.rs`, from the

--- a/server/src/commit_monitor.rs
+++ b/server/src/commit_monitor.rs
@@ -186,12 +186,19 @@ impl Actor for CommitMonitor {
                         }
                         DbEvent::Destroyed {
                             subject,
+                            drive,
                             source_id,
                             from_commit: false,
                         } => {
                             addr.do_send(ExternalChange {
                                 subject: subject.to_string(),
-                                drive: None,
+                                // Without this the removal reaches only
+                                // subscribers of the subject itself, and the
+                                // client subscribes per drive — so a
+                                // cascade-deleted child was announced to
+                                // nobody and stayed in every open tab, and in
+                                // the local database across a reload.
+                                drive: drive.clone(),
                                 loro_snapshot: None,
                                 commit_id: None,
                                 destroyed: true,


### PR DESCRIPTION
Destroying a folder removes its contents server-side, and the event that announces each child carried `drive: None`. The fanout routes on exactly that:

```rust
let Some(owner) = msg.drive.as_ref() else { return; };
```

So the removal reached only subscribers of the child's own subject — and in the v2 protocol there are none. `Store.subscribeWebSocket` is a documented no-op; clients subscribe once, per drive. Every cascade-deleted child was announced to nobody.

**What that costs a user:** delete a folder, and another open tab keeps rendering its contents. The tab that issued the destroy keeps them in its local database, where a reload brings them back. The parent vanishes and its children do not, which reads as a half-finished delete.

## The fix

The drive has to be read where the resource still exists — a listener reacting to the event cannot look it up, because by then it is gone. So `DbEvent::Destroyed` carries it, and `recursive_remove` passes its own drive down as the fallback for a child created before the server stamped one.

## Why the e2e never caught it

`getCurrentSubject` was read straight after clicking "New Folder", but `QuickCreateRow` fires `createNewResource` without awaiting, so the click returns before the navigation. The subject read there is the **parent's** — confirmed directly with a probe: `nested` and `parent` were the same string.

The test then destroyed that parent and asserted it was gone, which it was, by the commit it had just posted. It never once exercised the cascade it exists to cover. Whether the navigation had landed depended on load, which is what made it look flaky rather than wrong.

It now waits for the URL to change (as `sidebar subresource` already does) and asserts the two subjects differ — a test that silently checks the wrong resource should fail, not pass.

## Verification

- New lib test asserts the invariant that matters: the removal names a drive. Built on a genesis commit with rights validation on, because that is the path that stamps `drive` — a plain `save` skips the stamp and the test would pass for a reason the app never meets.
- Fails without the fix (`left: None`), passes with it.
- 429/429 lib tests pass on this branch.
- Server tracing confirmed the whole chain: cascade fires with the drive, fanout receives it, `within=true subs=1`. A client-side probe confirmed the other end: the child now appears in `removeResource` calls and leaves the store.
- `delete resource` e2e passes; reverting just the server fix fails it in 15s. `e2e.spec.ts` + `tables.spec.ts` together — the pairing that used to reproduce the failure locally — 23 passed.

The e2e runs were done on `feat/plugin-model`, where this was originally found; the commits cherry-picked onto develop with no conflicts and the lib suite is green here.