### PR TITLE
test(e2e): widen reload and materialization budgets for the shared runner

### DIFF
--- a/browser/e2e/tests/table-refresh.spec.ts
+++ b/browser/e2e/tests/table-refresh.spec.ts
@@ -39,7 +39,7 @@ test.describe('table refresh', () => {
     await page.locator('dialog[open] button:has-text("Create")').click();
 
     // Wait for the table to render.
-    await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
+    await expect(editableTitle(page)).toBeVisible({ timeout: 30000 });
 
     // Wait for the new-row placeholder to render (otherwise the count race
     // produces 1, 2 or 3 depending on render order). The bug being tested is
@@ -58,7 +58,7 @@ test.describe('table refresh', () => {
       // is monotonic ROW GROWTH, not transient fetch failures.
       for (let retry = 0; retry < 3; retry++) {
         const titleVisible = await editableTitle(page)
-          .isVisible({ timeout: 15000 })
+          .isVisible({ timeout: 30000 })
           .catch(() => false);
         if (titleVisible) break;
         const retryBtn = page.getByRole('button', { name: 'Retry' });
@@ -70,7 +70,7 @@ test.describe('table refresh', () => {
         }
       }
 
-      await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
+      await expect(editableTitle(page)).toBeVisible({ timeout: 30000 });
       // The regression is monotonic ROW GROWTH; under-render mid-mount is a
       // separate concern. Wait for the count to land at-or-below the
       // baseline (it can briefly read 0 or 1 before the new-row placeholder
@@ -109,7 +109,7 @@ test.describe('table refresh', () => {
     await expect(nameInput).toBeVisible();
     await nameInput.fill('TypedRefresh');
     await page.locator('dialog[open] button:has-text("Create")').click();
-    await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
+    await expect(editableTitle(page)).toBeVisible({ timeout: 30000 });
 
     // Type a value into row 2, column 2 (the first name cell). The cell
     // visibility expectation below already polls for the row to mount —
@@ -136,7 +136,7 @@ test.describe('table refresh', () => {
       // row growth, not a missing title on a stalled fetch.
       for (let retry = 0; retry < 3; retry++) {
         const titleVisible = await editableTitle(page)
-          .isVisible({ timeout: 15000 })
+          .isVisible({ timeout: 30000 })
           .catch(() => false);
         if (titleVisible) break;
         const retryBtn = page.getByRole('button', { name: 'Retry' });
@@ -159,7 +159,7 @@ test.describe('table refresh', () => {
         break;
       }
 
-      await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
+      await expect(editableTitle(page)).toBeVisible({ timeout: 30000 });
 
       // Wait for the table's collection to settle: server's `/query`
       // index lookup completed AND `totalMembers` is stable for two
@@ -262,7 +262,7 @@ test.describe('table refresh', () => {
     await expect(nameInput).toBeVisible();
     await nameInput.fill('NoClientDbRefresh');
     await page.locator('dialog[open] button:has-text("Create")').click();
-    await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
+    await expect(editableTitle(page)).toBeVisible({ timeout: 30000 });
 
     // Wait for the table to settle on its post-render baseline (header +
     // placeholder = 2). With ClientDb disabled the collection's first

--- a/browser/e2e/tests/tables.spec.ts
+++ b/browser/e2e/tests/tables.spec.ts
@@ -387,9 +387,9 @@ test.describe('tables', async () => {
       },
       values.length,
       // Forty genesis commits + OPFS puts. 15s is enough on a quiet runner
-      // and routinely not under dagger load (the post-reload wait below
-      // already uses 30s for the same queue).
-      { timeout: 30_000 },
+      // and routinely not under dagger load; 30s still tripped on an idle
+      // Mancave runner (2026-09-02), so match the post-reload wait below.
+      { timeout: 60_000 },
     );
 
     // Spot-check the bottom of the list is rendered (the active cell stayed in


### PR DESCRIPTION
## Why

With CI serialized (#1333) and never replayed (#1334), the develop run for 8348fac54 is the first trustworthy one since Aug 31: shards back at 9.5–12.5 minutes, 2 of 4 shards red, three tests failing. Two of them fail on a time budget, not on the behaviour they guard:

- `tables.spec.ts › fast row entry`: 40 rows materialize and drain to the server; the 30 s `waitForFunction` at line 371 tripped on an otherwise idle runner. Its sibling wait after the reload already uses 30 s and the comment there measured 18.5 s under load. Raised to 60 s.
- `table-refresh.spec.ts › reloading a table does not add empty rows`: one of ten reloads took more than 15 s to show the title, with no Retry button to click. The test is about monotonic row growth; the title wait is only a precondition. Raised to 30 s (both tests in the file).

## Not changed

`documents.spec.ts › shows a collaborator's ephemeral cursor position` fails on the caret count after it was attached (expected 1, received 0). The ephemeral store's TTL is 30 s, so this is not expiry; it fits page 1 replacing its document after an incomplete Loro import (the full-snapshot refetch remounts the editor and drops remote carets). That is an application issue and should be looked at separately rather than hidden behind a longer wait.
