### PR TITLE
feat: opt-in Sentry error reporting (server + data-browser)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,11 +366,20 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -1256,6 +1265,8 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "sanitize-filename",
+ "sentry",
+ "sentry-actix",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -1539,6 +1550,21 @@ dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2709,7 +2735,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "libm",
  "log",
@@ -3828,6 +3854,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -5403,6 +5430,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -8893,6 +8926,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9371,6 +9416,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -9546,6 +9592,15 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9822,6 +9877,22 @@ dependencies = [
  "hmac-sha256",
  "lzma-rust2 0.15.8",
  "ureq",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11971,7 +12042,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.23.2",
  "radix_trie",
  "scopeguard",
  "smallvec",
@@ -12205,6 +12276,116 @@ name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
+name = "sentry"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a88b65feb368d9dde5d531a2b59b25016e36fd6e4978432371a3ee77746ca2"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.3",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b59b6298f8b1c621e7e711050f7ae9620b972215eb2822db2bfc4b061ed0cd2"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c51511d67ed670266a93afeaa26a08019b04ad1420cb9191da30f2338d22c48"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b757ac1f335856e8d7f5062a1fd9bc07a05a7eb3cc48247db79bf2618a490bd"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d889520a375e5b93efb0a66def1630d21d168b0251eb55b286b03fa940ccfc84"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0fe456a7380e9df875a1ef4df1e468d35b19b9051599845fab9d8f0c71c4ae"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77796d14eedbef22c2fe78e9c69fb09f14c7ad607e624d48dce92eedc17a136e"
+dependencies = [
+ "bitflags 2.11.1",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71f5ca55942d9b2901af95d5df5c5d65c164134c22a83682cac3d0b6c7ef2d"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "seq-macro"
@@ -14745,6 +14926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15422,7 +15612,7 @@ version = "45.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.11.1",
  "bumpalo",
@@ -15431,13 +15621,13 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.33.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -15480,11 +15670,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -15565,10 +15755,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon 0.13.5",
@@ -15602,7 +15792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944942118aab67e7b4febfe88a65d0af4cfd10af8ed0e79fd6cf39d75359ab7e"
 dependencies = [
  "cc",
- "object",
+ "object 0.39.1",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -15628,7 +15818,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
@@ -15650,9 +15840,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81af36995b4720b32e3d667541b548a27184a859d09a6ee745eaba095f5a6f6e"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon 0.13.5",
  "wasmparser 0.248.0",
  "wasmtime-environ",
@@ -16022,7 +16212,7 @@ checksum = "d73bc25d27222248f9bafc7e9945f61e74275360c3ea0d34008810d436140a53"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "regalloc2",
  "smallvec",
  "target-lexicon 0.13.5",

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@sentry/react": "^10.73.0",
     "@tanstack/react-router": "^1.170.7",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-barcode-scanner": "^2.4.5",

--- a/browser/data-browser/src/helpers/sentry.ts
+++ b/browser/data-browser/src/helpers/sentry.ts
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/react';
+
+/**
+ * Browser error reporting. Strictly opt-in: nothing is initialised, and no
+ * network request is ever made, unless a DSN is provided.
+ *
+ * The DSN comes from one of two places:
+ * - Runtime: atomic-server injects `window.__ATOMIC_SENTRY__` into the served
+ *   index.html when started with `--sentry-dsn-browser` / `SENTRY_DSN_BROWSER`.
+ *   This keeps the shipped bundle identical for every install; only servers
+ *   that opt in get a reporting front-end.
+ * - Build time: `VITE_SENTRY_DSN`, for builds that aren't served by
+ *   atomic-server (the Tauri desktop app, a hosted static build).
+ */
+interface RuntimeSentryConfig {
+  dsn?: string;
+  environment?: string;
+}
+
+declare global {
+  interface Window {
+    __ATOMIC_SENTRY__?: RuntimeSentryConfig;
+  }
+}
+
+export function initSentry(): void {
+  if (typeof window === 'undefined') return;
+
+  const runtime = window.__ATOMIC_SENTRY__;
+  const dsn =
+    runtime?.dsn || (import.meta.env.VITE_SENTRY_DSN as string | undefined);
+
+  if (!dsn) return;
+
+  const environment =
+    runtime?.environment ||
+    (import.meta.env.VITE_SENTRY_ENVIRONMENT as string | undefined) ||
+    (import.meta.env.DEV ? 'development' : 'production');
+
+  Sentry.init({
+    dsn,
+    environment,
+    release: `atomic-data-browser@${__APP_VERSION__}+${__GIT_COMMIT__}`,
+    sendDefaultPii: false,
+    // Errors only: no performance tracing or session replay, to stay well
+    // within the free tier's quota and to keep the payload free of user data.
+    tracesSampleRate: 0,
+  });
+}

--- a/browser/data-browser/src/index.tsx
+++ b/browser/data-browser/src/index.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import App from './App';
+import { initSentry } from './helpers/sentry';
 // Side-effect import: installs a global capture-phase `wheel` listener
 // before any route mounts. CanvasPage uses it to ignore momentum-scroll
 // tails carried over from the previous view (see the file's doc-comment).
@@ -60,6 +61,9 @@ if (
     };
   }
 }
+
+// Before the first render, so errors thrown while mounting are reported too.
+initSentry();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@sentry/react':
+        specifier: ^10.73.0
+        version: 10.73.0(react@19.2.6)
       '@tanstack/react-router':
         specifier: ^1.170.7
         version: 1.170.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3719,6 +3722,40 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry/browser-utils@10.73.0':
+    resolution: {integrity: sha512-qQygxJZ+RV779+iL1+lrJ4f4sZLgbgW0/JWPNp0YlcEAE62yCsdKbqoTEjB/EugdS4mSjBMX0chZC6rblu2Ycw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.73.0':
+    resolution: {integrity: sha512-HqTe1S5RrWLufhX2LaFP3yNoMxfNDroh120bq1zdGHZfFDBMJQ0CDXxHO+L4UJfQ5dWdCCzWbXIAiZuWGa/DFQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.73.0':
+    resolution: {integrity: sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.73.0':
+    resolution: {integrity: sha512-D6nSngX+e46Mae2/oh2bxBvxNK1z2NERbuMAhB5sx9x4xMBWIyGnYYTECehvEqV9+AqGAgxxhOZoYIG3AmRwww==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.73.0':
+    resolution: {integrity: sha512-wJrzS98ddPvhGS/MKNHZyE8X7ecd4KwKdz7fHino2qkqBBrF4cxWr+q/uLTIk5PYWMkeJ4oKMjHAjOqmzGR4tg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.73.0':
+    resolution: {integrity: sha512-sxa2lKkHPfF/j5xFpW7gocthWXRqyoHz8KCPy6yGc8plT477nl57iGSKhQDYsx1Ny10TLjs7YkIuPP1GY/Ax2Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.73.0':
+    resolution: {integrity: sha512-nN2wjN/Y0J5BOJV5hqRHUEBfxwUsipp1PKjcDHh6Fpxnrtfldu3Y99E8cQInseo5heFdzEvrOHBBrqWZXOHVKQ==}
+    engines: {node: '>=18'}
 
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
@@ -13468,6 +13505,47 @@ snapshots:
       ebnf: 1.9.1
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry/browser-utils@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/browser@10.73.0':
+    dependencies:
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/feedback': 10.73.0
+      '@sentry/replay': 10.73.0
+      '@sentry/replay-canvas': 10.73.0
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.73.0':
+    dependencies:
+      '@sentry/core': 10.73.0
+
+  '@sentry/react@10.73.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.73.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      react: 19.2.6
+
+  '@sentry/replay-canvas@10.73.0':
+    dependencies:
+      '@sentry/core': 10.73.0
+      '@sentry/replay': 10.73.0
+
+  '@sentry/replay@10.73.0':
+    dependencies:
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/core': 10.73.0
 
   '@shikijs/core@1.29.2':
     dependencies:

--- a/docs/src/atomicserver/installation.md
+++ b/docs/src/atomicserver/installation.md
@@ -26,6 +26,31 @@ that code compiled into a code path that runs by default — it installs an open
 sync policy (every drive allowed, no quotas) and passes a no-op readiness hook.
 So running your own node keeps your data, and your traffic, entirely yours.
 
+The only exception is [error reporting](#error-reporting-opt-in), which is off
+unless you configure it yourself.
+
+## Error reporting (opt-in)
+
+AtomicServer can report crashes and `error`-level log events to a
+[Sentry](https://sentry.io) project (or a self-hosted Sentry). This is off by
+default: without a DSN no Sentry client is created and nothing leaves the
+machine. To enable it, set:
+
+```sh
+# Server-side: panics and error logs, with the HTTP request that caused them.
+SENTRY_DSN=https://<key>@<host>/<project>
+# Front-end: hands the bundled data-browser its own (public) DSN at runtime,
+# so browser errors are reported too. Separate, because browser DSNs are public.
+SENTRY_DSN_BROWSER=https://<key>@<host>/<project>
+# Tag events with where they came from (optional).
+SENTRY_ENVIRONMENT=production
+```
+
+Only errors are sent. Performance tracing stays off (use `ATOMIC_TRACING=opentelemetry`
+for that), no personal data is attached, and the served front-end bundle is
+identical whether or not a DSN is set: it only contacts Sentry when the server
+injects one.
+
 ## 1. Run using docker
 
 - Run: `docker run -p 80:80 -p 443:443 -v atomic-storage:/atomic-storage ghcr.io/ontola/atomic-server`

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,6 +58,17 @@ simple-server-timing-header = "0.1"
 static-files = "0.3.1"
 tantivy = "0.26.1"
 tracing = "0.1.44"
+# Error reporting. No-op unless SENTRY_DSN is set (see trace.rs). Built on
+# rustls + reqwest to match the rest of the server; no native-tls.
+sentry = { version = "0.49", default-features = false, features = [
+  "backtrace",
+  "contexts",
+  "panic",
+  "reqwest",
+  "rustls",
+  "tracing",
+] }
+sentry-actix = "0.49"
 tracing-chrome = "0.7.2"
 tracing-log = "0.2"
 ureq = "3.3.0"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -95,6 +95,21 @@ pub struct Opts {
     #[clap(value_enum, long, env = "ATOMIC_TRACING", default_value = "stdout")]
     pub trace: Tracing,
 
+    /// Sentry DSN for error reporting. When set, panics and `error!`-level
+    /// tracing events are sent to Sentry, with HTTP request context and
+    /// recent log lines as breadcrumbs. Leave unset to disable entirely.
+    /// `SENTRY_ENVIRONMENT` (e.g. `staging`, `production`) and
+    /// `SENTRY_RELEASE` are read from the environment as well.
+    #[clap(long, env = "SENTRY_DSN")]
+    pub sentry_dsn: Option<String>,
+
+    /// Sentry DSN for the bundled data-browser front-end. Injected into the
+    /// served HTML so the browser reports its own errors. Separate from
+    /// `--sentry-dsn` because browser DSNs are public. Leave unset to serve
+    /// a front-end that never contacts Sentry (the default).
+    #[clap(long, env = "SENTRY_DSN_BROWSER")]
+    pub sentry_dsn_browser: Option<String>,
+
     /// Introduces random delays in the server, to simulate a slow connection. Useful for testing.
     #[clap(long, env = "ATOMIC_SLOW_MODE")]
     pub slow_mode: bool,

--- a/server/src/handlers/single_page_app.rs
+++ b/server/src/handlers/single_page_app.rs
@@ -27,9 +27,10 @@ pub async fn single_page(
     };
 
     let script = format!(
-        "<script nonce=\"{}\">{}{}</script>",
+        "<script nonce=\"{}\">{}{}{}</script>",
         csp_nonce,
         home_drive_script(appstate.config.opts.home_drive.as_deref(), &origin),
+        sentry_script(appstate.config.opts.sentry_dsn_browser.as_deref()),
         appstate.config.opts.script
     );
 
@@ -222,6 +223,26 @@ fn home_drive_script(home_drive: Option<&str>, origin: &str) -> String {
     }
 }
 
+/// Hands the front-end its Sentry DSN and environment at runtime, so the same
+/// build reports to Sentry only on servers that opted in via
+/// `--sentry-dsn-browser`. Empty (no script at all) by default.
+fn sentry_script(dsn: Option<&str>) -> String {
+    let Some(dsn) = dsn.map(str::trim).filter(|d| !d.is_empty()) else {
+        return String::new();
+    };
+    let environment = std::env::var("SENTRY_ENVIRONMENT").unwrap_or_default();
+    let encode = |v: &str| {
+        serde_json::to_string(v)
+            .map(|e| e.replace('<', "\\u003C"))
+            .unwrap_or_else(|_| "\"\"".into())
+    };
+    format!(
+        "window.__ATOMIC_SENTRY__={{dsn:{},environment:{}}};",
+        encode(dsn),
+        encode(&environment)
+    )
+}
+
 fn generate_nonce() -> Result<String, ring::error::Unspecified> {
     use base64::{engine::general_purpose, Engine as _};
     use ring::rand::{SecureRandom, SystemRandom};
@@ -311,5 +332,24 @@ mod test {
         .to_string();
         println!("{}", html);
         assert!(!html.contains("<script>"));
+    }
+}
+
+#[cfg(test)]
+mod sentry_script_tests {
+    use super::sentry_script;
+
+    #[test]
+    fn empty_without_dsn() {
+        assert_eq!(sentry_script(None), "");
+        assert_eq!(sentry_script(Some("  ")), "");
+    }
+
+    #[test]
+    fn escapes_html_in_values() {
+        let out = sentry_script(Some("https://k@o.ingest.sentry.io/1</script>"));
+        assert!(out.starts_with("window.__ATOMIC_SENTRY__={dsn:\"https://k@o.ingest.sentry.io/1"));
+        assert!(!out.contains("</script>"));
+        assert!(out.contains("\\u003C/script>"));
     }
 }

--- a/server/src/serve.rs
+++ b/server/src/serve.rs
@@ -236,6 +236,9 @@ where
         let _ = rustls::crypto::ring::default_provider().install_default();
     }
 
+    // Sentry first, so the tracing layer below has a client to report to.
+    // The guard is held until the end of this function; dropping it flushes.
+    let _sentry_guard = crate::trace::init_sentry(&config);
     let tracing_chrome_flush_guard = crate::trace::init_tracing(&config);
 
     // Setup the database and more
@@ -398,6 +401,10 @@ where
             .app_data(web::PayloadConfig::new(PAYLOAD_MAX))
             .app_data(web::Data::new(appstate.clone()))
             .wrap(cors)
+            // Attaches the request (method, url, headers) to any Sentry event
+            // raised while handling it, and reports handler panics and 5xx
+            // errors. No-op without a bound Sentry client.
+            .wrap(sentry_actix::Sentry::new())
             .wrap(middleware::DefaultHeaders::new().add((SERVER_VERSION_HEADER, SERVER_VERSION)))
             .wrap(tracing_actix_web::TracingLogger::<AtomicRootSpanBuilder>::new())
             .wrap(middleware::Compress::default())

--- a/server/src/trace.rs
+++ b/server/src/trace.rs
@@ -25,7 +25,12 @@ pub fn init_tracing(config: &crate::config::Config) -> Option<tracing_chrome::Fl
             "{log_level},tantivy=warn,loro_internal=warn,pkarr=warn,reqwest=warn"
         ))
     });
-    let tracing_registry = tracing_subscriber::registry().with(filter);
+    // Sentry layer: `error!` events become Sentry issues, `warn!`/`info!`
+    // become breadcrumbs attached to the next issue. A no-op when no Sentry
+    // client is bound (see `init_sentry`), so it is always safe to install.
+    let tracing_registry = tracing_subscriber::registry()
+        .with(filter)
+        .with(sentry::integrations::tracing::layer());
 
     match config.opts.trace {
         crate::config::Tracing::Stdout => {
@@ -134,4 +139,37 @@ pub fn init_tracing(config: &crate::config::Config) -> Option<tracing_chrome::Fl
     }
 
     None
+}
+
+/// Starts the Sentry client if `--sentry-dsn` / `SENTRY_DSN` is set. Returns
+/// a guard that must be kept alive for the lifetime of the server: dropping it
+/// flushes pending events, so hold it in `serve_with_hook` and drop it last.
+///
+/// Call this *before* `init_tracing`, so the tracing layer has a client to
+/// report to, and before the async runtime spawns work, so the panic hook is
+/// in place for every task.
+///
+/// Privacy: this is strictly opt-in. Without a DSN no client is created, no
+/// network connection is opened, and nothing about the install ever leaves
+/// the machine. A stock self-hosted atomic-server has no DSN.
+pub fn init_sentry(config: &crate::config::Config) -> Option<sentry::ClientInitGuard> {
+    let dsn = config.opts.sentry_dsn.as_deref()?.trim();
+    if dsn.is_empty() {
+        return None;
+    }
+    let options = sentry::ClientOptions::new()
+        .dsn(dsn)
+        .release(concat!("atomic-server@", env!("CARGO_PKG_VERSION")))
+        // Errors only: performance tracing is left at its default (disabled).
+        // OpenTelemetry already covers it, and the free Sentry tier has a
+        // small event quota.
+        .attach_stacktrace(true)
+        .send_default_pii(false);
+    let guard = sentry::init(options);
+    if guard.is_enabled() {
+        println!("Sentry error reporting enabled");
+    } else {
+        eprintln!("SENTRY_DSN is set but invalid; Sentry error reporting is disabled");
+    }
+    Some(guard)
 }


### PR DESCRIPTION
## Summary
- `--sentry-dsn` / `SENTRY_DSN`: server-side error reporting. Panics and `error!`-level tracing events become Sentry issues, `warn!`/`info!` become breadcrumbs, and `sentry_actix` attaches the HTTP request.
- `--sentry-dsn-browser` / `SENTRY_DSN_BROWSER`: injected into the served `index.html` as `window.__ATOMIC_SENTRY__`, so the bundled data-browser reports browser errors only on servers that opt in. The shipped bundle is identical either way.
- Errors only, `send_default_pii` off, performance tracing left to OpenTelemetry.

## Privacy
Strictly opt-in. Without a DSN no Sentry client is constructed, no panic hook is installed, and no network request is made. The stock binary and Docker image set no DSN. Documented in the installation guide next to the "never phones home" section.

## Testing
- `cargo test -p atomic-server sentry_script` (injection escaping)
- `cargo clippy -p atomic-server`, `pnpm typecheck` (same pre-existing errors as develop), oxfmt/oxlint clean