### PR TITLE
chore: fix formatting in plugins and data-browser, gate db tests in hierarchy

### DIFF
--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -213,7 +213,10 @@ describe('evaluateServerReconciliation', () => {
 describe('localAgentIsDisposable', () => {
   const personalDrive = 'https://atomicdata.dev/properties/personalDrive';
 
-  function reader(resource: { error?: unknown; props?: Record<string, unknown> }) {
+  function reader(resource: {
+    error?: unknown;
+    props?: Record<string, unknown>;
+  }) {
     return {
       getResource: () =>
         Promise.resolve({

--- a/lib/src/hierarchy.rs
+++ b/lib/src/hierarchy.rs
@@ -411,6 +411,7 @@ mod test {
     /// refused — and because the walk then ascends and fails closed, the
     /// failure is a silent 401 rather than anything that looks like a bug.
     #[tokio::test]
+    #[cfg(feature = "db")]
     async fn legacy_internal_agent_grant_still_authorizes_its_did() {
         use crate::agents::ForAgent;
         use crate::hierarchy::{check_rights, Right};
@@ -460,6 +461,7 @@ mod test {
     /// the agent resource, and that read was refused: an agent grants `read` to
     /// nobody but itself and belongs to no drive, so no grant could reach it.
     #[tokio::test]
+    #[cfg(feature = "db")]
     async fn agents_are_readable_by_anyone_but_writable_only_by_their_owner() {
         use crate::agents::ForAgent;
         use crate::hierarchy::{check_rights, Right};

--- a/server/src/plugins/plugin.rs
+++ b/server/src/plugins/plugin.rs
@@ -5,13 +5,13 @@ use std::path::PathBuf;
 #[cfg(feature = "wasm-plugins")]
 use atomic_lib::urls::{DOWNLOAD_URL, MIMETYPE};
 use atomic_lib::{
-    AtomicError, Db, Resource, Storelike, Value,
     agents::{Agent, ForAgent},
     class_extender::{BoxFuture, ClassExtender, CommitExtenderContext, GetExtenderContext},
-    db::plugin_meta::{PluginMetaKey, validate_plugin_identifier, validate_plugin_identifiers},
+    db::plugin_meta::{validate_plugin_identifier, validate_plugin_identifiers, PluginMetaKey},
     errors::AtomicResult,
     storelike::ResourceResponse,
     urls::{self},
+    AtomicError, Db, Resource, Storelike, Value,
 };
 #[cfg(feature = "wasm-plugins")]
 use tracing::{error, info};

--- a/server/src/plugins/wasm.rs
+++ b/server/src/plugins/wasm.rs
@@ -12,31 +12,30 @@ use std::{
 };
 
 use atomic_lib::{
-    AtomicErrorType,
-    class_extender::{self, ClassExtenderScope},
-};
-use atomic_lib::{
-    Commit, Db, Resource, Storelike, Value,
     agents::{Agent, ForAgent},
     class_extender::ClassExtender,
     commit::{CommitBuilder, CommitOpts},
-    db::plugin_meta::{PermissionType, PluginManifest, PluginMeta, validate_plugin_identifiers},
+    db::plugin_meta::{validate_plugin_identifiers, PermissionType, PluginManifest, PluginMeta},
     errors::{AtomicError, AtomicResult},
-    parse::{ParseOpts, SaveOpts, parse_json_ad_resource},
+    parse::{parse_json_ad_resource, ParseOpts, SaveOpts},
     storelike::{Query, ResourceResponse},
-    urls,
+    urls, Commit, Db, Resource, Storelike, Value,
 };
-use base64::{Engine as _, engine::general_purpose};
-use ring::digest::{SHA256, digest};
+use atomic_lib::{
+    class_extender::{self, ClassExtenderScope},
+    AtomicErrorType,
+};
+use base64::{engine::general_purpose, Engine as _};
+use ring::digest::{digest, SHA256};
 use tracing::{error, info, warn};
 use wasmtime::{
-    Config, Engine, ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder, Trap,
     component::{Component, Linker, ResourceTable},
+    Config, Engine, ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder, Trap,
 };
-use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiView, p2};
+use wasmtime_wasi::{p2, DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiView};
 use wasmtime_wasi_http::{
+    p2::{add_only_http_to_linker_async, WasiHttpCtxView, WasiHttpView},
     WasiHttpCtx,
-    p2::{WasiHttpCtxView, WasiHttpView, add_only_http_to_linker_async},
 };
 
 use atomic_lib::db::plugin_meta::PluginMetaKey;


### PR DESCRIPTION
Fixes rustFmt failure in Dagger CI on develop:
- Runs `cargo fmt` on `server/src/plugins/plugin.rs` and `server/src/plugins/wasm.rs`
- Runs `oxfmt` on `browser/data-browser/src/helpers/managed/reconcile.test.ts`
- Gates two tests using `crate::db::Db::init_temp` behind `#[cfg(feature = "db")]` in `lib/src/hierarchy.rs`