### PR TITLE
Node-less origin: key-derived drive as default, vault fallback looks past it

### DIFF
--- a/browser/data-browser/src/App.tsx
+++ b/browser/data-browser/src/App.tsx
@@ -162,6 +162,33 @@ if (initialDrive) {
   }
 }
 
+// On an origin with no node, a signed-in device with no drive of its own
+// gets the account's key-derived one. The stored default is otherwise the
+// origin itself — a server root that a node-less origin cannot serve, so the
+// sidebar showed "/" with an offline error and nowhere to write. The derived
+// drive is the one place this identity can write before anything has synced,
+// and it lives only here until it does, hence local-only. A node-backed origin
+// keeps the origin as its main drive (atomicdata.dev); this is not about
+// which drive is open but about there being no server behind it. Only the
+// drive is registered, not the agent: `fetchPrivateDriveSubject` treats a
+// local-only agent as one whose drive is its secret's `initialDrive`.
+if (
+  initalAgent?.subject &&
+  isOriginWithoutNode(serverUrl) &&
+  (!initialDrive || Client.isBareHttpOrigin(initialDrive))
+) {
+  try {
+    const home = await initalAgent.privateDriveSubject();
+    store.registerLocalOnlyDrive(home);
+    driveStorage.set(home);
+    store.setDrive(home);
+  } catch (e) {
+    // A key that signs non-deterministically and no cached subject: the
+    // sign-in flow recomputes it. Better no drive than a made-up one.
+    console.warn('[atomic] Could not derive the personal drive:', e);
+  }
+}
+
 // A deep link into a resource (share/show `?subject=` entry URL) starts the
 // session in that resource's drive, overriding the stored/fallback drive.
 // Fire-and-forget: resolves once the resource is fetched, and `setDrive`

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -107,6 +107,8 @@ type DownloadUrl = {
 export type VaultEnrollment = {
   id: string;
   drive_subject: string;
+  /** The agent that enrolled it; an account may hold several agents' drives. */
+  agent_subject?: string;
   drive_pseudonym: string;
   status: string;
   used_bytes: number;

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4012,6 +4012,7 @@ msgstr ""
 #: src/components/Vault/VaultPanel.tsx
 #: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
+#: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
 msgstr ""
@@ -7120,4 +7121,8 @@ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Cloud Vault had nothing for this workspace:"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4012,6 +4012,7 @@ msgstr "Enter the recovery password you set for {0}."
 #: src/components/Vault/VaultPanel.tsx
 #: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
+#: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
 msgstr "Restoring…"
@@ -7155,3 +7156,7 @@ msgstr "Use your fingerprint, face, or screen lock — the same one that unlocks
 #: src/components/NewIdentitySection.tsx
 msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
 msgstr "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Cloud Vault had nothing for this workspace:"
+msgstr "Cloud Vault had nothing for this workspace:"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4012,6 +4012,7 @@ msgstr ""
 #: src/components/Vault/VaultPanel.tsx
 #: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
+#: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
 msgstr ""
@@ -7120,4 +7121,8 @@ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Cloud Vault had nothing for this workspace:"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4012,6 +4012,7 @@ msgstr ""
 #: src/components/Vault/VaultPanel.tsx
 #: src/components/Vault/VaultRestoreAction.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
+#: src/views/getting-started/ConnectDeviceStep.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Restoring…"
 msgstr ""
@@ -7120,4 +7121,8 @@ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Keep it somewhere safe. You'll need it — plus your email — to get back in. We can't show it again, but you can generate a new one from Settings whenever you like."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Cloud Vault had nothing for this workspace:"
 msgstr ""

--- a/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
+++ b/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
@@ -46,6 +46,13 @@ const WATCH_INTERVAL_MS = 3_000;
 interface ConnectDeviceStepProps {
   /** The drive that should be here but isn't. Absent if none resolved. */
   drive?: string;
+  /**
+   * Why sign-in's own vault restore of `drive` came back empty-handed, in the
+   * vault's words ("drive is not backed up", "the vault is empty", …). Shown
+   * when there is nothing to restore, so the screen says which of the several
+   * "no backup" situations this is instead of a generic shrug.
+   */
+  vaultReason?: string;
   /** Enter the app anyway, without its data. */
   onSkip: () => void;
   /** The drive's data arrived — open it. */
@@ -70,6 +77,7 @@ interface ConnectDeviceStepProps {
  */
 export function ConnectDeviceStep({
   drive,
+  vaultReason,
   onSkip,
   onConnected,
 }: ConnectDeviceStepProps): JSX.Element {
@@ -115,23 +123,40 @@ export function ConnectDeviceStep({
 
       if (cancelled) return;
 
-      if (local) {
-        setVaultDrive(local);
+      if (local) setVaultDrive(local);
 
-        return;
-      }
-
-      // Nothing locally, and `fetchPrivateDriveSubject` asks a *server* which
-      // a device holding nothing may not have — the desktop and Android apps
-      // embed their own, empty one. The control plane knows which drives this
-      // account has backed up, and asking it is the whole point of arriving
-      // with nothing: without this the restore offer never appears on exactly
-      // the device that needs it.
+      // The control plane knows which drives this account has backed up, and
+      // asking it matters in two cases. With no drive name at all: a device
+      // holding nothing may have no server to derive one from — the desktop
+      // and Android apps embed their own, empty one — and without this the
+      // restore offer never appears on exactly the device that needs it. With
+      // a name: the key-derived drive is only the *default* home. An account
+      // whose data lives in another drive (made before the derived scheme, or
+      // made by hand) has that one backed up and the derived one enrolled but
+      // empty, and asking about the empty one says "nothing to restore" while
+      // the backup sits one entry over.
       try {
         const enrolled = await listVaultDrives();
-        const backed = enrolled.find(e => e.status === 'active') ?? enrolled[0];
 
-        if (!cancelled && backed) setVaultDrive(backed.drive_subject);
+        if (cancelled) return;
+
+        const mine = enrolled.filter(
+          e =>
+            e.status === 'active' &&
+            (!agent || !e.agent_subject || e.agent_subject === agent.subject),
+        );
+        const named = local
+          ? mine.find(e => e.drive_subject === local)
+          : undefined;
+
+        if (named?.last_backup_at) return;
+
+        const backed = mine
+          .filter(e => e.last_backup_at)
+          .sort((a, b) => b.last_backup_at! - a.last_backup_at!)[0];
+
+        if (backed) setVaultDrive(backed.drive_subject);
+        else if (!local && mine[0]) setVaultDrive(mine[0].drive_subject);
       } catch {
         // No session, or no control plane at all. Nothing to offer, which the
         // panel renders as nothing rather than as an error.
@@ -368,6 +393,16 @@ export function ConnectDeviceStep({
                 'You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it.'
               : 'You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it.'}
           </CardSubtitle>
+
+          {/* The vault's own account of why there is nothing to restore. Five
+              situations answer "no backup" — no session, never enrolled,
+              enrolled but never uploaded, … — and they want different fixes
+              on the other device, so name it. */}
+          {!canRestoreFromVault && vaultReason && (
+            <Explainer data-testid='vault-no-backup-reason'>
+              Cloud Vault had nothing for this workspace: {vaultReason}.
+            </Explainer>
+          )}
 
           {/* First, because it is the only route that needs nothing but this
               device. Everything below wants a second device that is switched

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -178,6 +178,10 @@ export function GettingStartedFlow({
   // The drive a freshly signed-in device is missing, handed to the
   // connect-device step. Undefined when no drive resolved at all.
   const [missingDrive, setMissingDrive] = useState<string | undefined>();
+  /** Why the vault had nothing for `missingDrive`, if sign-in asked it. */
+  const [missingDriveVaultReason, setMissingDriveVaultReason] = useState<
+    string | undefined
+  >();
   const stepDotsSlotRef = useRef<HTMLDivElement | null>(null);
   const [secretValue, setSecretValue] = useState('');
   /** Shown only after blur/Enter — every prefix of a valid secret is invalid,
@@ -617,6 +621,11 @@ export function GettingStartedFlow({
       // moment it can happen. Anything short of a restore (no session, no
       // backup, an empty one, a failure) falls through to the connect-device
       // step, which still offers the same restore by hand.
+      // Why the vault had nothing, for the connect-device step to show. Five
+      // different situations answer `no-backup`; a screen that says only
+      // "your data is on another device" hides which one this is.
+      let vaultReason: string | undefined;
+
       if (!hasData && target) {
         const restored = await withDeadline(
           restoreFromVault(store, target),
@@ -625,25 +634,35 @@ export function GettingStartedFlow({
         );
 
         if (restored.status === 'restored') {
-          // On an origin with no node the restored drive lives only here,
-          // exactly like one made here; without this every commit would park
-          // in the outbox waiting for a server that is not coming.
-          if (isOriginWithoutNode(store.getServerUrl())) {
-            store.registerLocalOnlyDrive(target);
-          }
-
           hasData = await canRead(target);
+        } else if (restored.status === 'no-backup') {
+          vaultReason = restored.reason;
+        } else {
+          vaultReason = restored.error.message;
         }
       }
 
-      // Name the account's drive even when its data hasn't arrived: the Sync
-      // page says "your data is on another device" about *that* drive, which
-      // is true and useful. But when the account's drive cannot be named at
-      // all, no drive is the honest answer — the value here otherwise falls
-      // back to whatever was last open, or to the default, which is the
-      // server's own root. Showing that as your workspace is how signing in
-      // ends with somebody else's data on screen.
-      setDrive(hasData ? target! : '');
+      // On an origin with no node the account's drive lives only here — a
+      // restored one exactly like one made here, and one whose data has not
+      // arrived yet just as much: it is still the place this identity writes
+      // to. Without this every commit would park in the outbox waiting for a
+      // server that is not coming. The agent's own subject is deliberately
+      // not registered: `fetchPrivateDriveSubject` answers a local-only agent
+      // with its secret's `initialDrive`, which for an account made elsewhere
+      // is that server's URL, and handing that to `setDrive` moves the app.
+      if (target && isOriginWithoutNode(store.getServerUrl())) {
+        store.registerLocalOnlyDrive(target);
+      }
+
+      // Name the account's drive even when its data hasn't arrived: it is
+      // derived from the key, so it is the one place this identity can write
+      // right away, and the Sync page says "your data is on another device"
+      // about *that* drive, which is true and useful. Only when the drive
+      // cannot be named at all is no drive the honest answer — the value here
+      // otherwise falls back to whatever was last open, or to the default,
+      // which is the server's own root. Showing that as your workspace is how
+      // signing in ends with somebody else's data on screen.
+      setDrive(target ?? '');
 
       if (hasData) {
         // The home drive is derived from the key rather than looked up, so
@@ -674,6 +693,7 @@ export function GettingStartedFlow({
         navigate(constructOpenURL(target!));
       } else {
         setMissingDrive(target);
+        setMissingDriveVaultReason(vaultReason);
         setStep('connect-device');
       }
     } catch (err) {
@@ -1027,6 +1047,7 @@ export function GettingStartedFlow({
         <Swap key='connect-device'>
           <ConnectDeviceStep
             drive={missingDrive}
+            vaultReason={missingDriveVaultReason}
             onConnected={target => {
               setDrive(target);
               navigate(constructOpenURL(target));

--- a/browser/e2e/tests/sign-in-without-data.spec.ts
+++ b/browser/e2e/tests/sign-in-without-data.spec.ts
@@ -76,9 +76,28 @@ test.describe('signing in on a device that holds none of the account’s data', 
     );
 
     // The default is the server's origin. Anything of the server's own is not
-    // this account's, and must not be sitting there waiting to be opened.
-    expect(drive, 'signing in without data must not leave a drive active').toBe(
-      '',
+    // this account's, and must not be sitting there waiting to be opened. The
+    // account's own key-derived drive is fine — that one is empty, not
+    // somebody else's, and it is where this identity writes.
+    expect(
+      drive,
+      'signing in without data must not leave another workspace active',
+    ).not.toMatch(/^https?:/);
+  });
+
+  test('names the account’s own drive as the place to write', async ({
+    page,
+  }) => {
+    await signInAsAStranger(page);
+
+    await expect(page.getByText('Your data is on another device')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const drive = await page.evaluate(() =>
+      JSON.parse(localStorage.getItem('drive') ?? '""'),
     );
+
+    expect(drive).toMatch(/^did:ad:/);
   });
 });


### PR DESCRIPTION
Signing in on a phone with a recovery code (hosted app, origin without a node) ended with the sidebar on "/" showing "Offline: resource not available locally", and the Sync page saying there was no backup. Three causes, one fix each.

## 1. The drive default was the origin

`useLocalStorage('drive', baseURL)` defaults to the server origin. On a node-less origin nothing can serve that, so it renders as "/" with an offline error. Boot now derives the account's personal drive from the key when there is a signed-in agent and no stored drive (or a stored bare origin), registers it local-only, and opens it. Gated on `isOriginWithoutNode(serverUrl)` only — a node-backed origin such as atomicdata.dev keeps the origin as its main drive. The condition is the missing node, never "the drive equals the origin".

## 2. Sign-in set the drive to `''` when the data hadn't arrived

So the default showed through. Sign-in now names the key-derived drive whenever it can be named, data or no data — it is the one place this identity can write before anything has synced — and on a node-less origin registers it local-only so commits don't park in the outbox. `''` is only for a drive that cannot be named at all. The agent subject is deliberately not registered: `fetchPrivateDriveSubject` answers a local-only agent with its secret's `initialDrive`, which for an account made elsewhere is a server URL, and `setDrive` on that moves the app.

## 3. The vault said "no backup" and nobody said why

`restoreFromVault` has five distinct `no-backup` reasons; sign-in discarded them. The connect-device step now shows the reason.

And the reason in this case was almost certainly "the vault is empty": the account's `/api/cloud-vault/drives` shows the same agent with two drives, the key-derived one enrolled but never uploaded and another one with 52 KB backed up today. Sign-in only ever asked about the derived drive. The connect-device step now asks the control plane for the agent's other backed-up drives when the named one has no backup and offers the most recent. `VaultEnrollment` gains the `agent_subject` the API already returns.

## Tests

`sign-in-without-data.spec.ts`: the drive after signing in without data must not be a server URL (was: must be `''`), plus a new case that it is the `did:ad:` derived drive. 3/3 pass locally. Catalogs regenerated.

Still open, separate: the desktop enrolled the derived drive but never uploaded it (two enrollments with `last_backup_at: null`) — the edit-watcher gate in `vaultAutoBackup.ts` and the boot watcher's has-data requirement.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
