### PR TITLE
Tauri apps: restore by device link, and know the AtomicServer.eu provider

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -45,6 +45,17 @@ concurrency:
 permissions:
   contents: write
 
+# Baked into the frontend by `build:tauri` on every target (Vite reads VITE_*
+# at build time; see desktop/README.md). The apps embed their own node, which
+# is not managed and names no portal, so without this a fresh install has no
+# provider: the Sync page shows no "Sync with AtomicServer.eu", and restoring
+# an account has nowhere to restore from. This names the provider only — the
+# app stays a FOSS build (no VITE_ATOMIC_HOSTED_DISTRIBUTION): it creates its
+# identity locally and *links* to the account by device code, because a
+# webview on `tauri://localhost` cannot hold the portal's session cookie.
+env:
+  VITE_MANAGED_PORTAL_URL: https://atomicserver.eu
+
 jobs:
   # Secrets are not readable from a job-level `if:`, so the availability of each
   # signing identity is resolved once here and passed down as plain booleans.

--- a/browser/data-browser/src/helpers/managed/api.ts
+++ b/browser/data-browser/src/helpers/managed/api.ts
@@ -55,6 +55,20 @@ export function getRememberedManagedPortalUrl(): string | null {
   return rememberedPortalUrl;
 }
 
+/**
+ * The portal a build was compiled against, if any. Read here rather than via
+ * `managedServer.ts`'s `managedPortalOverride()` because that module imports
+ * this one.
+ */
+function portalFromEnv(): string | null {
+  const fromEnv =
+    typeof import.meta !== 'undefined'
+      ? (import.meta.env?.VITE_MANAGED_PORTAL_URL as string | undefined)
+      : undefined;
+
+  return fromEnv ? trimTrailingSlashes(fromEnv) : null;
+}
+
 /** Base URL of the control-plane API (includes the `/api` prefix). */
 export function getManagedApiBase(): string {
   const fromEnv =
@@ -68,12 +82,13 @@ export function getManagedApiBase(): string {
   // webview's origin is `tauri://localhost`, whose hostname is literally
   // `localhost`. Falling through would point every desktop build — shipped
   // ones included — at whatever happens to run on a dev machine's :3030.
-  // There is no same-origin `/api` here either, so the only real answer is
-  // the control plane the connected managed node named. Before any node has
+  // There is no same-origin `/api` here either, so the real answers are the
+  // control plane the connected managed node named, or the one the build was
+  // compiled against (the store apps; see tauri-release.yml). Before either
   // (pure self-hosted, or nothing fetched yet) these fetches just fail, which
   // every caller already treats as "no control plane".
   if (isRunningInTauri()) {
-    const portalUrl = getRememberedManagedPortalUrl();
+    const portalUrl = getRememberedManagedPortalUrl() ?? portalFromEnv();
 
     return portalUrl ? `${portalUrl}/api` : '/api';
   }

--- a/browser/data-browser/src/helpers/managed/deviceLink.test.ts
+++ b/browser/data-browser/src/helpers/managed/deviceLink.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   approvalUrl,
   awaitDeviceLink,
+  canHoldProviderCookie,
   isDeviceLinked,
   pollDeviceLink,
   requestDeviceLink,
@@ -215,5 +216,49 @@ describe('approvalUrl', () => {
     expect(approvalUrl(`${PORTAL}/`, 'K3F9-2XQP')).toBe(
       'https://portal.example/link?code=K3F9-2XQP',
     );
+  });
+});
+
+describe('canHoldProviderCookie', () => {
+  const saved = globalThis.window;
+
+  function at(href: string) {
+    globalThis.window = { location: new URL(href) } as unknown as Window &
+      typeof globalThis;
+  }
+
+  afterEach(() => {
+    globalThis.window = saved;
+  });
+
+  it('is true on the portal itself and on a subdomain of it', () => {
+    at('https://portal.example/app');
+    expect(canHoldProviderCookie(PORTAL)).toBe(true);
+
+    at('https://app.portal.example/app');
+    expect(canHoldProviderCookie(PORTAL)).toBe(true);
+  });
+
+  it('is true across ports in local development (cookies ignore the port)', () => {
+    at('http://localhost:6747/app');
+    expect(canHoldProviderCookie('http://localhost:49237')).toBe(true);
+  });
+
+  it('is false for the desktop and Android apps on tauri://localhost', () => {
+    at('tauri://localhost/app');
+    expect(canHoldProviderCookie(PORTAL)).toBe(false);
+  });
+
+  it('is false on a different site, and a look-alike is a different site', () => {
+    at('https://my-own-server.example/app');
+    expect(canHoldProviderCookie(PORTAL)).toBe(false);
+
+    at('https://notportal.example/app');
+    expect(canHoldProviderCookie(PORTAL)).toBe(false);
+  });
+
+  it('is false with no portal to hold a cookie for', () => {
+    at('https://portal.example/app');
+    expect(canHoldProviderCookie(null)).toBe(false);
   });
 });

--- a/browser/data-browser/src/helpers/managed/deviceLink.ts
+++ b/browser/data-browser/src/helpers/managed/deviceLink.ts
@@ -161,6 +161,34 @@ export function isDeviceLinked(): boolean {
 }
 
 /**
+ * Can this client sign in to the provider the ordinary way — by holding its
+ * session cookie?
+ *
+ * Only a page on the provider's own site can: the cookie is set for the
+ * portal's registrable domain, which covers `app.` on the same domain and
+ * nothing else. The desktop and Android apps live on `tauri://localhost`, a
+ * self-hoster's app on their own origin; sending either to the portal's sign-in
+ * page ends with a session in some browser and none in the app. Those link
+ * instead — see {@link requestDeviceLink}.
+ */
+export function canHoldProviderCookie(portalUrl: string | null): boolean {
+  if (!portalUrl) return false;
+
+  if (typeof window === 'undefined') return false;
+
+  if (!/^https?:$/.test(window.location.protocol)) return false;
+
+  try {
+    const portalHost = new URL(portalUrl).hostname;
+    const here = window.location.hostname;
+
+    return here === portalHost || here.endsWith(`.${portalHost}`);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * The provider this install linked to, so a later session knows where its token
  * is valid. Stored separately from the token: knowing the address is not the
  * same as being able to use it.

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -5914,9 +5914,8 @@ msgstr ""
 msgid "Paste your agent secret"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my account instead"
-msgstr ""
+#~ msgid "Use my account instead"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
@@ -7125,4 +7124,14 @@ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Cloud Vault had nothing for this workspace:"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Forgot it? Restore from {0}"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -5948,9 +5948,8 @@ msgstr "Could not reach your backup. Try again."
 msgid "Paste your agent secret"
 msgstr "Paste your agent secret"
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my account instead"
-msgstr "Use my account instead"
+#~ msgid "Use my account instead"
+#~ msgstr "Use my account instead"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
@@ -7160,3 +7159,13 @@ msgstr "Keep it somewhere safe. You'll need it — plus your email — to get ba
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Cloud Vault had nothing for this workspace:"
 msgstr "Cloud Vault had nothing for this workspace:"
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Forgot it? Restore from {0}"
+msgstr "Forgot it? Restore from {0}"
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
+msgstr "Your backup is kept by your {0} account. Connect this device to it to restore."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -5914,9 +5914,8 @@ msgstr ""
 msgid "Paste your agent secret"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my account instead"
-msgstr ""
+#~ msgid "Use my account instead"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
@@ -7125,4 +7124,14 @@ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Cloud Vault had nothing for this workspace:"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Forgot it? Restore from {0}"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -5914,9 +5914,8 @@ msgstr ""
 msgid "Paste your agent secret"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Use my account instead"
-msgstr ""
+#~ msgid "Use my account instead"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "That doesn’t look like a valid agent secret."
@@ -7125,4 +7124,14 @@ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Cloud Vault had nothing for this workspace:"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Forgot it? Restore from {0}"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
 msgstr ""

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -52,6 +52,11 @@ import { InputStyled, InputWrapper } from '../../components/forms/InputStyles';
 import { FaArrowLeft, FaKey } from 'react-icons/fa6';
 import { Logo } from '../../components/Logo';
 import { ConnectDeviceStep } from './ConnectDeviceStep';
+import { LinkProviderPanel } from '../../components/Vault/LinkProviderPanel';
+import {
+  canHoldProviderCookie,
+  getRememberedProvider,
+} from '../../helpers/managed/deviceLink';
 import {
   Shell,
   CardTitle,
@@ -146,7 +151,10 @@ export function GettingStartedFlow({
       if (cancelled) return;
 
       setCreateTarget(accountCreationTarget(info));
-      setKnownPortalUrl(getManagedPortalUrl(info));
+      // The remembered provider covers the desktop and Android apps: their
+      // embedded node names no portal, and the build may not either, but a
+      // device that linked once knows exactly where its account lives.
+      setKnownPortalUrl(getManagedPortalUrl(info) ?? getRememberedProvider());
     });
 
     return () => {
@@ -347,6 +355,13 @@ export function GettingStartedFlow({
   // the sign-in step: a returning user with a passkey should be offered it
   // straight away, not asked to paste an agent secret with recovery hidden
   // behind "Forgot your secret?".
+  /**
+   * Bumped when this device gains a provider session mid-step (a device link
+   * approved elsewhere), so the check below runs again without leaving the
+   * step. A page reload would do the same and lose the user's place.
+   */
+  const [restoreAttempt, setRestoreAttempt] = useState(0);
+
   useEffect(() => {
     if (step !== 'restore' && step !== 'signin') return;
     let cancelled = false;
@@ -389,7 +404,7 @@ export function GettingStartedFlow({
     return () => {
       cancelled = true;
     };
-  }, [step]);
+  }, [step, restoreAttempt]);
 
   /**
    * Unlock a backup with its passkey — one prompt, no typing. Returns whether
@@ -970,8 +985,11 @@ export function GettingStartedFlow({
                     ) : null}
                     {/* Hidden once accounts are listed above: that picker is
                         already the "recover via my account" route, and a
-                        second door to the same room just adds a button. */}
-                    {knownAccounts.length === 0 ? (
+                        second door to the same room just adds a button. Also
+                        hidden when no portal is known — a source build with
+                        nothing to restore from — because the step behind it
+                        can then only say "sign in first" with nowhere to. */}
+                    {knownAccounts.length === 0 && knownPortalUrl ? (
                       <Button
                         key='forgot'
                         type='button'
@@ -984,7 +1002,7 @@ export function GettingStartedFlow({
                           setStep('restore');
                         }}
                       >
-                        Use my account instead
+                        {`Forgot it? Restore from ${PRODUCT_NAME}`}
                       </Button>
                     ) : null}
                     {nextDrive ? (
@@ -1073,26 +1091,48 @@ export function GettingStartedFlow({
                 {restore.phase === 'checking' ? (
                   <p key='checking'>{`Checking your ${PRODUCT_NAME} account…`}</p>
                 ) : restore.phase === 'no-session' ? (
-                  <Column key='no-session' gap='0.75rem'>
-                    <p key='copy'>
-                      {`To restore your account, sign in to your ${PRODUCT_NAME} account first, then come back here.`}
-                    </p>
-                    {knownPortalUrl && (
-                      <Button
-                        key='signin'
-                        type='button'
-                        onClick={() => {
-                          // `/signin` rather than the root, which is the sales
-                          // page — someone mid-recovery should land on the form.
-                          window.location.assign(
-                            new URL('/signin', knownPortalUrl).toString(),
-                          );
-                        }}
-                      >
-                        {`Sign in to your ${PRODUCT_NAME} account`}
-                      </Button>
-                    )}
-                  </Column>
+                  // Two ways to get a session, and only one works per client.
+                  // A page on the portal's own site signs in there and comes
+                  // back with the cookie. The desktop and Android apps, and a
+                  // self-hosted origin, cannot hold that cookie: sending them
+                  // to the portal's sign-in ends with a session in some
+                  // browser and none here — which used to be this screen's
+                  // only advice, with the button missing on top when the
+                  // build knew no portal. They link this device instead, with
+                  // a code approved wherever they are already signed in.
+                  !canHoldProviderCookie(knownPortalUrl) ? (
+                    <Column key='no-session-link' gap='0.75rem'>
+                      <p key='copy'>
+                        {`Your backup is kept by your ${PRODUCT_NAME} account. Connect this device to it to restore.`}
+                      </p>
+                      <LinkProviderPanel
+                        key='link'
+                        portalUrl={knownPortalUrl}
+                        onLinked={() => setRestoreAttempt(n => n + 1)}
+                      />
+                    </Column>
+                  ) : (
+                    <Column key='no-session' gap='0.75rem'>
+                      <p key='copy'>
+                        {`To restore your account, sign in to your ${PRODUCT_NAME} account first, then come back here.`}
+                      </p>
+                      {knownPortalUrl && (
+                        <Button
+                          key='signin'
+                          type='button'
+                          onClick={() => {
+                            // `/signin` rather than the root, which is the sales
+                            // page — someone mid-recovery should land on the form.
+                            window.location.assign(
+                              new URL('/signin', knownPortalUrl).toString(),
+                            );
+                          }}
+                        >
+                          {`Sign in to your ${PRODUCT_NAME} account`}
+                        </Button>
+                      )}
+                    </Column>
+                  )
                 ) : restore.phase === 'no-backup' ? (
                   <p key='no-backup'>
                     No recovery backup was found for {restore.email}. Account

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -340,13 +340,13 @@ test.describe('Cloud Vault backup and restore', () => {
       await fresh.goto(await signUpAndGetMagicLink(email));
       await fresh.goto(driveUrl);
 
-      // "Use my account instead" is the portal path: the account is known from
+      // "Forgot it? Restore from …" is the portal path: the account is known from
       // the session cookie the magic link just set, so all it needs is the
       // recovery code. Minting a second agent here instead would leave the
       // vault's key envelope unopenable — the objects would still be stored and
       // permanently unreadable, which is the worst failure this feature has.
       await fresh
-        .getByRole('button', { name: 'Use my account instead' })
+        .getByRole('button', { name: /^Forgot it\? Restore from/ })
         .click({ timeout: 30_000 });
       await expect(
         fresh.getByRole('heading', { name: 'Restore account' }),


### PR DESCRIPTION
On the Android app, "Use my account instead" led to "To restore your account, sign in to your AtomicServer.eu account first, then come back here" — with no button, and no way to do that from inside an app. And the Sync page showed only "This device · Embedded server · stored locally": no "Sync with AtomicServer.eu", no Cloud Vault, no way to connect an account.

## 1. The step used the wrong mechanism

`window.location.assign(portal/signin)` sends the app's webview to the portal, the magic link opens in the system browser, and the session lands there, never in the app. Same for a self-hosted origin: only a page on the portal's own site can hold its cookie.

- `canHoldProviderCookie(portalUrl)`: true on the portal's host or a subdomain over http(s), false on `tauri://`, another site, or no portal. Unit-tested.
- Where the cookie cannot be held, the `no-session` phase renders `LinkProviderPanel` — the device-link flow the Sync page already uses — and re-runs the backup check in place once linked. The sign-in button stays for pages that can hold the cookie.
- `knownPortalUrl` falls back to the remembered provider; the button into the step is hidden when no portal is known at all, and is now labelled "Forgot it? Restore from AtomicServer.eu" ("Use my account instead" did not say what it did). `vault-backup-restore.spec.ts` follows the label.

## 2. The apps knew no provider

The embedded node is unmanaged and names no portal, and `tauri-release.yml` set no `VITE_MANAGED_PORTAL_URL`, so `getManagedPortalUrl()` was null — that is both `isCloudSyncAvailable` (the cloud cards) and the URL the link panel renders for.

- `tauri-release.yml` sets `VITE_MANAGED_PORTAL_URL=https://atomicserver.eu` for every target. Only the address: the apps stay FOSS builds (no `VITE_ATOMIC_HOSTED_DISTRIBUTION`) — the hosted flag would send "Create account" to the portal via `window.location.assign`, the same dead end as above. Identity is created locally and the account is attached by device code.
- `getManagedApiBase()` on Tauri falls back to that build-time portal when no node has named one, so `/api/me`, the vault and the device link resolve against it on first run instead of `tauri.localhost/api`.

Takes effect on the next tag build of the apps. For `tauri dev`, put the same line in `browser/data-browser/.env.local`.

tsc (no new errors), oxlint, 139 managed unit tests pass. Catalogs regenerated.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd
