### PR TITLE
fix(vault): a restore opens the drive, and brings the owner along

### DIFF
--- a/browser/data-browser/src/components/Vault/VaultRestoreAction.tsx
+++ b/browser/data-browser/src/components/Vault/VaultRestoreAction.tsx
@@ -1,9 +1,7 @@
-import { useStore } from '@tomic/react';
 import { FaRotateLeft } from 'react-icons/fa6';
 import { styled } from 'styled-components';
 import { Button } from '../Button';
 import { useDriveVault } from '../../helpers/managed/useDriveVault';
-import { isOriginWithoutNode } from '../../helpers/originNode';
 
 import type { JSX } from 'react';
 
@@ -25,29 +23,12 @@ export function VaultRestoreAction({
 }: {
   subject: string;
 }): JSX.Element | null {
-  const store = useStore();
   const vault = useDriveVault(subject);
 
   const canRestore =
     vault.status.state === 'on' && vault.status.details.confirmed_objects > 0;
 
   if (!canRestore) return null;
-
-  async function restore() {
-    const outcome = await vault.restore();
-
-    if (!outcome) return;
-
-    // On an origin with no node the restored drive lives only here, like one
-    // made here; without this every commit would park in the outbox.
-    if (isOriginWithoutNode(store.getServerUrl())) {
-      store.registerLocalOnlyDrive(subject);
-    }
-
-    // The failed fetch that brought us here is cached; ask again now that the
-    // drive is in local storage.
-    await store.fetchResourceFromServer(subject, { setLoading: true });
-  }
 
   return (
     <Offer data-testid='vault-restore-offer'>
@@ -58,7 +39,7 @@ export function VaultRestoreAction({
       )}
       <Button
         data-testid='vault-restore-now'
-        onClick={restore}
+        onClick={vault.restore}
         disabled={vault.busy}
       >
         <FaRotateLeft />{' '}

--- a/browser/data-browser/src/helpers/driveData.ts
+++ b/browser/data-browser/src/helpers/driveData.ts
@@ -1,4 +1,41 @@
 import type { Store } from '@tomic/lib';
+import { isOriginWithoutNode } from './originNode';
+
+/**
+ * Make a drive that a vault restore just put into local storage show up.
+ *
+ * The store still holds whatever fetch sent the user to the restore offer:
+ * on a node-backed origin a 401, fetched as the public agent before they
+ * signed in; on an origin without a node a "not available locally". Left
+ * alone, that cached answer is what the workspace renders after the restore
+ * — "Unauthorized" as the drive title, over a sidebar that already lists the
+ * restored folders — so look again, local database first, now that the data
+ * is there.
+ *
+ * On an origin with no node the restored drive lives only on this device,
+ * like one made here; without registering it as such every later commit
+ * would park in the outbox waiting for a server that does not exist.
+ *
+ * The pack also carries the drive's agent — the profile with the name typed
+ * on the first device — which the store looked up the same way, before it was
+ * there. Reloaded too, so settings shows the person and not an empty field.
+ */
+export async function reopenRestoredDrive(
+  store: Store,
+  drive: string,
+): Promise<void> {
+  if (isOriginWithoutNode(store.getServerUrl())) {
+    store.registerLocalOnlyDrive(drive);
+  }
+
+  await store.reloadResource(drive);
+
+  const agent = store.getAgent()?.subject;
+
+  if (agent) {
+    await store.reloadResource(agent);
+  }
+}
 
 /**
  * Whether this device can actually load the drive.

--- a/browser/data-browser/src/helpers/isDriveSignInError.test.ts
+++ b/browser/data-browser/src/helpers/isDriveSignInError.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   AtomicError,
   ErrorType,
+  LOCAL_ONLY_NOT_FOUND_MESSAGE,
   NOT_AVAILABLE_LOCALLY_MESSAGE,
   type Agent,
   type Resource,
@@ -14,6 +15,10 @@ const unauthorized = new AtomicError('Unauthorized', ErrorType.Unauthorized);
 const notFound = new AtomicError('not here', ErrorType.NotFound);
 const notLocal = new AtomicError(
   NOT_AVAILABLE_LOCALLY_MESSAGE,
+  ErrorType.Transport,
+);
+const localOnlyGone = new AtomicError(
+  LOCAL_ONLY_NOT_FOUND_MESSAGE,
   ErrorType.Transport,
 );
 const offline = new AtomicError('fetch failed', ErrorType.Transport);
@@ -54,6 +59,18 @@ describe('isDriveSignInError', () => {
   it('not held locally on an origin without a node → guard', () => {
     expect(
       isDriveSignInError(res(DRIVE, notLocal), undefined, BASE, {
+        originWithoutNode: true,
+      }),
+    ).toBe(true);
+  });
+
+  // A drive made on this device, after sign-out: the local-only registration
+  // outlives the per-agent database, so the fetch fails as "local-only, not
+  // in storage" rather than "not available locally". Same visitor, same way
+  // in — sign in.
+  it('a local-only drive gone from storage, no node → guard', () => {
+    expect(
+      isDriveSignInError(res(DRIVE, localOnlyGone), undefined, BASE, {
         originWithoutNode: true,
       }),
     ).toBe(true);

--- a/browser/data-browser/src/helpers/managed/useDriveVault.ts
+++ b/browser/data-browser/src/helpers/managed/useDriveVault.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useStore } from '@tomic/react';
+import { reopenRestoredDrive } from '../driveData';
 import { loadVaultKeyOps } from './vaultKeyOps';
 import { vaultLaneId, type VaultKeyOps } from './vault';
 import { getOrCreateDeviceId } from './devices';
@@ -53,7 +54,7 @@ export function useDriveVault(driveSubject: string | null): UseVaultBackup {
 
   const agent = store.getAgent();
 
-  return useVaultBackup({
+  const vault = useVaultBackup({
     // Whichever local store this build actually keeps the drive in. A browser
     // has the ClientDb; the desktop and Android apps have the embedded node and
     // deliberately no ClientDb, since a second copy of the same drive is the
@@ -68,4 +69,22 @@ export function useDriveVault(driveSubject: string | null): UseVaultBackup {
     proofMessage,
     devicePubkey: laneId,
   });
+
+  // A restore writes to the local database, which the store does not watch.
+  // Three screens offer the restore; one of them used to refetch the drive
+  // afterwards and the other two navigated straight into the cached "could
+  // not open" that had brought the user there. Done here, so an offer cannot
+  // forget.
+  const { restore: importFromVault } = vault;
+  const restore = useCallback(async () => {
+    const outcome = await importFromVault();
+
+    if (outcome && driveSubject) {
+      await reopenRestoredDrive(store, driveSubject);
+    }
+
+    return outcome;
+  }, [importFromVault, driveSubject, store]);
+
+  return { ...vault, restore };
 }

--- a/browser/lib/src/error.ts
+++ b/browser/lib/src/error.ts
@@ -54,10 +54,22 @@ export function isTransportError(error?: Error): boolean {
 export const NOT_AVAILABLE_LOCALLY_MESSAGE =
   'Offline: resource not available locally. Reconnect to fetch.';
 
+/**
+ * The same situation for a drive this device registered as local-only: no
+ * server will ever be asked, and the local database has no copy. Signing out
+ * leaves that registration in place while the (per-agent) database goes, so a
+ * signed-out visitor to a drive they made here ends up exactly where a visitor
+ * to one they never held does — and should be sent the same way, to sign in.
+ */
+export const LOCAL_ONLY_NOT_FOUND_MESSAGE =
+  'This resource belongs to a local-only drive but was not found in local storage.';
+
 /** True when the resource failed because no copy of it exists on this device. */
 export function isNotAvailableLocally(error?: Error): boolean {
   return (
-    isTransportError(error) && error!.message === NOT_AVAILABLE_LOCALLY_MESSAGE
+    isTransportError(error) &&
+    (error!.message === NOT_AVAILABLE_LOCALLY_MESSAGE ||
+      error!.message === LOCAL_ONLY_NOT_FOUND_MESSAGE)
   );
 }
 

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -3902,6 +3902,31 @@ export class Store {
   }
 
   /**
+   * Look at a resource again the way a first look does: the local database
+   * first, the server only if that has nothing.
+   *
+   * For a cached failure the store has since been given the answer to. A
+   * vault restore writes a drive straight into the local database; the copy
+   * in memory is still the fetch that sent the user to the restore offer — a
+   * 401 from before they signed in, or "not available locally". Asking the
+   * server (`fetchResourceFromServer`) is the wrong repair: on an origin
+   * without a node it asks the origin and gets `index.html` back, and the
+   * user's own workspace opens as "Could not parse JSON".
+   */
+  public async reloadResource(subject: string): Promise<void> {
+    const resolved = this.resolveSubject(subject);
+    const resource = this.resources.get(resolved);
+
+    if (resource) {
+      resource.error = undefined;
+      resource.loading = true;
+      this.notify(resource);
+    }
+
+    await this.fetchResourceWithLocalFallback(resolved);
+  }
+
+  /**
    * When coming back online, re-fetch resources whose state was affected by
    * being offline:
    *   - errored because we couldn't reach the server (the offline fallback's

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -17,6 +17,7 @@ import {
   AtomicError,
   ErrorType,
   isTransportError,
+  LOCAL_ONLY_NOT_FOUND_MESSAGE,
   NOT_AVAILABLE_LOCALLY_MESSAGE,
 } from './error.js';
 import { EventManager } from './EventManager.js';
@@ -3199,9 +3200,7 @@ export class Store {
       if (!hasLocalData) {
         this.failResource(
           subject,
-          new Error(
-            'This resource belongs to a local-only drive but was not found in local storage.',
-          ),
+          new AtomicError(LOCAL_ONLY_NOT_FOUND_MESSAGE, ErrorType.Transport),
         );
       }
 

--- a/lib/src/vault/sync.rs
+++ b/lib/src/vault/sync.rs
@@ -146,6 +146,32 @@ pub struct RestoreSummary {
     pub tombstones_applied: usize,
 }
 
+/// The agents named in a drive's `read` and `write` rights.
+///
+/// A drive walk never reaches them: an agent resource has no parent, it is
+/// nobody's child. Yet the name typed on the first device lives there, and on
+/// an origin without a node — the hosted app — nowhere else. Restored from a
+/// pack that leaves it out, the drive opens fine and settings shows an empty
+/// name: the account came back, the person did not. So the agents a drive
+/// grants rights to travel with it.
+///
+/// Rights the drive cannot be read for are treated as no agents: a drive that
+/// exports at all has already been read once, and a missing property is the
+/// ordinary case for a drive nobody was ever invited to.
+async fn drive_agent_subjects(store: &Db, drive: &Subject) -> Vec<String> {
+    let Ok(resource) = store.get_resource(drive).await else {
+        return Vec::new();
+    };
+
+    [crate::urls::READ, crate::urls::WRITE]
+        .iter()
+        .filter_map(|right| resource.get(right).ok())
+        .filter_map(|value| value.to_subjects(None).ok())
+        .flatten()
+        .filter(|subject| Subject::from_raw(subject, None).is_agent_did())
+        .collect()
+}
+
 /// Export a drive's history into one sealed pack and write it to `vault`.
 ///
 /// Every resource's full oplog is exported here. Incremental export against a
@@ -164,7 +190,8 @@ pub async fn export_vault_delta(
     device_pubkey: &str,
     segment: u32,
 ) -> AtomicResult<Option<BackupSummary>> {
-    let subjects = crate::sync::engine::collect_drive_subjects(store, drive).await;
+    let mut subjects = crate::sync::engine::collect_drive_subjects(store, drive).await;
+    subjects.extend(drive_agent_subjects(store, drive).await);
 
     let mut entries = Vec::new();
     for subject_str in &subjects {
@@ -467,7 +494,8 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("a populated drive must produce a pack");
-        assert_eq!(backup.resources, before.len());
+        // The drive, its children, and the one agent the drive grants rights to.
+        assert_eq!(backup.resources, before.len() + 1);
 
         // The device is gone: a brand new store, sharing nothing with the old.
         let restored = Db::init_temp("vault_round_trip_restored").await.unwrap();
@@ -475,10 +503,56 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.packs_read, 1);
-        assert_eq!(result.resources_restored, before.len());
+        assert_eq!(result.resources_restored, before.len() + 1);
 
         let after = drive_contents(&restored, &drive_subject).await;
         assert_eq!(after, before, "restored drive must match the original");
+    }
+
+    /// The person comes back with the account, not just the files.
+    ///
+    /// An agent resource is nobody's child, so the drive walk never sees it;
+    /// on the hosted app there is no node to fetch it from either. Left out of
+    /// the pack, a restore on a second browser opened the drive with an empty
+    /// name in settings — the first thing a returning user noticed.
+    #[tokio::test]
+    async fn the_drive_owner_is_restored_with_the_drive() {
+        let source = Db::init_temp("vault_agent_source").await.unwrap();
+        let (agent, drive) = source.setup("alice").await.unwrap();
+        let agent_subject = agent.subject.clone();
+        let mut profile = source.get_resource(&agent_subject).await.unwrap();
+        profile
+            .set_unsafe(
+                crate::urls::NAME.into(),
+                crate::Value::String("Alice Returning".into()),
+            )
+            .unwrap();
+        source
+            .add_resource_opts(&profile, false, true, true)
+            .await
+            .unwrap();
+
+        let drive_subject = Subject::from_raw(&drive, source.get_base_domain().as_deref());
+        let key = key();
+        let vault = MemoryVaultStore::new();
+        export_vault_delta(&source, &drive_subject, &key, &vault, PSEUDONYM, DEVICE, 1)
+            .await
+            .unwrap()
+            .expect("a populated drive must produce a pack");
+
+        let restored = Db::init_temp("vault_agent_restored").await.unwrap();
+        import_vault_batch(&restored, &key, &vault, &lane_prefix(PSEUDONYM, DEVICE))
+            .await
+            .unwrap();
+
+        let name = restored
+            .get_resource(&agent_subject)
+            .await
+            .expect("the drive's agent must come back with the drive")
+            .get(crate::urls::NAME)
+            .expect("with its profile")
+            .to_string();
+        assert_eq!(name, "Alice Returning");
     }
 
     /// The bug a backup must not have: a resource deleted after an earlier


### PR DESCRIPTION
A returning user on a second browser restored their drive from Cloud Vault and landed on "Unauthorized" as the drive title; on the hosted (node-less) app they got "Could not parse JSON" instead, with an empty name in settings. Signing out and reopening a drive made on the hosted app ended on "Could not open … local-only drive but was not found in local storage".

- `Store.reloadResource`: local database first, server only if that has nothing. `useDriveVault.restore` calls it after every import (three screens offer the restore; two never refetched, one asked the server and got `index.html`).
- `reopenRestoredDrive` registers the drive as local-only on a node-less origin.
- The vault pack carries the agents the drive grants rights to — an agent is nobody's child, so the drive walk never reached it and the name did not come back. Rust test `the_drive_owner_is_restored_with_the_drive`.
- `LOCAL_ONLY_NOT_FOUND_MESSAGE` is a named transport error and `isNotAvailableLocally` covers it, so the #1341 sign-in guard also catches a signed-out visit to a drive this device made.

Covered end to end by atomic-saas `portal/e2e/returning-user-second-browser.spec.ts`, run locally on both a node-backed app and a static hosted build (the shape of staging): 25/26 and 18/19 (the skip is `/app/dev-drive`, dev tooling that needs a node).

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
