### PR TITLE
One email, one identity: no silent agent swap, no account-less create

### DIFF
--- a/browser/data-browser/src/components/IdentityReconcileGate.tsx
+++ b/browser/data-browser/src/components/IdentityReconcileGate.tsx
@@ -3,27 +3,52 @@ import { useStore } from '@tomic/react';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useSettings } from '../helpers/AppSettings';
 import {
+  clearManagedAccountBinding,
   evaluateIdentityReconciliation,
   evaluateServerReconciliation,
+  localAgentIsDisposable,
+  logoutManagedSession,
+  PRODUCT_NAME,
   syncDeviceDirectory,
   writeManagedAccountBinding,
 } from '../helpers/managed';
 import { paths } from '../routes/paths';
+import { Button } from './Button';
+import { Column } from './Row';
+import {
+  CardSubtitle,
+  CardTitle,
+  OnboardingCard,
+  OnboardingWrap,
+  Shell,
+} from '../views/getting-started/chrome';
 
 type GateProps = {
   children: React.ReactNode;
 };
 
+/** A local identity worth asking about, and the account that wants to replace it. */
+type Conflict = {
+  managedAccountEmail: string;
+};
+
 /**
  * Keeps the device's Atomic agent aligned with the signed-in Managed Sync account
- * — **silently**. There is no "resolve mismatch" screen: the agent layer is
- * never surfaced to a user who only thinks in terms of their Managed Sync account.
- * (See the control-plane contract doc, decision 2026-06-25.)
+ * — silently wherever silence loses nothing. The agent layer is not surfaced
+ * to a user who only thinks in terms of their account (see the control-plane
+ * contract doc, decision 2026-06-25); the one exception below is the case
+ * where staying silent throws a workspace away.
  *
  * On a Managed Sync session whose account agent differs from the device agent:
- * - **Account has a restorable backup** (`recovery_agent`) → send the user to
- *   the welcome/recover flow ("unlock your data"), which replaces the local
- *   agent. Nothing is dropped here; the local agent stays until recovery lands.
+ * - **Account has a restorable backup** (`recovery_agent`) and the local agent
+ *   is disposable (the demo guest, an identity with no workspace) → send the
+ *   user to the welcome/recover flow ("unlock your data"), which replaces the
+ *   local agent. Nothing is dropped here; the local agent stays until recovery
+ *   lands.
+ * - **Same, but the local agent has a workspace** → ask. Someone who made an
+ *   identity here and then signed in to the portal with an email that already
+ *   has one was, until 2026-09-03, switched to the old identity without a
+ *   word. One email has one identity; which one that is stays their call.
  * - **Otherwise** → adopt this device's agent (bind it to the account) so it
  *   becomes the account's agent. No prompt, no logout.
  *
@@ -38,6 +63,8 @@ export function IdentityReconcileGate({
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const [checking, setChecking] = useState(true);
+  const [conflict, setConflict] = useState<Conflict | null>(null);
+  const [resolving, setResolving] = useState(false);
   // Re-checks fire on every `agent?.subject` change (e.g. a device
   // creating/accepting-as a brand new local agent, not just managed-sync
   // sign-in/out). Blanking `children` on every one of those unmounts the
@@ -68,6 +95,19 @@ export function IdentityReconcileGate({
     const result = await evaluateIdentityReconciliation(localAgent);
 
     if (!result.ok && result.issue.reason === 'recovery_agent') {
+      const disposable =
+        !result.issue.localAgentSubject ||
+        (await localAgentIsDisposable(store, result.issue.localAgentSubject));
+
+      if (!disposable) {
+        // Two identities that both have something on them. Render the
+        // question instead of the app, so nothing is used as the wrong one
+        // meanwhile.
+        setConflict({ managedAccountEmail: result.issue.managedAccountEmail });
+
+        return;
+      }
+
       // The account has a restorable identity. Unlock it via the recover flow;
       // it replaces the local agent. Keep `checking` true so we render nothing
       // during the redirect rather than flashing the app as the wrong agent.
@@ -105,6 +145,7 @@ export function IdentityReconcileGate({
     // routing hints only, must never delay or gate the app.
     void syncDeviceDirectory(store.getDrive());
 
+    setConflict(null);
     setChecking(false);
     hasCheckedOnceRef.current = true;
   }, [agent?.subject, skip, store, navigate, setServer]);
@@ -113,8 +154,77 @@ export function IdentityReconcileGate({
     void converge();
   }, [converge]);
 
+  /** Switch this browser to the account's identity: the recover flow does it. */
+  function switchToAccount() {
+    setConflict(null);
+    navigate({ to: paths.welcome, replace: true });
+  }
+
+  /**
+   * Keep the identity that is here. The stale thing is then the portal
+   * session — end it, as signing in with a secret already does when the two
+   * disagree — and converge again, which now finds no account and lets the
+   * local agent be primary.
+   */
+  async function keepLocal() {
+    setResolving(true);
+
+    try {
+      clearManagedAccountBinding();
+      await logoutManagedSession();
+    } finally {
+      setResolving(false);
+      setConflict(null);
+      void converge();
+    }
+  }
+
   if (skip) {
     return <>{children}</>;
+  }
+
+  if (conflict) {
+    return (
+      <Shell>
+        <OnboardingWrap>
+          <OnboardingCard data-testid='identity-conflict'>
+            <Column gap='1rem'>
+              <CardTitle>This email already has an identity</CardTitle>
+              <CardSubtitle>
+                {conflict.managedAccountEmail} is backed up with an identity
+                that is not the one this browser is using. An account has one
+                identity — which one should this be?
+              </CardSubtitle>
+              <Button
+                type='button'
+                onClick={switchToAccount}
+                disabled={resolving}
+                data-testid='identity-conflict-switch'
+              >
+                Switch to my account&apos;s identity
+              </Button>
+              <CardSubtitle>
+                Restores it here. The identity you made in this browser stays
+                reachable only with its agent secret.
+              </CardSubtitle>
+              <Button
+                type='button'
+                subtle
+                onClick={() => void keepLocal()}
+                disabled={resolving}
+                data-testid='identity-conflict-keep'
+              >
+                {resolving ? 'Signing out…' : 'Keep this one'}
+              </Button>
+              <CardSubtitle>
+                Signs this browser out of {PRODUCT_NAME}. Nothing here is backed
+                up until it has an account of its own.
+              </CardSubtitle>
+            </Column>
+          </OnboardingCard>
+        </OnboardingWrap>
+      </Shell>
+    );
   }
 
   if (checking && !hasCheckedOnceRef.current) {

--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { evaluateServerReconciliation } from './reconcile';
+import {
+  evaluateServerReconciliation,
+  localAgentIsDisposable,
+} from './reconcile';
 import type { ManagedEnrollmentSummary } from './enrollmentApi';
 
 /**
@@ -204,5 +207,46 @@ describe('evaluateServerReconciliation', () => {
     );
 
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('localAgentIsDisposable', () => {
+  const personalDrive = 'https://atomicdata.dev/properties/personalDrive';
+
+  function reader(resource: { error?: unknown; props?: Record<string, unknown> }) {
+    return {
+      getResource: () =>
+        Promise.resolve({
+          error: resource.error,
+          get: (property: string) => resource.props?.[property],
+        }),
+    };
+  }
+
+  it('keeps an agent that has a workspace', async () => {
+    const store = reader({ props: { [personalDrive]: 'did:ad:drive1' } });
+
+    expect(await localAgentIsDisposable(store, 'did:ad:agent:a')).toBe(false);
+  });
+
+  it('treats a guest (no personal drive) as disposable', async () => {
+    expect(
+      await localAgentIsDisposable(reader({ props: {} }), 'did:ad:agent:a'),
+    ).toBe(true);
+  });
+
+  it('treats an agent whose resource cannot load as disposable', async () => {
+    expect(
+      await localAgentIsDisposable(
+        reader({ error: new Error('nope') }),
+        'did:ad:agent:a',
+      ),
+    ).toBe(true);
+  });
+
+  it('treats a throwing store as disposable rather than blocking', async () => {
+    const store = { getResource: () => Promise.reject(new Error('down')) };
+
+    expect(await localAgentIsDisposable(store, 'did:ad:agent:a')).toBe(true);
   });
 });

--- a/browser/data-browser/src/helpers/managed/reconcile.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.ts
@@ -1,3 +1,4 @@
+import { core } from '@tomic/react';
 import { PRODUCT_NAME } from './product';
 import {
   clearManagedAccountBinding,
@@ -214,6 +215,42 @@ export async function assertAgentMatchesManagedAccount(
   throw new Error(
     `This device is signed in to a different Atomic agent than your ${PRODUCT_NAME} account. Resolve the identity mismatch before continuing.`,
   );
+}
+
+/**
+ * The least a store needs to answer `localAgentIsDisposable`. Narrow so the
+ * test can hand in a stub instead of a whole Store.
+ */
+export type AgentResourceReader = {
+  getResource(subject: string): Promise<{
+    error?: unknown;
+    get(property: string): unknown;
+  }>;
+};
+
+/**
+ * Whether the device's agent is one nobody would miss: the demo guest, or an
+ * identity that never got a workspace. Real accounts get a personal drive
+ * during onboarding; guests never do (same test `ensureAgentForDemo` uses).
+ *
+ * This is what decides whether the reconcile gate may swap the agent out
+ * silently. It used to swap every time — and a fresh local identity with a
+ * workspace on it was replaced, without a word, the moment its owner signed
+ * in to the portal with an email that already had one (staging, 2026-09-03).
+ */
+export async function localAgentIsDisposable(
+  store: AgentResourceReader,
+  agentSubject: string,
+): Promise<boolean> {
+  try {
+    const resource = await store.getResource(agentSubject);
+
+    if (resource.error) return true;
+
+    return !resource.get(core.properties.personalDrive);
+  } catch {
+    return true;
+  }
 }
 
 export function shortDid(subject: string): string {

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7069,9 +7069,8 @@ msgstr ""
 msgid "Restore from Cloud Vault"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Continue without an account"
-msgstr ""
+#~ msgid "Continue without an account"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
@@ -7084,4 +7083,34 @@ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signing out…"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Keep this one"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "This email already has an identity"
+msgstr ""
+
+#. 0: conflict.managedAccountEmail
+#: src/components/IdentityReconcileGate.tsx
+msgid "{0} is backed up with an identity that is not the one this browser is using. An account has one identity — which one should this be?"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Switch to my account's identity"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Restores it here. The identity you made in this browser stays reachable only with its agent secret."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7103,9 +7103,8 @@ msgstr "This workspace has an encrypted backup in Cloud Vault."
 msgid "Restore from Cloud Vault"
 msgstr "Restore from Cloud Vault"
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Continue without an account"
-msgstr "Continue without an account"
+#~ msgid "Continue without an account"
+#~ msgstr "Continue without an account"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
@@ -7119,3 +7118,33 @@ msgstr "{0}. We hold your key sealed, but only your passkey opens it. A browser 
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
 msgstr "Add a recovery code"
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signing out…"
+msgstr "Signing out…"
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Keep this one"
+msgstr "Keep this one"
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "This email already has an identity"
+msgstr "This email already has an identity"
+
+#. 0: conflict.managedAccountEmail
+#: src/components/IdentityReconcileGate.tsx
+msgid "{0} is backed up with an identity that is not the one this browser is using. An account has one identity — which one should this be?"
+msgstr "{0} is backed up with an identity that is not the one this browser is using. An account has one identity — which one should this be?"
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Switch to my account's identity"
+msgstr "Switch to my account's identity"
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Restores it here. The identity you made in this browser stays reachable only with its agent secret."
+msgstr "Restores it here. The identity you made in this browser stays reachable only with its agent secret."
+
+#. 0: PRODUCT_NAME
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
+msgstr "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7069,9 +7069,8 @@ msgstr ""
 msgid "Restore from Cloud Vault"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Continue without an account"
-msgstr ""
+#~ msgid "Continue without an account"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
@@ -7084,4 +7083,34 @@ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signing out…"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Keep this one"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "This email already has an identity"
+msgstr ""
+
+#. 0: conflict.managedAccountEmail
+#: src/components/IdentityReconcileGate.tsx
+msgid "{0} is backed up with an identity that is not the one this browser is using. An account has one identity — which one should this be?"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Switch to my account's identity"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Restores it here. The identity you made in this browser stays reachable only with its agent secret."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7069,9 +7069,8 @@ msgstr ""
 msgid "Restore from Cloud Vault"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Continue without an account"
-msgstr ""
+#~ msgid "Continue without an account"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Only your passkey opens this account. If it isn't on this device, unlock on the one where you set it up and add a recovery code under Settings — that gets you in anywhere."
@@ -7084,4 +7083,34 @@ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signing out…"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Keep this one"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "This email already has an identity"
+msgstr ""
+
+#. 0: conflict.managedAccountEmail
+#: src/components/IdentityReconcileGate.tsx
+msgid "{0} is backed up with an identity that is not the one this browser is using. An account has one identity — which one should this be?"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Switch to my account's identity"
+msgstr ""
+
+#: src/components/IdentityReconcileGate.tsx
+msgid "Restores it here. The identity you made in this browser stays reachable only with its agent secret."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/components/IdentityReconcileGate.tsx
+msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
 msgstr ""

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -765,27 +765,14 @@ export function GettingStartedFlow({
                   Create account
                 </CtaButton>
               )}
-              {/* The local path stays reachable in a hosted build, one tap
-                  down rather than gone. Someone who already has an identity,
-                  or who wants nothing to do with our account system, must not
-                  be walled out of their own software — and on a FOSS build
-                  "Create account" already is this, so offering it twice would
-                  just be noise.
-
-                  Named for what it does (a fresh local identity, no account),
-                  not for what the user brings: "Use my own secret" read as
-                  "paste the secret I have", which is the Sign in button below
-                  it — and pressing it minted a new secret instead. */}
-              {createTarget?.kind === 'portal' && (
-                <CtaButton
-                  key='local'
-                  type='button'
-                  subtle
-                  onClick={() => setStep('create')}
-                >
-                  Continue without an account
-                </CtaButton>
-              )}
+              {/* No account-less create path in a hosted build. It minted a
+                  second identity that the portal then swapped away the
+                  moment its owner signed in with an email that already had
+                  one (staging, 2026-09-03). One email, one identity: the
+                  hosted welcome creates through the portal or signs in with
+                  an existing secret — nothing in between. A FOSS build's
+                  "Create account" is the local path, and someone with their
+                  own secret has Sign in below. */}
               <CtaButton
                 key='signin'
                 type='button'


### PR DESCRIPTION
## What went wrong (staging, 2026-09-03)

1. Hosted welcome → **Continue without an account** → a new local identity with its own workspace.
2. Sync tab → **Sign in →** → portal magic link with an email that already has an identity.
3. `IdentityReconcileGate` sees `recovery_agent`, redirects to `/welcome`, and the restore flow replaces the just-made identity with the old one. Nothing tells the user; the new workspace is only reachable again by pasting its agent secret.

## Decision: one email = one identity

- **Close the door at creation.** The hosted welcome no longer offers "Continue without an account". Its two paths are *Create account* (portal) and *Sign in* (existing secret). On a FOSS build "Create account" already *is* the local path, so nothing is lost there.
- **Ask instead of swapping.** When the gate finds a `recovery_agent` mismatch and the local agent has a personal drive, it renders a card instead of the app:
  - **Switch to my account's identity** → the recover flow, as before.
  - **Keep this one** → `clearManagedAccountBinding()` + `logoutManagedSession()`, then re-converge; the local agent stays primary and the portal session is gone (same thing the secret sign-in does on a conflict).
- Demo guests / identities without a workspace still swap silently — nothing to protect there.

`localAgentIsDisposable(store, agentSubject)` in `helpers/managed/reconcile.ts` makes that call (guest detection = agent lacks `core.properties.personalDrive`, same as `ensureAgentForDemo`; unreadable resource ⇒ disposable so a flaky fetch never blocks). Four unit tests.

Test ids: `identity-conflict`, `identity-conflict-switch`, `identity-conflict-keep`.

## Not in this PR

- A pre-warning under the Sync tab's "Sign in →" — with the account-less path gone the gate covers the remaining cases.
- Multi-identity accounts. Deliberately not: the whole point is that an email maps to one identity.

## Checks

- `vitest run src/helpers/managed/reconcile.test.ts` — 14 pass
- oxlint / oxfmt on changed files; catalogs re-extracted via the vite plugin

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
