### PR TITLE
ci(dagger): never replay a cached e2e result

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1623,7 +1623,7 @@ export class AtomicServer {
   }
 
   /** Unique per `dagger call`; see `e2eShardContainer`. */
-  private readonly e2eRunNonce = `${Date.now()}-${process.pid}`;
+  private readonly e2eRunNonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   /** One Playwright shard against its own atomic-server service. */
   private e2eShardContainer(base: Container, shardIndex: number): Container {

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1622,6 +1622,9 @@ export class AtomicServer {
       );
   }
 
+  /** Unique per `dagger call`; see `e2eShardContainer`. */
+  private readonly e2eRunNonce = `${Date.now()}-${process.pid}`;
+
   /** One Playwright shard against its own atomic-server service. */
   private e2eShardContainer(base: Container, shardIndex: number): Container {
     const shardCount = this.e2eRun.shardCount;
@@ -1633,6 +1636,15 @@ export class AtomicServer {
         '-c',
         `for i in $(seq 1 30); do curl -fsS http://${ATOMIC_DOMAIN}:9883/setup && exit 0 || sleep 1; done; exit 1`,
       ])
+      // Dagger caches an exec by its inputs, and the shard script always
+      // exits 0 (the real exit code goes to a file), so a run whose sources
+      // matched an earlier one replayed that run's output verbatim: a
+      // workflow-only change, an empty commit or `gh run rerun` all "passed"
+      // or "failed" with the previous run's exact log and shard timings. A
+      // per-invocation nonce on this step makes the browsers run every time.
+      // It sits after the service binding and the setup probe, so the build
+      // layers above stay cached; only the Playwright exec is unique.
+      .withEnvVariable('E2E_RUN_NONCE', this.e2eRunNonce)
       .withExec([
         '/bin/bash',
         '-c',


### PR DESCRIPTION
## Problem

Dagger caches an exec by its inputs, and the e2e shard script always exits 0 (the real exit code goes to a file). So any run whose sources match an earlier run replays that run's output verbatim. Seen today three times: an empty commit, a `gh run rerun`, and the develop run for #1333 (a workflow-only change) all reported the previous run's exact failure list and shard timings (17.0m / 18.8m / 20.1m / 21.2m) without starting a browser. The #1333 develop job took 54 seconds.

## Fix

A per-invocation nonce is set as an env var on the Playwright step of each shard container. It sits after the service binding and the setup probe, so the rust build, the frontend build and the Playwright base image stay cached; only the test exec is unique per run.

## Effect

Every pipeline run executes the e2e suite. Combined with #1333 (one pipeline at a time), a develop result now reflects that commit on an uncontended runner.
