### PR TITLE
build(android): ship Tauri APK as arm64-v8a only

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -392,7 +392,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android,wasm32-unknown-unknown
+          # arm64 only: phones/tablets we ship to. The other three Android
+          # targets were Tauri's generated default and made the universal APK
+          # ~4× (369 MB on v0.41.0-beta.3). wasm32 is for `pnpm -C browser
+          # build`, which wasm-packs the ClientDb before the APK is assembled.
+          targets: aarch64-linux-android,wasm32-unknown-unknown
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -475,7 +479,7 @@ jobs:
           echo "Signing configured (keystore at $keystore)."
 
       - name: Build
-        run: cargo tauri android build --apk --aab
+        run: cargo tauri android build --target aarch64 --apk --aab
         working-directory: desktop
 
       - name: Collect artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Tauri Android: ship `arm64-v8a` only. The sideloadable universal APK was ~369 MB because it bundled four copies of `libatomic_server_tauri.so` (armeabi-v7a / x86 / x86_64 as well). Phones and tablets we install on are arm64; override with `cargo tauri android build --target …` for an Intel emulator.
+
 ## [v0.41.0-beta.4] - 2026-09-03
 
 - Fix: with `ATOMIC_HOME_DRIVE` set, `GET /server` answered 500 for plain JSON and JSON-LD (`Accept: application/json`): the `homeDrive` property the endpoint sets was never defined in the default store, so rendering tried to fetch it from atomicdata.dev. JSON-AD (what the data-browser asks for) was unaffected. The property is now part of the defaults.

--- a/desktop/gen/android/app/build.gradle.kts
+++ b/desktop/gen/android/app/build.gradle.kts
@@ -56,10 +56,8 @@ android {
             isDebuggable = true
             isJniDebuggable = true
             isMinifyEnabled = false
-            packaging {                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
-                jniLibs.keepDebugSymbols.add("*/armeabi-v7a/*.so")
-                jniLibs.keepDebugSymbols.add("*/x86/*.so")
-                jniLibs.keepDebugSymbols.add("*/x86_64/*.so")
+            packaging {
+                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
             }
         }
         getByName("release") {

--- a/desktop/gen/android/buildSrc/src/main/java/com/atomicdata/dev/kotlin/RustPlugin.kt
+++ b/desktop/gen/android/buildSrc/src/main/java/com/atomicdata/dev/kotlin/RustPlugin.kt
@@ -17,13 +17,19 @@ open class RustPlugin : Plugin<Project> {
     override fun apply(project: Project) = with(project) {
         config = extensions.create("rust", Config::class.java)
 
-        val defaultAbiList = listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64");
+        // Phones and tablets we actually install on are arm64. Shipping
+        // armeabi-v7a / x86 / x86_64 as well packed four copies of
+        // libatomic_server_tauri.so (~100 MB each) into the sideloadable
+        // universal APK — 369 MB on v0.41.0-beta.3. Override with Gradle
+        // properties (or `cargo tauri android build --target …`) if an
+        // Intel emulator build is needed.
+        val defaultAbiList = listOf("arm64-v8a")
         val abiList = (findProperty("abiList") as? String)?.split(',') ?: defaultAbiList
 
-        val defaultArchList = listOf("arm64", "arm", "x86", "x86_64");
+        val defaultArchList = listOf("arm64")
         val archList = (findProperty("archList") as? String)?.split(',') ?: defaultArchList
 
-        val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf("aarch64", "armv7", "i686", "x86_64")
+        val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf("aarch64")
 
         extensions.configure<ApplicationExtension> {
             @Suppress("UnstableApiUsage")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

N/A — follow-up to the Tauri APK size investigation. The v0.41.0-beta.3 sideloadable `app-universal-release.apk` is **369 MB** because it ships four copies of `libatomic_server_tauri.so` (~100 MB each).

## What

Default the Tauri Android build to **arm64-v8a only**. Phones and tablets we actually install on are arm64; `armeabi-v7a` / `x86` / `x86_64` were Tauri's generated Gradle default, not a product choice.

- `RustPlugin.kt` defaults: `abiList` / `archList` / `targetList` → arm64 only
- CI: rustc target list drops the three unused Android triples; `cargo tauri android build --target aarch64`
- Debug `keepDebugSymbols` only lists the ABI we still ship
- Override still works: `cargo tauri android build --target x86_64` (Intel emulator)

## Size check

Took the published v0.41.0-beta.3 universal APK and removed the three extra ABI directories (same `.so` the next release will omit). No rebuild of Rust — this is the packaging change only.

| Artifact | Size |
|---|---|
| v0.41.0-beta.3 `app-universal-release.apk` (4 ABIs) | **369 MB** |
| Same APK with only `lib/arm64-v8a/` | **99 MB** |
| v0.41.0-beta.3 `app-universal-release.aab` | 158 MB |

Play's AAB already splits by ABI; this change mainly helps the APK people download from the GitHub release.

[tauri-apk-arm64-only.log](https://cursor.com/agents/bc-39fd156c-8a9a-465e-bbc0-f48bd95a6fe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftauri-apk-arm64-only.log)

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [x] Update docs if needed


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39fd156c-8a9a-465e-bbc0-f48bd95a6fe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39fd156c-8a9a-465e-bbc0-f48bd95a6fe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

