### PR TITLE
Hosted app: full-screen sign-in for signed-out visitors; passkey backups always get a recovery code

### DIFF
--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -16,7 +16,7 @@ import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
 import {
   addRecoveryCodeWrapper,
   buildEnvelopeV2,
-  buildEnvelopeWithPasskey,
+  buildEnvelopeWithPasskeyAndCode,
   envelopeWrapperKinds,
   getRecoverySecret,
   isPasskeySupported,
@@ -295,14 +295,18 @@ export function AccountRecoveryCard({
 
       let request;
 
+      // Passkey plus code, as at onboarding: the passkey reaches only the
+      // devices its vendor syncs it to, the code reaches the rest.
       if (await isPasskeySupported()) {
         try {
-          ({ request } = await buildEnvelopeWithPasskey({
+          const built = await buildEnvelopeWithPasskeyAndCode({
             secret: typed,
             agentSubject: subject,
             driveSubject,
             userName: accountEmail ?? 'Atomic account',
-          }));
+          });
+          request = built.request;
+          setNewCode(built.recoveryCode);
         } catch (e) {
           // Only knowable by trying, so this is a normal outcome rather than a
           // failure: fall through to the code path instead of dead-ending on

--- a/browser/data-browser/src/components/Navigation.tsx
+++ b/browser/data-browser/src/components/Navigation.tsx
@@ -22,6 +22,7 @@ import { useSettings } from '../helpers/AppSettings';
 import { ChromeTheme } from '../styling';
 import { paths } from '../routes/paths';
 import { useRootWelcomeLayout } from '../context/RootWelcomeLayoutContext';
+import { isHostedDistribution } from '../helpers/managedServer';
 
 interface NavWrapperProps {
   children: React.ReactNode;
@@ -33,7 +34,7 @@ const FollowSessionPanelMemo = React.memo(FollowSessionPanelContainer);
 
 /** Wraps the entire app and adds a navbar at the top or bottom */
 export function NavWrapper({ children }: NavWrapperProps): JSX.Element {
-  const { navbarTop } = useSettings();
+  const { navbarTop, agent } = useSettings();
   const { rootWelcomeChromeHidden } = useRootWelcomeLayout();
   const [subject] = useCurrentSubject();
   const { pathname, searchStr } = useLocation();
@@ -47,11 +48,19 @@ export function NavWrapper({ children }: NavWrapperProps): JSX.Element {
   // full-screen moment; rendering it between the sidebars reads as a
   // broken page.
   const demoSplash = pathname === paths.demo;
+  // The hosted product has no signed-out mode: the sidebar's "new user /
+  // sign in" affordances next to a spinner or an error read as a broken
+  // account rather than as a page for a visitor. Until an identity is
+  // loaded, whatever is on screen (a loading state, a sign-in guard, a
+  // public share) stands on its own. A self-hosted node keeps its chrome
+  // for anonymous browsing.
+  const signedOutHosted = isHostedDistribution() && !agent;
   const hideGlobalChrome =
     rootWelcomeChromeHidden ||
     onboardingOrChild ||
     welcomeOrChild ||
-    demoSplash;
+    demoSplash ||
+    signedOutHosted;
 
   const search = useMemo(() => new URLSearchParams(searchStr), [searchStr]);
 

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -18,10 +18,8 @@ import { InputStyled, InputWrapper } from './forms/InputStyles';
 import Field from './forms/Field';
 import { PRODUCT_NAME } from '../helpers/managed';
 import {
-  addRecoveryCodeWrapper,
   isPasskeySupported,
   PrfUnsupportedError,
-  type PasskeyDurability,
 } from '../helpers/managed/recovery';
 
 type Step =
@@ -55,12 +53,13 @@ interface NewIdentitySectionProps {
    * makes sense when signed in to a managed account that can store it.
    */
   offerRecoveryBackup?: boolean;
-  /** Encrypt + store the secret under a newly registered passkey. Resolves
-   * with whether that passkey is synced across the user's devices or bound to
-   * this one — a device-bound passkey is the only case that still warrants
-   * offering a recovery code. Rejects with `PrfUnsupportedError` if this
-   * device can't do PRF, which moves the step onto the recovery-code path. */
-  onBackupWithPasskey?: (secret: string) => Promise<PasskeyDurability>;
+  /** Encrypt + store the secret under a newly registered passkey AND a
+   * freshly generated recovery code. Resolves with the plaintext code to
+   * show the user once: the passkey only reaches the devices its vendor
+   * syncs it to, the code reaches the rest. Rejects with
+   * `PrfUnsupportedError` if this device can't do PRF, which moves the step
+   * onto the code-only path. */
+  onBackupWithPasskey?: (secret: string) => Promise<string>;
   /** Encrypt + store the secret under a freshly generated recovery code.
    * Resolves with the plaintext code to show the user once. The fallback for
    * devices without passkey support, or when the user asks for it. */
@@ -103,12 +102,11 @@ export function NewIdentitySection({
   const [identity, setIdentity] = useState<IdentityData | null>(null);
   /** True after the user copies the secret or saves the backup file. */
   const [secretBackedUp, setSecretBackedUp] = useState(false);
-  /** Set once `onBackupWithCode` resolves; shown once, then never again. */
+  /** Set once a backup resolves; shown once, then never again. */
   const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
-  /** The registered passkey is bound to this device (not synced), so losing
-   * the device would lose the account — the only case that warrants pushing
-   * a recovery code on the user. */
-  const [deviceBoundPasskey, setDeviceBoundPasskey] = useState(false);
+  /** The backup also has a passkey wrapper, so the code screen can say what
+   * each key is for. */
+  const [passkeyRegistered, setPasskeyRegistered] = useState(false);
   /** null while the capability probe is still running. */
   const [passkeySupported, setPasskeySupported] = useState<boolean | null>(
     null,
@@ -251,8 +249,8 @@ export function NewIdentitySection({
   // ─── Step: Back up secret (encrypted recovery) ───────────────────────────
 
   // Probed once the backup step is reached, so the step can lead with the
-  // passkey path (nothing to store) and only fall back to a recovery code
-  // where PRF genuinely isn't available.
+  // passkey path (passkey + code) and only fall back to a code alone where
+  // PRF genuinely isn't available.
   useEffect(() => {
     if (step !== 'recovery-backup') return;
     let cancelled = false;
@@ -298,17 +296,9 @@ export function NewIdentitySection({
     setError(undefined);
 
     try {
-      const durability = await onBackupWithPasskey(identity.secret);
-
-      if (durability === 'device-bound') {
-        // This passkey lives on one device only, so it genuinely is a single
-        // point of failure — the one case worth interrupting for.
-        setDeviceBoundPasskey(true);
-
-        return;
-      }
-
-      finishWithoutSecretStep();
+      const code = await onBackupWithPasskey(identity.secret);
+      setPasskeyRegistered(true);
+      setRecoveryCode(code);
     } catch (e) {
       if (e instanceof PrfUnsupportedError) {
         // The authenticator turned out not to support PRF (only knowable by
@@ -323,23 +313,6 @@ export function NewIdentitySection({
             : 'Could not back up your secret. You can still save it yourself.',
         );
       }
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  /** Device-bound passkey: re-seal under both that passkey and a new code. */
-  async function handleAddCodeToPasskey() {
-    setLoading(true);
-    setError(undefined);
-
-    try {
-      const { recoveryCode: code } = await addRecoveryCodeWrapper();
-      setRecoveryCode(code);
-    } catch (e) {
-      setError(
-        e instanceof Error ? e.message : 'Could not add a recovery code.',
-      );
     } finally {
       setLoading(false);
     }
@@ -469,15 +442,13 @@ export function NewIdentitySection({
           passkeySupported={passkeySupported}
           useCodeFallback={useCodeFallback || !onBackupWithPasskey}
           recoveryCode={recoveryCode}
-          deviceBoundPasskey={deviceBoundPasskey}
+          passkeyRegistered={passkeyRegistered}
           onUsePasskey={handleBackupWithPasskey}
           onUseCodeInstead={() => {
             setError(undefined);
             setUseCodeFallback(true);
           }}
           onGenerate={handleGenerateRecoveryCode}
-          onAddCodeToPasskey={handleAddCodeToPasskey}
-          onKeepPasskeyOnly={finishWithoutSecretStep}
           onContinue={finishWithoutSecretStep}
           onSkip={() => {
             setError(undefined);
@@ -774,12 +745,10 @@ function RecoveryBackupStep({
   passkeySupported,
   useCodeFallback,
   recoveryCode,
-  deviceBoundPasskey,
+  passkeyRegistered,
   onUsePasskey,
   onUseCodeInstead,
   onGenerate,
-  onAddCodeToPasskey,
-  onKeepPasskeyOnly,
   onContinue,
   onSkip,
 }: {
@@ -788,12 +757,10 @@ function RecoveryBackupStep({
   passkeySupported: boolean | null;
   useCodeFallback: boolean;
   recoveryCode: string | null;
-  deviceBoundPasskey: boolean;
+  passkeyRegistered: boolean;
   onUsePasskey: () => void;
   onUseCodeInstead: () => void;
   onGenerate: () => void;
-  onAddCodeToPasskey: () => void;
-  onKeepPasskeyOnly: () => void;
   onContinue: () => void;
   onSkip: () => void;
 }) {
@@ -831,48 +798,21 @@ function RecoveryBackupStep({
     );
   }
 
-  // Passkey registered, but bound to this one device — the single case where
-  // "lose the device, lose the account" is literally true, so it's the only
-  // case worth asking anyone to store something.
-  if (deviceBoundPasskey && !recoveryCode) {
-    return (
-      <Column gap='1rem'>
-        <h3 key='title'>This passkey only works on this device</h3>
-        <p key='copy'>
-          It isn&apos;t synced to your other devices, so losing this one would
-          lock you out. A recovery code is a spare key — you&apos;ll need your
-          email to use it, so it&apos;s safe to keep on paper.
-        </p>
-        {error && <ErrorText key='error'>{error}</ErrorText>}
-        <Row key='actions' gap='1rem' wrapItems>
-          <ContinueButton
-            type='button'
-            onClick={onAddCodeToPasskey}
-            disabled={loading}
-          >
-            {loading ? 'Generating…' : 'Give me a recovery code'}
-          </ContinueButton>
-          <Button
-            type='button'
-            subtle
-            onClick={onKeepPasskeyOnly}
-            disabled={loading}
-          >
-            Continue without one
-          </Button>
-        </Row>
-      </Column>
-    );
-  }
-
   if (recoveryCode) {
     return (
       <Column gap='1rem'>
         <h3 key='title'>Save your recovery code</h3>
+        {passkeyRegistered && (
+          <p key='why'>
+            Your passkey opens this account on this device and wherever it
+            syncs to. This code opens it on every other device — a phone, a
+            different browser, a new computer.
+          </p>
+        )}
         <p key='important'>
-          Keep this somewhere safe. You&apos;ll need it — plus your email — to
-          get back in. We can&apos;t show it again, but you can generate a new
-          one from Settings whenever you like.
+          Keep it somewhere safe. You&apos;ll need it — plus your email — to get
+          back in. We can&apos;t show it again, but you can generate a new one
+          from Settings whenever you like.
         </p>
         <StyledCodeBlock
           key='code'
@@ -942,14 +882,17 @@ function RecoveryBackupStep({
     );
   }
 
-  // The default path: one prompt, nothing for the user to keep.
+  // The default path: a passkey for everyday unlocking, plus a recovery code
+  // for the devices the passkey does not reach. Passkeys sync within one
+  // vendor's keychain only, so "it works on your other devices" was true for
+  // some of them; the code is what makes it true for all.
   return (
     <Column gap='1rem'>
       <h3 key='title'>Protect your account</h3>
       <p key='copy'>
         Use your fingerprint, face, or screen lock — the same one that unlocks
-        this device. Nothing to write down, and it works on your other devices
-        too.
+        this device. You&apos;ll also get a recovery code for devices your
+        passkey doesn&apos;t sync to.
       </p>
       {error && <ErrorText key='error'>{error}</ErrorText>}
       <Row key='actions' gap='1rem' wrapItems>

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -5669,7 +5669,6 @@ msgid "Are you sure you've stored this code somewhere safe? You cannot recover y
 msgstr ""
 
 #: src/components/NewIdentitySection.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Generating…"
 msgstr ""
 
@@ -5735,21 +5734,17 @@ msgid "Use your passkey instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Could not add a recovery code."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "This passkey only works on this device"
-msgstr ""
+#~ msgid "This passkey only works on this device"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Give me a recovery code"
-msgstr ""
+#~ msgid "Give me a recovery code"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Continue without one"
-msgstr ""
+#~ msgid "Continue without one"
+#~ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5789,9 +5784,8 @@ msgstr ""
 msgid "Protect your account"
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+#~ msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
@@ -5814,13 +5808,11 @@ msgstr ""
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+#~ msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+#~ msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
@@ -7113,4 +7105,19 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/components/IdentityReconcileGate.tsx
 msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Your passkey opens this account on this device and wherever it syncs to. This code opens it on every other device — a phone, a different browser, a new computer."
+msgstr ""
+
+#~ msgid "{0} Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. You'll also get a recovery code for devices your passkey doesn't sync to."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -5703,7 +5703,6 @@ msgid "Are you sure you've stored this code somewhere safe? You cannot recover y
 msgstr "Are you sure you've stored this code somewhere safe? You cannot recover your account without it."
 
 #: src/components/NewIdentitySection.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Generating…"
 msgstr "Generating…"
 
@@ -5769,21 +5768,17 @@ msgid "Use your passkey instead"
 msgstr "Use your passkey instead"
 
 #: src/components/AccountRecoveryCard.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Could not add a recovery code."
 msgstr "Could not add a recovery code."
 
-#: src/components/NewIdentitySection.tsx
-msgid "This passkey only works on this device"
-msgstr "This passkey only works on this device"
+#~ msgid "This passkey only works on this device"
+#~ msgstr "This passkey only works on this device"
 
-#: src/components/NewIdentitySection.tsx
-msgid "Give me a recovery code"
-msgstr "Give me a recovery code"
+#~ msgid "Give me a recovery code"
+#~ msgstr "Give me a recovery code"
 
-#: src/components/NewIdentitySection.tsx
-msgid "Continue without one"
-msgstr "Continue without one"
+#~ msgid "Continue without one"
+#~ msgstr "Continue without one"
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5823,9 +5818,8 @@ msgstr "Store it like a passport, not a password: a password manager, or{0} <0>S
 msgid "Protect your account"
 msgstr "Protect your account"
 
-#: src/components/NewIdentitySection.tsx
-msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
+#~ msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
+#~ msgstr "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
@@ -5848,13 +5842,11 @@ msgstr "Save a recovery code"
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
 msgstr "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
 
-#: src/components/NewIdentitySection.tsx
-msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
+#~ msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
+#~ msgstr "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
 
-#: src/components/NewIdentitySection.tsx
-msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
@@ -7148,3 +7140,18 @@ msgstr "Restores it here. The identity you made in this browser stays reachable 
 #: src/components/IdentityReconcileGate.tsx
 msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
 msgstr "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
+
+#: src/components/NewIdentitySection.tsx
+msgid "Your passkey opens this account on this device and wherever it syncs to. This code opens it on every other device — a phone, a different browser, a new computer."
+msgstr "Your passkey opens this account on this device and wherever it syncs to. This code opens it on every other device — a phone, a different browser, a new computer."
+
+#~ msgid "{0} Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr "{0} Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+
+#: src/components/NewIdentitySection.tsx
+msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. You'll also get a recovery code for devices your passkey doesn't sync to."
+msgstr "Use your fingerprint, face, or screen lock — the same one that unlocks this device. You'll also get a recovery code for devices your passkey doesn't sync to."
+
+#: src/components/NewIdentitySection.tsx
+msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+msgstr "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -5669,7 +5669,6 @@ msgid "Are you sure you've stored this code somewhere safe? You cannot recover y
 msgstr ""
 
 #: src/components/NewIdentitySection.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Generating…"
 msgstr ""
 
@@ -5735,21 +5734,17 @@ msgid "Use your passkey instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Could not add a recovery code."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "This passkey only works on this device"
-msgstr ""
+#~ msgid "This passkey only works on this device"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Give me a recovery code"
-msgstr ""
+#~ msgid "Give me a recovery code"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Continue without one"
-msgstr ""
+#~ msgid "Continue without one"
+#~ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5789,9 +5784,8 @@ msgstr ""
 msgid "Protect your account"
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+#~ msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
@@ -5814,13 +5808,11 @@ msgstr ""
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+#~ msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+#~ msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
@@ -7113,4 +7105,19 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/components/IdentityReconcileGate.tsx
 msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Your passkey opens this account on this device and wherever it syncs to. This code opens it on every other device — a phone, a different browser, a new computer."
+msgstr ""
+
+#~ msgid "{0} Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. You'll also get a recovery code for devices your passkey doesn't sync to."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -5669,7 +5669,6 @@ msgid "Are you sure you've stored this code somewhere safe? You cannot recover y
 msgstr ""
 
 #: src/components/NewIdentitySection.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Generating…"
 msgstr ""
 
@@ -5735,21 +5734,17 @@ msgid "Use your passkey instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
-#: src/components/NewIdentitySection.tsx
 msgid "Could not add a recovery code."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "This passkey only works on this device"
-msgstr ""
+#~ msgid "This passkey only works on this device"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Give me a recovery code"
-msgstr ""
+#~ msgid "Give me a recovery code"
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Continue without one"
-msgstr ""
+#~ msgid "Continue without one"
+#~ msgstr ""
 
 #: src/routes/SettingsAgent.tsx
 msgid "How you get back in on a new device — and where to find your agent secret."
@@ -5789,9 +5784,8 @@ msgstr ""
 msgid "Protect your account"
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
-msgstr ""
+#~ msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. Nothing to write down, and it works on your other devices too."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Use a passkey"
@@ -5814,13 +5808,11 @@ msgstr ""
 msgid "{0}{1} You'll also need to sign in to your email to use it, so it's safe to keep in a password manager or on paper."
 msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
-msgstr ""
+#~ msgid "It isn't synced to your other devices, so losing this one would lock you out. A recovery code is a spare key — you'll need your email to use it, so it's safe to keep on paper."
+#~ msgstr ""
 
-#: src/components/NewIdentitySection.tsx
-msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
-msgstr ""
+#~ msgid "Keep this somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Protect my account"
@@ -7113,4 +7105,19 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/components/IdentityReconcileGate.tsx
 msgid "Signs this browser out of {0}. Nothing here is backed up until it has an account of its own."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Your passkey opens this account on this device and wherever it syncs to. This code opens it on every other device — a phone, a different browser, a new computer."
+msgstr ""
+
+#~ msgid "{0} Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+#~ msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Use your fingerprint, face, or screen lock — the same one that unlocks this device. You'll also get a recovery code for devices your passkey doesn't sync to."
+msgstr ""
+
+#: src/components/NewIdentitySection.tsx
+msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
 msgstr ""

--- a/browser/data-browser/src/routes/ShowRoute.tsx
+++ b/browser/data-browser/src/routes/ShowRoute.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Client } from '@tomic/react';
+import { Client, useStore } from '@tomic/react';
 import ResourcePage from '../views/ResourcePage';
 import { Search } from './Search/SearchRoute';
 import { About } from './AboutRoute';
-import { createRoute } from '@tanstack/react-router';
+import { createRoute, useNavigate } from '@tanstack/react-router';
 import { appRoute } from './RootRoutes';
-import { pathNames } from './paths';
+import { pathNames, paths } from './paths';
+import { useSettings } from '../helpers/AppSettings';
+import { isOriginWithoutNode } from '../helpers/originNode';
 
 export type ShowRouteSearch = {
   subject: string;
@@ -30,6 +32,34 @@ export const ShowRoute = createRoute({
 export const ShowComponent: React.FunctionComponent = () => {
   // Value shown in navbar, after Submitting
   const subject = ShowRoute.useSearch({ select: state => state.subject });
+  const { agent } = useSettings();
+  const store = useStore();
+  const navigate = useNavigate();
+
+  // Signed out on an origin that runs no node: nothing can load until a
+  // sign-in restores the data, so go straight to the sign-in step with the
+  // subject as `next`. Without this the page first fetches, shows
+  // "Loading…", fails as "not available locally" and only then redirects
+  // from ErrorPage — several seconds of a spinner between the portal link
+  // and the sign-in screen.
+  const signInFirst =
+    !agent &&
+    Client.isValidSubject(subject) &&
+    isOriginWithoutNode(store.getServerUrl());
+
+  React.useEffect(() => {
+    if (!signInFirst) return;
+
+    navigate({
+      to: paths.welcome,
+      search: { next: subject, from_portal: undefined },
+      replace: true,
+    });
+  }, [signInFirst, subject, navigate]);
+
+  if (signInFirst) {
+    return null;
+  }
 
   if (subject === undefined || subject === '') {
     return <About />;

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -35,7 +35,7 @@ import {
 import { isOriginWithoutNode } from '../../helpers/originNode';
 import {
   buildEnvelopeV2,
-  buildEnvelopeWithPasskey,
+  buildEnvelopeWithPasskeyAndCode,
   saveRecoverySecret,
   getRecoverySecret,
   getUnlockableRecoverySecret,
@@ -45,7 +45,6 @@ import {
   decryptEnvelopeWithPasskey,
   envelopeWrapperKinds,
   upgradeToEnvelopeV2,
-  type PasskeyDurability,
   type RecoverySecret,
 } from '../../helpers/managed/recovery';
 import { CodeBlock } from '../../components/CodeBlock';
@@ -268,11 +267,16 @@ export function GettingStartedFlow({
     return emailParam ?? managedUsername ?? 'Atomic account';
   }
 
-  // The default backup: a random DEK encrypts the agent secret, and a newly
-  // registered passkey's PRF output wraps the DEK. Nothing comes back for the
-  // user to store — the passkey *is* the recovery credential.
-  async function backupWithPasskey(secret: string): Promise<PasskeyDurability> {
-    const { request, durability } = await buildEnvelopeWithPasskey({
+  // The default backup: a random DEK encrypts the agent secret, wrapped both
+  // by a newly registered passkey's PRF output and by a generated recovery
+  // code. The passkey is the everyday key; the code is for every device the
+  // passkey does not reach. A passkey "syncs" only within one vendor's
+  // keychain (one made in Firefox on a Mac is not in Google Password Manager
+  // on an Android phone), so a passkey-only backup locked people out of their
+  // own account on their second device. Returns the plaintext code for
+  // NewIdentitySection to show once — it's never sent anywhere.
+  async function backupWithPasskey(secret: string): Promise<string> {
+    const { request, recoveryCode } = await buildEnvelopeWithPasskeyAndCode({
       secret,
       agentSubject: requireAgentSubject(),
       driveSubject: newDriveSubject.current ?? null,
@@ -280,7 +284,7 @@ export function GettingStartedFlow({
     });
     await saveRecoverySecret(request);
 
-    return durability;
+    return recoveryCode;
   }
 
   // The fallback: the DEK is wrapped by a generated recovery code (Argon2id)


### PR DESCRIPTION
Two things found by opening a portal drive link on a phone that had never seen the account.

## 1. Signed out on the hosted app = no chrome, no fetch

What the phone showed: the full app shell with a "new user / sign in" sidebar around a "Loading…" spinner for several seconds, *then* the sign-in guard. The fetch was pointless — on an origin without a node a signed-out device holds nothing, and nothing can arrive until a sign-in restores it.

- `ShowRoute`: no agent + node-less origin → straight to the welcome sign-in step with the subject as `next`. `ErrorPage`'s redirect stays for the node-backed 401 case.
- `NavWrapper`: the hosted distribution hides sidebar and top bar while there is no agent. There is no signed-out mode in the hosted product; a self-hosted node keeps its chrome for anonymous browsing (`isHostedDistribution()` is build-time, off for source builds and e2e).

## 2. Every passkey backup also gets a recovery code

The real blocker on the phone: "Unlock with your passkey" → Android's "error connecting to web authentication service". The passkey was made in Firefox on a Mac; passkeys sync within one vendor's keychain and no further, so Google Password Manager on the phone had nothing. The backup was passkey-only, and the guard cannot add a code (that is a write to the backup, which needs the missing passkey). Dead end, on the device where people first meet the product a second time.

- Onboarding's `backupWithPasskey` and the first-time setup in `AccountRecoveryCard` now seal under both wrappers (`buildEnvelopeWithPasskeyAndCode`, which already existed for the device-bound case). The code is shown once and copy-gated, same as the code-only path.
- The device-bound interstitial and "Continue without one" are gone — there is no passkey-only outcome any more. Code-only fallback for PRF-less devices and the two-stage skip are unchanged.
- Existing passkey-only accounts are unaffected until their owner adds a code from Settings on the device that has the passkey; `PasskeyOnlyHint` still covers them.

Catalogs (`de/en/es/fr.po`) regenerated. No e2e change: chromium has no PRF, so `vault-backup-restore.spec.ts` already walks the code-only path.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
