### PR TITLE
fix(plugins): reject path traversal in plugin namespace/name on uninstall

### DIFF
--- a/lib/src/db/plugin_meta.rs
+++ b/lib/src/db/plugin_meta.rs
@@ -85,18 +85,7 @@ impl PluginManifest {
     }
 
     pub fn validate(&self) -> Result<(), AtomicError> {
-        let forbidden = ['/', '.'];
-
-        for field_name in [("name", &self.name), ("namespace", &self.namespace)] {
-            if field_name.1.contains(forbidden) {
-                return Err(AtomicError::from(format!(
-                    "{} cannot contain '/' or '.'",
-                    field_name.0
-                )));
-            }
-        }
-
-        Ok(())
+        validate_plugin_identifiers(&self.namespace, &self.name)
     }
 
     pub fn has_permission(&self, permission: PermissionType) -> bool {
@@ -104,5 +93,77 @@ impl PluginManifest {
             return permissions.iter().any(|p| p.permission == permission);
         }
         false
+    }
+}
+
+/// Checks that a plugin `namespace` and `name` are safe to use as path components.
+///
+/// Both values end up in filesystem paths (`{namespace}.{name}.wasm`, `{namespace}/assets`),
+/// so they must be a single, non-empty path segment: only ASCII alphanumerics, `-` and `_`.
+/// This rejects path separators, `.` / `..` traversal, absolute paths and control characters.
+///
+/// Call this on every code path that turns user-controlled namespace/name values into paths,
+/// not only when parsing a manifest.
+pub fn validate_plugin_identifiers(namespace: &str, name: &str) -> Result<(), AtomicError> {
+    for (field, value) in [("namespace", namespace), ("name", name)] {
+        validate_plugin_identifier(field, value)?;
+    }
+    Ok(())
+}
+
+pub fn validate_plugin_identifier(field: &str, value: &str) -> Result<(), AtomicError> {
+    const MAX_LEN: usize = 128;
+
+    if value.is_empty() {
+        return Err(AtomicError::from(format!("plugin {field} cannot be empty")));
+    }
+    if value.len() > MAX_LEN {
+        return Err(AtomicError::from(format!(
+            "plugin {field} cannot be longer than {MAX_LEN} characters"
+        )));
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AtomicError::from(format!(
+            "plugin {field} '{value}' is invalid: only ASCII letters, digits, '-' and '_' are allowed"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_simple_identifiers() {
+        validate_plugin_identifiers("my-namespace", "my_plugin1").unwrap();
+    }
+
+    #[test]
+    fn rejects_traversal_and_separators() {
+        for bad in [
+            "../../tmp",
+            "..",
+            ".",
+            "a/b",
+            "a\\b",
+            "/tmp",
+            "a.b",
+            "",
+            "with space",
+            "nul\0byte",
+        ] {
+            assert!(
+                validate_plugin_identifiers(bad, "ok").is_err(),
+                "namespace {bad:?} should be rejected"
+            );
+            assert!(
+                validate_plugin_identifiers("ok", bad).is_err(),
+                "name {bad:?} should be rejected"
+            );
+        }
     }
 }

--- a/server/src/plugins/plugin.rs
+++ b/server/src/plugins/plugin.rs
@@ -5,13 +5,13 @@ use std::path::PathBuf;
 #[cfg(feature = "wasm-plugins")]
 use atomic_lib::urls::{DOWNLOAD_URL, MIMETYPE};
 use atomic_lib::{
+    AtomicError, Db, Resource, Storelike, Value,
     agents::{Agent, ForAgent},
     class_extender::{BoxFuture, ClassExtender, CommitExtenderContext, GetExtenderContext},
-    db::plugin_meta::PluginMetaKey,
+    db::plugin_meta::{PluginMetaKey, validate_plugin_identifier, validate_plugin_identifiers},
     errors::AtomicResult,
     storelike::ResourceResponse,
     urls::{self},
-    AtomicError, Db, Resource, Storelike, Value,
 };
 #[cfg(feature = "wasm-plugins")]
 use tracing::{error, info};
@@ -71,6 +71,9 @@ fn get_namespace_and_name(resource: &Resource) -> AtomicResult<(String, String)>
         )));
     };
 
+    // These values are user-controlled and end up in filesystem paths.
+    validate_plugin_identifiers(namespace, name)?;
+
     Ok((namespace.to_string(), name.to_string()))
 }
 
