### PR TITLE
Docs / planning: Atomic as an MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Docs / planning: Atomic as an MCP server — local stdio signs writes as the
+  user's Agent; remote Streamable HTTP is read-only until issued-agent
+  writes. OAuth Bearer never hits `/commit`. See
+  [`planning/mcp-endpoint.md`](planning/mcp-endpoint.md).
 - Fix: with `ATOMIC_HOME_DRIVE` set, `GET /server` answered 500 for plain JSON and JSON-LD (`Accept: application/json`): the `homeDrive` property the endpoint sets was never defined in the default store, so rendering tried to fetch it from atomicdata.dev. JSON-AD (what the data-browser asks for) was unaffected. The property is now part of the defaults.
 
 ## [v0.41.0-beta.3] - 2026-09-01

--- a/planning/README.md
+++ b/planning/README.md
@@ -71,6 +71,7 @@ Remaining work, not "this file exists."
 | [`reticulum-sync.md`](./reticulum-sync.md) | **Proposal.** Atomic sync protocol over Reticulum. |
 | [`json-schema-code-first.md`](./json-schema-code-first.md) | **Proposal**; `defineSchema` + frozen `did:ad:` schemas in flight in PR #1262 (not on `develop`). Code-first JSON Schema → local DID-backed Class/Property resources. |
 | [`SDK-API-design.md`](./SDK-API-design.md) | SDK / agent DX direction. |
+| [`mcp-endpoint.md`](./mcp-endpoint.md) | **Proposal.** Atomic as an MCP server. Local stdio signs as the user; remote HTTP is read-only until issued-agent writes. Does not wait on #1310; remote auth is the #1275 AS shape. |
 | [`plugins.md`](./plugins.md) | **Partial** — one plugin model (`run` end to end, per-app agents, unattended runs). The code lives on `feat/plugin-model` (PR #1307), not `develop`. Absorbed `llm-wasm-gui-plugins.md`, `importers.md`, `habits-app.md` (2026-09-01); the habits RPC-`query` blocker is a line in it. |
 | [`personal-information-suite.md`](./personal-information-suite.md) | Exploration: contacts, calendar, email. |
 | [`social-apps.md`](./social-apps.md) | Requirements for social-network-shaped apps. Companion to `zones.md`. |

--- a/planning/SDK-API-design.md
+++ b/planning/SDK-API-design.md
@@ -35,3 +35,5 @@ In the "old" HTTP based Atomic(Server) UX, an app developer had to:
 - [ ] Make tutorial describing the future situation (I think this is where we should start, so we design from the perspective of a developer)
 - [ ] Schema creation in-code. See [`json-schema-code-first.md`](./json-schema-code-first.md).
 - [ ] Update APIs
+- [ ] MCP server so external agents (Cursor, Claude, …) speak the same
+      compact tools as the in-app assistant. See [`mcp-endpoint.md`](./mcp-endpoint.md).

--- a/planning/actions.md
+++ b/planning/actions.md
@@ -27,7 +27,7 @@ the JS API — but each surface enumerates and implements them independently:
 - The ⌘K overlay exposes exactly one verb (navigate to search result).
 - Coverage is inconsistent: Delete has no hotkey and no AI tool; Share/History/
   Favorite exist only in the context menu.
-- There is no MCP server yet; when one exists it would be a fifth enumeration.
+- There is no MCP server yet; when one exists it would be a fifth enumeration. Plan: [`mcp-endpoint.md`](./mcp-endpoint.md).
 
 ## Design
 

--- a/planning/json-ad-compact.md
+++ b/planning/json-ad-compact.md
@@ -3,9 +3,11 @@
 > Status: **Phase 1–2 shipped** (resolver, tool I/O, table/context providers).
 > Remaining: rebase `create_table.rows` on `fromCompact`; server
 > `format=compact`. First consumer: the data-browser AI assistant tools
-> (`useAtomicTools.ts`). Related: [[SDK-API-design]] (agent DX), the
-> `create_table` spec vocabulary in `createTableFromSpec.ts`, and the
-> drive-structure / custom-classes system-prompt inventories.
+> (`useAtomicTools.ts`). Related: [[SDK-API-design]] (agent DX),
+> [`mcp-endpoint.md`](./mcp-endpoint.md) (Atomic as MCP server; phase 4 is
+> its Rust path), the `create_table` spec vocabulary in
+> `createTableFromSpec.ts`, and the drive-structure / custom-classes
+> system-prompt inventories.
 
 ## Problem
 
@@ -112,7 +114,7 @@ section); tool descriptions just say "compact form".
 | 1 | Short subject refs (`#xxxxxxxx`) at the tool boundary + drive-tree/custom-classes seeding + markdown-link and tool-bubble expansion | **done** |
 | 2 | Context items (`processAtomicResources`) emit compact; per-class context providers (table → row-class schema + tag map + first N rows + count in transient context) | **done** |
 | 3 | `create_table.rows` / `rowToPropVals` re-based on `fromCompact` | remaining |
-| 4 | Server-side `format=compact` so MCP server & other clients share it instead of reimplementing resolution | remaining |
+| 4 | Server-side `format=compact` so MCP server & other clients share it instead of reimplementing resolution | remaining; consumer: [`mcp-endpoint.md`](./mcp-endpoint.md) |
 
 ## Decisions record
 

--- a/planning/mcp-endpoint.md
+++ b/planning/mcp-endpoint.md
@@ -1,0 +1,206 @@
+# Atomic as an MCP server
+
+> **Status:** Proposal (2026-09). Nothing in this file is implemented.
+> Companion to [`actions.md`](./actions.md) (one verb list, many surfaces),
+> [`json-ad-compact.md`](./json-ad-compact.md) (the wire dialect),
+> [`atomic-lib-runtime.md`](./atomic-lib-runtime.md) (`AtomicNode`),
+> [`plugins.md`](./plugins.md) (issued agents, unattended writes),
+> [`SDK-API-design.md`](./SDK-API-design.md) (agent DX), and
+> [`planning/oidc-oauth.md`](https://github.com/ontola/atomic-server/blob/cursor/oidc-oauth-reconsider-1cb5/planning/oidc-oauth.md)
+> (PR #1310; not on `develop` yet).
+>
+> **Decision:** Ship Atomic as an MCP *server*. Reads may live on the node.
+> Writes stay signed commits from a key the caller holds — locally that is
+> the user's Agent; remotely that is an **issued agent**, never the user's
+> root and never an OAuth Bearer on `/commit`. Do not grow a fifth tool
+> list. Do not wrap the Tauri DOM bridge and call it a data API.
+
+## Why
+
+The in-app assistant already *consumes* MCP (`McpServersContext`, Exa as a
+default). Cursor, Claude Desktop, Claude Code, and ChatGPT cannot *talk to
+Atomic*. That is the missing half of
+[`SDK-API-design.md`](./SDK-API-design.md): an LLM agent should read and
+edit a drive the same way a human does, from any client that speaks MCP.
+
+The tool surface already exists. `useAtomicTools.ts` is a React hook around
+get / query / search / schema / create / edit, speaking compact JSON-AD.
+[`actions.md`](./actions.md) already lists "MCP server (future)" as a
+projection of the same registry and warns that a new server would otherwise
+become a fifth enumeration. [`json-ad-compact.md`](./json-ad-compact.md)
+phase 4 is explicitly "server-side `format=compact` so MCP server & other
+clients share it". The product intent is not new; the endpoint is.
+
+## What this is not
+
+| Existing thing | Why it is not this |
+| --- | --- |
+| Atomic Assistant + user-added MCP servers | We are a client of other people's tools. This plan is Atomic *as* the server. |
+| Desktop `tauri-plugin-mcp-bridge` (`127.0.0.1:9223`) | DOM automation for e2e. Unauthenticated loopback, page JS, not the graph. Keep it; do not extend it. |
+| `/app/token` Bearer AUTH | Signed Authentication Resource. MCP HTTP clients speak OAuth 2.1, not Ed25519 AUTH. |
+| OpenAI-compatible chat endpoint (#1259) | Model inference. Orthogonal. A hosted proxy still must not sign user commits. |
+
+## The write problem
+
+Atomic writes are Ed25519 commits with a Loro update. The private key is
+the identity (`did:ad:agent:{pubkey}`). MCP HTTP clients (Cursor, etc.)
+are generic JSON-RPC callers: they present a Bearer token and invoke a
+tool. They will not mint a Loro delta or sign a commit.
+
+So a *remote* MCP handler that "just writes" has only two honest options,
+and one of them is forbidden:
+
+1. **The node signs as the user.** Forbidden. [#1310](https://github.com/ontola/atomic-server/pull/1310)
+   D1: `POST /commit`, resource AUTH, WS `AUTH`, and Iroh `AUTH` never
+   accept an OIDC/OAuth token. "The node signing content commits as the
+   user" is on that PR's forbidden list. A Bearer on `/mcp` must not
+   become a commit whose `signer` is the human's root DID.
+2. **A different Agent signs, and the node may hold that key.** This is
+   already how unattended plugins work (`plugins.md` B4): an app is issued
+   its own Agent, the key lives on the node wrapped by the node key, writes
+   are attributable to that DID, revoking is taking it off `write`. MCP is
+   the same shape with a different caller.
+
+A *local* MCP process sits next to a key the user already has. It signs
+the way the data-browser does (`resource.save()` → `exportLoroDelta` →
+commit). That is the "writes happen client-side" path, and it needs no
+new identity primitive.
+
+Two deployments, one tool list:
+
+```text
+Local (stdio / loopback HTTP)
+  key = the user's Agent (env, desktop keychain, OPFS)
+  signs commits itself
+  MCP spec: stdio does not do OAuth
+
+Remote (Streamable HTTP on the node)
+  OAuth 2.1 resource server  (MCP spec 2025-06-18+)
+  reads  = existing check_read, as the consented Agent
+  writes = issued agent the node holds, scoped at consent
+           never the user's root, never Bearer-on-/commit
+```
+
+v1 is local, with writes. Remote starts **read-only**. Hosted writes wait
+on issued agents landing for plugins (#1307 / the #1275 shape) so MCP does
+not invent a third signing identity.
+
+## OAuth: which PR is actually relevant
+
+MCP's HTTP transport is OAuth 2.1 with PKCE. The MCP *server* is a
+**resource server** (RFC 9728 protected-resource metadata, `401` +
+`WWW-Authenticate: resource_metadata=...`). The **authorization server**
+is a separate role. Stdio is exempt.
+
+Two open/closed PRs look similar and are not:
+
+| PR | Role | What MCP needs from it |
+| --- | --- | --- |
+| **#1310** OIDC/OAuth retarget | Atomic as *relying party* ("Sign in with Google") | Helps a *human* reach the data-browser with nothing to memorize. An MCP client will not complete that browser flow just to get an `atomic_session` cookie. Useful later as *an* AS if the operator's IdP is advertised as the MCP authorization server — optional, not v1. |
+| **#1275** (closed) issued agents / "Sign in with Atomic" | Atomic as *authorization server* | This is the load-bearing one. Consent page, app-shaped client, issued Agent, redirect with no secret in the URL. Remote MCP is that product with a standardized token instead of a one-off query string. Reopen the AS slice when remote MCP is scheduled; do not rebuild it inside `/mcp`. |
+
+#1310 D1 still applies verbatim: an OIDC access token is not an Atomic
+principal. Token-exchange into a SessionCert or an issued Agent; then
+Ed25519 as today. The MCP Bearer is proof *to the MCP handler*, not to
+`/commit`.
+
+#1310's "use my OIDC token to call the API from a script → No, by design
+(D1); issued app keys, PR #1275 shape" is the same sentence as this plan.
+
+Do not implement a bespoke MCP auth that skips RFC 9728. Cursor and Claude
+will not speak it.
+
+## Tool surface
+
+Do not copy `TOOL_NAMES`. Extract the **headless** verbs from
+`useAtomicTools.ts` so the assistant, a CLI, and MCP are one implementation.
+
+In MCP:
+
+- **Tools** — `get_atomic_resource`, `query`, `semantic_search`,
+  `get_schema`, `get_user_classes`, `describe_table`, `describe_dashboard`,
+  `create_resource`, `edit_atomic_resource`, and the table/dashboard
+  builders that already go through compact. Same compact JSON-AD as the
+  assistant (`toCompact` / `fromCompact`). Short `#xxxxxxxx` refs at the
+  tool boundary.
+- **Resources** — `atomic://{subject}` (or the subject URL itself).
+  `resources/read` is GET; `resources/list` is a drive/query listing.
+  This mapping is almost free and is how clients that prefer resources
+  over tools will find data.
+- **Not MCP** — `navigate_to_resource`, `change_theme`, anything that
+  needs a React `navigate` or a toast. Those stay assistant-only.
+
+[`actions.md`](./actions.md) step 4 (AI-tool / MCP derivation) is the
+simple verbs (delete, favorite, …). The data tools above are richer and
+already written; extract them first, derive the simple ones from the
+registry second.
+
+Wire dialect stays compact, never stored. Phase 4 of
+[`json-ad-compact.md`](./json-ad-compact.md) (`format=compact` on the
+server) is what lets a *Rust* MCP handler skip reimplementing resolution.
+A TypeScript local MCP can ship before that, importing the existing
+module. Long-term the graph verbs belong on `AtomicNode`; UI verbs do not.
+
+## Sequencing
+
+1. **Extract headless tools** from `useAtomicTools.ts` (and
+   `jsonAdCompact.ts`) so they take a `Store`, not a hook. Assistant keeps
+   working; this is the shared library MCP will call. Cheap, unblocks
+   everything, and is the
+   [`actions.md`](./actions.md) "fifth enumeration" fix even if MCP slips.
+2. **Local stdio MCP.** Node script or small binary. Agent secret from
+   env / config (same family as `/app/token`). Read + write. This is the
+   Cursor/Claude Desktop config people actually add. Highest ROI; no AS.
+3. **Server `format=compact`.** json-ad-compact phase 4. Needed before a
+   Rust remote handler is worth writing.
+4. **Remote Streamable HTTP, read-only.** RFC 9728 metadata, OAuth 2.1
+   against Atomic-as-AS (#1275 reopened) *or* the operator IdP if #1310
+   has already advertised one. Writes return a clear "use local MCP /
+   issued agent not yet" error, not a silent server-side save.
+5. **Remote writes as issued agent.** Same key-on-node pattern as plugin
+   unattended runs. Consent scopes: at least drive + read/write. `signer`
+   is the issued DID. The user's root never touches the commit.
+
+## Allowed and forbidden
+
+Allowed: local MCP that signs as the user; remote MCP that reads under
+`check_read`; remote writes as a consented issued agent; compact JSON-AD
+on the tool wire; MCP resources keyed by subject; extracting tools from
+the assistant so MCP is a projection.
+
+Forbidden: OAuth/OIDC Bearer on `/commit` or WS `AUTH`; the node signing
+as the user's root because an MCP tool was called; a second tool list in
+Rust that drifts from `useAtomicTools`; extending `tauri-plugin-mcp-bridge`
+into a data API; storing compact JSON-AD; stdio OAuth.
+
+## Open questions
+
+- **Dogfood.** Should the in-app assistant call the same MCP server once
+  it exists, or keep a direct `Store` path? Direct is faster and works
+  offline; MCP-only is one surface. Recommend: keep the extracted library
+  as the in-process path; MCP is the out-of-process projection.
+- **Scope granularity.** Drive-level read/write is enough for v1 remote.
+  Resource-level scopes wait until they have a UI that is not a lie.
+- **Where compact lives.** TS module now; `format=compact` on the node
+  next; do not twin the resolver. Runtime-boundary C: Rust-authoritative
+  for ingest, TS may keep the first MCP binary.
+- **Flutter / mobile.** Out of v1. Local MCP is a desktop/CLI concern.
+
+## Consequences for open PRs
+
+- **#1310** (OIDC retarget) — merge-as-is for human login. Do not stretch
+  it into MCP auth. If remote MCP later uses the operator IdP as AS, that
+  is an adapter on top of D2's advertised issuer, not a change to D1.
+- **#1275** (issued agents, closed) — the AS + issued-agent slice is what
+  remote MCP writes wait on. Reopen or fold into #1307 rather than
+  designing a parallel "MCP user".
+- **#1307** (plugin model) — issued-agent-on-the-node is the write
+  identity remote MCP should reuse. MCP must not mint a second wrapped-key
+  tree.
+- **#1259** (OpenAI-compatible inference) — unrelated. Keep BYOK
+  browser→provider; an MCP server is not a chat completions proxy.
+- **#1258** — superseded by #1259; ignore.
+- json-ad-compact phase 3 (`create_table.rows` on `fromCompact`) is
+  independent and should land before a table-creating MCP tool is
+  advertised as stable.
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Planning only. Related: #1310 (OIDC/OAuth retarget — relevant, not the MCP auth path), #1275 (issued agents / Atomic as AS — the remote-auth path).

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [x] Update docs if needed

## What this is

A proposal for exposing Atomic as an MCP *server* (Cursor, Claude Desktop, etc.), not another in-app MCP *client*. No protocol or server code.

## Decision

- **Local stdio MCP** signs writes as the user's Agent. This is v1, and it is the "writes happen client-side" path.
- **Remote Streamable HTTP** starts read-only. Writes, if they come, are an **issued agent** the node holds — the same shape as unattended plugins — never the user's root, never an OAuth Bearer on `/commit`.
- Do not grow a fifth tool list: extract the headless verbs from `useAtomicTools.ts`. Compact JSON-AD stays the wire dialect; `format=compact` on the server is the Rust path.
- **#1310** (Atomic as OIDC relying party) is for human login. MCP HTTP clients speak OAuth 2.1; they need Atomic as an *authorization server* (#1275's shape), with the MCP server as a resource server (RFC 9728). D1 still holds.

See `planning/mcp-endpoint.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35b98e94-f7b7-4355-a1bf-9ae9f1ea53a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35b98e94-f7b7-4355-a1bf-9ae9f1ea53a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

