### PR TITLE
chore(release): bump to v0.41.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+## [v0.41.0-beta.3] - 2026-09-01
+
 - Git / CI: one integration branch (`develop`) plus stable `v*` tags. Staging
   follows `develop`; production and live docs follow a tagged release. `master`
   is no longer a deploy or docs trigger, and `main` is not introduced as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 dependencies = [
  "assert_cmd",
  "async-recursion",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 dependencies = [
  "actix",
  "actix-cors",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server-tauri"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 dependencies = [
  "actix-rt",
  "android_system_properties",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "atomic_lib"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,12 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+## [v0.41.0-beta.3] - 2026-09-01
+
 - Fix: opening a v1 document no longer shows a read-only page with an "Update Document" button that throws. Writable v1 documents migrate silently to the Loro-backed editor. Leftover Yjs-era V2 bodies still convert, but `yjs` is loaded only when those bytes are present.
 - Fix: opening an adopted HTTP drive no longer moves the home server. A bare origin (`https://host`) is still a server switch; an HTTP subject with a path is a workspace and is fetched cross-origin, so a pre-DID drive on `atomicdata.dev` cannot take the session with it (websocket, DID auth, every later fetch).
 - Fix: opening a filled table no longer flashes rows (or sidebar children) in the wrong order. Local queries are unsorted; hydrating each member used to optimistic-add them in arrival order before the client-side sort landed. The sidebar also listed every table row until the resource's class arrived. OPFS cold-load could shuffle array properties the same way by merging a JSON-AD-seeded LoroList with the stored snapshot. Reloading a table after a cell edit no longer leaves the page stuck loading: an OPFS snapshot replace was importing the same bytes twice and could drop `isA`. Table totals now re-query after the edit is queued to OPFS, so a sum follows a cell change without a reload.
-
 - Dev: React Compiler now runs through native `oxc-transform-react` instead of `babel-plugin-react-compiler`. JSX/TS and Fast Refresh share that pass. styled-components `displayName` comes from Oxc's built-in plugin on Vite's oxc pass, so Babel is gone (`babel-plugin-react-compiler`, `babel-plugin-styled-components`, `@rolldown/plugin-babel`). Vite dev no longer pays a Babel tax per module (files that used to take ~100ms now land around ~10ms). Oxlint 1.79's compiler-powered Rules of React (`react/immutability`, `react/purity`, `react/error-boundaries`, …) are on; `set-state-in-effect` / `refs` / `static-components` stay warn until those call sites are cleaned up.
-
 - Fix: clicking a button in the navbar no longer draws a blue outline around the whole bar. The bar used `:has(:focus)`, which matched mouse clicks; keyboard focus still shows on the button itself.
 
 ## [v0.41.0-beta.2] - 2026-08-01

--- a/browser/cli/package.json
+++ b/browser/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/js-cli",
   "repository": {

--- a/browser/create-template/package.json
+++ b/browser/create-template/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/create-template/atomic-template",
   "repository": {

--- a/browser/create-template/templates/nextjs-site/package.json
+++ b/browser/create-template/templates/nextjs-site/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.11.1",
-    "@tomic/lib": "^0.41.0-beta.2",
-    "@tomic/react": "^0.41.0-beta.2",
+    "@tomic/lib": "^0.41.0-beta.3",
+    "@tomic/react": "^0.41.0-beta.3",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "loro-crdt": "^1.12.1",
@@ -25,7 +25,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@tomic/cli": "^0.41.0-beta.2",
+    "@tomic/cli": "^0.41.0-beta.3",
     "@types/node": "^20",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/browser/create-template/templates/sveltekit-site/package.json
+++ b/browser/create-template/templates/sveltekit-site/package.json
@@ -18,7 +18,7 @@
 		"@sveltejs/adapter-node": "^5.2.9",
 		"@sveltejs/kit": "^2.7.3",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
-		"@tomic/cli": "^0.41.0-beta.2",
+		"@tomic/cli": "^0.41.0-beta.3",
 		"@types/eslint": "^9.6.1",
 		"eslint": "^9.13.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -37,8 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@tomic/lib": "^0.41.0-beta.2",
-		"@tomic/svelte": "^0.41.0-beta.2",
+		"@tomic/lib": "^0.41.0-beta.3",
+		"@tomic/svelte": "^0.41.0-beta.3",
 		"loro-crdt": "^1.12.1",
 		"svelte-markdown": "^0.4.1"
 	},

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "author": {
     "email": "joep@ontola.io",
     "name": "Joep Meindertsma"

--- a/browser/e2e/package.json
+++ b/browser/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/e2e",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "private": true,
   "homepage": "https://atomicdata.dev/",
   "license": "MIT",

--- a/browser/edit-mode/package.json
+++ b/browser/edit-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/edit-mode",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "description": "Turn any page rendered from Atomic Data into an editable local-first clone: 'Edit this page' for visitors (guest agent + local-only drive, zero server writes) and inline-editing UI chrome.",
   "type": "module",
   "license": "MIT",

--- a/browser/lib/package.json
+++ b/browser/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/lib",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "author": "Joep Meindertsma",
   "homepage": "https://docs.atomicdata.dev/js",
   "repository": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -14,7 +14,7 @@
     "vitest": "^4.1.7"
   },
   "name": "@tomic/root",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/browser/plugin/package.json
+++ b/browser/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tomic/plugin",
   "type": "module",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "description": "Utils for building UI plugins for AtomicServer",
   "author": "Polle Pas <polle@ontola.io>",
   "license": "MIT",

--- a/browser/react/package.json
+++ b/browser/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/react",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "author": "Joep Meindertsma",
   "description": "Atomic Data React library",
   "homepage": "https://docs.atomicdata.dev/usecases/react",

--- a/browser/svelte/package.json
+++ b/browser/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ontola, Polle Pas",
   "name": "@tomic/svelte",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "license": "MIT",
   "homepage": "https://docs.atomicdata.dev/svelte",
   "repository": {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT"
 name = "atomic-cli"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 
 [dependencies]
 async-recursion = "1.1.1"
-atomic_lib = { version = "0.41.0-beta.2", path = "../lib", features = [
+atomic_lib = { version = "0.41.0-beta.3", path = "../lib", features = [
     "config",
     "rdf",
 ] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ name = "atomic-server-tauri"
 # crates.io forbids — see the note on `publish` in ../wasm/Cargo.toml.
 publish = false
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Atomic Server",
-  "version": "0.41.0-beta.2",
+  "version": "0.41.0-beta.3",
   "identifier": "io.ontola.atomicserver",
   "build": {
     "frontendDist": "../browser/data-browser/dist-tauri",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "atomic_lib"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "atomic-server"
 readme = "./README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 
 [[bin]]
 name = "atomic-server"
@@ -158,7 +158,7 @@ version = "4.13.0"
 # present, so it adds no runtime cost for fresh installs.
 features = ["config", "db-redb", "db-sled", "rdf", "discovery", "iroh", "ring", "ws"]
 path = "../lib"
-version = "0.41.0-beta.2"
+version = "0.41.0-beta.3"
 
 [dependencies.clap]
 features = ["derive", "env", "cargo"]


### PR DESCRIPTION
Version bump 0.41.0-beta.2 -> 0.41.0-beta.3 across all 15 version sites (`scripts/bump-version.mjs`, `--check` passes), regenerated `Cargo.lock` (`cargo update --workspace`) and `pnpm-lock.yaml` (unchanged, workspace links), and moved the `UNRELEASED` sections of both changelogs under `## [v0.41.0-beta.3] - 2026-09-01`.

No tag is created by this PR. After merge, tag the merge commit on `develop` with `v0.41.0-beta.3`.

## Headline changes since v0.41.0-beta.2

- `atomic_lib`: new `runtime::AtomicNode` boundary over `Db` with `IngestPolicy::{Hub, Peer, Replica, LocalCache}`; WASM `ClientDb` is the first adapter (#1324).
- Built-in defaults now re-seed add-only on every store open via a fingerprint, so new Properties/Classes reach existing stores (#1323).
- Sync trust gaps closed: AUTH before SYNC, SUBSCRIBE rights checks, loud SYNC_PUSH rejection (#1321); plus the fixes from running two sync nodes against each other (#1286).
- Public FOSS nodes gated: a server can be reachable without hosting strangers (#1303).
- Cloud Server enrollment challenge is now signed (#1322).
- Git/CI: single `develop` branch plus stable `v*` tags; Playwright runs light on branches, full on `develop` and tags.
- Browser: v1 documents migrate silently to the Loro editor instead of throwing (#1295); adopted HTTP drives no longer hijack the home server.
- Browser: tables and sidebar no longer flash rows in the wrong order; OPFS snapshot double-import fixed; totals re-query after a cell edit; rows that scroll away before saving are no longer lost.
- Browser: "private drive" naming and presentation across the UI; drive creation refuses early when the drive cannot be listed.
- Dev: React Compiler runs through native `oxc-transform-react`, Babel removed from the Vite pipeline; navbar focus-outline fix.
- Canvas (Flutter): keeps the drawing open on rotation, undo-bootstrap race fixes, faster canvas open.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd