### PR TITLE
ux(recovery): say so when only a passkey opens the account

### DIFF
--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4010,6 +4010,7 @@ msgid "Enter the recovery password you set for {0}."
 msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
@@ -6664,9 +6665,8 @@ msgstr ""
 msgid "Safari"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my own secret"
-msgstr ""
+#~ msgid "Use my own secret"
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore this workspace"
@@ -7059,4 +7059,29 @@ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "Open a drive by URL or DID"
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "This workspace has an encrypted backup in Cloud Vault."
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "Restore from Cloud Vault"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Continue without an account"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Add a recovery code"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4010,6 +4010,7 @@ msgid "Enter the recovery password you set for {0}."
 msgstr "Enter the recovery password you set for {0}."
 
 #: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
@@ -6698,9 +6699,8 @@ msgstr "Chrome"
 msgid "Safari"
 msgstr "Safari"
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my own secret"
-msgstr "Use my own secret"
+#~ msgid "Use my own secret"
+#~ msgstr "Use my own secret"
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore this workspace"
@@ -7094,3 +7094,28 @@ msgstr "Open a drive by URL"
 #: src/routes/SettingsAgent.tsx
 msgid "Open a drive by URL or DID"
 msgstr "Open a drive by URL or DID"
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "This workspace has an encrypted backup in Cloud Vault."
+msgstr "This workspace has an encrypted backup in Cloud Vault."
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "Restore from Cloud Vault"
+msgstr "Restore from Cloud Vault"
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Continue without an account"
+msgstr "Continue without an account"
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
+msgstr "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
+msgstr "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
+
+#: src/routes/SyncRoute.tsx
+msgid "Add a recovery code"
+msgstr "Add a recovery code"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4010,6 +4010,7 @@ msgid "Enter the recovery password you set for {0}."
 msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
@@ -6664,9 +6665,8 @@ msgstr ""
 msgid "Safari"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my own secret"
-msgstr ""
+#~ msgid "Use my own secret"
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore this workspace"
@@ -7059,4 +7059,29 @@ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "Open a drive by URL or DID"
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "This workspace has an encrypted backup in Cloud Vault."
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "Restore from Cloud Vault"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Continue without an account"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Add a recovery code"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4010,6 +4010,7 @@ msgid "Enter the recovery password you set for {0}."
 msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
+#: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
@@ -6664,9 +6665,8 @@ msgstr ""
 msgid "Safari"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my own secret"
-msgstr ""
+#~ msgid "Use my own secret"
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore this workspace"
@@ -7059,4 +7059,29 @@ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "Open a drive by URL or DID"
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "This workspace has an encrypted backup in Cloud Vault."
+msgstr ""
+
+#: src/components/Vault/VaultRestoreAction.tsx
+msgid "Restore from Cloud Vault"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Continue without an account"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
+msgstr ""
+
+#. 0: managedAccount.email
+#: src/routes/SyncRoute.tsx
+msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Add a recovery code"
 msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -47,6 +47,7 @@ import {
 } from '../helpers/managed/session';
 import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
 import {
+  envelopeWrapperKinds,
   getRecoverySecret,
   readCachedBackups,
 } from '../helpers/managed/recovery';
@@ -636,12 +637,19 @@ function SyncPage() {
    * loses the account. Settings reads that local copy too, so a two-state
    * answer here had the two pages contradicting each other in plain sight.
    *
+   * `passkey-only` is stored, but the only thing that opens it is a passkey.
+   * That is the default onboarding leaves behind, and it is the case this row
+   * used to describe as "this email gets you back in on a new device" — while
+   * a browser the passkey never synced to (Firefox next to Safari, say)
+   * offered nothing but a field for the agent secret. Nothing was lost, but
+   * the promise was not kept, so the row must not be drawn as covered.
+   *
    * `null` until asked, and on failure — "we could not check" is not "you have
    * none", and telling someone their recovery is missing when the control
    * plane was merely unreachable is the one wrong answer this row can give.
    */
   const [recoveryBackup, setRecoveryBackup] = useState<
-    'stored' | 'device-only' | 'none' | null
+    'stored' | 'passkey-only' | 'device-only' | 'none' | null
   >(null);
 
   useEffect(() => {
@@ -656,7 +664,9 @@ function SyncPage() {
         if (cancelled) return;
 
         if (stored) {
-          setRecoveryBackup('stored');
+          const { hasPasskey, hasCode } = envelopeWrapperKinds(stored);
+
+          setRecoveryBackup(hasPasskey && !hasCode ? 'passkey-only' : 'stored');
 
           return;
         }
@@ -1381,9 +1391,11 @@ function SyncPage() {
                       ? `Signed in as ${managedAccount.email}.`
                       : recoveryBackup === 'stored'
                         ? `${managedAccount.email}. We hold your key sealed, so this email gets you back in on a new device.`
-                        : recoveryBackup === 'device-only'
-                          ? `${managedAccount.email}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in.`
-                          : `${managedAccount.email}. No recovery backup stored, so losing every device loses this workspace.`}
+                        : recoveryBackup === 'passkey-only'
+                          ? `${managedAccount.email}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would.`
+                          : recoveryBackup === 'device-only'
+                            ? `${managedAccount.email}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in.`
+                            : `${managedAccount.email}. No recovery backup stored, so losing every device loses this workspace.`}
                 </ConnSub>
                 {/* Signed out, the account itself is the missing piece, and it
                     is made in the portal: on a device that cannot hold our
@@ -1408,12 +1420,18 @@ function SyncPage() {
                     </LearnMore>
                   </ConnActions>
                 ) : recoveryBackup === 'none' ||
-                  recoveryBackup === 'device-only' ? (
+                  recoveryBackup === 'device-only' ||
+                  recoveryBackup === 'passkey-only' ? (
                   <ConnActions>
-                    <LearnMoreLink to={paths.agentSettings}>
+                    <LearnMoreLink
+                      to={paths.agentSettings}
+                      data-testid='recovery-row-action'
+                    >
                       {recoveryBackup === 'device-only'
                         ? 'Store it with ' + PRODUCT_NAME
-                        : 'Set up email recovery'}
+                        : recoveryBackup === 'passkey-only'
+                          ? 'Add a recovery code'
+                          : 'Set up email recovery'}
                     </LearnMoreLink>
                   </ConnActions>
                 ) : null}

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -770,7 +770,12 @@ export function GettingStartedFlow({
                   or who wants nothing to do with our account system, must not
                   be walled out of their own software — and on a FOSS build
                   "Create account" already is this, so offering it twice would
-                  just be noise. */}
+                  just be noise.
+
+                  Named for what it does (a fresh local identity, no account),
+                  not for what the user brings: "Use my own secret" read as
+                  "paste the secret I have", which is the Sign in button below
+                  it — and pressing it minted a new secret instead. */}
               {createTarget?.kind === 'portal' && (
                 <CtaButton
                   key='local'
@@ -778,7 +783,7 @@ export function GettingStartedFlow({
                   subtle
                   onClick={() => setStep('create')}
                 >
-                  Use my own secret
+                  Continue without an account
                 </CtaButton>
               )}
               <CtaButton
@@ -907,7 +912,9 @@ export function GettingStartedFlow({
                       >
                         Use a recovery code instead
                       </Button>
-                    ) : null}
+                    ) : (
+                      <PasskeyOnlyHint />
+                    )}
                     <OtherWaysLabel>or sign in another way</OtherWaysLabel>
                   </Column>
                 ) : null}
