### PR TITLE
fix(browser): sign-in guard for a drive this device does not hold on a node-less origin

### DIFF
--- a/browser/data-browser/src/helpers/isDriveSignInError.test.ts
+++ b/browser/data-browser/src/helpers/isDriveSignInError.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   AtomicError,
   ErrorType,
+  NOT_AVAILABLE_LOCALLY_MESSAGE,
   type Agent,
   type Resource,
 } from '@tomic/react';
@@ -11,6 +12,11 @@ const BASE = 'https://example.com';
 const DRIVE = 'https://example.com/drive/x';
 const unauthorized = new AtomicError('Unauthorized', ErrorType.Unauthorized);
 const notFound = new AtomicError('not here', ErrorType.NotFound);
+const notLocal = new AtomicError(
+  NOT_AVAILABLE_LOCALLY_MESSAGE,
+  ErrorType.Transport,
+);
+const offline = new AtomicError('fetch failed', ErrorType.Transport);
 
 const res = (subject: string, error?: Error): Resource =>
   ({ subject, error }) as unknown as Resource;
@@ -43,5 +49,40 @@ describe('isDriveSignInError', () => {
 
   it('no error at all → no guard', () => {
     expect(isDriveSignInError(res(DRIVE), undefined, BASE)).toBe(false);
+  });
+
+  it('not held locally on an origin without a node → guard', () => {
+    expect(
+      isDriveSignInError(res(DRIVE, notLocal), undefined, BASE, {
+        originWithoutNode: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('not held locally, but a node exists → just offline, no guard', () => {
+    expect(isDriveSignInError(res(DRIVE, notLocal), undefined, BASE)).toBe(
+      false,
+    );
+    expect(
+      isDriveSignInError(res(DRIVE, notLocal), undefined, BASE, {
+        originWithoutNode: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('other transport errors on a node-less origin → no guard', () => {
+    expect(
+      isDriveSignInError(res(DRIVE, offline), undefined, BASE, {
+        originWithoutNode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('signed in + not held locally → no guard (the agent owns that)', () => {
+    expect(
+      isDriveSignInError(res(DRIVE, notLocal), someAgent, BASE, {
+        originWithoutNode: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/browser/data-browser/src/helpers/isDriveSignInError.ts
+++ b/browser/data-browser/src/helpers/isDriveSignInError.ts
@@ -1,4 +1,9 @@
-import { type Agent, type Resource, isUnauthorized } from '@tomic/react';
+import {
+  type Agent,
+  type Resource,
+  isNotAvailableLocally,
+  isUnauthorized,
+} from '@tomic/react';
 import { isRootWelcomeResourceError } from './isRootWelcomeResourceError';
 
 /**
@@ -11,15 +16,26 @@ import { isRootWelcomeResourceError } from './isRootWelcomeResourceError';
  *
  * Gated on `!agent`: an already-signed-in atomic-server identity opens the
  * resource directly — its access is independent of any managed session.
+ *
+ * On an origin that runs no node (`originWithoutNode`) there is no server to
+ * say "unauthorized": a drive this device does not hold fails as "not
+ * available locally" instead. For a signed-out visitor that is the same
+ * situation — the data can only arrive through a sign-in (a vault restore, or
+ * a connected device) — so it gets the same guard. A drive opened from the
+ * portal on a fresh phone is exactly this.
  */
 export function isDriveSignInError(
   resource: Resource,
   agent: Agent | undefined,
   baseURL: string,
+  options: { originWithoutNode?: boolean } = {},
 ): boolean {
+  if (agent || isRootWelcomeResourceError(resource, agent, baseURL)) {
+    return false;
+  }
+
   return (
-    !agent &&
-    !isRootWelcomeResourceError(resource, agent, baseURL) &&
-    isUnauthorized(resource.error)
+    isUnauthorized(resource.error) ||
+    (!!options.originWithoutNode && isNotAvailableLocally(resource.error))
   );
 }

--- a/browser/data-browser/src/views/ErrorPage.tsx
+++ b/browser/data-browser/src/views/ErrorPage.tsx
@@ -13,6 +13,7 @@ import { AtomicLink } from '../components/AtomicLink';
 import { paths } from '../routes/paths';
 import { isRootWelcomeResourceError } from '../helpers/isRootWelcomeResourceError';
 import { isDriveSignInError } from '../helpers/isDriveSignInError';
+import { isOriginWithoutNode } from '../helpers/originNode';
 import { RootWelcomeGate } from './RootWelcomeGate';
 import { VaultRestoreAction } from '../components/Vault/VaultRestoreAction';
 
@@ -33,7 +34,9 @@ function ErrorPage({ resource }: ResourcePageProps): JSX.Element {
   // panel's sign-in step, carrying the resource as `next` so we return the user
   // here once they sign in. (Already signed in? No redirect — that agent just
   // lacks access, handled below.)
-  const isDriveSignIn = isDriveSignInError(resource, agent, baseURL);
+  const isDriveSignIn = isDriveSignInError(resource, agent, baseURL, {
+    originWithoutNode: isOriginWithoutNode(store.getServerUrl()),
+  });
   const shouldGoToWelcome = (!agent && isHomeWelcome) || isDriveSignIn;
 
   React.useEffect(() => {

--- a/browser/lib/src/error.ts
+++ b/browser/lib/src/error.ts
@@ -46,6 +46,21 @@ export function isTransportError(error?: Error): boolean {
   return error instanceof AtomicError && error.type === ErrorType.Transport;
 }
 
+/**
+ * The message a fetch fails with when the Store has no server to ask and the
+ * local database does not hold the resource. Named so callers can tell this
+ * apart from other transport errors: it means "nothing here", not "try again".
+ */
+export const NOT_AVAILABLE_LOCALLY_MESSAGE =
+  'Offline: resource not available locally. Reconnect to fetch.';
+
+/** True when the resource failed because no copy of it exists on this device. */
+export function isNotAvailableLocally(error?: Error): boolean {
+  return (
+    isTransportError(error) && error!.message === NOT_AVAILABLE_LOCALLY_MESSAGE
+  );
+}
+
 /** Pass any error. If the error is an AtomicError and it's Unauthorized, return true */
 export function isUnauthorized(error?: Error): boolean {
   if (error instanceof AtomicError) {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -13,7 +13,12 @@ import {
   type Commit,
 } from './commit.js';
 import { datatypeFromUrl, type Datatype } from './datatypes.js';
-import { AtomicError, ErrorType, isTransportError } from './error.js';
+import {
+  AtomicError,
+  ErrorType,
+  isTransportError,
+  NOT_AVAILABLE_LOCALLY_MESSAGE,
+} from './error.js';
 import { EventManager } from './EventManager.js';
 import { hasBrowserAPI } from './hasBrowserAPI.js';
 import { collections } from './ontologies/collections.js';
@@ -3243,7 +3248,7 @@ export class Store {
               this.failResource(
                 subject,
                 new AtomicError(
-                  'Offline: resource not available locally. Reconnect to fetch.',
+                  NOT_AVAILABLE_LOCALLY_MESSAGE,
                   ErrorType.Transport,
                 ),
               );


### PR DESCRIPTION
fix(browser): send a signed-out visitor to sign-in for a drive this device does not hold

Opening a drive from the portal on a browser that has never held it
ended on "Could not open did:ad:… / Offline: resource not available
locally" with Retry and Use proxy — neither of which can help, since
the hosted origin runs no node and the only way the data arrives is a
sign-in (which restores it from Cloud Vault, or connects a device).

The error page already has a sign-in guard for this: not signed in +
unauthorized → welcome sign-in step with `next` set to the drive. On an
origin without a node nothing ever answers "unauthorized"; the drive
fails as "not available locally" instead. Treat that the same way when
the origin has no node. Other transport errors, a signed-in agent, and
origins that do run a node are untouched.

`@tomic/lib` names the message (`NOT_AVAILABLE_LOCALLY_MESSAGE`) and
exports `isNotAvailableLocally`, so the check is not a string match in
the app.

Claude-Session: https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
