### PR TITLE
feat(managed): sign the Cloud Server enrollment challenge

### DIFF
--- a/browser/data-browser/src/helpers/managed/cloudSync.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.ts
@@ -7,15 +7,18 @@
 //   1. There must be a managed account/session — without one there's nothing to
 //      enroll against, so we bail out asking the caller to send the user to the
 //      portal to sign up.
-//   2. Create the enrollment. The control plane picks an available node and
-//      returns its `http_origin`; only after the enrollment exists will that
-//      node ACCEPT the drive's pushed commits (open nodes admit anything; a
-//      managed node checks the enrollment first).
+//   2. Create the enrollment, signed: the control plane issues a challenge that
+//      the drive's agent signs with its key (plus the drive's genesis
+//      certificate for a non-personal drive), proving it controls the drive
+//      before anyone can host it under their account. The control plane then
+//      picks an available node and returns its `http_origin`; only after the
+//      enrollment exists will that node ACCEPT the drive's pushed commits
+//      (open nodes admit anything; a managed node checks the enrollment first).
 //   3. Point the app at that node and, if the drive was local-only, promote it
 //      so the sync engine actually pushes it up.
 
 import { getManagedAccount } from './session';
-import { createManagedSyncEnrollment } from './enrollment';
+import { createManagedSyncEnrollment, genesisCertOf } from './enrollment';
 import { getManagedEnrollments } from './enrollmentApi';
 import type { ManagedInfo } from '../managedServer';
 import { isRunningInTauri } from '../tauri';