@@ -1113,7 +1120,9 @@ export function GettingStartedFlow({
                       >
                         Use a recovery code instead
                       </Button>
-                    ) : null}
+                    ) : (
+                      <PasskeyOnlyHint key='passkey-only' />
+                    )}
                   </Column>
                 ) : (
                   <form key='ready' onSubmit={handleRestore}>
@@ -1355,6 +1364,26 @@ const OwnedElsewhere = styled.p`
   color: ${p => p.theme.colors.textLight};
   font-size: 0.85rem;
 `;
+
+/**
+ * Shown under the passkey button when the backup has no recovery-code
+ * wrapper — the shape onboarding leaves behind by default. Without this the
+ * code button simply did not render, and someone on a browser their passkey
+ * never synced to (Firefox next to Safari on the same laptop) was left with a
+ * passkey prompt that finds nothing and a field for an agent secret they were
+ * never shown. Says where the way out is, since the guard itself cannot add a
+ * code: that is a write to the backup, which needs the passkey that is
+ * missing here.
+ */
+function PasskeyOnlyHint(): React.JSX.Element {
+  return (
+    <OwnedElsewhere data-testid='passkey-only-hint'>
+      Only your passkey opens this account. If it isn&apos;t on this device,
+      unlock on the one where you set it up and add a recovery code under
+      Settings — that gets you in anywhere.
+    </OwnedElsewhere>
+  );
+}
 
 const PlainExternalLink = styled.a`
   color: ${p => p.theme.colors.main};


### PR DESCRIPTION
Found on staging 2026-09-03: onboard in one browser (Zen), open the same account in another (Firefox). The guard finds the Cloud Vault backup, offers "Unlock with your passkey" — which the second browser does not have — and nothing else but a field for an agent secret the user was never shown. The "Use a recovery code instead" button is gated on the backup having a code wrapper, and onboarding by default produces none: the passkey *is* the recovery credential, and a code is only offered when the passkey fails or reports itself device-bound. "Synced" is per vendor keychain, not per machine.

Nothing is lost in that state; the UI just doesn't say where the way out is. This PR makes it say so, in the three places that were silent or wrong:

- **Sign-in guard / restore step** — under the passkey button, when the backup has no code wrapper: only your passkey opens this account; if it isn't on this device, unlock where you set it up and add a recovery code under Settings. (`data-testid="passkey-only-hint"`)
- **Sync page, "Email recovery" row** — new `passkey-only` state. It read "this email gets you back in on a new device" for exactly the backup that could not, and was coloured as covered. Neutral now, with "Add a recovery code" → Settings, where `addRecoveryCodeWrapper` already lives (re-wraps the same DEK, no re-enrol).
- **Welcome** — "Use my own secret" → "Continue without an account". It calls `setStep('create')`; the old label read as "paste the secret I have" (that's Sign in) and minted a new one.

Catalogs settled for these plus two `VaultRestoreAction` strings #1342 left unextracted.

Not in this PR: whether onboarding should always mint a code. The current design deliberately interrupts only for device-bound passkeys (the comment in `GettingStartedFlow.tsx` cites a `planning/BACKUP_SECURITY.md` that isn't in the repo); the row + guard copy make the gap visible without reopening that. Also not here: e2e coverage of the passkey path itself — Playwright can drive it through CDP's `WebAuthn.addVirtualAuthenticator` (`hasPrf: true`), which would let the returning-user spec run the real default onboarding shape instead of the code fallback.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
