### PR TITLE
fix(table): show the entry row before the collection is ready

### DIFF
--- a/browser/data-browser/src/chunks/TablePage/TableResource.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableResource.tsx
@@ -1174,11 +1174,16 @@ export const TableResource: React.FC<TableResourceProps> = ({
               readOnly={!canWrite}
               columns={gridColumns}
               columnSizes={gridColumnSizes}
-              itemCount={
-                ready
-                  ? memberCount + newRowSubjects.length
-                  : collection.totalMembers
-              }
+              // The session's empty entry row is local state: it needs
+              // nothing from the collection, so it is not gated on `ready`.
+              // Gating it made a fresh table wait for the collection's first
+              // fetch, and when the socket is not authenticated yet that fetch
+              // sits out a 3s `waitForServerConnected` grace period
+              // (`Collection.fetchPage`) before an empty page lands — five
+              // seconds with no row to type into. Members that arrive during
+              // load shift the row's index, not its key (`itemKey` offsets by
+              // `memberCount`), so nothing remounts.
+              itemCount={memberCount + newRowSubjects.length}
               itemKey={itemKey}
               columnToKey={columnToKey}
               labelledBy={titleId}


### PR DESCRIPTION
## Problem

A new table (e.g. from the Workout log template) could take ~5 seconds before the empty entry row appeared, while the header, tabs and quick-add bar were already on screen.

The grid only counted the session's placeholder row once `useCollection` reported `ready`. On a fresh table the collection's first fetch cannot be answered locally (an empty local result is only trusted once the drive has completed a sync), so it falls through to the server, and while the WebSocket is not authenticated yet `Collection.fetchPage` sits out a 3s `waitForServerConnected` grace period before resolving. That is the whole delay: the row is local state waiting on a network grace period it does not need.

## Fix

Count the placeholder rows from the start (`memberCount + newRowSubjects.length`). Session rows are keyed by their `_new:` subject and `itemKey` offsets by `memberCount`, so members arriving during load shift the row's index without remounting it. Rebuilt collections (filter/sort changes) already rendered the placeholder while loading, since `ready` never went back to false; this only changes the initial load.

## Verification

Cold reload of a Workout log table, time until the entry row is in the DOM:

| Scenario | Before | After |
|---|---|---|
| Server reachable | 1.15 s | 1.15 s |
| Server unreachable | 5.0 s | 0.86 s |

- Typing into the row still materializes it and spawns a fresh placeholder below.
- `pnpm vitest run src/chunks/TablePage`: 341 passed.
- `tables.spec.ts` + `quick-add.spec.ts`: 9/10 pass; "fast row entry" also fails on unmodified code in the same environment (its post-materialize wait), so it is unrelated.
