### PR TITLE
style(lib): format store.connect.test.ts (unbreaks develop CI)

### DIFF
--- a/browser/lib/src/store.connect.test.ts
+++ b/browser/lib/src/store.connect.test.ts
@@ -64,7 +64,9 @@ describe('Store connect option', () => {
     expect(store.getSyncStatus().serverConnected).toBe(false);
   });
 
-  it('setting the drive to that same origin still opens nothing', ({ expect }) => {
+  it('setting the drive to that same origin still opens nothing', ({
+    expect,
+  }) => {
     // The drive defaults to the server URL, and `setDrive(origin)` goes
     // through `setServerUrl` again — which is how the hosted build ended up
     // with a socket after all.


### PR DESCRIPTION
develop CI (run 33659227780) fails at `lib lint`: `oxfmt --check` on `lib/src/store.connect.test.ts`, introduced by #1332 whose own run was cancelled before lint. Formatting only.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd