### PR TITLE
Close sync trust gaps: AUTH-before-SYNC, SUBSCRIBE rights, loud SYNC_PUSH rejection

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -83,6 +83,9 @@ Two things worth knowing about the runners:
 | A peer only receives what its agent may read | `iroh_e2e.rs`, `peer.rs` |
 | A peer cannot forge a third agent's resource | `iroh_e2e.rs` |
 | Relayed write accepted only for a drive we own and dialled | `peer.rs` |
+| Iroh accept side refuses any frame before `AUTH` (ERROR + closed stream), binds `AUTH.requestedSubject` to the handshake drive | `peer.rs` (`accept_gate_tests`, raw QUIC stream) |
+| Rejected `SYNC_PUSH` answers `ERROR SYNC_REJECTED`, never `SYNC_OK` | `peer.rs` (`accept_gate_tests`), `server/tests/it/ws_auth_gate.rs` |
+| WS: writes and identity-bearing subscriptions need `AUTH`; anonymous `SUB` on a public drive still works; unreadable subscriptions answer `ERROR UNAUTHORIZED_READ` | `server/tests/it/ws_auth_gate.rs` |
 | Engine-level two-store sync, private drives, blobs, live push | `lib/src/sync/tests.rs` |
 | RBSR reconciliation, drive hashing | `lib/src/sync/rbsr.rs`, `tests.rs` |
 | RBSR finds a remote-only subject sorting below every local one | `lib/src/sync/rbsr.rs` **and** `browser/lib/src/rbsr.test.ts` (regression, see below) |

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -144,6 +144,15 @@ export interface StoreSyncStatus {
     count: number;
     timestamp: number;
   };
+  /** Set when the server refused the last SYNC_PUSH for a drive
+   *  (`SYNC_REJECTED`: no write right, quota, not enrolled). Local edits
+   *  are kept and offered again on the next handshake. Cleared by the
+   *  next successful sync of that drive. */
+  lastDriveSyncError?: {
+    drive: string;
+    message: string;
+    timestamp: number;
+  };
 }
 
 /** Compact representation of all Loro version vectors in a drive, for sync comparison. */
@@ -542,6 +551,11 @@ export class Store {
    * `planning/outbox-drain-data-loss-race.md`.
    */
   private _scheduledSaves = 0;
+  private _lastDriveSyncError?: {
+    drive: string;
+    message: string;
+    timestamp: number;
+  };
   private _lastDriveSync?: {
     drive: string;
     count: number;
@@ -3887,6 +3901,30 @@ export class Store {
 
     if (drive) {
       this._syncedDrives.add(drive);
+
+      if (this._lastDriveSyncError?.drive === drive) {
+        this._lastDriveSyncError = undefined;
+      }
+    }
+
+    this.emitSyncStatus();
+  }
+
+  /**
+   * The server refused our SYNC_PUSH for `drive` outright (`SYNC_REJECTED`).
+   * Nothing we sent landed, so the drive is not recorded as synced —
+   * `hasCompletedDriveSyncFor` keeps answering false and collection queries
+   * keep asking the server — and nothing local is cleared: the resources we
+   * offered stay as they are and are offered again on the next handshake.
+   * Distinct from `finishDriveSync` so a UI can show "your changes were
+   * refused" instead of a green check.
+   */
+  public failDriveSync(drive: string, message: string): void {
+    this._driveSyncInProgress = false;
+    this._lastDriveSyncError = { drive, message, timestamp: Date.now() };
+
+    if (drive) {
+      this._syncedDrives.delete(drive);
     }
 
     this.emitSyncStatus();
@@ -3952,6 +3990,7 @@ export class Store {
       clientDbAttached: !!this.clientDb,
       clientDbError: this.clientDb?.initError?.message,
       lastDriveSync: this._lastDriveSync,
+      lastDriveSyncError: this._lastDriveSyncError,
     };
   }
 

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -19,6 +19,7 @@ import {
 import {
   Tag,
   Flags,
+  ErrorCode,
   encodeAuth,
   encodeCommit,
   encodeGet,
@@ -863,6 +864,30 @@ export class WSClient {
           } else {
             this.takePendingCommit(msg.requestId)?.reject(err);
           }
+        } else if (msg.code === ErrorCode.SYNC_REJECTED) {
+          // Our SYNC_PUSH was refused as a whole (no write right on the
+          // drive, quota, not enrolled). Nothing we sent landed and no
+          // SYNC_OK will follow for it. `handleSyncDiff` may already have
+          // reported the drive as synced (it does so as soon as the
+          // server has nothing left to push), so correct that: the drive
+          // is NOT in sync and the local edits stay where they are, to be
+          // offered again on the next handshake.
+          console.error('[WS] SYNC_PUSH rejected:', msg.message);
+          this.store.failDriveSync(
+            this.driveFromRejection(msg.message),
+            msg.message,
+          );
+        } else if (
+          msg.code === ErrorCode.AUTH_REQUIRED ||
+          msg.code === ErrorCode.UNAUTHORIZED_READ
+        ) {
+          // Session-level refusals of a single frame: a subscription or
+          // push we sent without (enough) identity. The socket stays
+          // open and every other pending request is unaffected, so
+          // neither `rejectAllPending` nor a toast is right — an
+          // anonymous viewer of a shared page would see one on every
+          // navigation. Logged so it is diagnosable.
+          console.warn('[WS] refused:', msg.message);
         } else {
           this.rejectAllPending(msg.message);
           this.store.notifyError(msg.message);
@@ -1136,6 +1161,14 @@ export class WSClient {
     // Drive-wide live subscription. Previously sent only inside
     // `authenticate()`, so an anonymous session never subscribed at all.
     this.subscribeToDrive();
+
+    // Loro and presence subscriptions carry an identity (peers see who
+    // is editing), so the server refuses them before AUTH with
+    // `AUTH_REQUIRED`. Don't send them for a session without an agent;
+    // `authenticate()` calls back in here once one is set.
+    if (!this.store.getAgent()) {
+      return;
+    }
 
     for (const subject of this.store.getLoroSyncSubjects()) {
       this.subscribeLoroSync(subject);
@@ -1455,6 +1488,15 @@ export class WSClient {
   }
 
   // ---- Private: helpers ----
+
+  /** The drive a `SYNC_REJECTED` message is about. The server formats it
+   *  as `SYNC_PUSH rejected for drive <drive>: <reason>`; when that shape
+   *  is not recognised, fall back to the drive we are syncing. */
+  private driveFromRejection(message: string): string {
+    const match = /rejected for drive (\S+?):/.exec(message);
+
+    return match?.[1] ?? this.store.getDrive() ?? '';
+  }
 
   private async checkForMissingBlobs(resource: Resource) {
     const blobDid = resource.get(BLOB) as string | undefined;

--- a/browser/lib/src/ws-v2.ts
+++ b/browser/lib/src/ws-v2.ts
@@ -72,6 +72,18 @@ export const ErrorCode = {
    *  Blocking rather than terminal: the write is well-formed and would apply
    *  once the class arrives, so it must not be discarded. */
   MISSING_CLASS: 4,
+  /** A frame that needs an identity (SYNC_PUSH, LORO_SYNC_UPDATE,
+   *  SUBSCRIBE, ...) arrived before AUTH. Connection-level (`requestId`
+   *  0); the socket stays open and the frame is simply not processed. */
+  AUTH_REQUIRED: 5,
+  /** The server refused a SYNC_PUSH as a whole (no write right on the
+   *  drive, quota, not enrolled). Nothing from the push landed, and no
+   *  SYNC_OK follows for it. The message names the drive. */
+  SYNC_REJECTED: 6,
+  /** A subscription (SUB, SUBSCRIBE, SUBSCRIBE_QUERY, LORO_SYNC_SUBSCRIBE,
+   *  PRESENCE_SUBSCRIBE) was refused because the agent cannot read the
+   *  subject or drive. Nothing was subscribed. */
+  UNAUTHORIZED_READ: 7,
 } as const;
 
 // ---- Low-level read/write helpers ----

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -73,6 +73,31 @@ Before sending any other messages, the initiator must authenticate:
 1. The initiator sends `AUTH (0x01)` with a JSON payload containing signed credentials.
 2. The responder responds with `AUTH_OK (0x02)` or `ERROR (0x03)`.
 
+### What is refused before AUTH
+
+Until an `AUTH` has succeeded the connection is `Public`, and the responder
+fails closed on identity. A frame sent too early is answered with
+`ERROR (0x03)` carrying `request_id = 0` and code `AUTH_REQUIRED (5)`; the
+frame itself is not processed.
+
+**Iroh streams**: only `AUTH` is accepted before authentication. Any other
+frame — `SYNC`, `SYNC_PUSH`, `HELLO`, ... — gets the `ERROR` and the
+responder closes the stream. A failed `AUTH` also closes the stream. In
+addition, `AUTH.requestedSubject` is bound to the drive: the first `SYNC` /
+`SYNC_PUSH` on the stream must name the drive the `AUTH` was signed for
+(same code, message `AUTH was for <x>, not <y>`, stream closed).
+
+**Browser / WebSocket**: an anonymous session may still *read* — `GET`,
+`SUB <drive>`, `SYNC` / `SYNC_VV`, `RBSR_*` all stay open, each gated by
+`check_read` (this is what a public share link relies on for live updates).
+Frames that write, or that carry an identity to other peers, require
+`AUTH` first: `SYNC_PUSH`, `BLOB_RESPONSE`, `LORO_SYNC_UPDATE`,
+`LORO_EPHEMERAL_UPDATE`, `PRESENCE_UPDATE`, `SUBSCRIBE`, `SUBSCRIBE_QUERY`,
+`LORO_SYNC_SUBSCRIBE`, `PRESENCE_SUBSCRIBE`. The socket stays open after the
+refusal; the client may `AUTH` and retry on the same connection. The
+browser signs the server origin as `requestedSubject`, so no drive binding is
+possible over WebSocket.
+
 ## Peer Handshake (HELLO, Iroh streams only)
 
 On Iroh peer-to-peer streams (not browser WS), each side announces a
@@ -131,6 +156,10 @@ today (JSON-AD `did:ad:commit:<sig>`). On failure, the responder emits
 | `1`  | `GENESIS_COLLISION`          | Commit tried to create a subject that already exists.       |
 | `2`  | `MISSING_REQUIRED_PROPERTY`  | Commit is missing a property required by its class/shape.   |
 | `3`  | `UNAUTHORIZED_WRITE`         | Signer lacks write rights on the target subject/drive.      |
+| `4`  | `MISSING_CLASS`              | Commit names a class the responder does not hold; blocking, not terminal. |
+| `5`  | `AUTH_REQUIRED`              | Frame needs an authenticated identity; sent with `request_id = 0`. See *What is refused before AUTH*. |
+| `6`  | `SYNC_REJECTED`              | A `SYNC_PUSH` was refused as a whole; nothing from it landed. Message: `SYNC_PUSH rejected for drive <drive>: <reason>`. |
+| `7`  | `UNAUTHORIZED_READ`          | A subscription was refused: the agent cannot read the subject or drive. Message: `<FRAME> refused for <subject>: <reason>`. |
 
 Only these known codes are safe for callers to branch on (e.g. to decide
 whether to give up retrying vs. keep retrying); an unrecognized code should be
@@ -172,7 +201,18 @@ same response channel (`UPDATE (0x11)` / `DESTROY (0x12)`):
 
 All three require authorization at registration time — `check_read` on
 the drive (for `SUB` and `SUBSCRIBE_QUERY`) or on the resource (for
-`SUBSCRIBE`).
+`SUBSCRIBE`) — the same check a `GET` runs. A subscription that fails it
+(or names a subject the responder does not hold) is not registered, and the
+responder says so: `ERROR (0x03)` with `request_id = 0` and code
+`UNAUTHORIZED_READ (7)`, message `<FRAME> refused for <subject>: <reason>`,
+where `<FRAME>` is `SUB`, `SUBSCRIBE`, `SUBSCRIBE_QUERY`,
+`LORO_SYNC_SUBSCRIBE` or `PRESENCE_SUBSCRIBE`. One frame gets one answer:
+the companion resource subscription a `SUB` registers for the drive
+resource itself does not send a second one. A subscription that is
+accepted is silent. `SUBSCRIBE`, `SUBSCRIBE_QUERY` and the Loro / presence
+subscriptions additionally require `AUTH` first (`AUTH_REQUIRED (5)`);
+`SUB` does not, so an anonymous viewer of a public drive still gets live
+updates.
 
 > Historical: an earlier protocol revision included a dedicated `QUERY_UPDATE (0x36)` membership-notification frame carrying just the subject string, requiring the client to follow up with a `GET`. This was retired because the same information arrives with one fewer round-trip as a regular `UPDATE` carrying the snapshot. Tag `0x36` is reserved.
 
@@ -183,6 +223,26 @@ Drive sync ensures two peers have the same set of resources. It uses Loro CRDT v
 1. **`SYNC (0x30)`**: Peers exchange drive-level hashes and version vectors.
 2. **`SYNC_DIFF (0x32)`**: A peer determines which resources to `pull`, `push`, and `remove`.
 3. **`SYNC_PUSH (0x33)`**: Peers exchange binary Loro deltas for missing resources, **chunked**. Each chunk carries `[drive] [flags: u8] [count: u16] [entries...]`; bit 0 of `flags` is `LAST`. Senders cap chunks at 100 entries or 1 MiB (whichever fills first); receivers loop reading `SYNC_PUSH` frames until they see a chunk with `LAST` set. An empty push still emits a single `LAST`-flagged frame so the receiver doesn't hang.
+
+### `SYNC_PUSH` acknowledgement and rejection
+
+A receiver answers each admitted `SYNC_PUSH` chunk with `SYNC_OK (0x31)` for
+the drive (followed by any `BLOB_REQUEST`s the chunk gave rise to). `SYNC_OK`
+acknowledges the *chunk*: entries inside it may still be skipped
+individually (tombstoned locally, unreadable, malformed), so a sender that
+needs proof re-probes with a second `SYNC`.
+
+A push the receiver refuses *as a whole* — the connection's agent has no
+write right on the drive, the drive is over quota, or the node's sync
+policy does not admit it — is answered with `ERROR (0x03)`, `request_id =
+0`, code `SYNC_REJECTED (6)`, message `SYNC_PUSH rejected for drive
+<drive>: <reason>`. **No `SYNC_OK` is sent for a rejected push** and none
+of its entries land. (Earlier revisions answered `SYNC_OK` here too, which
+let a sender believe its data had arrived.) Senders should treat this as
+"nothing of mine was accepted": keep the local state, surface the reason,
+and offer it again once the cause is fixed. Over WebSocket, `SYNC_PUSH`
+before `AUTH` is refused with `AUTH_REQUIRED (5)` instead; the
+anonymous-bootstrap carve-out no longer exists.
 
 ### `SYNC_DIFF` payload
 

--- a/lib/src/sync/engine.rs
+++ b/lib/src/sync/engine.rs
@@ -203,11 +203,18 @@ pub async fn handle_frame(
                 // WS): no owned-drive relaxation — the sender must itself hold
                 // write rights. The dial side calls import_sync_push directly
                 // with trust_owned=true.
-                let (_count, mut blob_requests) =
-                    import_sync_push(&push, store, agent, false).await;
-                let mut responses = vec![protocol::encode_sync_ok(&push.drive)];
-                responses.append(&mut blob_requests);
-                responses
+                match import_sync_push(&push, store, agent, false).await {
+                    Ok((_count, mut blob_requests)) => {
+                        let mut responses = vec![protocol::encode_sync_ok(&push.drive)];
+                        responses.append(&mut blob_requests);
+                        responses
+                    }
+                    // A refused import used to be answered with `SYNC_OK` all
+                    // the same, so a sender could never tell "landed" from
+                    // "dropped" (`replicate.rs` re-probed with a second SYNC
+                    // to find out). Say no when the answer is no.
+                    Err(rejected) => vec![rejected.to_error_frame()],
+                }
             } else {
                 vec![protocol::encode_error(
                     0,
@@ -953,18 +960,53 @@ pub(crate) async fn may_accept_drive_write(
     false
 }
 
+/// Why a `SYNC_PUSH` was refused as a whole. Distinct from "imported zero
+/// entries" (every entry tombstoned or malformed), which is still a
+/// successful import from the protocol's point of view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncPushRejected {
+    /// The drive the push named.
+    pub drive: String,
+    /// Human-readable reason; goes on the wire in the `ERROR` frame.
+    pub reason: String,
+}
+
+impl SyncPushRejected {
+    /// The `ERROR` frame (`request_id = 0`, [`protocol::error_code::SYNC_REJECTED`])
+    /// that answers the push instead of `SYNC_OK`.
+    pub fn to_error_frame(&self) -> Vec<u8> {
+        protocol::encode_error(0, protocol::error_code::SYNC_REJECTED, &self.to_string())
+    }
+}
+
+impl std::fmt::Display for SyncPushRejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SYNC_PUSH rejected for drive {}: {}",
+            self.drive, self.reason
+        )
+    }
+}
+
 /// Import resources from a SYNC_PUSH message into the local store.
 ///
 /// `for_agent` is the identity the sending peer proved. `trust_owned` is true
 /// when WE dialed this peer, which lets a relayed push to a drive we own through
 /// even though the relaying peer is a different agent (see
 /// [`may_accept_drive_write`]). When importing locally, pass `Sudo`.
+///
+/// `Ok((imported, blob_requests))` when the push was admitted — `imported`
+/// may still be 0 if every entry was skipped. `Err` when the push was refused
+/// as a whole: the agent may not write the drive, or the sync policy does not
+/// admit it. Nothing is written in the `Err` case, and the caller must answer
+/// with the rejection's `ERROR` frame, never `SYNC_OK`.
 pub async fn import_sync_push(
     push: &protocol::DecodedSyncPush,
     store: &Db,
     for_agent: &crate::agents::ForAgent,
     trust_owned: bool,
-) -> (usize, Vec<Vec<u8>>) {
+) -> Result<(usize, Vec<Vec<u8>>), SyncPushRejected> {
     // Check write access to the drive
     let drive_subject = crate::Subject::from_raw(&push.drive, store.get_base_domain().as_deref());
     if let Ok(drive_resource) = store.get_resource(&drive_subject).await {
@@ -975,7 +1017,10 @@ pub async fn import_sync_push(
                 push.drive,
                 trust_owned
             );
-            return (0, vec![]);
+            return Err(SyncPushRejected {
+                drive: push.drive.clone(),
+                reason: format!("agent {for_agent} has no write right on the drive"),
+            });
         }
     }
     // Admission gate. A no-op under the default OpenPolicy (self-hosted / FOSS
@@ -1007,7 +1052,19 @@ pub async fn import_sync_push(
                 decision,
                 for_agent
             );
-            return (0, vec![]);
+            let reason = match decision {
+                super::policy::AdmitDecision::OverQuota => {
+                    format!(
+                        "drive {} is over its storage quota on this node",
+                        push.drive
+                    )
+                }
+                _ => policy.not_enrolled_message(&push.drive),
+            };
+            return Err(SyncPushRejected {
+                drive: push.drive.clone(),
+                reason,
+            });
         }
     }
 
@@ -1141,7 +1198,7 @@ pub async fn import_sync_push(
             entry.loro_bytes.len()
         );
     }
-    (count, blob_requests)
+    Ok((count, blob_requests))
 }
 
 /// Whether the owner deliberately dialled this node. Peer-to-peer sync only

--- a/lib/src/sync/iroh_e2e.rs
+++ b/lib/src/sync/iroh_e2e.rs
@@ -526,7 +526,8 @@ async fn e2e_engine_pull_after_iroh_bulk_sync() {
                     &ForAgent::Sudo,
                     false,
                 )
-                .await;
+                .await
+                .expect("Sudo import is never rejected");
                 imported += count;
             }
         }

