### PR TITLE
Revert "fix(populate): re-seed built-in defaults on Db open via a fingerprint (#1323)"

### DIFF
--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -2011,3 +2011,5 @@ export async function acceptInvite(page: Page) {
     40000,
   );
 }
+
+// CI cache-bust 2026-09-02: forces a real e2e execution for this branch.

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -210,10 +210,6 @@ pub struct ReplicationTarget {
 
 const REPLICATION_PREFIX: &str = "replication:";
 
-/// `Tree::PluginMeta` key holding the fingerprint of the built-in defaults
-/// last seeded into this store. See `populate::bootstrap`.
-const DEFAULTS_FINGERPRINT_KEY: &[u8] = b"defaults_fingerprint";
-
 fn replication_key(drive: &str) -> String {
     format!("{REPLICATION_PREFIX}{drive}")
 }
@@ -434,10 +430,8 @@ impl Db {
         // see the right state.
         store.populate_watched_queries_cache()?;
 
-        // Runs on every open, but only writes when the embedded defaults
-        // (`lib/defaults/*.json` + base models) changed since this store was
-        // last seeded: `bootstrap` compares a fingerprint of them against the
-        // one stored in `Tree::PluginMeta` and adds what is missing.
+        // Re-run on every startup so new vocabulary (properties, classes) added
+        // to default_store.json is available without a manual `populate` command.
         crate::populate::bootstrap(&store)
             .await
             .map_err(|e| format!("Failed to populate base models. {}", e))?;
@@ -3434,23 +3428,6 @@ impl Storelike for Db {
         self.get_propvals(&normalized.pure_id()).is_ok()
     }
 
-    fn get_defaults_fingerprint(&self) -> AtomicResult<Option<String>> {
-        Ok(self
-            .kv
-            .get(Tree::PluginMeta, DEFAULTS_FINGERPRINT_KEY)?
-            .and_then(|v| String::from_utf8(v).ok()))
-    }
-
-    fn set_defaults_fingerprint(&self, fingerprint: &str) -> AtomicResult<()> {
-        // Folds into the open bootstrap batch, so the fingerprint is only
-        // persisted together with the seed it describes.
-        self.kv.insert(
-            Tree::PluginMeta,
-            DEFAULTS_FINGERPRINT_KEY,
-            fingerprint.as_bytes(),
-        )
-    }
-
     #[instrument(skip_all)]
     async fn get_resource_extended(
         &self,
@@ -3653,7 +3630,7 @@ impl Storelike for Db {
     }
 
     async fn populate(&self) -> AtomicResult<()> {
-        crate::populate::bootstrap(self).await.map(|_| ())
+        crate::populate::bootstrap(self).await
     }
 
     #[instrument(skip_all)]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -64,15 +64,6 @@ pub enum SaveOpts {
     /// Removes existing properties that are not present in the imported resource.
     /// Does not perform authorization checks.
     Save,
-    /// Add-only upsert, used for seeding built-in defaults into a store that
-    /// may already hold (possibly user-edited) copies of them.
-    /// Missing resources are added; on an existing resource only the
-    /// properties it does not have yet are added. Existing values are never
-    /// overwritten or removed, and nothing is written when there is nothing
-    /// to add.
-    /// Does not validate required properties, does not create Commits,
-    /// does not perform authorization checks.
-    Merge,
     /// Create Commits for every change.
     /// Does not remove existing properties.
     /// Performs authorization cheks (if enabled)
@@ -787,43 +778,6 @@ async fn parse_json_ad_map_to_resource(
             r.set_propvals_unsafe(propvals);
             store.add_resource(&r).await?;
             r
-        }
-        SaveOpts::Merge => {
-            let subj = subject.ok_or_else(|| {
-                AtomicError::parse_error("No @id or localId found in resource", None, None)
-            })?;
-            // `has_stored_resource`, not `get_resource`: the latter may fetch
-            // an `https://` subject from the network and would turn a missing
-            // default into a remote copy instead of the embedded one.
-            let stored = if store.has_stored_resource(&subj.as_str().into()) {
-                Some(store.get_resource(&subj.as_str().into()).await?)
-            } else {
-                None
-            };
-            match stored {
-                Some(mut existing) => {
-                    let mut added = false;
-                    for (prop, val) in propvals {
-                        if existing.get_propvals().contains_key(&prop) {
-                            continue;
-                        }
-                        existing.set_unsafe(prop, val)?;
-                        added = true;
-                    }
-                    if added {
-                        store
-                            .add_resource_opts(&existing, false, true, true)
-                            .await?;
-                    }
-                    existing
-                }
-                None => {
-                    let mut r = Resource::new(subj);
-                    r.set_propvals_unsafe(propvals);
-                    store.add_resource_opts(&r, false, true, true).await?;
-                    r
-                }
-            }
         }
         SaveOpts::Commit => {
             let signer = parse_opts

--- a/lib/src/populate.rs
+++ b/lib/src/populate.rs
@@ -5,16 +5,19 @@
 use crate::{
     datatype::DataType,
     errors::AtomicResult,
-    parse::{ParseOpts, SaveOpts},
+    parse::ParseOpts,
     schema::{Class, Property},
     urls, Storelike, Value,
 };
 
-/// The hardcoded Properties and Classes that `populate_base_models` seeds.
-/// Kept as data (rather than inline in the seeding loop) so the defaults
-/// fingerprint can cover them: a base model added here must reach existing
-/// stores just like a new `lib/defaults/*.json` entry.
-fn base_models() -> (Vec<Property>, Vec<Class>) {
+/// Populates a store with some of the most fundamental Properties and Classes needed to bootstrap the whole.
+/// This is necessary to prevent a loop where Property X (like the `shortname` Property)
+/// cannot be added, because it's Property Y (like `description`) has to be fetched before it can be added,
+/// which in turn has property Property X (`shortname`) which needs to be fetched before.
+/// https://github.com/atomicdata-dev/atomic-server/issues/60
+pub async fn populate_base_models(store: &impl Storelike) -> AtomicResult<()> {
+    // Start with adding the most fundamental properties - the properties for Properties
+
     let properties = vec![
         Property {
             class_type: None,
@@ -223,16 +226,6 @@ fn base_models() -> (Vec<Property>, Vec<Class>) {
             subject: urls::COMMIT.into(),
         },
     ];
-    (properties, classes)
-}
-
-/// Populates a store with some of the most fundamental Properties and Classes needed to bootstrap the whole.
-/// This is necessary to prevent a loop where Property X (like the `shortname` Property)
-/// cannot be added, because it's Property Y (like `description`) has to be fetched before it can be added,
-/// which in turn has property Property X (`shortname`) which needs to be fetched before.
-/// https://github.com/atomicdata-dev/atomic-server/issues/60
-pub async fn populate_base_models(store: &impl Storelike) -> AtomicResult<()> {
-    let (properties, classes) = base_models();
 
     // Only ever ADD. This runs again on a store that already holds part of the
     // vocabulary (see `bootstrap`), and on atomicdata.dev itself those
@@ -271,252 +264,115 @@ pub async fn populate_base_models(store: &impl Storelike) -> AtomicResult<()> {
     Ok(())
 }
 
-/// The embedded `lib/defaults/*.json` files, in import order. Properties a
-/// later file uses must be defined by an earlier one (or by the base models).
-/// This list is the single source for both `populate_default_store` and
-/// `defaults_fingerprint`, so a file cannot be imported without being
-/// fingerprinted or vice versa.
-const DEFAULT_FILES: &[(&str, &str)] = &[
-    (
-        "default_store.json",
-        include_str!("../defaults/default_store.json"),
-    ),
-    ("chatroom.json", include_str!("../defaults/chatroom.json")),
-    ("meeting.json", include_str!("../defaults/meeting.json")),
-    ("table.json", include_str!("../defaults/table.json")),
-    ("dashboard.json", include_str!("../defaults/dashboard.json")),
-    (
-        "ontologies.json",
-        include_str!("../defaults/ontologies.json"),
-    ),
-    ("ai.json", include_str!("../defaults/ai.json")),
-    ("plugins.json", include_str!("../defaults/plugins.json")),
-    ("forks.json", include_str!("../defaults/forks.json")),
-    ("i18n.json", include_str!("../defaults/i18n.json")),
-];
-
-/// Fingerprint of everything `bootstrap` seeds: the base models and the
-/// embedded default JSON files, byte for byte. Computed from the compiled-in
-/// data, so it is a property of the binary (or wasm bundle), and it changes
-/// whenever a default is added or edited in the source tree.
-///
-/// `bootstrap` stores it in the `Db` and re-seeds only when it differs, which
-/// is what lets a new `lib/defaults/*.json` Property or Class reach a store
-/// that was seeded by an older build, without a manual `--repopulate-defaults`.
-pub fn defaults_fingerprint() -> String {
-    let mut hasher = blake3::Hasher::new();
-    // Version the layout so a change in what is hashed cannot collide with an
-    // old fingerprint by accident.
-    hasher.update(b"atomic-defaults-fingerprint-v1\0");
-    let (properties, classes) = base_models();
-    let base_models_json =
-        serde_json::to_string(&(properties, classes)).expect("base models serialize to JSON");
-    hasher.update(base_models_json.as_bytes());
-    hasher.update(b"\0");
-    for (name, contents) in DEFAULT_FILES {
-        hasher.update(name.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(contents.as_bytes());
-        hasher.update(b"\0");
-    }
-    hasher.finalize().to_hex().to_string()
-}
-
 /// Imports the Atomic Data Core items (the entire atomicdata.dev Ontology / Vocabulary)
-/// and the built-in app ontologies from `lib/defaults/*.json`.
-///
-/// Add-only: a resource that is already in the store keeps every value it
-/// has (those may have been edited by a user, or are the site's own content
-/// on atomicdata.dev itself); only the properties it lacks are added. See
-/// [`SaveOpts::Merge`]. Consequently a *changed* value of an existing default
-/// never propagates to an existing store — only new resources and new
-/// properties do.
 pub async fn populate_default_store(store: &impl Storelike) -> AtomicResult<()> {
-    let opts = ParseOpts {
-        save: SaveOpts::Merge,
-        ..ParseOpts::default()
-    };
-    for (name, contents) in DEFAULT_FILES {
-        store
-            .import(contents, &opts)
-            .await
-            .map_err(|e| format!("Failed to import {name}: {e}"))?;
-    }
+    store
+        .import(
+            include_str!("../defaults/default_store.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import default_store.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/chatroom.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import chatroom.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/meeting.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import meeting.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/table.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import table.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/dashboard.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import dashboard.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/ontologies.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import ontologies.json: {e}"))?;
+    store
+        .import(include_str!("../defaults/ai.json"), &ParseOpts::default())
+        .await
+        .map_err(|e| format!("Failed to import ai.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/plugins.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import plugins.json: {e}"))?;
+    store
+        .import(
+            include_str!("../defaults/forks.json"),
+            &ParseOpts::default(),
+        )
+        .await
+        .map_err(|e| format!("Failed to import forks.json: {e}"))?;
+    store
+        .import(include_str!("../defaults/i18n.json"), &ParseOpts::default())
+        .await
+        .map_err(|e| format!("Failed to import i18n.json: {e}"))?;
     Ok(())
-}
-
-/// What [`bootstrap`] did.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BootstrapOutcome {
-    /// The stored fingerprint matches this build; nothing was written.
-    UpToDate,
-    /// The store had no defaults yet; everything was seeded.
-    Seeded,
-    /// The store was seeded by a different build (or predates fingerprints);
-    /// missing defaults were added, existing values left alone.
-    Updated,
 }
 
 /// Bootstraps the store with core models and default ontologies.
-///
-/// Runs on every `Db` open. Compares [`defaults_fingerprint`] of this build
-/// against the one the store recorded when it was last seeded, and does
-/// nothing when they match. On a mismatch (new build, or a store from before
-/// fingerprints existed) it upserts the base models and `lib/defaults/*.json`
-/// add-only and records the new fingerprint. The whole thing is one DB
-/// transaction (`begin_batch`/`commit_batch`), so the fingerprint is only
-/// persisted together with the seed it describes.
-///
-/// [`repopulate_defaults`] is the forced variant that skips the comparison.
-pub async fn bootstrap(store: &impl Storelike) -> AtomicResult<BootstrapOutcome> {
-    let current = defaults_fingerprint();
-    let stored = store.get_defaults_fingerprint()?;
-    if stored.as_deref() == Some(current.as_str()) {
-        tracing::debug!("populate::bootstrap: defaults up to date, skipping");
-        return Ok(BootstrapOutcome::UpToDate);
+/// Uses `begin_batch`/`commit_batch` to fold all writes into a single DB transaction.
+pub async fn bootstrap(store: &impl Storelike) -> AtomicResult<()> {
+    // "Seeded" cannot be decided from one sentinel. `shortname` has existed
+    // since the beginning, so a store migrated from an older release passes
+    // that check while missing every property added to the vocabulary since
+    // its snapshot was taken — and the seeding is then skipped wholesale, so
+    // they are never added. On a store migrated from the pre-DID era that
+    // means `loroUpdate`, `genesis`, `drive` and `sortOrder` are simply
+    // absent, and since commit validation resolves `loroUpdate`'s Property
+    // definition, EVERY write fails: the server can't find it locally, tries
+    // to fetch `https://atomicdata.dev/properties/loroUpdate` from the real
+    // atomicdata.dev, and gets a 404 back.
+    //
+    // So probe for the newest thing the vocabulary is expected to contain as
+    // well. Both must be present to call the store seeded.
+    //
+    // This must be a local storage check, not `get_resource`: `get_resource`
+    // may fetch external Atomic URLs and can make a fresh store look seeded
+    // after fetching only the sentinel resource.
+    let has_legacy_sentinel = store.has_stored_resource(&crate::urls::SHORTNAME.into());
+    let has_current_sentinel = store.has_stored_resource(&crate::urls::LORO_UPDATE.into());
+
+    if has_legacy_sentinel && has_current_sentinel {
+        tracing::debug!("populate::bootstrap: store already seeded, skipping");
+        return Ok(());
     }
 
-    // Local storage check, not `get_resource`: `get_resource` may fetch
-    // external Atomic URLs and could make a fresh store look seeded.
-    let outcome = if store.has_stored_resource(&urls::SHORTNAME.into()) {
+    if has_legacy_sentinel {
         tracing::info!(
-            "populate::bootstrap: store was seeded by a different build; \
-             adding missing defaults (existing values are left untouched)"
+            "populate::bootstrap: store predates part of the current vocabulary; \
+             adding what is missing (existing resources are left untouched)"
         );
-        BootstrapOutcome::Updated
     } else {
         tracing::info!("populate::bootstrap: seeding base models and ontologies");
-        BootstrapOutcome::Seeded
-    };
+    }
 
-    seed_defaults(store, &current).await?;
-    Ok(outcome)
-}
-
-/// Forced re-seed, ignoring the stored fingerprint. Same add-only semantics
-/// as [`bootstrap`]: nothing that exists is overwritten or removed. Backs the
-/// server's `--repopulate-defaults` flag.
-pub async fn repopulate_defaults(store: &impl Storelike) -> AtomicResult<()> {
-    seed_defaults(store, &defaults_fingerprint()).await
-}
-
-async fn seed_defaults(store: &impl Storelike, fingerprint: &str) -> AtomicResult<()> {
     store.begin_batch();
     populate_base_models(store).await?;
     populate_default_store(store).await?;
-    store.set_defaults_fingerprint(fingerprint)?;
     store.commit_batch()?;
     Ok(())
-}
-
-#[cfg(all(test, feature = "db-redb", not(target_arch = "wasm32")))]
-mod tests {
-    use super::*;
-    use crate::Db;
-
-    /// A Property that only `lib/defaults/chatroom.json` defines.
-    const NEW_DEFAULT: &str = "https://atomicdata.dev/properties/messages";
-
-    fn temp_paths(id: &str) -> (std::path::PathBuf, std::path::PathBuf) {
-        (
-            std::path::PathBuf::from(format!(".temp/db/{id}")),
-            std::path::PathBuf::from(format!(".temp/db/{id}/uploads")),
-        )
-    }
-
-    #[test]
-    fn fingerprint_is_deterministic() {
-        let a = defaults_fingerprint();
-        let b = defaults_fingerprint();
-        assert_eq!(a, b);
-        assert_eq!(a.len(), 64, "blake3 hex");
-    }
-
-    /// A store seeded by an older build (different fingerprint) picks up a
-    /// default it lacks on the next open — no `--repopulate-defaults` needed.
-    #[tokio::test]
-    async fn seeded_store_gains_new_default_on_reopen() {
-        let id = "populate_new_default_on_reopen";
-        let (db_path, uploads) = temp_paths(id);
-        {
-            let store = Db::init_temp(id).await.unwrap();
-            assert_eq!(
-                store.get_defaults_fingerprint().unwrap().as_deref(),
-                Some(defaults_fingerprint().as_str())
-            );
-            // Make it look like a store seeded before `messages` existed and
-            // by a build with a different set of defaults.
-            store.remove_resource(&NEW_DEFAULT.into()).await.unwrap();
-            assert!(!store.has_stored_resource(&NEW_DEFAULT.into()));
-            store.set_defaults_fingerprint("older-build").unwrap();
-            store.flush().unwrap();
-        }
-
-        let store = Db::init_redb_file(&db_path, Some("https://localhost".into()), &uploads)
-            .await
-            .unwrap();
-        assert!(
-            store.has_stored_resource(&NEW_DEFAULT.into()),
-            "a default missing from a store seeded by another build must be added on open"
-        );
-        assert_eq!(
-            store.get_defaults_fingerprint().unwrap().as_deref(),
-            Some(defaults_fingerprint().as_str()),
-            "the fingerprint is updated after the re-seed"
-        );
-    }
-
-    /// Re-seeding only adds; a value the user changed on a default resource
-    /// is kept, while a property the resource lost is put back.
-    #[tokio::test]
-    async fn user_edited_default_survives_reseed() {
-        let store = Db::init_temp("populate_user_edit_survives").await.unwrap();
-        let mut resource = store.get_resource(&NEW_DEFAULT.into()).await.unwrap();
-        resource
-            .set_unsafe(
-                urls::DESCRIPTION.into(),
-                Value::String("edited by a user".into()),
-            )
-            .unwrap();
-        resource.remove_propval(urls::IS_DYNAMIC).unwrap();
-        store
-            .add_resource_opts(&resource, false, true, true)
-            .await
-            .unwrap();
-
-        repopulate_defaults(&store).await.unwrap();
-
-        let after = store.get_resource(&NEW_DEFAULT.into()).await.unwrap();
-        assert_eq!(
-            after.get(urls::DESCRIPTION).unwrap().to_string(),
-            "edited by a user",
-            "an existing propval must not be clobbered by the default"
-        );
-        assert!(
-            after.get(urls::IS_DYNAMIC).is_ok(),
-            "a propval the default has and the resource lacks is added"
-        );
-    }
-
-    /// With a matching fingerprint `bootstrap` returns without writing.
-    #[tokio::test]
-    async fn bootstrap_is_a_noop_when_fingerprint_matches() {
-        let store = Db::init_temp("populate_noop").await.unwrap();
-        // If bootstrap wrote anything, this default would come back.
-        store.remove_resource(&NEW_DEFAULT.into()).await.unwrap();
-
-        let outcome = bootstrap(&store).await.unwrap();
-
-        assert_eq!(outcome, BootstrapOutcome::UpToDate);
-        assert!(
-            !store.has_stored_resource(&NEW_DEFAULT.into()),
-            "an up-to-date store must not be re-seeded"
-        );
-
-        // And a stale fingerprint is exactly what makes it write.
-        store.set_defaults_fingerprint("older-build").unwrap();
-        assert_eq!(bootstrap(&store).await.unwrap(), BootstrapOutcome::Updated);
-        assert!(store.has_stored_resource(&NEW_DEFAULT.into()));
-        assert_eq!(bootstrap(&store).await.unwrap(), BootstrapOutcome::UpToDate);
-    }
 }

--- a/lib/src/storelike.rs
+++ b/lib/src/storelike.rs
@@ -447,20 +447,6 @@ pub trait Storelike: Sized + Send + Sync {
         false
     }
 
-    /// The fingerprint of the built-in defaults (`lib/defaults/*.json` + base
-    /// models) that were last seeded into this store, if the store persists
-    /// one. See [`crate::populate::bootstrap`]. Stores that do not persist it
-    /// return `None`, which makes every open re-run the (idempotent) seed.
-    fn get_defaults_fingerprint(&self) -> AtomicResult<Option<String>> {
-        Ok(None)
-    }
-
-    /// Records the defaults fingerprint after a successful seed. No-op for
-    /// stores that do not persist it.
-    fn set_defaults_fingerprint(&self, _fingerprint: &str) -> AtomicResult<()> {
-        Ok(())
-    }
-
     /// Returns an existing resource, or creates a new one with the given Subject
     async fn get_resource_new(&self, subject: &Subject) -> Resource {
         match self.get_resource(subject).await {

--- a/planning/content-i18n.md
+++ b/planning/content-i18n.md
@@ -89,8 +89,7 @@ approach and it is worth paying.
   are generic, not website-ontology-specific. **Inherits the known bootstrap
   gap** (`drafts-and-suggestions.md` §Known gap): existing stores don't pick up
   new defaults without `--repopulate-defaults` / a rebuilt wasm bundle. i18n
-  ships behind whatever migration story closes that. *(Closed: `Db` open
-  re-seeds defaults add-only whenever their build fingerprint changed.)*
+  ships behind whatever migration story closes that.
 - `translationOf` points at the canonical resource, not at a minted
   "translation key". Asymmetric on purpose: it matches the `originalSubject`
   precedent, needs no key uniqueness machinery, and makes the reverse query
@@ -325,8 +324,7 @@ language on the canonical resource) and, later, a drive-wide saved query.
 - [x] **Defaults:** `localizedText` Datatype resource (`default_store.json`);
       `i18n.json` ontology with `language`, `translationOf`,
       `defaultLanguage`, `languages`; imported in `populate_default_store`.
-      Bootstrap gap fixed — existing stores re-seed on open (fingerprint gate
-      in `populate::bootstrap`); `--repopulate-defaults` is only the forced path.
+      Bootstrap gap applies — existing stores need `--repopulate-defaults`.
 - [x] **TS `@tomic/lib`:** `Datatype.LOCALIZEDTEXT`, `validateDatatype`,
       `datatypeTag` lockstep, `localizeText` resolver, `i18n` ontology
       binding, and a native-LoroMap write path in `loroSetProperty`

--- a/planning/drafts-and-suggestions.md
+++ b/planning/drafts-and-suggestions.md
@@ -221,12 +221,6 @@ so each verb appears in the context menu, ⌘K, ⌘M and the AI/MCP surface for 
 
 ## Known gap: seeding a new default ontology into existing stores
 
-> **Fixed.** `populate::bootstrap` now fingerprints the embedded base models +
-> `lib/defaults/*.json` and, on every `Db` open (server and OPFS/WASM), re-seeds
-> add-only when the fingerprint differs from the stored one. A new build carries
-> a new fingerprint, so both ends below pick up new defaults on next open;
-> `--repopulate-defaults` remains only as a forced re-run. Kept for history.
-
 `bootstrap()` is guarded by `has_stored_resource(SHORTNAME)`, so a store that was
 already populated never picks up a newly-added `lib/defaults/*.json`. That applies
 to **both** ends:

--- a/planning/emoji-cover-images.md
+++ b/planning/emoji-cover-images.md
@@ -16,9 +16,7 @@
 > - **Client-side `validate: false`** on the decoration setters: the new
 >   property subject doesn't resolve on atomicdata.dev yet, so client datatype
 >   validation would fail on the fetch. The server validates commits against
->   its local copy from `lib/defaults/`. *(The bootstrap gap that left existing
->   stores without new defaults is fixed: `Db` open re-seeds `lib/defaults/*.json`
->   add-only when the embedded defaults' fingerprint changed. The workaround stays.)*
+>   its local copy from `lib/defaults/`.
 > - Mounted in: ResourcePageDefault, ArticlePage, FolderPage,
 >   DocumentV2FullPage. Emoji glyph surfaces: sidebar, inline links, search
 >   ResultLine, resource cards. The emoji picker gained a "Remove emoji" action
@@ -199,7 +197,7 @@ Perf note: emoji lives on the resource itself, which these components have alrea
 1. Define `coverImage` in `lib/defaults/` (next to `emoji` in table.json, or default_store.json) so self-hosted servers have it locally.
 2. Publish the same property on atomicdata.dev, since the subject must resolve.
 3. Regenerate TS ontologies with `@tomic/cli` (`browser/lib/atomic.config.json` → `browser/lib/src/ontologies/`); until regen, the subject can be hardcoded in `urls.ts` the way `emoji` already is (`urls.ts:162`).
-4. Existing servers only pick up the new property + class `recommends` via `ATOMIC_REPOPULATE_DEFAULTS` — mention in release notes. *(No longer needed: existing stores re-seed on open, see `populate::bootstrap`.)*
+4. Existing servers only pick up the new property + class `recommends` via `ATOMIC_REPOPULATE_DEFAULTS` — mention in release notes.
 
 ## Edge cases
 

--- a/planning/kanban-views-test-spec.md
+++ b/planning/kanban-views-test-spec.md
@@ -9,9 +9,7 @@
 
 - A running `atomic-server` (default `http://localhost:9883`) initialized with
   `ATOMIC_INITIALIZE=true`, its store carrying the new `view-group-by` ontology
-  property (fresh init, or `ATOMIC_REPOPULATE_DEFAULTS=true`; a store opened by
-  a build that embeds the property picks it up on its own since the bootstrap
-  fingerprint landed).
+  property (fresh init, or `ATOMIC_REPOPULATE_DEFAULTS=true`).
 - The data-browser served against it — either the Vite dev server (source, HMR)
   or the built bundle. Front-end must include this branch's changes.
 - Signed-in agent with write access to a drive.

--- a/planning/table-view-filters.md
+++ b/planning/table-view-filters.md
@@ -111,8 +111,7 @@ Reuses existing primitives (`Popover`, `ResourceSelector`, `BasicSelect`,
 atomicdata.dev, which doesn't have these yet). The dead `ATOMIC_REPOPULATE_DEFAULTS`
 flag was wired in `server/src/appstate.rs` to re-import defaults into an existing
 store (`populate_default_store`), so the running store picks up the new schema
-without a wipe. *(Since the bootstrap fingerprint landed this happens on `Db`
-open without the flag.)*
+without a wipe.
 
 **Frontend**: `useTableView` hook — local React state (instant UX) hydrated once
 from the active View and debounce-persisted back; lazily creates a "Default View"

--- a/server/src/appstate.rs
+++ b/server/src/appstate.rs
@@ -154,14 +154,25 @@ impl AppState {
                 .await
                 .map_err(|e| format!("Failed to bootstrap store. {}", e))?;
         } else if config.repopulate_defaults {
-            // Forced re-seed of the built-in base models + `lib/defaults/*.json`
-            // into an already-seeded store, ignoring the defaults fingerprint.
-            // Normally unnecessary: `Db` open (`bootstrap`) already re-seeds
-            // whenever the embedded defaults changed since the store was last
-            // seeded. Add-only either way — existing values are never
-            // overwritten. Triggered by `ATOMIC_REPOPULATE_DEFAULTS=true`.
+            // Re-import the built-in ontologies + default resources into an
+            // already-seeded store (without an index rebuild). `import` upserts,
+            // so this only adds new/changed default resources (e.g. a freshly
+            // added Class) and leaves user data untouched. Triggered by
+            // `ATOMIC_REPOPULATE_DEFAULTS=true`.
+            //
+            // `populate_base_models` must run too: `bootstrap()` only calls it
+            // once, on the very first init (`should_init` above), gated on
+            // `has_stored_resource(SHORTNAME)`. A store seeded before a new
+            // base-model property/class was added (e.g. `genesis`, `drive`,
+            // the `Commit` class) never gets it — `populate_default_store`
+            // alone only covers the JSON ontology imports, not this fixed set.
+            // Both writers use `overwrite_existing: true` / upsert import, so
+            // re-running them here is idempotent and safe on live data.
             tracing::info!("Repopulating built-in ontologies and default resources...");
-            atomic_lib::populate::repopulate_defaults(&store)
+            atomic_lib::populate::populate_base_models(&store)
+                .await
+                .map_err(|e| format!("Failed to repopulate base models. {}", e))?;
+            atomic_lib::populate::populate_default_store(&store)
                 .await
                 .map_err(|e| format!("Failed to repopulate defaults. {}", e))?;
         }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -18,7 +18,7 @@ pub struct Opts {
     #[clap(long, env = "ATOMIC_INITIALIZE")]
     pub initialize: bool,
 
-    /// Forces a re-import of the built-in ontologies and default server resources, ignoring the defaults fingerprint. Add-only (existing values are kept). Normally unnecessary: the store re-seeds itself on open whenever the built-in defaults changed.
+    /// Re-imports built-in ontologies and default server resources (`populate_all`) without rebuilding indexes or re-running full initialization.
     #[clap(long, env = "ATOMIC_REPOPULATE_DEFAULTS")]
     pub repopulate_defaults: bool,
 


### PR DESCRIPTION
## Why

Every `develop` push since 4aa5afe4f (#1323) fails the full e2e suite on the same tests, 3/3 attempts each: `calendar.spec.ts` "add an item on a day, and it persists", `documents.spec.ts` "shows a collaborator's ephemeral cursor position", `tables.spec.ts` "fast row entry". All three read state back through a reload or a second session. The run right before that commit (3f2ca1875) was green, and the commit is the only change in that window.

## What I could and could not reproduce

- Locally, with server binary + WASM + frontend all built from `origin/develop`, the ephemeral-cursor test failed once (page 2 got the document title but not the Loro text; the server's snapshot and commit chain never contained the typed text) and passed on later runs. With #1323 reverted it passed every time. Swapping only the server or only the WASM did not reproduce either, so it is timing-sensitive and needs the CI runner's load to show reliably.
- The `[full-e2e]` marker on this commit makes CI run the full suite on the branch. This PR is a draft until that run is in.

## Follow-up

The feature (re-seeding defaults on open) is worth keeping; the revert is to get `develop` green while the mechanism is found. The suspicious part is that `Db::init_redb_opfs` now runs the seed on every WASM open whose fingerprint mismatches, inside one `Durability::None` batch, and the JS-side seed in `initClientDb.ts` trusts the WASM defaults on a first visit.