@@ -212,9 +215,21 @@ export async function enableCloudSyncForDrive(params: {
 
   const wasLocalOnly = store.isLocalOnlyDrive(drive);
 
+  // The proof needs the key (the store's agent) and, for a drive that is not
+  // the agent's personal one, the drive's genesis certificate. A drive we
+  // cannot load locally is enrolled without the certificate; the control plane
+  // then decides whether it can still prove control from the key alone.
+  const agent = store.getAgent();
+  const genesisCert = await store
+    .getResource(drive)
+    .then(resource => genesisCertOf(resource))
+    .catch(() => undefined);
+
   const enrollment = await createManagedSyncEnrollment({
     driveSubject: drive,
     agentSubject,
+    agent: agent?.subject === agentSubject ? agent : undefined,
+    genesisCert,
   });
 
   const httpOrigin = enrollment.http_origin ?? null;

--- a/browser/data-browser/src/helpers/managed/enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Agent, JSCryptoProvider, decodeB64 } from '@tomic/lib';
 
 const managedFetch = vi.fn();
 vi.mock('./api', () => ({
@@ -8,7 +9,8 @@ vi.mock('./api', () => ({
 vi.mock('./session', () => ({ getManagedAccount: async () => null }));
 vi.mock('./binding', () => ({ writeManagedAccountBinding: () => undefined }));
 
-const { createManagedSyncEnrollment } = await import('./enrollment');
+const { createManagedSyncEnrollment, buildEnrollmentProof, genesisCertOf } =
+  await import('./enrollment');
 
 beforeEach(() => {
   managedFetch.mockReset();
@@ -21,11 +23,27 @@ const failWith = (status: number, body: unknown) =>
     json: async () => body,
   });
 
+const succeedWith = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
 const enroll = () =>
   createManagedSyncEnrollment({
     driveSubject: 'did:ad:drive',
     agentSubject: 'did:ad:agent:x',
   });
+
+const failureOf = async (promise: Promise<unknown>): Promise<Error> => {
+  try {
+    await promise;
+  } catch (e) {
+    return e as Error;
+  }
+
+  throw new Error('expected the enrollment to fail');
+};
 
 /**
  * Every one of these used to raise the same sentence, which is how a full
@@ -56,7 +74,7 @@ describe('createManagedSyncEnrollment failures', () => {
   it('explains a 500 as capacity rather than parroting the body', async () => {
     failWith(500, { error: 'Internal Server Error' });
 
-    const error = await enroll().catch(e => e as Error);
+    const error = await failureOf(enroll());
     expect(error.message).toMatch(/capacity/i);
     expect(error.message).not.toMatch(/Internal Server Error/);
   });
@@ -72,5 +90,255 @@ describe('createManagedSyncEnrollment failures', () => {
     });
 
     await expect(enroll()).rejects.toThrow(/418/);
+  });
+
+  /**
+   * The control plane's 403s name the reason in `error_code`; the user gets a
+   * sentence about what to do, not the server's talk of signatures.
+   */
+  it('turns a refused proof into a user-facing explanation', async () => {
+    failWith(403, {
+      error: 'enrollment proof: signature does not verify',
+      error_code: 'enrollment_proof_invalid',
+    });
+
+    const error = await failureOf(enroll());
+    expect(error.message).toMatch(/could not verify.*controls the workspace/i);
+    expect(error.message).not.toMatch(/signature does not verify/);
+  });
+
+  it('explains a missing proof as something to retry after signing in', async () => {
+    failWith(403, {
+      error: 'enrollment proof required',
+      error_code: 'enrollment_proof_required',
+    });
+
+    await expect(enroll()).rejects.toThrow(/no proof was sent/i);
+  });
+});
+
+// A fixed Ed25519 key, so the derived personal-drive DID is stable.
+const PRIVATE_KEY = 'CapMWIhFUT+w7ANv9oCPqrHrwZpkP2JhzF9JnyT6WcI=';
+
+async function testAgent(): Promise<Agent> {
+  const provider = new JSCryptoProvider(PRIVATE_KEY);
+  const publicKey = await provider.getPublicKey();
+
+  return new Agent(provider, `did:ad:agent:${publicKey}`);
+}
+
+/** A fresh `ArrayBuffer`-backed copy, which is what WebCrypto's types accept. */
+const bytes = (b64: string): Uint8Array<ArrayBuffer> =>
+  Uint8Array.from(decodeB64(b64));
+
+/** Verify an Ed25519 signature with WebCrypto — independent of `@tomic/lib`'s signer. */
+async function verifies(
+  publicKeyB64: string,
+  message: string,
+  signatureB64: string,
+): Promise<boolean> {
+  const key = await globalThis.crypto.subtle.importKey(
+    'raw',
+    bytes(publicKeyB64),
+    { name: 'Ed25519' },
+    false,
+    ['verify'],
+  );
+
+  return globalThis.crypto.subtle.verify(
+    { name: 'Ed25519' },
+    key,
+    bytes(signatureB64),
+    new TextEncoder().encode(message),
+  );
+}
+
+const challengeFor = (agentSubject: string, driveSubject: string) => ({
+  nonce: 'nonce-1',
+  challenge: `atomic-saas:enroll:v1:nonce-1:${driveSubject}:me@example.com:1900000000`,
+  drive_subject: driveSubject,
+  agent_subject: agentSubject,
+  expires_at: 1900000000,
+});
+
+describe('buildEnrollmentProof', () => {
+  it('signs "{challenge} {timestamp}" with the agent key and echoes the nonce', async () => {
+    const agent = await testAgent();
+    const challenge = challengeFor(agent.subject!, 'did:ad:somedrive');
+
+    const proof = await buildEnrollmentProof({
+      challenge,
+      agent,
+      driveSubject: 'did:ad:somedrive',
+      genesisCert: 'AQID',
+    });
+
+    expect(proof.nonce).toBe('nonce-1');
+    expect(proof.public_key).toBe(await agent.getPublicKey());
+    expect(typeof proof.timestamp).toBe('number');
+    expect(
+      await verifies(
+        proof.public_key,
+        `${challenge.challenge} ${proof.timestamp}`,
+        proof.signature,
+      ),
+    ).toBe(true);
+    // Not a signature over the bare challenge: the timestamp is bound in.
+    expect(
+      await verifies(proof.public_key, challenge.challenge, proof.signature),
+    ).toBe(false);
+  });
+
+  it('attaches the genesis certificate for a drive that is not the personal one', async () => {
+    const agent = await testAgent();
+
+    const proof = await buildEnrollmentProof({
+      challenge: challengeFor(agent.subject!, 'did:ad:shared'),
+      agent,
+      driveSubject: 'did:ad:shared',
+      genesisCert: 'AQID',
+    });
+
+    expect(proof.genesis_cert).toBe('AQID');
+  });
+
+  it('leaves the certificate off for the personal drive', async () => {
+    const agent = await testAgent();
+    const personal = await agent.privateDriveSubject();
+
+    const proof = await buildEnrollmentProof({
+      challenge: challengeFor(agent.subject!, personal),
+      agent,
+      driveSubject: personal,
+      // The personal drive carries one too; the control plane derives it.
+      genesisCert: 'AQID',
+    });
+
+    expect(proof).not.toHaveProperty('genesis_cert');
+  });
+
+  it('refuses to sign a challenge issued for another agent', async () => {
+    const agent = await testAgent();
+
+    await expect(
+      buildEnrollmentProof({
+        challenge: challengeFor('did:ad:agent:someoneelse', 'did:ad:d'),
+        agent,
+        driveSubject: 'did:ad:d',
+      }),
+    ).rejects.toThrow(/someoneelse/);
+  });
+
+  it('reads the certificate off the drive resource', () => {
+    expect(
+      genesisCertOf({
+        get: p =>
+          p === 'https://atomicdata.dev/properties/genesis'
+            ? 'AQID'
+            : undefined,
+      }),
+    ).toBe('AQID');
+    expect(genesisCertOf({ get: () => '' })).toBeUndefined();
+  });
+});
+
+describe('createManagedSyncEnrollment with an agent', () => {
+  const bodyOf = (call: unknown[]) =>
+    JSON.parse((call[1] as { body: string }).body) as Record<string, unknown>;
+
+  const created = { drive: 'did:ad:shared', node: null, http_origin: null };
+
+  it('requests a challenge, signs it, and sends the proof', async () => {
+    const agent = await testAgent();
+    const challenge = challengeFor(agent.subject!, 'did:ad:shared');
+
+    managedFetch
+      .mockResolvedValueOnce(succeedWith(challenge))
+      .mockResolvedValueOnce(succeedWith(created));
+
+    await createManagedSyncEnrollment({
+      driveSubject: 'did:ad:shared',
+      agentSubject: agent.subject!,
+      agent,
+      genesisCert: 'AQID',
+    });
+
+    expect(managedFetch).toHaveBeenCalledTimes(2);
+    expect(managedFetch.mock.calls[0][0]).toBe('/sync-enrollments/challenge');
+    expect(bodyOf(managedFetch.mock.calls[0])).toEqual({
+      drive_subject: 'did:ad:shared',
+      agent_subject: agent.subject,
+    });
+
+    expect(managedFetch.mock.calls[1][0]).toBe('/sync-enrollments');
+    const body = bodyOf(managedFetch.mock.calls[1]);
+    const proof = body.proof as Record<string, unknown>;
+    expect(proof.nonce).toBe('nonce-1');
+    expect(proof.genesis_cert).toBe('AQID');
+    expect(proof.public_key).toBe(await agent.getPublicKey());
+    expect(
+      await verifies(
+        proof.public_key as string,
+        `${challenge.challenge} ${proof.timestamp}`,
+        proof.signature as string,
+      ),
+    ).toBe(true);
+  });
+
+  /**
+   * An older control plane has no challenge route. The app must keep working
+   * against it — unsigned, exactly as before — rather than fail every backup
+   * until the fleet is upgraded.
+   */
+  it('falls back to an unsigned enrollment when the challenge route 404s', async () => {
+    const agent = await testAgent();
+
+    managedFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Not Found' }),
+      })
+      .mockResolvedValueOnce(succeedWith(created));
+
+    const result = await createManagedSyncEnrollment({
+      driveSubject: 'did:ad:shared',
+      agentSubject: agent.subject!,
+      agent,
+      genesisCert: 'AQID',
+    });
+
+    expect(result.drive).toBe('did:ad:shared');
+    expect(managedFetch).toHaveBeenCalledTimes(2);
+    expect(bodyOf(managedFetch.mock.calls[1])).toEqual({
+      drive_subject: 'did:ad:shared',
+      agent_subject: agent.subject,
+    });
+  });
+
+  /** Any other challenge failure is a real failure, surfaced like the rest. */
+  it('surfaces a challenge failure other than 404', async () => {
+    const agent = await testAgent();
+
+    failWith(401, { error: 'No session' });
+
+    await expect(
+      createManagedSyncEnrollment({
+        driveSubject: 'did:ad:shared',
+        agentSubject: agent.subject!,
+        agent,
+      }),
+    ).rejects.toThrow(/session expired/i);
+    expect(managedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('never asks for a challenge without an agent to sign it', async () => {
+    managedFetch.mockResolvedValue(succeedWith(created));
+
+    await enroll();
+
+    expect(managedFetch).toHaveBeenCalledTimes(1);
+    expect(managedFetch.mock.calls[0][0]).toBe('/sync-enrollments');
+    expect(bodyOf(managedFetch.mock.calls[0])).not.toHaveProperty('proof');
   });
 });

--- a/browser/data-browser/src/helpers/managed/enrollment.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.ts
@@ -1,3 +1,4 @@
+import { type Agent, createAuthentication, GENESIS } from '@tomic/lib';
 import { PRODUCT_NAME } from './product';
 import { managedFetch } from './api';
 import { writeManagedAccountBinding } from './binding';
@@ -17,19 +18,65 @@ export type ManagedSyncEnrollmentResult = {
 };
 
 /**
+ * What `POST /api/sync-enrollments/challenge` hands back. The control plane
+ * stores every bound field itself; the client only echoes `nonce` and signs
+ * `challenge`.
+ */
+export type ManagedEnrollmentChallenge = {
+  nonce: string;
+  challenge: string;
+  drive_subject: string;
+  agent_subject: string;
+  expires_at: number;
+};
+
+/**
+ * The signed answer to a {@link ManagedEnrollmentChallenge} — the `proof`
+ * field of `POST /api/sync-enrollments` (`EnrollmentProof` in the control
+ * plane's `enrollment_proof.rs`).
+ */
+export type ManagedEnrollmentProof = {
+  nonce: string;
+  public_key: string;
+  timestamp: number;
+  signature: string;
+  /** Base64 genesis certificate of the drive; omitted for a personal drive,
+   *  whose certificate the control plane derives from the agent's key. */
+  genesis_cert?: string;
+};
+
+/** Why an enrollment was refused, when the control plane names the reason. */
+export type ManagedEnrollmentErrorCode =
+  | 'enrollment_proof_required'
+  | 'enrollment_proof_invalid'
+  | (string & {});
+
+const PROOF_ERROR_MESSAGES: Record<string, string> = {
+  enrollment_proof_required:
+    `${PRODUCT_NAME} needs proof that this device controls the workspace ` +
+    'before hosting it, but no proof was sent. Sign in again and retry.',
+  enrollment_proof_invalid:
+    `${PRODUCT_NAME} could not verify that this device controls the ` +
+    'workspace: only the identity that created it can back it up. If this is ' +
+    'your workspace, sign in with the identity that created it and retry.',
+};
+
+/**
  * Say what actually went wrong.
  *
  * This used to throw one sentence — "Could not enable Cloud Server" — for every
  * failure, discarding the status and the body. The control plane is more
  * forthcoming than that: it answers 402 with "Cloud Server requires a
- * subscription" and an upgrade URL, 401 when the session lapsed, and 500 when
- * the fleet has no node with free capacity. All three arrived as the same dead
- * end, which is how a full fleet in production read as a mysterious backup
- * failure with no next step.
+ * subscription" and an upgrade URL, 401 when the session lapsed, 403 with an
+ * `error_code` when the enrollment proof is missing or does not check out,
+ * and 500 when the fleet has no node with free capacity. All of these arrived
+ * as the same dead end, which is how a full fleet in production read as a
+ * mysterious backup failure with no next step.
  */
 async function enrollmentError(response: Response): Promise<Error> {
   const body = (await response.json().catch(() => null)) as {
     error?: string;
+    error_code?: ManagedEnrollmentErrorCode;
     upgrade_url?: string;
   } | null;
 
@@ -37,6 +84,15 @@ async function enrollmentError(response: Response): Promise<Error> {
     return new Error(
       `Your ${PRODUCT_NAME} session expired. Sign in and retry.`,
     );
+  }
+
+  // A refused proof gets a sentence that says what the user can do about it;
+  // the server's own wording is about signatures and certificates.
+  const proofMessage =
+    body?.error_code && PROOF_ERROR_MESSAGES[body.error_code];
+
+  if (proofMessage) {
+    return new Error(proofMessage);
   }
 
   // The server's own words when it has them: it knows why far better than a
@@ -59,23 +115,160 @@ async function enrollmentError(response: Response): Promise<Error> {
   );
 }
 
-export async function createManagedSyncEnrollment({
+/**
+ * Ask the control plane for an enrollment challenge to sign.
+ *
+ * Returns `null` when the control plane has no challenge route (404): an older
+ * deployment that still trusts the session plus the client-supplied DIDs. The
+ * caller then enrolls unsigned, exactly as before the proof existed, so a
+ * newer app keeps working against an older control plane.
+ */
+export async function requestEnrollmentChallenge({
   driveSubject,
   agentSubject,
 }: {
   driveSubject: string;
   agentSubject: string;
+}): Promise<ManagedEnrollmentChallenge | null> {
+  const response = await managedFetch(`/sync-enrollments/challenge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      drive_subject: driveSubject,
+      agent_subject: agentSubject,
+    }),
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw await enrollmentError(response);
+  }
+
+  return (await response.json()) as ManagedEnrollmentChallenge;
+}
+
+/**
+ * Whether `driveSubject` is `agent`'s personal drive — the DID derived from
+ * its key alone. If that derivation is unavailable (a non-deterministic
+ * SubtleCrypto signer with no stored subject), treat the drive as
+ * non-personal: sending the certificate for a personal drive is merely
+ * redundant, while omitting it for a non-personal one fails the proof.
+ */
+async function isPersonalDrive(
+  agent: Agent,
+  driveSubject: string,
+): Promise<boolean> {
+  try {
+    return (await agent.privateDriveSubject()) === driveSubject;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Answer a challenge with the agent's signature, in the shape the control
+ * plane's `EnrollmentProof` expects.
+ *
+ * Signing reuses `@tomic/lib`'s `createAuthentication`: the challenge is
+ * signed exactly as a request subject would be (`"{challenge} {timestamp}"`),
+ * with the same key and encoding, so nothing cryptographic is reimplemented
+ * here. The `atomic-saas:enroll:` prefix of a challenge can never collide with
+ * a URL, so a proof cannot double as request authentication.
+ *
+ * `genesisCert` is the drive's `genesis` propval (base64). It is attached only
+ * when the drive is not the agent's personal drive: the control plane rebuilds
+ * a personal drive's certificate from the public key, but for any other drive
+ * it needs the certificate to check that this agent created it.
+ */
+export async function buildEnrollmentProof({
+  challenge,
+  agent,
+  driveSubject,
+  genesisCert,
+}: {
+  challenge: ManagedEnrollmentChallenge;
+  agent: Agent;
+  driveSubject: string;
+  genesisCert?: string;
+}): Promise<ManagedEnrollmentProof> {
+  if (agent.subject !== challenge.agent_subject) {
+    throw new Error(
+      `${PRODUCT_NAME} issued the challenge for ${challenge.agent_subject}, ` +
+        `but the signing identity is ${agent.subject}.`,
+    );
+  }
+
+  const auth = await createAuthentication(challenge.challenge, agent);
+  const personal = await isPersonalDrive(agent, driveSubject);
+
+  return {
+    nonce: challenge.nonce,
+    public_key: auth['https://atomicdata.dev/properties/auth/publicKey'],
+    timestamp: auth['https://atomicdata.dev/properties/auth/timestamp'],
+    signature: auth['https://atomicdata.dev/properties/auth/signature'],
+    ...(personal || !genesisCert ? {} : { genesis_cert: genesisCert }),
+  };
+}
+
+/** The drive's inline genesis certificate, base64, if the resource carries one. */
+export function genesisCertOf(drive: {
+  get: (property: string) => unknown;
+}): string | undefined {
+  const value = drive.get(GENESIS);
+
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Enroll a drive for hosting on the control plane.
+ *
+ * With an `agent`, the request carries a signed proof of control: a challenge
+ * is requested, signed with the agent's key, and sent along (see
+ * {@link buildEnrollmentProof}). Without one — or against a control plane that
+ * does not issue challenges — the request is unsigned, which an older or
+ * lenient control plane still accepts.
+ */
+export async function createManagedSyncEnrollment({
+  driveSubject,
+  agentSubject,
+  agent,
+  genesisCert,
+}: {
+  driveSubject: string;
+  agentSubject: string;
+  /** The agent holding the key for `agentSubject`; signs the challenge. */
+  agent?: Agent;
+  /** The drive's `genesis` propval, for a drive that is not the agent's personal drive. */
+  genesisCert?: string;
 }): Promise<ManagedSyncEnrollmentResult> {
   // Identity convergence happens silently at app boot (IdentityReconcileGate);
   // by the time we enroll, the active agent is the account's agent. Enrolling
   // also (re)binds it below, so the account adopts the agent in use here — we
   // never block enrollment with a mismatch error.
+  const challenge = agent
+    ? await requestEnrollmentChallenge({ driveSubject, agentSubject })
+    : null;
+
+  const proof =
+    agent && challenge
+      ? await buildEnrollmentProof({
+          challenge,
+          agent,
+          driveSubject,
+          genesisCert,
+        })
+      : undefined;
+
   const response = await managedFetch(`/sync-enrollments`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       drive_subject: driveSubject,
       agent_subject: agentSubject,
+      ...(proof ? { proof } : {}),
     }),
   });
 

--- a/browser/data-browser/src/helpers/managedUsage.ts
+++ b/browser/data-browser/src/helpers/managedUsage.ts
@@ -2,6 +2,7 @@
 // base (same endpoint as the other managed helpers).
 import { PRODUCT_NAME } from './managed/product';
 import { getManagedApiBase } from './managed/api';
+import { createManagedSyncEnrollment } from './managed/enrollment';
 
 export type ManagedUser = {
   email: string;
@@ -75,29 +76,9 @@ export async function getDriveUsage(
   };
 }
 
-// [RECOVERY-RECONSTRUCTED] Only the signature `createManagedEnrollment({` survived.
-// Reconstructed from the equivalent helpers/managed/enrollment.ts:createManagedSyncEnrollment
-// (POST /sync-enrollments). No code currently imports this export.
-export async function createManagedEnrollment({
-  driveSubject,
-  agentSubject,
-}: {
-  driveSubject: string;
-  agentSubject: string;
-}): Promise<unknown> {
-  const response = await fetch(`${getManagedApiBase()}/sync-enrollments`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({
-      drive_subject: driveSubject,
-      agent_subject: agentSubject,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Could not enable ${PRODUCT_NAME} backup.`);
-  }
-
-  return response.json();
-}
+/**
+ * Enroll a drive for hosting. Delegates to `createManagedSyncEnrollment`, which
+ * signs the control plane's challenge when given the agent, so there is only
+ * one code path that talks to `POST /sync-enrollments`.
+ */
+export const createManagedEnrollment = createManagedSyncEnrollment;

--- a/planning/cloud-sync-managed-node.md
+++ b/planning/cloud-sync-managed-node.md
@@ -149,9 +149,19 @@ first attempt. Design + status: `atomic-saas/planning/ENFORCEMENT_GATE.md`.
 > `atomic-saas/src/provisioning/templates/cloud-init.yaml`, which today
 > downloads the plain release `atomic-server` and starts it with
 > `--port 8080 --domain … --server-url …` — no managed wiring at all. So the
-> managed path is verified, but not yet the path provisioned nodes run; a fix
-> to the template is in flight. Read the checkmarks as "works when the node is
+> managed path is verified; the template fix (atomic-saas #22, merged
+> 2026-09-01) makes newly provisioned nodes run it. Read the checkmarks as "works when the node is
 > run managed".
+
+- ✅ **Signed enrollment proof (client half).** `createManagedSyncEnrollment`
+  (`helpers/managed/enrollment.ts`) now requests `POST /api/sync-enrollments/challenge`,
+  signs `"{challenge} {timestamp}"` with the agent's key via `@tomic/lib`'s
+  `createAuthentication`, and sends `proof: { nonce, public_key, timestamp, signature, genesis_cert? }`
+  — `genesis_cert` (the drive's `genesis` propval) only for a drive that is not the
+  agent's personal drive. A 404 on the challenge route (older control plane) falls back
+  to the unsigned request; 403 `enrollment_proof_required` / `enrollment_proof_invalid`
+  surface as a plain-language error. Server half: atomic-saas PR #24
+  (`ATOMIC_SAAS_REQUIRE_ENROLLMENT_PROOF` can be flipped on once this ships).
 
 - ✅ Onboarding: new user (username-from-email, auto cloud-sync, recovery backup), sign-in, restore (forgot secret).
 - ✅ Managed-node detection: `Create account` → portal when managed, else local (FOSS).


### PR DESCRIPTION
## What

The data-browser's managed-sync enrollment now proves it controls the drive. Client half of the signed enrollment proof introduced in https://github.com/ontola/atomic-saas/pull/24.

`createManagedSyncEnrollment` (`browser/data-browser/src/helpers/managed/enrollment.ts`):

- `POST /api/sync-enrollments/challenge` → sign `"{challenge} {timestamp}"` with the agent's key via `@tomic/lib`'s `createAuthentication` (same primitive as request auth; no Ed25519 reimplemented) → `POST /api/sync-enrollments` with `proof: { nonce, public_key, timestamp, signature, genesis_cert? }`.
- `genesis_cert` is the drive's `genesis` propval, attached only when the drive is not the agent's personal drive (`agent.privateDriveSubject()`); the control plane derives the personal drive's certificate from the key.
- Older control plane (challenge route 404s) → falls back to the unsigned request, so the app keeps working during the rollout.
- 403 `enrollment_proof_required` / `enrollment_proof_invalid` → plain-language user-visible error (surfaced through `store.notifyError` on the /sync page).
- `enableCloudSyncForDrive` passes the store's agent and the drive's genesis certificate. The unused duplicate `createManagedEnrollment` in `managedUsage.ts` now delegates, so there's one code path to the enroll endpoint.

## Tests

`enrollment.test.ts` (vitest, data-browser):

- proof signature verifies against the agent public key with WebCrypto (independent of the lib signer); timestamp is bound in; nonce echoed
- genesis cert attached for a non-personal drive, omitted for the personal drive
- refuses a challenge issued for another agent
- mocked-fetch: challenge → signed enroll body; 404 on challenge → unsigned fallback; non-404 challenge failure surfaces; no agent → no challenge request
- 403 proof error codes map to user-facing messages

Ran `pnpm typecheck` (no errors in touched files; remaining ones are pre-existing `@tomic/plugin`/node-types noise on an unbuilt workspace), `pnpm lint`, and `vitest run src/helpers/managed/` (90 passing).

## Rollout

Once this ships, `ATOMIC_SAAS_REQUIRE_ENROLLMENT_PROOF=1` can be flipped on the control plane. `planning/cloud-sync-managed-node.md` notes the client now signs.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
