### PR TITLE
style(browser): format NewIdentitySection.tsx

### DIFF
--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -804,9 +804,9 @@ function RecoveryBackupStep({
         <h3 key='title'>Save your recovery code</h3>
         {passkeyRegistered && (
           <p key='why'>
-            Your passkey opens this account on this device and wherever it
-            syncs to. This code opens it on every other device — a phone, a
-            different browser, a new computer.
+            Your passkey opens this account on this device and wherever it syncs
+            to. This code opens it on every other device — a phone, a different
+            browser, a new computer.
           </p>
         )}
         <p key='important'>


### PR DESCRIPTION
The main pipeline fails at data-browser format-check since #1349: one paragraph in RecoveryBackupStep wraps differently under oxfmt. pnpm format output, nothing else. cargo fmt and the other workspace lints are clean.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd