### PR TITLE
ci: run one main pipeline at a time on the shared runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,14 @@ on:
           - full
         default: auto
 
+# One pipeline at a time on the shared runner. Mancave picks up several jobs
+# at once, and a full suite is 4 shards x 2 browsers plus four debug servers
+# next to clippy and nextest; two of those overlapping is what turns the e2e
+# suite red run to run (reload-heavy specs time out waiting for the server).
+# Queue instead of overlap; never cancel a run that is already going.
+concurrency:
+  group: main-pipeline
+  cancel-in-progress: false
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.
 # GitHub-hosted runs ONLY when Mancave is unavailable — never as a retry


### PR DESCRIPTION
## Why

The Mancave runner picks up several pipelines at once. A full run is 4 e2e shards x 2 browsers plus four debug atomic-servers, next to clippy, nextest, flutter and vitest. When two of those overlap, the e2e suite goes red on a rotating set of reload-heavy specs (calendar persist, fast row entry, dashboards after reload, saved drives after reload), and the failure list changes run to run. Every red develop run since Sept 1 that I examined was overlapping another pipeline; the dagger module's own comments already describe this as a contended host, not broken tests.

Overlap also caused a second, harder failure today: two branches with different `lib` sources built into the shared cargo target cache concurrently, and cargo's mtime-based freshness kept the wrong `atomic_lib`, so develop failed to compile (`E0425`). #1329 reset the caches; this prevents the overlap.

## What

A workflow-level `concurrency` group so only one main pipeline runs at a time. `cancel-in-progress: false`: later pushes queue behind the current run instead of killing it, so develop never loses a result.

## Cost

Feature-branch pushes wait for whatever is running. With light runs at roughly 12 minutes and full runs at 20, that is the price of results that mean something.
