### PR TITLE
fix(browser): stop treating a non-node app origin as the server

### DIFF
--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: the hosted build no longer treats the origin it is served from as its server when that origin runs no atomic-server. The managed deployment serves the app from a shared static origin; someone on the free tier has no node, and the app kept retrying a WebSocket to that origin (with an error toast on the first screen), polled `/server` for a JSON document that came back as `index.html`, parked every commit in the outbox, and the Sync page counted the origin as "1 other device" and called Cloud Server "a migration, not a backup". The hosted build now asks its origin once at boot (`GET /server`); when the answer is not a node, the Store keeps the URL but opens no socket (`StoreOpts.connect: false`, `@tomic/lib`), a new identity and its personal drive are registered local-only from their first save (the same routing the demo uses), and switching Cloud Server on promotes both to the assigned node. Source builds and the desktop shell are unaffected: only the hosted distribution probes.
+
 ## [v0.41.0-beta.3] - 2026-09-01
 
 - Fix: opening a v1 document no longer shows a read-only page with an "Update Document" button that throws. Writable v1 documents migrate silently to the Loro-backed editor. Leftover Yjs-era V2 bodies still convert, but `yjs` is loaded only when those bytes are present.

--- a/browser/data-browser/src/App.tsx
+++ b/browser/data-browser/src/App.tsx
@@ -8,6 +8,11 @@ import { registerCustomCreateActions } from './components/forms/NewForm/CustomCr
 import { serverURLStorage } from './helpers/serverURLStorage';
 import { driveStorage } from './helpers/driveStorage';
 import { isRunningInTauri } from './helpers/tauri';
+import {
+  isOriginWithoutNode,
+  originMayLackNode,
+  probeOriginForNode,
+} from './helpers/originNode';
 
 import { useEffect, type JSX } from 'react';
 import { RouterProvider } from '@tanstack/react-router';
@@ -91,6 +96,15 @@ const embeddedNodeWins =
 const serverUrl =
   storedIsValid && !embeddedNodeWins ? storedServerUrl! : defaultServerUrl;
 
+// The hosted build may be served by something that is not a node (see
+// `originNode.ts`). Find out before the Store exists: it opens its WebSocket
+// in the constructor, and it is also the moment `createPrivateDrive` needs
+// the answer for — a workspace made against a non-node is local-only from
+// its first save. One same-origin request, hosted builds only.
+if (originMayLackNode() && serverUrl === window.location.origin) {
+  await probeOriginForNode(serverUrl);
+}
+
 // Fire-and-forget — first paint doesn't wait. Catch so a failed import
 // (offline + no cached module) doesn't show up as an unhandledrejection
 // in the console; LoroLoader.isLoaded() stays false and code paths
@@ -128,6 +142,7 @@ const initalAgent = locked ? undefined : storedAgent;
 const store = new Store({
   agent: initalAgent,
   serverUrl,
+  connect: !isOriginWithoutNode(serverUrl),
 });
 
 const initialDrive = driveStorage.get();

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Agent, JSCryptoProvider, core, useStore } from '@tomic/react';
 import { fetchPrivateDriveSubject } from '../helpers/privateDrive';
+import { isOriginWithoutNode } from '../helpers/originNode';
 import { useSettings } from '../helpers/AppSettings';
 import { saveAgentToIDB } from '../helpers/agentStorage';
 import { useNavigateWithTransition } from '../hooks/useNavigateWithTransition';
