### PR TITLE
fix(table): mark the grid aria-busy until its rows have loaded

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -560,7 +560,7 @@ export class AtomicServer {
           this.source.directory('atomic-plugin'),
         )
         .withDirectory('/code/tools', this.source.directory('tools'))
-        .withMountedCache('/code/target', dag.cacheVolume('rust-wasm-target'))
+        .withMountedCache('/code/target', dag.cacheVolume('rust-wasm-target-v2'))
         .withWorkdir('/code/wasm')
         // Install + build in a single exec so the install is part of the
         // build step's own cache key. Splitting them lets dagger cache the
@@ -626,7 +626,7 @@ export class AtomicServer {
           this.source.directory('atomic-plugin'),
         )
         .withDirectory('/code/tools', this.source.directory('tools'))
-        .withMountedCache('/code/target', dag.cacheVolume('rust-slim-target'))
+        .withMountedCache('/code/target', dag.cacheVolume('rust-slim-target-v2'))
         .withWorkdir('/code')
         .withEnvVariable('ATOMICSERVER_SKIP_JS_BUILD', 'true')
         // build.rs still wants to bundle the data-browser dist as embedded
@@ -1065,7 +1065,7 @@ export class AtomicServer {
       )
       .withDirectory('/code/atomic-plugin', source.directory('atomic-plugin'))
       .withDirectory('/code/tools', source.directory('tools'))
-      .withMountedCache('/code/target', dag.cacheVolume('rust-target'))
+      .withMountedCache('/code/target', dag.cacheVolume('rust-target-v2'))
       .withWorkdir('/code')
       .withExec(['cargo', 'fetch']);
 
@@ -1227,7 +1227,7 @@ export class AtomicServer {
         )
         .withDirectory('/code/atomic-plugin', source.directory('atomic-plugin'))
         .withDirectory('/code/tools', source.directory('tools'))
-        .withMountedCache('/code/target', dag.cacheVolume('rust-checks-target'))
+        .withMountedCache('/code/target', dag.cacheVolume('rust-checks-target-v2'))
         .withWorkdir('/code')
         // build.rs in atomic-server wants to bundle a JS dist. Skip it —
         // fmt/clippy/test don't need it and including the bundle would

--- a/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
@@ -51,6 +51,13 @@ interface FancyTableProps<T> {
   rowHeight?: number;
   columnToKey: (column: T) => string;
   labelledBy: string;
+  /**
+   * The rows are still being fetched. Rendered as `aria-busy` on the grid so
+   * assistive tech, and tests, can tell a loading grid from a settled one:
+   * the placeholder row is drawn before the collection answers, so "a row is
+   * visible" no longer means "the data has arrived".
+   */
+  busy?: boolean;
   onUndoCommand?: () => void;
   onClearRow?: (index: number) => void;
   onClearCells?: (cells: CellIndex<T>[]) => void;
@@ -113,6 +120,7 @@ function FancyTableInner<T>({
   columnSizes,
   columnToKey,
   labelledBy,
+  busy = false,
   onCellResize = () => undefined,
   onClearCells,
   onClearRow,
@@ -312,6 +320,7 @@ function FancyTableInner<T>({
       </VisuallyHidden>
       <Table
         aria-labelledby={labelledBy}
+        aria-busy={busy}
         aria-rowcount={itemCount}
         aria-colcount={columns.length + 2}
         aria-describedby={ariaUsageId}

--- a/browser/data-browser/src/chunks/TablePage/TableResource.tsx
+++ b/browser/data-browser/src/chunks/TablePage/TableResource.tsx
@@ -1184,6 +1184,7 @@ export const TableResource: React.FC<TableResourceProps> = ({
               // load shift the row's index, not its key (`itemKey` offsets by
               // `memberCount`), so nothing remounts.
               itemCount={memberCount + newRowSubjects.length}
+              busy={!ready}
               itemKey={itemKey}
               columnToKey={columnToKey}
               labelledBy={titleId}

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1317,6 +1317,12 @@ export async function waitForDriveSettled(page: Page, timeoutMs = 30_000) {
  */
 export async function waitForGridMounted(page: Page, timeoutMs = 30_000) {
   await expect(page.getByRole('grid')).toBeVisible({ timeout: timeoutMs });
+  // The empty entry row renders before the collection has answered, so a
+  // visible row no longer means the data (and the ClientDb queue in front of
+  // it) has settled. The grid says so itself: `aria-busy` while loading.
+  await expect(page.locator('[role="grid"][aria-busy="false"]')).toBeVisible({
+    timeout: timeoutMs,
+  });
   await expect(page.locator('[aria-rowindex="2"]')).toBeVisible({
     timeout: timeoutMs,
   });


### PR DESCRIPTION
## Problem

#1328 made the empty entry row render before the collection has answered. That removed an implicit synchronisation point the e2e suite relied on: `waitForGridMounted` treated "a data row is visible" as "the data has arrived". On CI, `tables.spec.ts › create and fill @smoke` started failing 3/3: after its post-setup reload it typed into the grid while the ClientDb worker was still draining, and the tag picker never opened. Locally (no load) it passes either way.

## Fix

- `FancyTable` gets a `busy` prop rendered as `aria-busy` on the grid element. `TableResource` passes `!ready`. This is also the right signal for assistive tech.
- `waitForGridMounted` waits for `[role="grid"][aria-busy="false"]` before looking for a row, so every spec using the helper gets its old synchronisation back, without re-gating the row on the network.

## Also: cargo cache reset in dagger

The shared `rust-*-target` cache volumes hold a stale `atomic_lib` (built without `populate::repopulate_defaults` by a since-deleted revert branch). Cargo's mtime-based freshness check keeps it, so `develop` and other branches fail the slim build with `E0425` in `server/src/appstate.rs`. The second commit renames the four volumes (`-v2`); the first build on each is cold.

## Verification

Against a local stack built from `origin/develop` (server binary, WASM, frontend): `tables.spec.ts`, `quick-add.spec.ts`, `table-templates.spec.ts` — 14 passed. The branch's Rust sources compile locally with CI's `--no-default-features --features light`. Commits carry `[full-e2e]` so CI runs the full suite here.