@@ -83,19 +86,8 @@ async fn do_uninstall_plugin(
 ) -> AtomicResult<()> {
     tracing::info!("destroying plugin {}", resource.get_subject());
 
-    let Ok(Value::String(name)) = resource.get(urls::NAME) else {
-        return Err(AtomicError::from(format!(
-            "Plugin {} has no name",
-            resource.get_subject()
-        )));
-    };
-
-    let Ok(Value::String(namespace)) = resource.get(urls::NAMESPACE) else {
-        return Err(AtomicError::from(format!(
-            "Plugin {} has no namespace",
-            resource.get_subject()
-        )));
-    };
+    // Validates namespace/name so path traversal payloads never reach the filesystem.
+    let (namespace, name) = get_namespace_and_name(resource)?;
 
     tracing::info!(
         "uninstalling plugin {} in namespace {} for drive {}",
@@ -106,7 +98,15 @@ async fn do_uninstall_plugin(
 
     // Even if the uninstall fails we still want to continue the commit
     // If we don't do this the resource will not be able to be deleted.
-    let _ = uninstall_plugin(name, namespace, parent_subject, store, plugins_dir).await;
+    if let Err(e) = uninstall_plugin(&name, &namespace, parent_subject, store, plugins_dir).await {
+        tracing::warn!(
+            "Failed to uninstall plugin {}.{} for drive {}: {}",
+            namespace,
+            name,
+            parent_subject,
+            e
+        );
+    }
 
     Ok(())
 }
@@ -319,6 +319,14 @@ fn on_before_commit(
                     ));
                 }
             } else {
+                // Reject unsafe identifiers at creation time, so a traversal payload can never be
+                // stored and later reach the uninstall path.
+                for (field, prop) in [("name", urls::NAME), ("namespace", urls::NAMESPACE)] {
+                    if let Ok(Value::String(value)) = resource.get(prop) {
+                        validate_plugin_identifier(field, value)?;
+                    }
+                }
+
                 // For new plugins, check if name/namespace are already used on this drive.
                 if let Ok((namespace, name)) = get_namespace_and_name(resource) {
                     let key = PluginMetaKey::new(&parent_subject, &namespace, &name);
@@ -366,7 +374,11 @@ fn on_resource_get(context: GetExtenderContext) -> BoxFuture<AtomicResult<Resour
 
         let drive = get_parent_drive(db_resource, store).await?;
 
-        let (namespace, name) = get_namespace_and_name(db_resource)?;
+        // A resource with missing or invalid identifiers has no meta to enrich it with.
+        // Return it untouched so it can still be viewed and deleted.
+        let Ok((namespace, name)) = get_namespace_and_name(db_resource) else {
+            return Ok(db_resource.clone().into());
+        };
 
         let Some(meta) = store.get_plugin_meta(&PluginMetaKey::new(&drive, &namespace, &name))?
         else {

--- a/server/src/plugins/wasm.rs
+++ b/server/src/plugins/wasm.rs
@@ -12,30 +12,31 @@ use std::{
 };
 
 use atomic_lib::{
+    AtomicErrorType,
+    class_extender::{self, ClassExtenderScope},
+};
+use atomic_lib::{
+    Commit, Db, Resource, Storelike, Value,
     agents::{Agent, ForAgent},
     class_extender::ClassExtender,
     commit::{CommitBuilder, CommitOpts},
-    db::plugin_meta::{PermissionType, PluginManifest, PluginMeta},
+    db::plugin_meta::{PermissionType, PluginManifest, PluginMeta, validate_plugin_identifiers},
     errors::{AtomicError, AtomicResult},
-    parse::{parse_json_ad_resource, ParseOpts, SaveOpts},
+    parse::{ParseOpts, SaveOpts, parse_json_ad_resource},
     storelike::{Query, ResourceResponse},
-    urls, Commit, Db, Resource, Storelike, Value,
+    urls,
 };
-use atomic_lib::{
-    class_extender::{self, ClassExtenderScope},
-    AtomicErrorType,
-};
-use base64::{engine::general_purpose, Engine as _};
-use ring::digest::{digest, SHA256};
+use base64::{Engine as _, engine::general_purpose};
+use ring::digest::{SHA256, digest};
 use tracing::{error, info, warn};
 use wasmtime::{
-    component::{Component, Linker, ResourceTable},
     Config, Engine, ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder, Trap,
+    component::{Component, Linker, ResourceTable},
 };
-use wasmtime_wasi::{p2, DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiView, p2};
 use wasmtime_wasi_http::{
-    p2::{add_only_http_to_linker_async, WasiHttpCtxView, WasiHttpView},
     WasiHttpCtx,
+    p2::{WasiHttpCtxView, WasiHttpView, add_only_http_to_linker_async},
 };
 
 use atomic_lib::db::plugin_meta::PluginMetaKey;
@@ -996,11 +997,20 @@ fn extract_plugin_to_disk(
         } else if file_name.starts_with("assets/") {
             // Replace "assets/" with "{namespace}/"
             let stripped = file_name.strip_prefix("assets/").unwrap();
+            let assets_dir = target_dir.join(namespace);
             if stripped.is_empty() {
                 // It is the "assets/" directory itself
-                target_dir.join(namespace)
+                assets_dir
             } else {
-                target_dir.join(namespace).join(stripped)
+                // Zip entry names are attacker-controlled: reject anything that is not a
+                // plain relative path made of normal components (no `..`, no absolute paths).
+                let relative = safe_relative_path(stripped).ok_or_else(|| {
+                    AtomicError::from(format!(
+                        "Plugin zip contains an unsafe asset path: {}",
+                        file_name
+                    ))
+                })?;
+                assets_dir.join(relative)
             }
         } else {
             continue;
@@ -1100,6 +1110,46 @@ fn setup_plugin_data_dir(wasm_file_path: &Path, plugin_dir: &Path) -> Option<Pat
     }
 }
 
+/// Returns `Some(path)` if `raw` is a relative path consisting only of normal components
+/// (no `..`, no root/prefix, no `.`), otherwise `None`.
+fn safe_relative_path(raw: &str) -> Option<PathBuf> {
+    use std::path::Component;
+
+    // Zip archives always use `/`, but be strict about backslashes too so a Windows-style
+    // traversal cannot slip through on any platform.
+    if raw.contains('\\') || raw.contains('\0') {
+        return None;
+    }
+    let path = Path::new(raw);
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            _ => return None,
+        }
+    }
+    if out.as_os_str().is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+/// Errors unless `child` is exactly one path component below `parent`.
+fn ensure_direct_child(parent: &Path, child: &Path) -> AtomicResult<()> {
+    let is_direct_child = child.parent() == Some(parent)
+        && matches!(
+            child.components().next_back(),
+            Some(std::path::Component::Normal(_))
+        );
+    if !is_direct_child {
+        return Err(AtomicError::from(format!(
+            "Refusing to touch path outside plugin directory: {}",
+            child.display()
+        )));
+    }
+    Ok(())
+}
+
 pub async fn uninstall_plugin(
     name: &str,
     namespace: &str,
@@ -1107,6 +1157,11 @@ pub async fn uninstall_plugin(
     store: &Db,
     plugins_dir: &Path,
 ) -> AtomicResult<()> {
+    // `namespace` and `name` may come straight from a user-controlled Plugin resource
+    // (see `plugin.rs`), not only from a validated manifest. They are used to build
+    // filesystem paths below, so they must be plain path segments (GHSA-vr56-vwrw-w2vg).
+    validate_plugin_identifiers(namespace, name)?;
+
     let encoded_subject = general_purpose::URL_SAFE.encode(drive_subject);
     let target_dir = plugins_dir
         .join(CLASS_EXTENDER_DIR_NAME)
@@ -1125,6 +1180,18 @@ pub async fn uninstall_plugin(
     let json_path = target_dir.join(format!("{}.{}.json", namespace, name));
     let ui_js_path = target_dir.join(format!("{}.{}.ui.js", namespace, name));
     let ui_css_path = target_dir.join(format!("{}.{}.ui.css", namespace, name));
+    let assets_dir = target_dir.join(namespace);
+
+    // Defense in depth: every path we are about to delete must be a direct child of `target_dir`.
+    for path in [
+        &wasm_path,
+        &json_path,
+        &ui_js_path,
+        &ui_css_path,
+        &assets_dir,
+    ] {
+        ensure_direct_child(&target_dir, path)?;
+    }
 
     if !wasm_path.exists() {
         return Err(AtomicError::not_found(format!(
@@ -1196,18 +1263,15 @@ pub async fn uninstall_plugin(
         }
     }
 
-    if !namespace_still_used {
-        let assets_dir = target_dir.join(namespace);
-        if assets_dir.exists() && assets_dir.is_dir() {
-            info!("Removing unused assets directory: {}", assets_dir.display());
-            std::fs::remove_dir_all(&assets_dir).map_err(|e| {
-                AtomicError::from(format!(
-                    "Failed to remove assets directory {}: {}",
-                    assets_dir.display(),
-                    e
-                ))
-            })?;
-        }
+    if !namespace_still_used && assets_dir.is_dir() {
+        info!("Removing unused assets directory: {}", assets_dir.display());
+        std::fs::remove_dir_all(&assets_dir).map_err(|e| {
+            AtomicError::from(format!(
+                "Failed to remove assets directory {}: {}",
+                assets_dir.display(),
+                e
+            ))
+        })?;
     }
 
     delete_plugin_meta(store, drive_subject, namespace, name).await?;
@@ -1713,4 +1777,68 @@ async fn compare_manifest_to_resource(
     }
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod path_safety_tests {
+    use super::*;
+
+    #[test]
+    fn safe_relative_path_rejects_traversal() {
+        assert!(safe_relative_path("../x").is_none());
+        assert!(safe_relative_path("a/../../x").is_none());
+        assert!(safe_relative_path("/etc/passwd").is_none());
+        assert!(safe_relative_path("a\\..\\b").is_none());
+        assert!(safe_relative_path("").is_none());
+        assert_eq!(
+            safe_relative_path("img/logo.png"),
+            Some(PathBuf::from("img/logo.png"))
+        );
+    }
+
+    #[test]
+    fn ensure_direct_child_rejects_escapes() {
+        let parent = Path::new("/plugins/scoped/abc");
+        assert!(ensure_direct_child(parent, &parent.join("ns.name.wasm")).is_ok());
+        assert!(ensure_direct_child(parent, &parent.join("../x")).is_err());
+        assert!(ensure_direct_child(parent, &parent.join("a/b")).is_err());
+        assert!(ensure_direct_child(parent, parent).is_err());
+    }
+
+    /// Regression test for GHSA-vr56-vwrw-w2vg: a traversal payload in namespace/name must
+    /// never delete anything outside the drive's scoped plugin directory.
+    #[tokio::test]
+    async fn uninstall_rejects_path_traversal() {
+        let db = Db::init_temp("uninstall_rejects_path_traversal")
+            .await
+            .unwrap();
+        let (_agent, drive) = db.setup("Attacker").await.unwrap();
+
+        let plugins_dir =
+            std::env::temp_dir().join(format!("atomic_uninstall_traversal_{}", std::process::id()));
+        let victim_dir = plugins_dir.join("victim");
+        std::fs::create_dir_all(&victim_dir).unwrap();
+        let victim_file = victim_dir.join("target.wasm");
+        std::fs::write(&victim_file, b"do not delete").unwrap();
+
+        let encoded_subject = general_purpose::URL_SAFE.encode(&drive);
+        let target_dir = plugins_dir
+            .join(CLASS_EXTENDER_DIR_NAME)
+            .join("scoped")
+            .join(&encoded_subject);
+        std::fs::create_dir_all(&target_dir).unwrap();
+
+        // Traverses from target_dir up to plugins_dir/victim/target.wasm
+        let result =
+            uninstall_plugin("target", "../../../victim/", &drive, &db, &plugins_dir).await;
+        assert!(result.is_err(), "traversal namespace must be rejected");
+        assert!(victim_file.exists(), "victim file must not be deleted");
+
+        // Same for the assets dir branch: namespace resolving to a directory outside target_dir.
+        let result = uninstall_plugin("target", "../../../victim", &drive, &db, &plugins_dir).await;
+        assert!(result.is_err());
+        assert!(victim_dir.exists(), "victim directory must not be deleted");
+
+        std::fs::remove_dir_all(&plugins_dir).ok();
+    }
 }


### PR DESCRIPTION
Fixes GHSA-vr56-vwrw-w2vg (arbitrary file / recursive directory delete via `uninstall_plugin`).

## Root cause

Plugin `namespace` and `name` were validated only when parsed from a zip manifest. The uninstall path read them straight off the Plugin resource and joined them into filesystem paths. A user with ordinary write access to a drive could create a Plugin resource with a `../` payload and then destroy it, deleting arbitrary files. The assets-dir branch calls `remove_dir_all`, so a whole directory could go too.

## Changes

- **Shared validator** (`lib/src/db/plugin_meta.rs`): `validate_plugin_identifiers` requires a single non-empty path segment of ASCII letters, digits, `-` and `_` (max 128 chars). `PluginManifest::validate` now delegates to it so install and uninstall share one rule.
- **`uninstall_plugin`** (`server/src/plugins/wasm.rs`): validates both identifiers up front. As defense in depth, every path it deletes must be a direct child of the drive's scoped plugin directory.
- **Commit hooks** (`server/src/plugins/plugin.rs`): unsafe identifiers are rejected when a Plugin resource is created, and `get_namespace_and_name` validates so the destroy hook never reaches the filesystem with a payload. The read hook tolerates bad identifiers so an already-stored resource stays viewable and deletable. Uninstall failures are now logged instead of silently dropped.
- **Zip-slip hardening**: asset entries from the plugin zip must be plain relative paths with normal components only (no `..`, no absolute paths, no backslashes). Same `join`-on-untrusted-input pattern, same file.

## Tests

- Unit tests for the validator and the two path helpers.
- A regression test that reproduces the advisory's attack against `uninstall_plugin` and asserts the victim file and directory survive.

All existing plugin tests pass, clippy is clean on the touched files.

## Compatibility

The validator is stricter than the old one (which only rejected `/` and `.`). All plugin manifests in the repo (`ontola`, `random-folder`, `extender`, `test-plugin`) pass. Any externally distributed plugin whose namespace or name uses other characters will fail to install after this change.