--- a/lib/src/sync/peer.rs
+++ b/lib/src/sync/peer.rs
@@ -24,7 +24,7 @@ fn io_err(e: impl std::fmt::Display) -> crate::errors::AtomicError {
 }
 
 /// ALPN protocol identifier for Atomic Data over Iroh.
-const ATOMIC_ALPN: &[u8] = b"atomic/1";
+pub(crate) const ATOMIC_ALPN: &[u8] = b"atomic/1";
 
 /// Canonical 64-char lowercase hex NodeID for map keys and UI matching.
 pub fn normalize_node_id(id: &str) -> String {
@@ -988,6 +988,41 @@ fn register_live_peer(
                 continue;
             }
 
+            // Fail closed on identity (planning/serverless-p2p.md, principle 5):
+            // a peer that dialed us and never proved who it is gets no live
+            // frame processed — not even as `Public`. `handle_stream` already
+            // refuses to reach live mode without an AUTH, so this is the same
+            // rule restated where the frames actually land, in case the two
+            // ever drift. Only for connections dialed *into* us: on the dial
+            // side `agent` is the remote's best-effort auth-back, and every
+            // write there is gated on our own ownership (`initiated_by_us`).
+            if !initiated_by_us
+                && matches!(agent, ForAgent::Public)
+                && buf[0] != super::protocol::tag::AUTH
+            {
+                tracing::warn!(
+                    "[live] closing: 0x{:02x} from {} before AUTH",
+                    buf[0],
+                    &read_peer_id[..read_peer_id.len().min(12)]
+                );
+                let _ = tx_for_read
+                    .send(frame_with_len(&auth_required_error(buf[0])))
+                    .await;
+                break;
+            }
+
+            // The peer answered something we sent (a SYNC_PUSH it refused, a
+            // BLOB_REQUEST it couldn't serve) with an ERROR. Nothing to apply;
+            // say so and keep the link — an ERROR is a verdict, not a fault.
+            if buf[0] == super::protocol::tag::ERROR {
+                let msg = std::str::from_utf8(buf.get(5..).unwrap_or(&[])).unwrap_or("(non-utf8)");
+                tracing::warn!(
+                    "[live] {} answered with an error: {msg}",
+                    &read_peer_id[..read_peer_id.len().min(12)]
+                );
+                continue;
+            }
+
             // Live collaboration: presence, cursors, and the ops of an edit in
             // progress. Handled before every other frame type and returned from
             // immediately, because the one thing none of it may do is reach the
@@ -1706,16 +1741,25 @@ pub async fn sync_drive_with_peer_using_outcome(
                     // `import_sync_push` still runs the drive-level check + the
                     // admission gate, with the bootstrap carve-out for a drive
                     // that doesn't exist locally yet.
-                    let (count, blob_requests) =
-                        super::engine::import_sync_push(&push, store, &remote_agent, true).await;
-                    total_imported += count;
+                    match super::engine::import_sync_push(&push, store, &remote_agent, true).await {
+                        Ok((count, blob_requests)) => {
+                            total_imported += count;
 
-                    // Send blob requests if any
-                    for req_frame in blob_requests {
-                        send.write_u32(req_frame.len() as u32)
-                            .await
-                            .map_err(io_err)?;
-                        send.write_all(&req_frame).await.map_err(io_err)?;
+                            // Send blob requests if any
+                            for req_frame in blob_requests {
+                                send.write_u32(req_frame.len() as u32)
+                                    .await
+                                    .map_err(io_err)?;
+                                send.write_all(&req_frame).await.map_err(io_err)?;
+                            }
+                        }
+                        // We dialed this peer and asked for its state; the
+                        // refusal is our own admission gate saying no to what
+                        // came back. Nothing landed, and there is nothing to
+                        // tell the peer — it did not ask us for anything.
+                        Err(rejected) => {
+                            tracing::warn!("[sync] dropped incoming push: {rejected}");
+                        }
                     }
                 }
                 // SYNC_PUSH is chunked: keep reading until the LAST flag fires.
@@ -1747,12 +1791,24 @@ pub async fn sync_drive_with_peer_using_outcome(
                 break;
             }
             super::protocol::tag::ERROR => {
-                // [request_id: u16] [code: u16] [message: utf8] — `code`
-                // (F5, planning/unified-sync.md) isn't consumed here yet;
-                // Iroh live-mode just logs and drops the connection either
-                // way on an ERROR.
+                // [request_id: u16] [code: u16] [message: utf8] (F5,
+                // planning/unified-sync.md).
+                let code = payload
+                    .get(2..4)
+                    .map(|b| u16::from_be_bytes([b[0], b[1]]))
+                    .unwrap_or(super::protocol::error_code::UNKNOWN);
                 let msg =
                     std::str::from_utf8(payload.get(4..).unwrap_or(&[])).unwrap_or("unknown error");
+                // A refused push or a refused identity is the peer saying
+                // "nothing of yours landed". Going live and reporting
+                // `pushed` as if it had would tell the user the opposite of
+                // what happened, so this is the outcome of the sync.
+                if code == super::protocol::error_code::SYNC_REJECTED
+                    || code == super::protocol::error_code::AUTH_REQUIRED
+                {
+                    tracing::warn!("[sync] peer refused: {msg}");
+                    return Err(format!("Peer refused to sync: {msg}").into());
+                }
                 tracing::warn!("Peer returned error: {msg}");
                 break;
             }
@@ -2147,6 +2203,59 @@ pub fn remove_known_peer(store: &Db, node_id: &str) {
 /// Returns the number of resources imported from the remote peer.
 /// After SYNC_OK or SYNC_PUSH response, transitions to live mode by
 /// registering the stream for real-time updates.
+/// The `ERROR` frame a peer gets for sending `tag` before it authenticated.
+fn auth_required_error(tag: u8) -> Vec<u8> {
+    super::protocol::encode_error(
+        0,
+        super::protocol::error_code::AUTH_REQUIRED,
+        &format!("AUTH required before frame 0x{tag:02x}"),
+    )
+}
+
+/// Prefix a frame with the u32 length the Iroh stream framing expects.
+fn frame_with_len(frame: &[u8]) -> Vec<u8> {
+    let mut framed = Vec::with_capacity(4 + frame.len());
+    framed.extend_from_slice(&(frame.len() as u32).to_be_bytes());
+    framed.extend_from_slice(frame);
+    framed
+}
+
+/// Write `frames`, close our half of the stream, and wait (briefly) for the
+/// peer to acknowledge them. Best effort: the peer is being refused, so a
+/// failed write changes nothing. The wait matters, though: the caller
+/// returns straight after, `accept` then drops the connection, and QUIC
+/// would discard anything not yet delivered — the peer would see a closed
+/// stream with no ERROR in it, which is the silence this exists to replace.
+async fn refuse_stream(send: &mut iroh::endpoint::SendStream, frames: &[Vec<u8>]) {
+    for frame in frames {
+        let _ = send.write_all(&frame_with_len(frame)).await;
+    }
+    let _ = send.finish();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), send.stopped()).await;
+}
+
+/// The drive an `AUTH` frame was signed for (`requestedSubject`). `None`
+/// when the payload does not parse — a frame that did not parse did not
+/// authenticate either, so nothing is bound.
+fn auth_requested_subject(payload: &[u8]) -> Option<String> {
+    let json = std::str::from_utf8(payload).ok()?;
+    let auth: crate::authentication::AuthValues = serde_json::from_str(json).ok()?;
+    Some(auth.requested_subject)
+}
+
+/// The drive a handshake `SYNC` / `SYNC_PUSH` names, or `None` for any other
+/// frame (and for a frame that does not decode — the engine will answer
+/// that one with its own ERROR).
+fn handshake_frame_drive(buf: &[u8]) -> Option<String> {
+    match *buf.first()? {
+        super::protocol::tag::SYNC => super::protocol::decode_sync(&buf[1..]).map(|s| s.drive),
+        super::protocol::tag::SYNC_PUSH => {
+            super::protocol::decode_sync_push(&buf[1..]).map(|p| p.drive)
+        }
+        _ => None,
+    }
+}
+
 async fn handle_stream(
     mut send: iroh::endpoint::SendStream,
     mut recv: iroh::endpoint::RecvStream,
@@ -2155,6 +2264,11 @@ async fn handle_stream(
 ) -> anyhow::Result<usize> {
     let remote_key = normalize_node_id(&remote_id);
     let mut agent = ForAgent::Public;
+    // The drive the peer's AUTH was signed for. The AUTH proof is bound to
+    // this (`requestedSubject` is what the signature covers), so a proof
+    // minted for one drive must not open a SYNC on another. Set once, when
+    // the AUTH succeeds; checked against every handshake SYNC / SYNC_PUSH.
+    let mut bound_drive: Option<crate::Subject> = None;
     let mut total_imported = 0;
     let mut sent_sync_ok = false;
     let mut hello_sent = false;
@@ -2183,11 +2297,56 @@ async fn handle_stream(
 
         let mut buf = vec![0u8; len];
         recv.read_exact(&mut buf).await.map_err(io_err)?;
+        let Some(&tag) = buf.first() else {
+            continue;
+        };
+
+        // Fail closed on identity (planning/serverless-p2p.md, principle 5;
+        // planning/authorization-sync.md phase 1). Until an AUTH has
+        // succeeded, the only frame this loop processes is AUTH. Anything
+        // else — SYNC, SYNC_PUSH, even HELLO — gets an ERROR and the stream
+        // closed, rather than being handled as `Public`. "Public semantics"
+        // was never nothing: an unauthenticated SYNC still walked the drive
+        // and served every publicly readable subject, and an unauthenticated
+        // SYNC_PUSH could bootstrap a brand-new drive onto an open node. A
+        // dialer that wants either can say who it is first; every initiator
+        // in this codebase already does.
+        if matches!(agent, ForAgent::Public) && tag != super::protocol::tag::AUTH {
+            tracing::warn!(
+                "[accept] closing: 0x{tag:02x} from {} before AUTH",
+                &remote_key[..remote_key.len().min(12)]
+            );
+            refuse_stream(&mut send, &[auth_required_error(tag)]).await;
+            return Ok(total_imported);
+        }
+
+        // AUTH.requestedSubject ↔ SYNC.drive binding: the proof the peer gave
+        // covers one drive, so a handshake frame for a different drive is a
+        // replay of that proof against something it was never signed for.
+        if let (Some(bound), Some(named)) = (&bound_drive, handshake_frame_drive(&buf)) {
+            let named = crate::Subject::from_raw(&named, store.get_base_domain().as_deref());
+            if &named != bound {
+                tracing::warn!(
+                    "[accept] closing: {} authenticated for {bound} but sent 0x{tag:02x} for {named}",
+                    &remote_key[..remote_key.len().min(12)]
+                );
+                refuse_stream(
+                    &mut send,
+                    &[super::protocol::encode_error(
+                        0,
+                        super::protocol::error_code::AUTH_REQUIRED,
+                        &format!("AUTH was for {bound}, not {named}"),
+                    )],
+                )
+                .await;
+                return Ok(total_imported);
+            }
+        }
 
         // HELLO is a peer-stream concern, not an engine concern. Browser WS
         // sessions never see it (they don't speak peer-sync). Intercept here
         // so the engine doesn't have to know about it.
-        if !buf.is_empty() && buf[0] == super::protocol::tag::HELLO {
+        if tag == super::protocol::tag::HELLO {
             if peer_display_name.is_none() {
                 peer_display_name = super::protocol::decode_hello(&buf[1..]);
                 if let Some(name) = &peer_display_name {
@@ -2216,25 +2375,48 @@ async fn handle_stream(
             continue;
         }
 
-        // Track imports from SYNC_PUSH frames
-        if !buf.is_empty() && buf[0] == super::protocol::tag::SYNC_PUSH {
+        let responses = super::engine::handle_frame(&buf, &store, &mut agent).await;
+
+        // Track imports from SYNC_PUSH frames. A push the engine refused
+        // (answered with ERROR instead of SYNC_OK) landed nothing.
+        if tag == super::protocol::tag::SYNC_PUSH
+            && responses
+                .iter()
+                .any(|r| r.first() == Some(&super::protocol::tag::SYNC_OK))
+        {
             if let Some(push) = super::protocol::decode_sync_push(&buf[1..]) {
                 total_imported += push.entries.len();
             }
         }
-
-        let responses = super::engine::handle_frame(&buf, &store, &mut agent).await;
 
         // Send our HELLO once, immediately after AUTH succeeded. We tack it
         // on to the AUTH_OK response so old peers that don't read past
         // AUTH_OK still get something coherent (an unknown tag they'll just
         // skip). Skipping HELLO before AUTH_OK would leak our hostname to
         // unauthenticated peers — small thing, but no reason to.
-        let just_authed = !buf.is_empty()
-            && buf[0] == super::protocol::tag::AUTH
+        let just_authed = tag == super::protocol::tag::AUTH
             && responses
                 .iter()
                 .any(|r| !r.is_empty() && r[0] == super::protocol::tag::AUTH_OK);
+
+        if tag == super::protocol::tag::AUTH {
+            if just_authed {
+                if bound_drive.is_none() {
+                    bound_drive = auth_requested_subject(&buf[1..])
+                        .map(|s| crate::Subject::from_raw(&s, store.get_base_domain().as_deref()));
+                }
+            } else {
+                // A failed AUTH leaves `agent` as Public; the next frame would
+                // be refused anyway. Say why and close now, rather than let a
+                // peer keep guessing on an open stream.
+                tracing::warn!(
+                    "[accept] closing: AUTH from {} failed",
+                    &remote_key[..remote_key.len().min(12)]
+                );
+                refuse_stream(&mut send, &responses).await;
+                return Ok(total_imported);
+            }
+        }
 
         // Who this agent is decides nothing here; what they may read decides
         // everything, per subject, in `check_read` — the same answer they would
@@ -2257,7 +2439,7 @@ async fn handle_stream(
         }
 
         // Check if the client sent us a SYNC_PUSH (bidirectional data exchange complete)
-        let client_pushed = !buf.is_empty() && buf[0] == super::protocol::tag::SYNC_PUSH;
+        let client_pushed = tag == super::protocol::tag::SYNC_PUSH;
         // Check if we responded with SYNC_OK (fast path — already in sync)
         let sync_ok = responses
             .iter()
@@ -2589,7 +2771,10 @@ mod initiator_trust_tests {
 
     /// Build a drive whose read/write is restricted to `owner` (no public
     /// grant) plus one child resource under it. Returns `(drive_did, child)`.
-    async fn private_drive_with_child(db: &Db, owner: &crate::agents::Agent) -> (String, String) {
+    pub(super) async fn private_drive_with_child(
+        db: &Db,
+        owner: &crate::agents::Agent,
+    ) -> (String, String) {
         let mut builder = crate::commit::CommitBuilder::new("placeholder".into());
         builder.set(
             crate::urls::IS_A.into(),
@@ -2809,6 +2994,258 @@ mod initiator_trust_tests {
         assert!(
             crate::sync::tombstones::is_tombstoned(&db, &child),
             "the owner's remove[] entry must record a tombstone"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "db-redb"))]
+mod accept_gate_tests {
+    //! The accept side of the Iroh transport (`handle_stream`) and the sync
+    //! engine's `SYNC_PUSH` answer, exercised the way a hostile or merely
+    //! confused peer would hit them: frames before AUTH, AUTH for one drive
+    //! followed by a handshake for another, and a push from an agent with
+    //! no write right. Each refusal must be *visible* — an `ERROR` frame with
+    //! a registered code — never a silent drop or a `SYNC_OK` for nothing.
+    use super::initiator_trust_tests::private_drive_with_child;
+    use super::*;
+    use crate::sync::protocol::{self, error_code, tag};
+    use crate::Db;
+
+    /// `(request_id, code, message)` of an ERROR frame, or `None` for any
+    /// other frame.
+    fn parse_error(frame: &[u8]) -> Option<(u16, u16, String)> {
+        if frame.first() != Some(&tag::ERROR) || frame.len() < 5 {
+            return None;
+        }
+        let request_id = u16::from_be_bytes([frame[1], frame[2]]);
+        let code = u16::from_be_bytes([frame[3], frame[4]]);
+        let message = String::from_utf8_lossy(&frame[5..]).into_owned();
+        Some((request_id, code, message))
+    }
+
+    /// A SYNC_PUSH frame carrying the owner's current snapshot of `child`,
+    /// as a peer that replays it would send it.
+    async fn push_frame_for(
+        db: &Db,
+        owner: &crate::agents::Agent,
+        drive: &str,
+        child: &str,
+    ) -> Vec<u8> {
+        let snapshots = crate::sync::engine::collect_readable_snapshots(
+            db,
+            &ForAgent::AgentSubject(owner.subject.clone()),
+            &[child.to_string()],
+            None,
+        )
+        .await;
+        assert_eq!(snapshots.len(), 1, "owner can read its own child");
+        let entries: Vec<(&str, &[u8])> = snapshots
+            .iter()
+            .map(|(s, b)| (s.as_str(), b.as_slice()))
+            .collect();
+        protocol::encode_sync_push(drive, &entries, true)
+    }
+
+    #[tokio::test]
+    async fn import_sync_push_refuses_agent_without_write_right() {
+        let db = Db::init_temp("gate_import_stranger").await.unwrap();
+        let alice = crate::agents::Agent::new(Some("Alice")).unwrap();
+        db.set_default_agent(alice.clone());
+        let (drive, child) = private_drive_with_child(&db, &alice).await;
+        let mallory = crate::agents::Agent::new(Some("Mallory")).unwrap();
+
+        let frame = push_frame_for(&db, &alice, &drive, &child).await;
+        let push = protocol::decode_sync_push(&frame[1..]).unwrap();
+
+        for (who, agent) in [
+            ("Public", ForAgent::Public),
+            (
+                "a stranger",
+                ForAgent::AgentSubject(mallory.subject.clone()),
+            ),
+        ] {
+            let rejected = crate::sync::engine::import_sync_push(&push, &db, &agent, false)
+                .await
+                .expect_err(&format!(
+                    "{who} must not be able to push into a private drive"
+                ));
+            assert_eq!(rejected.drive, drive);
+            assert!(
+                rejected.reason.contains("no write right"),
+                "reason names the cause: {}",
+                rejected.reason
+            );
+        }
+
+        // The owner's push is admitted — the refusal is about rights, not a
+        // blanket one.
+        crate::sync::engine::import_sync_push(
+            &push,
+            &db,
+            &ForAgent::AgentSubject(alice.subject.clone()),
+            false,
+        )
+        .await
+        .expect("the owner may push into its own drive");
+    }
+
+    /// The wire-level consequence: a refused push is answered with ERROR
+    /// `SYNC_REJECTED`, and there is no `SYNC_OK` anywhere in the response.
+    /// Before this, the engine answered `SYNC_OK` for a push it had dropped,
+    /// so the sender believed its data had landed.
+    #[tokio::test]
+    async fn rejected_sync_push_is_answered_with_error_not_sync_ok() {
+        let db = Db::init_temp("gate_push_error_frame").await.unwrap();
+        let alice = crate::agents::Agent::new(Some("Alice")).unwrap();
+        db.set_default_agent(alice.clone());
+        let (drive, child) = private_drive_with_child(&db, &alice).await;
+        let mallory = crate::agents::Agent::new(Some("Mallory")).unwrap();
+
+        let frame = push_frame_for(&db, &alice, &drive, &child).await;
+        let mut as_mallory = ForAgent::AgentSubject(mallory.subject.clone());
+        let responses = crate::sync::engine::handle_frame(&frame, &db, &mut as_mallory).await;
+
+        assert!(
+            !responses.iter().any(|f| f.first() == Some(&tag::SYNC_OK)),
+            "a rejected push must never be acknowledged with SYNC_OK"
+        );
+        let (request_id, code, message) = responses
+            .iter()
+            .find_map(|f| parse_error(f))
+            .expect("a rejected push is answered with an ERROR frame");
+        assert_eq!(
+            request_id, 0,
+            "connection-level error, not tied to a request"
+        );
+        assert_eq!(code, error_code::SYNC_REJECTED);
+        assert!(
+            message.contains(&drive),
+            "the message names the drive so the sender can act on it: {message}"
+        );
+
+        // And the owner's push still gets its SYNC_OK.
+        let mut as_alice = ForAgent::AgentSubject(alice.subject.clone());
+        let responses = crate::sync::engine::handle_frame(&frame, &db, &mut as_alice).await;
+        assert!(
+            responses.iter().any(|f| f.first() == Some(&tag::SYNC_OK)),
+            "the owner's push is acknowledged"
+        );
+    }
+
+    /// Dial a running accept side with a raw endpoint and return the stream.
+    async fn raw_stream(
+        router: &Router,
+        node_id: &NodeId,
+    ) -> (
+        iroh::Endpoint,
+        iroh::endpoint::SendStream,
+        iroh::endpoint::RecvStream,
+    ) {
+        let ep = iroh::Endpoint::builder().bind().await.unwrap();
+        let addr = router.endpoint().node_addr().await.unwrap();
+        ep.add_node_addr(addr).unwrap();
+        let conn = ep.connect(*node_id, ATOMIC_ALPN).await.unwrap();
+        let (send, recv) = conn.open_bi().await.unwrap();
+        (ep, send, recv)
+    }
+
+    async fn write_frame(send: &mut iroh::endpoint::SendStream, frame: &[u8]) {
+        send.write_all(&frame_with_len(frame)).await.unwrap();
+    }
+
+    /// The next frame from the accept side, or `None` once it closed the
+    /// stream. The unsolicited HELLO and the auth-back AUTH the accept side
+    /// sends after AUTH_OK are skipped; they are not what these tests are
+    /// about.
+    async fn read_frame(recv: &mut iroh::endpoint::RecvStream) -> Option<Vec<u8>> {
+        loop {
+            let n = tokio::time::timeout(std::time::Duration::from_secs(10), recv.read_u32())
+                .await
+                .expect("accept side answers within 10s")
+                .ok()?;
+            let mut buf = vec![0u8; n as usize];
+            recv.read_exact(&mut buf).await.ok()?;
+            if !matches!(buf.first(), Some(&tag::HELLO) | Some(&tag::AUTH)) {
+                return Some(buf);
+            }
+        }
+    }
+
+    /// A handshake frame before AUTH — here a SYNC for a *public* drive,
+    /// which the old code would happily have served as `Public` — gets
+    /// `AUTH_REQUIRED` and a closed stream. Fail closed on identity.
+    #[tokio::test]
+    async fn iroh_sync_before_auth_is_refused_and_stream_closed() {
+        let db = Db::init_temp("gate_iroh_preauth").await.unwrap();
+        let (_alice, drive) = db.setup("Alice").await.unwrap();
+        let (node_id, router) = start(db.clone()).await.unwrap();
+
+        let (_ep, mut send, mut recv) = raw_stream(&router, &node_id).await;
+        let sync = protocol::encode_sync(&drive, "", &[], &std::collections::HashMap::new());
+        write_frame(&mut send, &sync).await;
+
+        let reply = read_frame(&mut recv)
+            .await
+            .expect("an ERROR frame, not silence");
+        let (_, code, message) = parse_error(&reply).expect("ERROR frame");
+        assert_eq!(code, error_code::AUTH_REQUIRED, "{message}");
+        assert!(
+            read_frame(&mut recv).await.is_none(),
+            "the accept side closes the stream after refusing"
+        );
+    }
+
+    /// `AUTH.requestedSubject` is bound to the drive of the handshake that
+    /// follows: an AUTH signed for drive X does not open drive Y.
+    #[tokio::test]
+    async fn iroh_auth_for_one_drive_does_not_open_another() {
+        let db = Db::init_temp("gate_iroh_binding").await.unwrap();
+        let (alice, drive) = db.setup("Alice").await.unwrap();
+        let (node_id, router) = start(db.clone()).await.unwrap();
+
+        let (_ep, mut send, mut recv) = raw_stream(&router, &node_id).await;
+        let auth = protocol::encode_auth(&alice, "did:key:z6MkSomeOtherDrive").unwrap();
+        write_frame(&mut send, &auth).await;
+        let reply = read_frame(&mut recv).await.expect("AUTH_OK");
+        assert_eq!(reply.first(), Some(&tag::AUTH_OK), "AUTH itself is valid");
+
+        let sync = protocol::encode_sync(&drive, "", &[], &std::collections::HashMap::new());
+        write_frame(&mut send, &sync).await;
+        let reply = read_frame(&mut recv)
+            .await
+            .expect("an ERROR frame, not a SYNC_DIFF");
+        let (_, code, message) = parse_error(&reply).expect("ERROR frame");
+        assert_eq!(code, error_code::AUTH_REQUIRED, "{message}");
+        assert!(message.contains(&drive), "{message}");
+        assert!(read_frame(&mut recv).await.is_none(), "stream closed");
+    }
+
+    /// The happy path through the same raw stream, so the two refusals
+    /// above are known to be about the gate and not about the fixture:
+    /// AUTH for the drive, then SYNC of it, yields a handshake answer.
+    #[tokio::test]
+    async fn iroh_auth_then_sync_for_same_drive_is_served() {
+        let db = Db::init_temp("gate_iroh_happy").await.unwrap();
+        let (alice, drive) = db.setup("Alice").await.unwrap();
+        let (node_id, router) = start(db.clone()).await.unwrap();
+
+        let (_ep, mut send, mut recv) = raw_stream(&router, &node_id).await;
+        write_frame(&mut send, &protocol::encode_auth(&alice, &drive).unwrap()).await;
+        assert_eq!(
+            read_frame(&mut recv).await.unwrap().first(),
+            Some(&tag::AUTH_OK)
+        );
+
+        let sync = protocol::encode_sync(&drive, "", &[], &std::collections::HashMap::new());
+        write_frame(&mut send, &sync).await;
+        let reply = read_frame(&mut recv).await.expect("a handshake answer");
+        assert!(
+            matches!(
+                reply.first(),
+                Some(&tag::SYNC_DIFF) | Some(&tag::SYNC_PUSH) | Some(&tag::SYNC_OK)
+            ),
+            "expected a sync answer, got 0x{:02x}",
+            reply[0]
         );
     }
 }

--- a/lib/src/sync/protocol.rs
+++ b/lib/src/sync/protocol.rs
@@ -135,6 +135,27 @@ pub mod error_code {
     /// still arrive, at which point the same commit would apply — so dropping
     /// it would discard a good edit. Keep it, stop retrying, and say so.
     pub const MISSING_CLASS: u16 = 4;
+    /// The frame needs an authenticated session and none has been
+    /// established: no `AUTH` frame succeeded on this connection (and, on
+    /// WebSocket, no auth headers came with the upgrade). Sent with
+    /// `request_id = 0`. Iroh closes the stream right after; a WebSocket
+    /// stays open so the client can still `AUTH` and retry. The client should
+    /// authenticate first — retrying the same frame without an `AUTH`
+    /// changes nothing.
+    pub const AUTH_REQUIRED: u16 = 5;
+    /// A `SYNC_PUSH` was refused as a whole — the agent may not write the
+    /// drive, or this node's sync policy does not admit it — and **nothing**
+    /// from it landed. Replaces the old behaviour of silently dropping the
+    /// import and still answering `SYNC_OK`, which made the ack meaningless.
+    /// The message names the drive. Blocking, not terminal: keep the local
+    /// state, stop pushing, and surface it.
+    pub const SYNC_REJECTED: u16 = 6;
+    /// A subscription (`SUB`, `SUBSCRIBE`, `SUBSCRIBE_QUERY`,
+    /// `LORO_SYNC_SUBSCRIBE`, `PRESENCE_SUBSCRIBE`) was refused because the
+    /// session's agent may not read the subject or drive it named. Nothing
+    /// was registered; no frames will follow for it. Same verdict a `GET`
+    /// would get, delivered instead of the old silent drop.
+    pub const UNAUTHORIZED_READ: u16 = 7;
 }
 
 /// Classify a commit-application error message into a structured code for

--- a/lib/src/sync/replicate.rs
+++ b/lib/src/sync/replicate.rs
@@ -45,9 +45,10 @@ pub enum ReplicateAuth {
     /// so this server can push as the owner without ever holding their key.
     /// The frame is timestamp-bound, so it must be minted for this attempt.
     PreSigned(Vec<u8>),
-    /// Connect anonymously. The remote then sees `ForAgent::Public`, which only
-    /// gets a drive in through the bootstrap carve-out (a drive it does not yet
-    /// have). Useful for public mirrors; useless for a private drive.
+    /// Connect anonymously. Only useful for *reading*: a WebSocket remote
+    /// refuses `SYNC_PUSH` before `AUTH` (`ERROR` code `AUTH_REQUIRED`), so an
+    /// anonymous replication can verify that a public drive is already in
+    /// sync, but can never land data.
     Anonymous,
 }
 
@@ -59,9 +60,11 @@ pub struct ReplicateOutcome {
     /// Blobs the remote asked for and we served.
     pub blobs_served: usize,
     /// The remote's drive hash matched ours on a second probe — i.e. the data
-    /// really landed. `SYNC_OK` alone does **not** prove this: the receiver
-    /// answers `SYNC_OK` even when it silently dropped the import for lack of
-    /// write rights, so we re-ask rather than trust the ack.
+    /// really landed. A refused import comes back as an `ERROR` frame
+    /// (`SYNC_REJECTED`) and fails the attempt outright; the second probe
+    /// guards against the subtler case where the remote accepted the push but
+    /// kept less than we sent (per-subject drops, quota), so we re-ask rather
+    /// than trust the per-chunk `SYNC_OK` ack.
     pub in_sync: bool,
 }
 
@@ -123,8 +126,8 @@ pub async fn replicate_drive_to_remote(
 
     // Round 2 — the honest verification. Re-offer our (unchanged) version
     // vector: if the push really landed, the remote's hash now matches ours and
-    // it answers SYNC_OK. A SYNC_DIFF here means it kept nothing, which is what
-    // a rights-rejected import looks like from the outside.
+    // it answers SYNC_OK. A SYNC_DIFF here means it kept less than we sent
+    // (an outright refusal would already have surfaced as an ERROR frame).
     outcome.in_sync = false;
     client
         .send_binary(build_sync_frame(store, drive).await)
@@ -171,9 +174,9 @@ async fn drive_exchange(
 
         match msg {
             // A SYNC_OK arriving before we pushed anything means our hashes
-            // already match. One arriving *after* is just a per-chunk ack, and
-            // acks prove nothing here — the receiver sends them for a dropped
-            // import too — so those fall through and we keep listening.
+            // already match. One arriving *after* is just a per-chunk ack —
+            // it says the chunk was admitted, not that every subject in it
+            // was kept — so those fall through and we keep listening.
             WsMessage::SyncOk { drive: d } if d == drive && sent_this_round == 0 => {
                 outcome.in_sync = true;
 

--- a/lib/src/sync/tests.rs
+++ b/lib/src/sync/tests.rs
@@ -102,7 +102,8 @@ mod peer_sync_tests {
                     );
                     let (count, _blob_requests) =
                         crate::sync::engine::import_sync_push(&push, &db_b, &ForAgent::Sudo, false)
-                            .await;
+                            .await
+                            .expect("Sudo import is never rejected");
                     total_imported += count;
                 }
             } else if tag == crate::sync::protocol::tag::SYNC_DIFF {
@@ -188,7 +189,8 @@ mod peer_sync_tests {
                             &ForAgent::Sudo,
                             false,
                         )
-                        .await;
+                        .await
+                        .expect("Sudo import is never rejected");
                         imported += count;
                     }
                 }
@@ -293,7 +295,8 @@ mod peer_sync_tests {
                 let push = crate::sync::protocol::decode_sync_push(&frame[1..]).unwrap();
                 let (_count, reqs) =
                     crate::sync::engine::import_sync_push(&push, &db_b, &ForAgent::Sudo, false)
-                        .await;
+                        .await
+                        .expect("Sudo import is never rejected");
                 blob_requests.extend(reqs);
             }
         }

--- a/planning/serverless-p2p.md
+++ b/planning/serverless-p2p.md
@@ -174,10 +174,14 @@ unblocked:
   (`sync::peer::initiator_trust_tests`), each proven against a reverted build
   (3 fail vulnerable, owner-still-works stays green); full 64-test sync suite
   incl. real two-endpoint Iroh e2e green.
-- [ ] **Require `AUTH` before `SYNC`/`SYNC_PUSH`/live frames** on accept
-  paths; reject instead of defaulting to `Public`.
-- [ ] **Bind `AUTH.requestedSubject` to the session's drive** so a proof for
-  one drive can't be replayed against another.
+- [x] **Require `AUTH` before `SYNC`/`SYNC_PUSH`/live frames** on accept
+  paths; reject instead of defaulting to `Public`. (2026-09-01: Iroh
+  `handle_stream` and the accept-side live loop answer `ERROR AUTH_REQUIRED`
+  and close; WS gates writes and identity-bearing subscriptions, anonymous
+  reads stay `check_read`-gated. `sync::peer::accept_gate_tests`.)
+- [x] **Bind `AUTH.requestedSubject` to the session's drive** so a proof for
+  one drive can't be replayed against another. (2026-09-01, Iroh accept
+  path; the browser signs the server origin so WS has nothing to bind.)
 - [ ] **Destroys become signed commits on the wire** (Principle 3): the live
   loop and bulk `remove[]` stop accepting naked deletes from peers; a
   destroy is a commit, validated like any other. Closes OQ4 and the F10
@@ -185,9 +189,11 @@ unblocked:
   closed as a decision — see the table below — but this item is still
   open: as of 2026-09-01 `peer.rs` still accepts the live `DESTROY` frame,
   gated by the cached drive-level write verdict.)*
-- [ ] Pre-auth frame budget in the live read loop (the `matches!(agent,
+- [x] Pre-auth frame budget in the live read loop (the `matches!(agent,
   Public)` gate exists in `handle_stream`; mirror it in
-  `register_live_peer`).
+  `register_live_peer`). (2026-09-01: the live loop now refuses every
+  non-AUTH frame from a still-`Public` peer we did not dial, which
+  subsumes the budget.)
 - [ ] **OQ5 for serverless:** a drive is admitted on a device iff the
   authenticated agent has write rights on it (same-agent: always true for
   your own drives). The `Err(_) => true` carve-out is replaced by "the

--- a/planning/unified-sync.md
+++ b/planning/unified-sync.md
@@ -741,7 +741,7 @@ Layer 2 — Bulk reconcile (same-agent catch-up / offline gap)
 | Layer | Proves identity | Proves rights | Deletes |
 | --- | --- | --- | --- |
 | **1 — Live / COMMIT** | WS `AUTH` or HTTP auth | Hub `apply_commit` + hierarchy | Signed destroy commit → `DESTROY` |
-| **2 — Bulk** | `AUTH` on stream before `SYNC` (required policy — not yet enforced) | `check_read` on push; `check_write` + admission on import | `remove[]` from peer tombstones — **not** signed on the wire |
+| **2 — Bulk** | `AUTH` on stream before `SYNC` (enforced on Iroh accept 2026-09-01; WS gates writes + identity-bearing subs, anonymous reads stay `check_read`-gated) | `check_read` on push; `check_write` + admission on import | `remove[]` from peer tombstones — **not** signed on the wire |
 
 **Policy:** authoritative delete = Layer 1 on the hub. Layer 2 `remove` only prevents
 resurrection between honest replicas of the same agent.
@@ -790,9 +790,25 @@ resurrection between honest replicas of the same agent.
   destroyed via the initiator's ungated `SYNC_DIFF.remove[]` apply — that's F9 proper.
 - [x] **F11:** clear tombstone when a rights-checked commit re-creates the subject
   (2026-07-02).
-- [ ] **Require `AUTH` before `SYNC` / `SYNC_PUSH`** on accept paths (fail closed) —
-  F9 is the concrete exploit this abstract item was about.
-- [ ] **Bind `AUTH.requestedSubject` to `SYNC.drive`** for the session.
+- [x] **Require `AUTH` before `SYNC` / `SYNC_PUSH`** on accept paths (fail closed) —
+  F9 is the concrete exploit this abstract item was about. (2026-09-01) Iroh
+  `handle_stream` accepts only `AUTH` pre-auth and answers anything else with
+  `ERROR AUTH_REQUIRED (5)` + closed stream; a failed `AUTH` closes too; the
+  `register_live_peer` read loop refuses non-AUTH frames from a still-`Public`
+  peer we did not dial. WS: `SYNC_PUSH`, `BLOB_RESPONSE`, `LORO_SYNC_UPDATE`,
+  `LORO_EPHEMERAL_UPDATE`, `PRESENCE_UPDATE`, `SUBSCRIBE`, `SUBSCRIBE_QUERY`,
+  `LORO_SYNC_SUBSCRIBE`, `PRESENCE_SUBSCRIBE` require `AUTH`; anonymous
+  `GET` / `SUB` / `SYNC` / `SYNC_VV` stay open behind `check_read` (public share
+  links). Tests: `sync::peer::accept_gate_tests`, `server/tests/it/ws_auth_gate.rs`.
+- [x] **Bind `AUTH.requestedSubject` to `SYNC.drive`** for the session (2026-09-01,
+  Iroh accept path only: the first handshake `SYNC`/`SYNC_PUSH` must name the
+  drive the `AUTH` was signed for. Not possible over WS — the browser signs the
+  server origin, not a drive.)
+- [x] **`SYNC_PUSH` rejection is visible** (2026-09-01): `import_sync_push` returns
+  `Err(SyncPushRejected)` for a rights/policy refusal and the engine answers
+  `ERROR SYNC_REJECTED (6)` instead of `SYNC_OK`; subscriptions refused by
+  `check_read` answer `ERROR UNAUTHORIZED_READ (7)` instead of dropping silently.
+  Browser keeps the drive un-synced (`Store.failDriveSync`, `lastDriveSyncError`).
 - [ ] **Subscription identity refresh:** re-evaluate `SUBSCRIBE`/`SUBSCRIBE_QUERY`
   agent binding when a connection's AUTH lands or changes (see drift inventory).
 - [ ] **F6:** fence `apply_commit_json` (trusted-hub-only naming/docs); consider the
@@ -954,9 +970,10 @@ work in that plan's Phase P0, not a decision-gated maybe.
   `remote_agent` instead of `Sudo` on initiator `import_sync_push`; the initiator's
   ungated `apply_destroy` on `SYNC_DIFF.remove[]` for known subjects now gated via
   `apply_peer_remove` (closes the F10 known-subject residual). Revert-proven
-  `sync::peer::initiator_trust_tests`. The remaining P0 items (fail-closed AUTH-before-SYNC,
-  `AUTH.requestedSubject`↔drive binding, "deletes as signed destroy commits" per OQ4)
-  stay open in [`serverless-p2p.md`](./serverless-p2p.md) Phase P0.
+  `sync::peer::initiator_trust_tests`. Fail-closed AUTH-before-SYNC and the
+  `AUTH.requestedSubject`↔drive binding landed 2026-09-01 (see the ticked items
+  above); "deletes as signed destroy commits" per OQ4 stays open in
+  [`serverless-p2p.md`](./serverless-p2p.md) Phase P0.
 - [x] F10: reject phantom tombstones for locally-*unknown* subjects from
   unprivileged peers (2026-07-02). **Does not** cover a known subject destroyed via
   the initiator's ungated remove-apply — that's F9 proper, above.

--- a/planning/unify-subscription-primitives.md
+++ b/planning/unify-subscription-primitives.md
@@ -25,9 +25,10 @@ and doesn't need to. Three actor handlers + three fanout loops on every
 
 ## Observations
 
-- `SUBSCRIBE <subject>` has **no permission check** today. That's a
-  latent issue: any authenticated agent can SUB any subject and receive
-  every commit on it.
+- `SUBSCRIBE <subject>` used to have **no permission check**; it now runs
+  `check_read` on the subject in `CommitMonitor::Subscribe`, and (since
+  2026-09-01) every refused subscription answers `ERROR UNAUTHORIZED_READ`
+  instead of dropping silently, and needs `AUTH` first.
 - The `SUB <drive>` binary tag and the `SUBSCRIBE <subject>` text frame
   are doing nearly the same job. The former is "drive-scoped", the
   latter is "subject-scoped" — both could be a degenerate filter.

--- a/server/src/actor_messages.rs
+++ b/server/src/actor_messages.rs
@@ -17,6 +17,13 @@ pub struct Subscribe {
     /// to subscribers whose `source_id` matches an event's `source_id`,
     /// so a client never receives its own commit back.
     pub source_id: String,
+    /// The wire frame this subscription came from — `"SUBSCRIBE"` for the
+    /// text frame, `"SUB"` for the binary drive subscription. Named in the
+    /// ERROR a refusal sends back. `None` for the companion subscription a
+    /// `SUB` adds for the drive resource itself: the `SubscribeDrive` sent
+    /// alongside it already answers that frame, and one frame gets one
+    /// answer.
+    pub refusal_frame: Option<&'static str>,
 }
 
 /// A message containing a Resource, which should be sent to subscribers
@@ -204,6 +211,31 @@ pub struct UnsubscribeAll {
 #[rtype(result = "()")]
 pub struct SendFrame {
     pub frame: Arc<[u8]>,
+}
+
+/// Tell a connection that a subscription it asked for was refused, as an
+/// `ERROR` frame (`request_id = 0`,
+/// [`atomic_lib::sync::protocol::error_code::UNAUTHORIZED_READ`]). Every
+/// subscription handler used to drop a failed `check_read` on the floor, so
+/// a client could not tell "subscribed, nothing has changed yet" from
+/// "never subscribed" — the same silence `SYNC_OK`-on-rejection produced
+/// for pushes. Sent from the actor that made the decision, since the
+/// connection actor fired the request off with `do_send` and is not
+/// waiting on a reply.
+pub fn refuse_subscription(
+    addr: &Addr<crate::handlers::web_sockets::WebSocketConnection>,
+    what: &str,
+    subject: &str,
+    reason: &str,
+) {
+    let frame = atomic_lib::sync::protocol::encode_error(
+        0,
+        atomic_lib::sync::protocol::error_code::UNAUTHORIZED_READ,
+        &format!("{what} refused for {subject}: {reason}"),
+    );
+    addr.do_send(SendFrame {
+        frame: Arc::from(frame),
+    });
 }
 
 /// Forwarded into `CommitMonitor` by the `DbEvent::QueryMembershipChanged`

--- a/server/src/commit_monitor.rs
+++ b/server/src/commit_monitor.rs
@@ -310,6 +310,14 @@ impl Handler<Subscribe> for CommitMonitor {
                                     &msg.subject,
                                     unauthorized_err
                                 );
+                                if let Some(frame) = msg.refusal_frame {
+                                    crate::actor_messages::refuse_subscription(
+                                        &msg.addr,
+                                        frame,
+                                        &msg.subject.to_string(),
+                                        &unauthorized_err.to_string(),
+                                    );
+                                }
                                 None
                             }
                         }
@@ -321,6 +329,18 @@ impl Handler<Subscribe> for CommitMonitor {
                             msg.agent,
                             e
                         );
+                        // Same frame as a rights failure: whether the subject
+                        // is unreadable or absent is not something an agent
+                        // without read rights gets to learn here, any more
+                        // than a GET would tell it.
+                        if let Some(frame) = msg.refusal_frame {
+                            crate::actor_messages::refuse_subscription(
+                                &msg.addr,
+                                frame,
+                                &msg.subject.to_string(),
+                                "not readable",
+                            );
+                        }
                         None
                     }
                 }
@@ -360,6 +380,12 @@ impl Handler<SubscribeDrive> for CommitMonitor {
                     Ok(r) => r,
                     Err(e) => {
                         tracing::debug!("SubscribeDrive: drive {drive_subject} not found: {e}");
+                        crate::actor_messages::refuse_subscription(
+                            &msg.addr,
+                            "SUB",
+                            &drive_subject.to_string(),
+                            "not readable",
+                        );
                         return None;
                     }
                 };
@@ -375,6 +401,12 @@ impl Handler<SubscribeDrive> for CommitMonitor {
                         tracing::debug!(
                             "SubscribeDrive: {} cannot read drive {drive_subject}: {e}",
                             msg.agent
+                        );
+                        crate::actor_messages::refuse_subscription(
+                            &msg.addr,
+                            "SUB",
+                            &drive_subject.to_string(),
+                            &e.to_string(),
                         );
                         None
                     }
@@ -437,6 +469,12 @@ impl Handler<SubscribeQuery> for CommitMonitor {
                         tracing::debug!(
                             "Rejecting SUBSCRIBE_QUERY: drive {drive_subject} not found: {e}"
                         );
+                        crate::actor_messages::refuse_subscription(
+                            &msg.addr,
+                            "SUBSCRIBE_QUERY",
+                            &drive_subject.to_string(),
+                            "not readable",
+                        );
                         return None;
                     }
                 };
@@ -472,6 +510,12 @@ impl Handler<SubscribeQuery> for CommitMonitor {
                     Err(e) => {
                         tracing::debug!(
                             "Rejecting SUBSCRIBE_QUERY: {agent} cannot read drive {drive_subject}: {e}"
+                        );
+                        crate::actor_messages::refuse_subscription(
+                            &msg.addr,
+                            "SUBSCRIBE_QUERY",
+                            &drive_subject.to_string(),
+                            &e.to_string(),
                         );
                         None
                     }

--- a/server/src/handlers/web_sockets.rs
+++ b/server/src/handlers/web_sockets.rs
@@ -229,9 +229,49 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebSocketConnecti
 }
 
 impl WebSocketConnection {
+    /// Whether this session has a proven identity: auth headers on the
+    /// upgrade request, or an `AUTH` frame that succeeded. A session that
+    /// has neither is `Public`.
+    fn is_authenticated(&self) -> bool {
+        !matches!(self.agent, ForAgent::Public)
+    }
+
+    /// Gate for frames that need an identity. Reads (`GET`, `SUB <drive>`,
+    /// `SYNC`, `SYNC_VV`) stay open to anonymous sessions, gated per subject
+    /// on `check_read` exactly like an anonymous HTTP GET — that is what
+    /// lets a public drive's share link show live updates without an
+    /// account. Everything that writes (`SYNC_PUSH`, `BLOB_RESPONSE`,
+    /// `LORO_SYNC_UPDATE`, `PRESENCE_UPDATE`, …) or that registers an
+    /// identity-bearing subscription goes through here, and an anonymous
+    /// session gets an `ERROR` (`AUTH_REQUIRED`, request_id 0) instead of
+    /// being handled as `Public`. The socket stays open: the client can
+    /// still `AUTH` and retry. See `docs/src/websockets.md`.
+    fn require_auth(&self, what: &str, ctx: &mut ws::WebsocketContext<Self>) -> bool {
+        if self.is_authenticated() {
+            return true;
+        }
+        tracing::debug!("ws {}: refused {what} before AUTH", self.connection_id);
+        ctx.binary(ws_v2::encode_error(
+            0,
+            ws_v2::error_code::AUTH_REQUIRED,
+            &format!("AUTH required before {what}"),
+        ));
+        false
+    }
+
     /// Handle a binary v2 frame.
     fn handle_binary(&mut self, bin: &[u8], ctx: &mut ws::WebsocketContext<Self>) {
         if bin.is_empty() {
+            return;
+        }
+
+        // Writes need an identity. The engine would refuse them for `Public`
+        // anyway (no write right, no admission) — but "refuse" used to mean
+        // a silent drop answered with `SYNC_OK`; now it is an explicit
+        // `AUTH_REQUIRED` before the frame is even looked at.
+        if matches!(bin[0], ws_v2::tag::SYNC_PUSH | ws_v2::tag::BLOB_RESPONSE)
+            && !self.require_auth(&format!("frame 0x{:02x}", bin[0]), ctx)
+        {
             return;
         }
 
@@ -357,6 +397,7 @@ impl WebSocketConnection {
                             subject: subject.clone(),
                             agent: self.agent.to_string(),
                             source_id: self.connection_id.clone(),
+                            refusal_frame: None,
                         });
                     self.subscribed.insert(subject);
                 }
@@ -403,6 +444,9 @@ impl WebSocketConnection {
                 }
             }
         } else if let Some(json) = text.strip_prefix("LORO_SYNC_SUBSCRIBE ") {
+            if !self.require_auth("LORO_SYNC_SUBSCRIBE", ctx) {
+                return;
+            }
             if let Ok(msg) =
                 serde_json::from_str::<crate::actor_messages::LoroSubscriptionJSON>(json)
             {
@@ -425,6 +469,9 @@ impl WebSocketConnection {
                 );
             }
         } else if let Some(json) = text.strip_prefix("LORO_SYNC_UPDATE ") {
+            if !self.require_auth("LORO_SYNC_UPDATE", ctx) {
+                return;
+            }
             if let Ok(mut update) =
                 serde_json::from_str::<crate::actor_messages::LoroSyncUpdate>(json)
             {
@@ -432,6 +479,9 @@ impl WebSocketConnection {
                 self.loro_sync_broadcaster_addr.do_send(update);
             }
         } else if let Some(json) = text.strip_prefix("LORO_EPHEMERAL_UPDATE ") {
+            if !self.require_auth("LORO_EPHEMERAL_UPDATE", ctx) {
+                return;
+            }
             if let Ok(mut update) =
                 serde_json::from_str::<crate::actor_messages::LoroEphemeralUpdate>(json)
             {
@@ -441,6 +491,9 @@ impl WebSocketConnection {
         } else if let Some(json) = text.strip_prefix("PRESENCE_SUBSCRIBE ") {
             // Drive-scoped ephemeral presence (issue #1229). Reuses the
             // Loro subscription JSON shape: `{"subject": "<drive>"}`.
+            if !self.require_auth("PRESENCE_SUBSCRIBE", ctx) {
+                return;
+            }
             if let Ok(msg) =
                 serde_json::from_str::<crate::actor_messages::LoroSubscriptionJSON>(json)
             {
@@ -463,6 +516,9 @@ impl WebSocketConnection {
                 );
             }
         } else if let Some(json) = text.strip_prefix("PRESENCE_UPDATE ") {
+            if !self.require_auth("PRESENCE_UPDATE", ctx) {
+                return;
+            }
             if let Ok(mut update) =
                 serde_json::from_str::<crate::actor_messages::PresenceUpdate>(json)
             {
@@ -475,6 +531,9 @@ impl WebSocketConnection {
             // `UPDATE` / `DESTROY` frames via `MembershipNotification`
             // — see `Handler<MembershipNotification>` below and
             // `planning/drop-query-update.md`.
+            if !self.require_auth("SUBSCRIBE_QUERY", ctx) {
+                return;
+            }
             if let Ok(query) =
                 serde_json::from_str::<crate::actor_messages::QuerySubscriptionJSON>(json)
             {
@@ -487,6 +546,9 @@ impl WebSocketConnection {
                     });
             }
         } else if let Some(json) = text.strip_prefix("SUBSCRIBE ") {
+            if !self.require_auth("SUBSCRIBE", ctx) {
+                return;
+            }
             let subject =
                 atomic_lib::Subject::from_raw(json, self.store.get_base_domain().as_deref());
             self.commit_monitor_addr
@@ -495,6 +557,7 @@ impl WebSocketConnection {
                     subject: subject.clone(),
                     agent: self.agent.to_string(),
                     source_id: self.connection_id.clone(),
+                    refusal_frame: Some("SUBSCRIBE"),
                 });
             self.subscribed.insert(subject);
         } else if let Some(json) = text.strip_prefix("SYNC_VV ") {

--- a/server/src/loro_sync_broadcaster.rs
+++ b/server/src/loro_sync_broadcaster.rs
@@ -102,6 +102,12 @@ impl Handler<SubscribeLoroSync> for LoroSyncBroadcaster {
                                     &msg.subject,
                                     unauthorized_err
                                 );
+                                crate::actor_messages::refuse_subscription(
+                                    &msg.addr,
+                                    "LORO_SYNC_SUBSCRIBE",
+                                    &msg.subject.to_string(),
+                                    &unauthorized_err.to_string(),
+                                );
                                 return None;
                             }
                         }
@@ -287,6 +293,12 @@ impl Handler<SubscribePresence> for LoroSyncBroadcaster {
                         &msg.agent,
                         &msg.drive,
                         unauthorized_err
+                    );
+                    crate::actor_messages::refuse_subscription(
+                        &msg.addr,
+                        "PRESENCE_SUBSCRIBE",
+                        &msg.drive.to_string(),
+                        &unauthorized_err.to_string(),
                     );
                     return None;
                 }

--- a/server/tests/it/main.rs
+++ b/server/tests/it/main.rs
@@ -17,6 +17,7 @@ mod put_blob;
 mod replicate;
 mod server_cli;
 mod sync;
+mod ws_auth_gate;
 mod ws_commit;
 mod ws_commit_isolation;
 mod ws_destroy;

--- a/server/tests/it/replicate.rs
+++ b/server/tests/it/replicate.rs
@@ -43,8 +43,8 @@ async fn source_node(unique: &str) -> (Db, atomic_lib::agents::Agent, String, St
 /// The whole point of the feature: a drive on a server the target has never
 /// heard of, pushed to it, and *verifiably* present afterwards.
 ///
-/// `in_sync` is the assertion that matters. The receiver answers `SYNC_OK` even
-/// when it silently discards an import for lack of write rights, so only a
+/// `in_sync` is the assertion that matters. A refused import now comes back as
+/// an `ERROR` frame, but `SYNC_OK` still only acknowledges the chunk, so only a
 /// second version-vector probe agreeing proves the data is really there.
 #[tokio::test]
 async fn pushes_a_drive_to_a_server_that_has_never_seen_it() {

--- a/server/tests/it/ws_auth_gate.rs
+++ b/server/tests/it/ws_auth_gate.rs
@@ -1,0 +1,260 @@
+//! Integration tests for the WebSocket trust gates: which frames need an
+//! AUTH first, that a subscription without read rights is refused out loud,
+//! and that a refused SYNC_PUSH is answered with an ERROR and never with
+//! SYNC_OK.
+//!
+//! Every refusal here used to be silent (a dropped frame, or a `SYNC_OK`
+//! for an import that never happened). These tests pin the *visible*
+//! answer: an `ERROR` frame whose code says what went wrong.
+//!
+//! Run with: cargo test -p atomic-server --test it ws_auth_gate
+
+use atomic_lib::{
+    agents::Agent,
+    client::{
+        connected::Client,
+        ws::{WsClient, WsMessage},
+    },
+    sync::protocol,
+};
+use std::time::Duration;
+use tokio::sync::broadcast::Receiver;
+
+use crate::common::{start_server, wait_for_server};
+
+/// Wait for the next `ERROR` the server sends on this connection.
+async fn next_error(rx: &mut Receiver<WsMessage>) -> String {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(WsMessage::Error(e)) => return e,
+                Ok(_) => continue,
+                Err(e) => panic!("connection closed before an ERROR arrived: {e}"),
+            }
+        }
+    })
+    .await
+    .expect("server answers a refused frame with an ERROR within 5s")
+}
+
+/// Assert that no `SYNC_OK` (and no ERROR either) shows up for a while.
+async fn assert_quiet(rx: &mut Receiver<WsMessage>) {
+    let unexpected = tokio::time::timeout(Duration::from_millis(700), async {
+        loop {
+            match rx.recv().await {
+                Ok(WsMessage::SyncOk { .. }) => return "SYNC_OK",
+                Ok(WsMessage::Error(_)) => return "ERROR",
+                Ok(_) => continue,
+                Err(_) => return "closed",
+            }
+        }
+    })
+    .await;
+    assert!(
+        unexpected.is_err(),
+        "expected silence, got {}",
+        unexpected.unwrap()
+    );
+}
+
+/// A SYNC_PUSH frame for `drive` carrying one entry with `bytes`. The
+/// content is irrelevant to a rights refusal: the gate fires before any
+/// entry is looked at.
+fn sync_push(drive: &str, subject: &str, bytes: &[u8]) -> Vec<u8> {
+    protocol::encode_sync_push(drive, &[(subject, bytes)], true)
+}
+
+/// A private drive owned by `owner`, plus one child in it that a stranger
+/// cannot read.
+async fn private_drive_with_child(client: &Client, owner: &Agent) -> (String, String) {
+    let drive = client.new_drive(owner, "Private").await.unwrap();
+    let mut child = client.new_resource(&drive).unwrap();
+    child.set_name("Secret").unwrap();
+    child
+        .set_unsafe(
+            atomic_lib::urls::SHORTNAME.into(),
+            atomic_lib::Value::Slug("secret".into()),
+        )
+        .unwrap();
+    child
+        .set_unsafe(
+            atomic_lib::urls::DESCRIPTION.into(),
+            atomic_lib::Value::String("only the owner can read this".into()),
+        )
+        .unwrap();
+    child
+        .set_unsafe(
+            atomic_lib::urls::IS_A.into(),
+            atomic_lib::Value::ResourceArray(vec![atomic_lib::urls::CLASS.into()]),
+        )
+        .unwrap();
+    let subject = child.save_remote(client.store()).await.unwrap();
+    (drive, subject)
+}
+
+/// Frames that write, or that carry an identity to peers, are refused
+/// before AUTH with `AUTH_REQUIRED`. The socket stays open: an anonymous
+/// session of a public share link keeps reading.
+#[tokio::test]
+async fn anonymous_writes_and_identity_subscriptions_are_refused() {
+    let port = start_server("ws_gate_anon");
+    wait_for_server(port).await;
+    let server_url = format!("http://localhost:{port}");
+    let ws_url = format!("ws://localhost:{port}/ws");
+
+    let client = Client::new(&server_url).await.unwrap();
+    let alice = client.new_agent("Alice").await.unwrap();
+    let drive = client.new_public_drive(&alice, "Public").await.unwrap();
+
+    let ws = WsClient::connect(&ws_url).await.unwrap();
+    let mut rx = ws.subscribe();
+
+    // Binary SYNC_PUSH: the one that used to bootstrap a stranger's drive
+    // onto an open node without anyone saying who they were.
+    ws.send_binary(sync_push(&drive, "did:ad:x", b"junk"))
+        .await
+        .unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(err.contains("AUTH required"), "{err}");
+
+    // The text frames that carry an identity or write.
+    for frame in [
+        format!("SUBSCRIBE {drive}"),
+        format!(r#"SUBSCRIBE_QUERY {{"drive":"{drive}"}}"#),
+        format!(r#"LORO_SYNC_SUBSCRIBE {{"subject":"{drive}"}}"#),
+        format!(r#"LORO_SYNC_UPDATE {{"subject":"{drive}","update":""}}"#),
+        format!(r#"PRESENCE_SUBSCRIBE {{"subject":"{drive}"}}"#),
+        format!(r#"PRESENCE_UPDATE {{"subject":"{drive}","update":""}}"#),
+    ] {
+        ws.send_raw(&frame).await.unwrap();
+        let err = next_error(&mut rx).await;
+        assert!(err.contains("AUTH required"), "{frame} -> {err}");
+    }
+
+    // And the socket is still usable: AUTH now succeeds on the same
+    // connection, so the refusals were per frame, not per connection.
+    ws.authenticate(&alice)
+        .await
+        .expect("the connection survives its refused frames");
+}
+
+/// Anonymous *reads* are not gated by AUTH — `SUB <drive>` is what a
+/// public share link uses for live updates. The read gate is `check_read`,
+/// which an anonymous session passes for a public drive.
+#[tokio::test]
+async fn anonymous_drive_subscription_on_a_public_drive_is_accepted() {
+    let port = start_server("ws_gate_anon_sub");
+    wait_for_server(port).await;
+    let server_url = format!("http://localhost:{port}");
+    let ws_url = format!("ws://localhost:{port}/ws");
+
+    let client = Client::new(&server_url).await.unwrap();
+    let alice = client.new_agent("Alice").await.unwrap();
+    let drive = client.new_public_drive(&alice, "Public").await.unwrap();
+
+    let ws = WsClient::connect(&ws_url).await.unwrap();
+    let mut rx = ws.subscribe();
+    ws.send_binary(protocol::encode_sub(&drive)).await.unwrap();
+    assert_quiet(&mut rx).await;
+}
+
+/// An authenticated agent without read rights on the subject is told so
+/// (`UNAUTHORIZED_READ`) instead of being left to wait for updates that
+/// never come.
+#[tokio::test]
+async fn subscription_without_read_right_is_refused_out_loud() {
+    let port = start_server("ws_gate_read");
+    wait_for_server(port).await;
+    let server_url = format!("http://localhost:{port}");
+    let ws_url = format!("ws://localhost:{port}/ws");
+
+    let client = Client::new(&server_url).await.unwrap();
+    let alice = client.new_agent("Alice").await.unwrap();
+    let (drive, secret) = private_drive_with_child(&client, &alice).await;
+    let mallory = client.new_agent("Mallory").await.unwrap();
+
+    let ws = WsClient::connect(&ws_url).await.unwrap();
+    ws.authenticate(&mallory).await.unwrap();
+    let mut rx = ws.subscribe();
+
+    ws.subscribe_resource(&secret).await.unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(
+        err.contains("SUBSCRIBE refused") && err.contains(&secret),
+        "{err}"
+    );
+
+    ws.send_binary(protocol::encode_sub(&drive)).await.unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(err.contains("SUB refused") && err.contains(&drive), "{err}");
+
+    ws.send_raw(&format!(r#"SUBSCRIBE_QUERY {{"drive":"{drive}"}}"#))
+        .await
+        .unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(err.contains("SUBSCRIBE_QUERY refused"), "{err}");
+
+    ws.subscribe_loro_sync(&secret).await.unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(err.contains("LORO_SYNC_SUBSCRIBE refused"), "{err}");
+
+    ws.send_raw(&format!(r#"PRESENCE_SUBSCRIBE {{"subject":"{drive}"}}"#))
+        .await
+        .unwrap();
+    let err = next_error(&mut rx).await;
+    assert!(err.contains("PRESENCE_SUBSCRIBE refused"), "{err}");
+
+    // The owner's subscriptions to the same things go through silently.
+    let ws_owner = WsClient::connect(&ws_url).await.unwrap();
+    ws_owner.authenticate(&alice).await.unwrap();
+    let mut rx_owner = ws_owner.subscribe();
+    ws_owner.subscribe_resource(&secret).await.unwrap();
+    ws_owner
+        .send_binary(protocol::encode_sub(&drive))
+        .await
+        .unwrap();
+    assert_quiet(&mut rx_owner).await;
+}
+
+/// A SYNC_PUSH into a drive the agent may not write is answered with
+/// `SYNC_REJECTED` — and, the point of the change, *not* with `SYNC_OK`.
+#[tokio::test]
+async fn rejected_sync_push_gets_error_not_sync_ok() {
+    let port = start_server("ws_gate_push");
+    wait_for_server(port).await;
+    let server_url = format!("http://localhost:{port}");
+    let ws_url = format!("ws://localhost:{port}/ws");
+
+    let client = Client::new(&server_url).await.unwrap();
+    let alice = client.new_agent("Alice").await.unwrap();
+    let (drive, secret) = private_drive_with_child(&client, &alice).await;
+    let mallory = client.new_agent("Mallory").await.unwrap();
+
+    let ws = WsClient::connect(&ws_url).await.unwrap();
+    ws.authenticate(&mallory).await.unwrap();
+    let mut rx = ws.subscribe();
+
+    ws.send_binary(sync_push(&drive, &secret, b"junk"))
+        .await
+        .unwrap();
+
+    let answer = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(WsMessage::Error(e)) => return Ok(e),
+                Ok(WsMessage::SyncOk { drive }) => return Err(drive),
+                Ok(_) => continue,
+                Err(e) => panic!("connection closed: {e}"),
+            }
+        }
+    })
+    .await
+    .expect("the push is answered within 5s");
+    let err = answer.expect("a refused push is answered with ERROR, not SYNC_OK");
+    assert!(
+        err.contains("SYNC_PUSH rejected") && err.contains(&drive),
+        "{err}"
+    );
+    assert!(err.contains("no write right"), "{err}");
+    assert_quiet(&mut rx).await;
+}


### PR DESCRIPTION
## What

Three concrete trust gaps in the peer protocol, on both transports (WebSocket and Iroh) plus the browser client.

### 1. AUTH before SYNC (fail-closed)

**Iroh** (`lib/src/sync/peer.rs`): the accept path serves nothing but `AUTH` until a successful `AUTH`; anything else before that gets `ERROR AUTH_REQUIRED` and the stream is finished (the ERROR is flushed before close — `refuse_stream` awaits `send.stopped()`). A failed `AUTH` closes the stream. `AUTH.requestedSubject` is bound to the drive named by the handshake `SYNC`/`SYNC_PUSH`: an AUTH for drive A does not open drive B. The live loop refuses non-AUTH frames from Public peers we did not dial.

**WebSocket** (`server/src/handlers/web_sockets.rs`): writes (`SYNC_PUSH`, `BLOB_RESPONSE`, `LORO_SYNC_UPDATE`, `LORO_EPHEMERAL_UPDATE`, `PRESENCE_UPDATE`) and identity-bearing subscriptions (`SUBSCRIBE`, `SUBSCRIBE_QUERY`, `LORO_SYNC_SUBSCRIBE`, `PRESENCE_SUBSCRIBE`) are answered with `ERROR AUTH_REQUIRED` before AUTH. The socket stays open.

**Judgment call:** anonymous *reads* on the WebSocket (`GET`, `SUB <drive>`, `SYNC`, `SYNC_VV`, RBSR) stay open behind `check_read`. Public share links and the e2e canvas-live-update flow rely on an anonymous `SUB <drive>`, and those reads were already rights-checked. Closing the socket on refusal would also break the "log in on the same connection" flow the browser uses. If we want the WS fully fail-closed like Iroh, that is a one-line change in `handle_binary`/`handle_text`, but it needs a browser-side change first. The WS cannot bind `requestedSubject` to a drive: the browser signs the server origin, not a drive.

### 2. SUBSCRIBE checks read rights, out loud

`SUBSCRIBE <subject>`, `SUB <drive>`, `SUBSCRIBE_QUERY`, `LORO_SYNC_SUBSCRIBE` and `PRESENCE_SUBSCRIBE` all ran `check_read` already but dropped the request silently on failure. They now answer `ERROR UNAUTHORIZED_READ` (`<FRAME> refused for <subject>: <reason>`) via `actor_messages::refuse_subscription`, from `CommitMonitor` and `LoroSyncBroadcaster`. A resource that does not exist is refused the same way (no existence oracle).

### 3. A refused SYNC_PUSH is never answered with SYNC_OK

`SyncEngine::import_sync_push` returns `Result<(usize, Vec<Vec<u8>>), SyncPushRejected>` (no write right / over quota / not enrolled). `handle_frame` answers `ERROR SYNC_REJECTED` (`SYNC_PUSH rejected for drive <drive>: <reason>`) instead of `SYNC_OK`. The Rust replicator and the Iroh initiator turn it into an `Err`. The browser (`browser/lib/src/websockets.ts`, `store.ts`) logs it, calls the new `store.failDriveSync(drive, message)` which clears the drive from `_syncedDrives` and records `StoreSyncStatus.lastDriveSyncError`, so the subject stays dirty and is retried on the next push. `AUTH_REQUIRED`/`UNAUTHORIZED_READ` are logged as warnings without rejecting unrelated pending requests; `reSubscribeAll` skips Loro/presence subs when there is no agent.

New error codes in `lib/src/sync/protocol.rs::error_code` and `browser/lib/src/ws-v2.ts::ErrorCode`: `AUTH_REQUIRED 5`, `SYNC_REJECTED 6`, `UNAUTHORIZED_READ 7`.

## Tests

- `lib/src/sync/peer.rs::accept_gate_tests` (5): engine-level rejection, ERROR-not-SYNC_OK, Iroh SYNC-before-AUTH refused + stream closed, AUTH for one drive does not open another, AUTH then SYNC for the same drive is served.
- `server/tests/it/ws_auth_gate.rs` (4): anonymous writes/identity subs refused and the socket survives, anonymous `SUB` on a public drive accepted, subscriptions without read right refused out loud (owner is silent), rejected push gets ERROR not SYNC_OK.
- Ran: `cargo test -p atomic_lib --features "iroh,db-redb" --lib -- sync:: --test-threads=1`, `atomic-server` lib tests plus it suites `sync ws_get ws_commit ws_subscribe_query multi_client_sync replicate blob_sync drive_presence loro_ephemeral_sync iroh_pairing ws_drive_membership ws_destroy ws_commit_isolation ws_auth_gate`, clippy on both crates (remaining warnings are pre-existing), `pnpm exec tsc --noEmit && pnpm lint && pnpm test` in `browser/lib`.

## Docs / planning

`docs/src/websockets.md` (refused-before-AUTH, error codes 4–7, subscription refusal, SYNC_PUSH ack/rejection), `planning/unified-sync.md`, `planning/serverless-p2p.md`, `planning/unify-subscription-primitives.md` (stale "no permission check" claim corrected), `TESTING_COVERAGE.md`.

## Out of scope

The F1 redesign (signed state root / provenance-carrying SYNC_PUSH so a node can verify *who* authored entries rather than trusting the pushing agent's rights) is intentionally not attempted here. `SYNC_OK` still only acknowledges that the chunk was imported.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