@@ -136,6 +137,19 @@ export function NewIdentitySection({
       const newAgent = new Agent(agentProvider, agentDID);
 
       store.setAgent(newAgent);
+
+      // With no node behind the app's origin (the hosted build on the free
+      // tier — see `originNode.ts`) this identity exists nowhere but here.
+      // Its own resource, and the drive made below, must route to local
+      // storage from their first save, or every commit parks in the outbox
+      // waiting for a server that is not coming. Same registration the demo
+      // guest uses; `enableCloudSyncForDrive` lifts it when a node is
+      // assigned. Registered right after `setAgent` and before anything
+      // async, so no consumer can mount `useResource(agent)` and fetch first.
+      if (isOriginWithoutNode(store.getServerUrl())) {
+        store.registerLocalOnlyDrive(agentDID);
+        store.registerLocalOnlyDrive(await newAgent.privateDriveSubject());
+      }
 
       setIdentity({
         secret: '', // will be built after drive is created

--- a/browser/data-browser/src/helpers/managed/cloudSync.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.ts
@@ -214,6 +214,12 @@ export async function enableCloudSyncForDrive(params: {
   }
 
   const wasLocalOnly = store.isLocalOnlyDrive(drive);
+  // An identity minted against a non-node origin registered its own agent
+  // resource as local-only too (see `NewIdentitySection`), so the node has
+  // never seen the profile that names this account. It is promoted alongside
+  // the drive: `promoteLocalDrive` reconciles a subject and what it parents,
+  // and for a free-standing agent DID that is the agent resource itself.
+  const agentWasLocalOnly = store.isLocalOnlyDrive(agentSubject);
 
   // The proof needs the key (the store's agent) and, for a drive that is not
   // the agent's personal one, the drive's genesis certificate. A drive we
@@ -240,14 +246,24 @@ export async function enableCloudSyncForDrive(params: {
     // node's origin resyncs through the normal reconnect.
     setServer(httpOrigin);
 
-    if (wasLocalOnly) {
+    if (wasLocalOnly || agentWasLocalOnly) {
       await waitForServerConnected(store);
-      await store.promoteLocalDrive(drive);
+      await promoteLocalOnly();
     }
-  } else if (wasLocalOnly && store.getSyncStatus().serverConnected) {
+  } else if (
+    (wasLocalOnly || agentWasLocalOnly) &&
+    store.getSyncStatus().serverConnected
+  ) {
     // No origin came back (older control plane) — best effort against whatever
     // node is currently connected.
-    await store.promoteLocalDrive(drive);
+    await promoteLocalOnly();
+  }
+
+  async function promoteLocalOnly() {
+    // Agent first: the drive's commits are signed by it, and a node that can
+    // resolve the signer before the drive arrives has nothing to defer.
+    if (agentWasLocalOnly) await store.promoteLocalDrive(agentSubject);
+    if (wasLocalOnly) await store.promoteLocalDrive(drive);
   }
 
   return { ok: true, httpOrigin };

--- a/browser/data-browser/src/helpers/managedServer.ts
+++ b/browser/data-browser/src/helpers/managedServer.ts
@@ -2,6 +2,7 @@ import { signRequest, type Agent } from '@tomic/react';
 import { serverProps, peerProps } from './serverOntology';
 import { rememberManagedPortalUrl } from './managed/api';
 import { isRunningInTauri } from './tauri';
+import { isOriginWithoutNode } from './originNode';
 
 /** A device the server syncs with directly, from `/server`'s `peers`. */
 export type ServerPeer = {
@@ -66,6 +67,10 @@ export async function fetchManagedInfo(
   serverUrl: string,
 ): Promise<ManagedInfo> {
   if (!serverUrl) return DEFAULT;
+
+  // Already asked at boot and answered "not a node" — the Sync page re-polls
+  // this every few seconds, and index.html does not change its mind.
+  if (isOriginWithoutNode(serverUrl)) return DEFAULT;
 
   try {
     const res = await fetch(new URL('/server', serverUrl).toString(), {

--- a/browser/data-browser/src/helpers/originNode.test.ts
+++ b/browser/data-browser/src/helpers/originNode.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isOriginWithoutNode,
+  originMayLackNode,
+  probeOriginForNode,
+  rememberOriginWithoutNode,
+} from './originNode';
+import { serverProps } from './serverOntology';
+
+const ORIGIN = 'https://app.example';
+
+function respond(status: number, body: string, json = true) {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      if (!json) throw new SyntaxError('not JSON');
+
+      return JSON.parse(body);
+    },
+  }));
+}
+
+describe('probeOriginForNode', () => {
+  beforeEach(() => {
+    rememberOriginWithoutNode(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('a node answering /server with its version stays a node', async () => {
+    vi.stubGlobal(
+      'fetch',
+      respond(200, JSON.stringify({ [serverProps.version]: '0.41.0' })),
+    );
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(false);
+  });
+
+  it('a static host serving index.html for /server is not a node', async () => {
+    // What the managed shared app origin actually does: SPA fallback.
+    vi.stubGlobal('fetch', respond(200, '<!doctype html>', false));
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(true);
+    // Any URL on that origin, not just the exact string that was probed.
+    expect(isOriginWithoutNode(`${ORIGIN}/app/welcome`)).toBe(true);
+    expect(isOriginWithoutNode('https://node1.example')).toBe(false);
+  });
+
+  it('a 404 is not a node either', async () => {
+    vi.stubGlobal('fetch', respond(404, ''));
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(true);
+  });
+
+  it('JSON without a version or node id is not a node', async () => {
+    vi.stubGlobal('fetch', respond(200, JSON.stringify({ hello: 'world' })));
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(true);
+  });
+
+  it('no answer at all leaves the default alone', async () => {
+    // Offline is "server unreachable", not "there is no server" — a
+    // node-served install reopened without network must keep reconnecting.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(false);
+  });
+
+  it('a server error is not a verdict', async () => {
+    vi.stubGlobal('fetch', respond(502, ''));
+
+    await probeOriginForNode(ORIGIN);
+
+    expect(isOriginWithoutNode(ORIGIN)).toBe(false);
+  });
+});
+
+describe('originMayLackNode', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('only the hosted distribution probes its own origin', () => {
+    vi.stubEnv('VITE_ATOMIC_HOSTED_DISTRIBUTION', '');
+    expect(originMayLackNode()).toBe(false);
+
+    vi.stubEnv('VITE_ATOMIC_HOSTED_DISTRIBUTION', '1');
+    expect(originMayLackNode()).toBe(true);
+  });
+});

--- a/browser/data-browser/src/helpers/originNode.ts
+++ b/browser/data-browser/src/helpers/originNode.ts
@@ -1,0 +1,119 @@
+import { isRunningInTauri } from './tauri';
+import { isHostedDistribution } from './managedServer';
+import { serverProps } from './serverOntology';
+
+/**
+ * Is the origin this app was served from an atomic-server?
+ *
+ * Usually yes: a node serves its own data-browser, and `window.location.origin`
+ * is the server. The managed deployment breaks that: it serves the very same
+ * SPA from a shared origin (`app.atomicserver.eu`) that is the portal's
+ * process, not a node. Someone on the free tier has no node at all — their
+ * workspace lives in this browser (OPFS) and in Cloud Vault — yet the store
+ * still needs *some* `serverUrl`, and defaulting to the origin made the app
+ * treat a static host as its server: a WebSocket retried forever with a toast
+ * per attempt, `/server` polled for a JSON document that came back as
+ * index.html, every commit parked in the outbox, and the Sync page insisting
+ * the workspace "already lives on app.atomicserver.eu".
+ *
+ * So the hosted build asks once, at boot, before the Store exists. The answer
+ * is kept here so later code can tell "no server" from "server offline"
+ * without a second round trip.
+ */
+
+let originWithoutNode: string | undefined;
+
+/** Origin (no trailing slash) as `new URL(...).origin` would give it. */
+function originOf(url: string): string | undefined {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when `url` points at the origin that was probed and found to run no
+ * atomic-server. False for every other URL, including one never probed.
+ */
+export function isOriginWithoutNode(url: string | undefined): boolean {
+  if (!url || !originWithoutNode) return false;
+
+  return originOf(url) === originWithoutNode;
+}
+
+/** Only in tests. Boot sets this through {@link probeOriginForNode}. */
+export function rememberOriginWithoutNode(origin: string | undefined): void {
+  originWithoutNode = origin ? originOf(origin) : undefined;
+}
+
+/**
+ * Whether this build should probe its own origin at all.
+ *
+ * Only the hosted distribution is ever served by a non-node — a source build
+ * comes out of an atomic-server, so asking would only delay its boot. The
+ * desktop shell has no HTTP origin to ask about (`tauri://localhost`).
+ */
+export function originMayLackNode(): boolean {
+  return isHostedDistribution() && !isRunningInTauri();
+}
+
+/**
+ * Ask `origin` whether it is an atomic-server, remembering a "no".
+ *
+ * A node answers `/server` with a JSON `Server` resource carrying its version
+ * (see `fetchManagedInfo`); a static host serves the SPA's index.html for
+ * that path, or a 404. Both are a definite no.
+ *
+ * Only a definite answer changes anything: a probe that fails outright
+ * (offline, timeout) leaves the default in place, so a node-served install
+ * reopened offline still tries to reconnect the way it always has.
+ */
+export async function probeOriginForNode(
+  origin: string,
+  timeoutMs = 3000,
+): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(new URL('/server', origin).toString(), {
+      headers: { Accept: 'application/ad+json' },
+      signal: controller.signal,
+    });
+
+    if (res.status === 404) {
+      rememberOriginWithoutNode(origin);
+
+      return;
+    }
+
+    if (!res.ok) return;
+
+    let data: unknown;
+
+    try {
+      data = await res.json();
+    } catch {
+      // index.html, not JSON.
+      rememberOriginWithoutNode(origin);
+
+      return;
+    }
+
+    const version = (data as Record<string, unknown> | null)?.[
+      serverProps.version
+    ];
+    const nodeId = (data as Record<string, unknown> | null)?.[
+      serverProps.nodeId
+    ];
+
+    if (!version && !nodeId) {
+      rememberOriginWithoutNode(origin);
+    }
+  } catch {
+    // No answer is not a "no".
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -62,6 +62,7 @@ import {
   forgetServerPeer,
   type NodeDriveUsage,
 } from '../helpers/managedServer';
+import { isOriginWithoutNode } from '../helpers/originNode';
 import { getDriveUsage } from '../helpers/managedUsage';
 import {
   normalizeServerUrl,
@@ -921,8 +922,14 @@ function SyncPage() {
     isNode &&
     (serverHostname === 'localhost' || serverHostname === '127.0.0.1');
   // Show a server connection card whenever the active server isn't this
-  // device's own embedded one (browser: always; Tauri: only a real remote).
-  const showServerConn = !!status.serverUrl && !embeddedActive;
+  // device's own embedded one (browser: always; Tauri: only a real remote) —
+  // and is a server at all. The hosted build's shared origin is not (see
+  // `originNode.ts`): counting it made a free-tier workspace "sync with 1
+  // other device" and call moving it to Cloud Server "a migration".
+  const showServerConn =
+    !!status.serverUrl &&
+    !embeddedActive &&
+    !isOriginWithoutNode(status.serverUrl);
   const pairedPeers = isNode ? knownPeers : [];
   // A browser is not a node, so it cannot pair with a device itself. But the
   // server it reads from can — and reports who, over `/server`. So a phone

--- a/browser/lib/src/store.connect.test.ts
+++ b/browser/lib/src/store.connect.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, afterEach, beforeEach } from 'vitest';
+import { Store } from './store.js';
+
+/**
+ * The managed deployment serves the app from an origin that runs no
+ * atomic-server. The store still needs that origin as `serverUrl`, but a
+ * socket to it can only fail — so `connect: false` keeps it closed, and a
+ * later switch to a real node connects as usual.
+ */
+class FakeWebSocket {
+  public static readonly OPEN = 1;
+  public static opened: string[] = [];
+  public url: string;
+  public protocol = 'atomicdata-ws.v2';
+  public binaryType = 'arraybuffer';
+  public readyState = 0;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.opened.push(url);
+  }
+
+  public addEventListener(): void {}
+  public removeEventListener(): void {}
+  public send(): void {}
+  public close(): void {}
+}
+
+const STATIC_HOST = 'https://app.example';
+const NODE = 'https://node1.example';
+
+describe('Store connect option', () => {
+  const original = globalThis.WebSocket;
+
+  beforeEach(() => {
+    // `test-setup.ts` disconnects every store's socket by default; this file
+    // is about exactly that decision, so it needs the real one back.
+    localStorage.removeItem('ws-disconnected');
+  });
+
+  afterEach(() => {
+    localStorage.setItem('ws-disconnected', '1');
+    globalThis.WebSocket = original;
+    FakeWebSocket.opened = [];
+  });
+
+  it('opens a socket to serverUrl by default', ({ expect }) => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const store = new Store({ serverUrl: NODE });
+
+    expect(FakeWebSocket.opened).toEqual([`wss://node1.example/ws`]);
+    expect(store.getDefaultWebSocket()).toBeDefined();
+  });
+
+  it('connect: false keeps the URL but opens nothing', ({ expect }) => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const store = new Store({ serverUrl: STATIC_HOST, connect: false });
+
+    expect(store.getServerUrl()).toBe(STATIC_HOST);
+    expect(FakeWebSocket.opened).toEqual([]);
+    expect(store.getDefaultWebSocket()).toBeUndefined();
+    expect(store.getSyncStatus().serverConnected).toBe(false);
+  });
+
+  it('switching to a real node afterwards connects as usual', ({ expect }) => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const store = new Store({ serverUrl: STATIC_HOST, connect: false });
+    store.setServerUrl(NODE);
+
+    expect(store.getServerUrl()).toBe(NODE);
+    expect(FakeWebSocket.opened).toEqual([`wss://node1.example/ws`]);
+  });
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -110,6 +110,17 @@ export interface StoreOpts {
   serverUrl?: string;
   /** Default Agent, used for signing commits. Is required for posting things. */
   agent?: Agent;
+  /**
+   * Whether to open a WebSocket to `serverUrl` right away. Defaults to true.
+   *
+   * `false` is for a `serverUrl` that is known not to run an atomic-server:
+   * the managed deployment serves this app from a shared origin that is a
+   * plain static host, and a socket to it can only fail — every few seconds,
+   * forever, with an error toast each time. The URL is still needed (relative
+   * subjects resolve against it), so it is kept; only the connection is not
+   * attempted. A later `setServerUrl` to a real node connects as usual.
+   */
+  connect?: boolean;
 }
 
 export interface StoreSyncStatus {
@@ -600,7 +611,10 @@ export class Store {
     this.webSockets = new Map();
     this.subscribers = new Map();
 
-    if (opts.serverUrl) this.setServerUrl(opts.serverUrl);
+    if (opts.serverUrl) {
+      this.setServerUrl(opts.serverUrl, { connect: opts.connect ?? true });
+    }
+
     if (opts.agent) this.setAgent(opts.agent);
 
     // Initialize drive from localStorage if available.
@@ -4489,8 +4503,12 @@ export class Store {
     await privateDrive.save();
   }
 
-  /** Sets the Server base URL, without the trailing slash. */
-  public setServerUrl(url: string): void {
+  /**
+   * Sets the Server base URL, without the trailing slash.
+   *
+   * `connect: false` keeps the socket closed — see `StoreOpts.connect`.
+   */
+  public setServerUrl(url: string, { connect = true } = {}): void {
     Client.tryValidSubject(url);
 
     if (url.substring(-1) === '/') {
@@ -4524,7 +4542,7 @@ export class Store {
         typeof localStorage !== 'undefined' &&
         localStorage.getItem('ws-disconnected') === '1';
 
-      if (!userDisconnected) {
+      if (!userDisconnected && connect) {
         this.openWebSocket(url);
       }
     }


### PR DESCRIPTION
## What

The managed deployment serves the data-browser from a shared origin (`app.atomicserver.eu`) that is the portal's process, not an atomic-server. Someone on the free tier has no node at all, yet `App.tsx` defaulted `serverUrl` to `window.location.origin`. Found on staging 2026-09-02 during the first real onboarding walkthrough:

- `wss://app.staging.atomicserver.eu/ws` retried forever, toasting "WebSocket … closed before it opened" on the first screen
- `GET /server` polled every 5s on the Sync page, answered with `index.html`
- every commit (agent profile, drive, default ontology) parked in the outbox
- Sync page: "syncs with 1 other device" and "This workspace already lives on app.staging.atomicserver.eu. Moving it here is a migration, not a backup." for a brand-new drive

## How

- **`helpers/originNode.ts`** (new): hosted builds probe their own origin once at boot (`GET /server`, 3s timeout). `index.html` or a 404 is a definite "not a node"; no answer at all leaves the default so a node-served install reopened offline still reconnects. Source builds and Tauri never probe.
- **`@tomic/lib`**: `StoreOpts.connect` / `setServerUrl(url, { connect })` — keep the URL, open no socket. A later switch to a real node connects as usual.
- **`NewIdentitySection`**: with a non-node origin, registers the agent DID and the derived personal drive as local-only *before* their first save — the same routing the demo guest uses.
- **`cloudSync.enableCloudSyncForDrive`**: promotes the agent resource alongside the drive once a node is assigned, so the node also receives the profile.
- **`fetchManagedInfo`** short-circuits for that origin; **`SyncRoute`** drops the server card, which fixes both the count and the blocker copy.

## Tests

- `lib/src/store.connect.test.ts` — default connects, `connect:false` doesn't, later `setServerUrl` does
- `data-browser/src/helpers/originNode.test.ts` — node / index.html / 404 / JSON-without-version / offline / 5xx
- Full `lib` (309) and `data-browser` (651) unit suites green; hosted-flag production build compiles.

## Not covered here

- Accounts created on staging *before* this change have a non-local-only drive with parked commits; test accounts only.
- SYNC_PUSH of a free-standing agent DID via `promoteLocalDrive(agentSubject)` should be verified on staging the first time Cloud Server is switched on for a free-tier drive.
- atomic-saas pins `ATOMIC_SERVER_REF` in `ci-body.yml`; staging only picks this up after that pin is bumped to the merge commit.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd