### PR TITLE
fix(browser): wait for the local database before an automatic vault pass

### DIFF
--- a/browser/data-browser/src/helpers/managed/useVaultBackup.ts
+++ b/browser/data-browser/src/helpers/managed/useVaultBackup.ts
@@ -15,7 +15,7 @@ import {
   type VaultKeyOps,
   type VaultProofSigner,
 } from './vault';
-import { setVaultOptOut } from './vaultAutoBackup';
+import { onVaultChanged, setVaultOptOut } from './vaultAutoBackup';
 
 /**
  * Cloud Vault state for one drive, ready to bind to a UI.
@@ -151,6 +151,16 @@ export function useVaultBackup({
       setStatus({ state: 'unavailable', reason: (e as Error).message });
     }
   }, [driveSubject]);
+
+  // The automatic path (sign-in, the boot watcher) may enrol this drive after
+  // the first read came back "off"; re-read when it says so.
+  useEffect(
+    () =>
+      onVaultChanged(changed => {
+        if (changed === driveSubject) void refresh();
+      }),
+    [driveSubject, refresh],
+  );
 
   useEffect(() => {
     if (ready) {

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
@@ -3,6 +3,7 @@ import { Agent, JSCryptoProvider, Store } from '@tomic/lib';
 import {
   ensureVaultBackup,
   forgetEnrolledVaults,
+  onVaultChanged,
   restoreFromVault,
   watchForVaultBackups,
   type VaultAutoBackupDeps,
@@ -56,7 +57,7 @@ function fakeDeps(overrides: Partial<VaultAutoBackupDeps> = {}) {
     hasAccount: vi.fn(async () => true),
     loadKeys: vi.fn(async () => keys),
     laneId: vi.fn(async () => LANE),
-    db: vi.fn(() => ({}) as never),
+    db: vi.fn(async () => ({}) as never),
     setUpVaultForDrive: vi.fn(async () => ({ enrollment, driveKey: KEY })),
     runVaultBackup: vi.fn(async () => ({
       status: 'backed-up' as const,
@@ -199,6 +200,54 @@ describe('ensureVaultBackup', () => {
     const second = await ensureVaultBackup(store, DRIVE, deps);
     expect(second.status).toBe('nothing-to-do');
     expect(deps.setUpVaultForDrive).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for the local database rather than skipping', async () => {
+    const store = await signedInStore();
+    let attach!: () => void;
+    const deps = fakeDeps({
+      db: vi.fn(
+        () =>
+          new Promise<never>(resolve => {
+            attach = () => resolve({} as never);
+          }),
+      ),
+    });
+
+    const pass = ensureVaultBackup(store, DRIVE, deps);
+    await Promise.resolve();
+    expect(deps.setUpVaultForDrive).not.toHaveBeenCalled();
+
+    attach();
+    expect((await pass).status).toBe('backed-up');
+  });
+
+  it('skips when this build has no local database', async () => {
+    const store = await signedInStore();
+    const deps = fakeDeps({ db: vi.fn(async () => null) });
+
+    const outcome = await ensureVaultBackup(store, DRIVE, deps);
+
+    expect(outcome).toEqual({
+      status: 'skipped',
+      reason: 'no local database or device id',
+    });
+    expect(deps.setUpVaultForDrive).not.toHaveBeenCalled();
+  });
+
+  it('tells vault-status listeners which drive changed', async () => {
+    const store = await signedInStore();
+    const deps = fakeDeps();
+    const changed: string[] = [];
+    const off = onVaultChanged(drive => changed.push(drive));
+
+    await ensureVaultBackup(store, DRIVE, deps);
+    expect(changed).toEqual([DRIVE]);
+
+    off();
+    forgetEnrolledVaults();
+    await ensureVaultBackup(store, DRIVE, deps);
+    expect(changed).toEqual([DRIVE]);
   });
 });
 

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
@@ -53,7 +53,13 @@ export type VaultAutoBackupDeps = {
   loadKeys: () => Promise<VaultKeyOps & { proofMessage: Uint8Array }>;
   /** The lane this device writes to, or null when it has no identity yet. */
   laneId: () => Promise<string | null>;
-  db: (store: Store) => VaultCapableDb | null;
+  /**
+   * The local store the drive lives in, once it is attached — or null when
+   * this build has none. Async because the ClientDb attaches a few hundred ms
+   * after sign-in, and a restore or first backup asked for in that window
+   * must wait for it rather than conclude there is nothing to write to.
+   */
+  db: (store: Store) => Promise<VaultCapableDb | null>;
   setUpVaultForDrive: typeof setUpVaultForDrive;
   runVaultBackup: typeof runVaultBackup;
   listVaultDrives: typeof listVaultDrives;
@@ -115,7 +121,13 @@ const defaultDeps: VaultAutoBackupDeps = {
   },
   // Same choice `useDriveVault` makes: the desktop and Android apps keep the
   // drive in their embedded node and have no ClientDb.
-  db: store => (isRunningInTauri() ? nodeVault : (store.getClientDb() ?? null)),
+  db: async store => {
+    if (isRunningInTauri()) return nodeVault;
+
+    await store.waitForClientDb(CLIENT_DB_WAIT_MS);
+
+    return store.getClientDb() ?? null;
+  },
   setUpVaultForDrive,
   runVaultBackup,
   listVaultDrives,
@@ -174,15 +186,52 @@ export function ensureVaultBackup(
 
   if (existing) return existing;
 
-  const pass = ensureVaultBackupOnce(store, driveSubject, deps).finally(() => {
-    ensuring.delete(driveSubject);
-  });
+  const pass = ensureVaultBackupOnce(store, driveSubject, deps)
+    .then(outcome => {
+      // Skips are by design, but the reason is exactly what someone looking
+      // at a Sync page that still says "off" needs to see.
+      if (outcome.status === 'skipped') {
+        console.info('[cloud-vault] backup skipped:', outcome.reason);
+      }
+
+      return outcome;
+    })
+    .finally(() => {
+      ensuring.delete(driveSubject);
+    });
   ensuring.set(driveSubject, pass);
 
   return pass;
 }
 
 const ensuring = new Map<string, Promise<EnsureVaultOutcome>>();
+
+/**
+ * How long to wait for the ClientDb to attach after sign-in. Deriving the
+ * database name and unwrapping the agent's key takes a few hundred ms on a
+ * laptop; a phone with a slow key unwrap wants a generous ceiling.
+ */
+const CLIENT_DB_WAIT_MS = 20_000;
+
+type VaultChangeListener = (driveSubject: string) => void;
+const vaultChangeListeners = new Set<VaultChangeListener>();
+
+/**
+ * Called when a drive's enrollment or backup changed through the automatic
+ * path, so a screen that shows the vault's status (the Sync page) re-reads it
+ * rather than keeping the "off" it rendered a moment earlier.
+ */
+export function onVaultChanged(listener: VaultChangeListener): () => void {
+  vaultChangeListeners.add(listener);
+
+  return () => {
+    vaultChangeListeners.delete(listener);
+  };
+}
+
+function notifyVaultChanged(driveSubject: string): void {
+  for (const listener of vaultChangeListeners) listener(driveSubject);
+}
 
 async function ensureVaultBackupOnce(
   store: Store,
@@ -198,7 +247,7 @@ async function ensureVaultBackupOnce(
   }
 
   try {
-    const db = deps.db(store);
+    const db = await deps.db(store);
     const lane = await deps.laneId();
 
     if (!db || !lane) {
@@ -225,13 +274,16 @@ async function ensureVaultBackupOnce(
       enrolled.set(driveSubject, known);
     }
 
-    return await deps.runVaultBackup({
+    const outcome = await deps.runVaultBackup({
       db,
       driveSubject,
       drivePseudonym: known.drivePseudonym,
       devicePubkey: lane,
       driveKey: known.driveKey,
     });
+    notifyVaultChanged(driveSubject);
+
+    return outcome;
   } catch (error) {
     // A stale key or enrollment must not be reused after a failure; the next
     // attempt re-derives both from the control plane.
@@ -278,7 +330,7 @@ export async function restoreFromVault(
   if (!agent?.subject) return { status: 'no-backup', reason: 'not signed in' };
 
   try {
-    const db = deps.db(store);
+    const db = await deps.db(store);
 
     if (!db) return { status: 'no-backup', reason: 'no local database' };
 
@@ -320,6 +372,7 @@ export async function restoreFromVault(
       drivePseudonym: enrollment.drive_pseudonym,
       driveKey,
     });
+    notifyVaultChanged(driveSubject);
 
     return { status: 'restored', outcome };
   } catch (error) {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -732,8 +732,13 @@ export class Store {
   /**
    * Resolves `true` once a ClientDb is attached, `false` if none arrives
    * within `timeoutMs` — or immediately, if none was ever expected.
+   *
+   * Public because the attach lands a few hundred ms after boot and a few
+   * hundred ms after each agent change, and anything that needs the local
+   * database right after sign-in (a vault restore, a first backup) would
+   * otherwise read `getClientDb()` as "this app has no database".
    */
-  private waitForClientDb(timeoutMs: number): Promise<boolean> {
+  public waitForClientDb(timeoutMs: number): Promise<boolean> {
     if (this.clientDb) return Promise.resolve(true);
     if (!this.clientDbExpected) return Promise.resolve(false);
 


### PR DESCRIPTION
fix(browser): wait for the local database before an automatic vault pass

`ensureVaultBackup` and `restoreFromVault` read `store.getClientDb()`
synchronously. The ClientDb attaches a few hundred ms after boot and
after every agent change — exactly when sign-in asks for a restore and
the boot watcher asks for a first backup — so both concluded "no local
database" and skipped, silently. A drive that never went through
onboarding therefore stayed unenrolled after the sign-in that was
meant to enrol it.

- `Store.waitForClientDb` is public; the default `db` dep awaits it
  (20 s ceiling) before reading the worker.
- Skips are logged (`[cloud-vault] backup skipped: <reason>`), since a
  Sync page that still says "off" is otherwise unexplained.
- `onVaultChanged` tells `useVaultBackup` to re-read the status after
  the automatic path enrols or restores a drive, so the panel does not
  keep the "off" it rendered a moment earlier.

Claude-Session: https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
