### PR TITLE
Fix Firefox page transitions

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -398,6 +398,14 @@ vector (`personal_drive_cross_lang_vector`) pins the nonce, signature, and DID.
 | Parent action stays available on a non-drive stub and fetches parent at run | glue | `browser/data-browser/src/actions/resourceActions.parent.test.ts` |
 
 Not covered: derived AI tools invoked through a real model; MCP protocol projection (no Atomic MCP server yet); collapsing specialized `destroy()` call sites (table rows, views, tags) onto the resource delete action.
+## View transitions
+
+| Flow | Layer | Where |
+|---|---|---|
+| Hashed `view-transition-name` plus `view-transition-class` per tag | glue | `browser/data-browser/src/helpers/viewTransition.test.ts` |
+| `startViewTransition` throw / hung `finished` / rejected `ready` still navigates and skips the overlay | glue | `browser/data-browser/src/helpers/viewTransition.test.ts` |
+
+Not covered: visual morph of a grid card into the resource page in Firefox (needs a headed Firefox run; Playwright's firefox project is locks-only and automation bypasses view transitions unless `forceViewTransitions` is set).
 
 ## Documents
 

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: page transitions on Firefox no longer smear into a giant overlay or get skipped entirely. Snapshot sizing is scoped by `view-transition-class` (titles keep the height-based aspect-ratio rule; card→page morphs fill the group), title links that wrap a heading are `inline-block` so Firefox does not treat them as duplicate names (IB splits), and a failed or hung `startViewTransition` still navigates and skips the overlay instead of covering the page.
 - Add peer rooms for up to eight simultaneous browsers on the Sync page with WebRTC collaboration, OPFS reconciliation and attachment sync without a Cloud subscription. Discovery defaults to shared Atomic SaaS signaling, independent of the drive’s data node. Export `BrowserPeerSync`, `WebRtcPeer` and `WebRtcTransport` from `@tomic/lib` ([#1396](https://github.com/ontola/atomic-server/issues/1396)).
 - Portal Open links select their workspace; ordinary resource links keep the current drive.
 - Sync distinguishes remote node data from Cloud Server enrollment, explains drive-specific plans, and refreshes account/recovery status after portal sign-in.

--- a/browser/data-browser/src/helpers/transitionName.ts
+++ b/browser/data-browser/src/helpers/transitionName.ts
@@ -50,7 +50,10 @@ export function transitionName(tag: string, subject: string | undefined) {
     return 'view-transition-name: none';
   }
 
-  return `view-transition-name: ${name}`;
+  // Class lets us target a *kind* of snapshot (title vs page) without
+  // enumerating hashed names. Firefox needs different sizing rules per
+  // kind — a global `block-size: 100%` on `*` inflates card→page morphs.
+  return `view-transition-name: ${name}; view-transition-class: ${tag}`;
 }
 
 export function getTransitionStyle(tag: string, subject: string | undefined) {
@@ -64,5 +67,6 @@ export function getTransitionStyle(tag: string, subject: string | undefined) {
 
   return {
     viewTransitionName: name,
+    viewTransitionClass: tag,
   };
 }

--- a/browser/data-browser/src/helpers/viewTransition.test.ts
+++ b/browser/data-browser/src/helpers/viewTransition.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resetViewTransitionQueue,
+  wrapWithViewTransition,
+} from './viewTransition';
+import {
+  getTransitionName,
+  getTransitionStyle,
+  PAGE_TITLE_TRANSITION_TAG,
+  RESOURCE_PAGE_TRANSITION_TAG,
+  transitionName,
+} from './transitionName';
+
+vi.mock('react-dom', () => ({
+  flushSync: (fn: () => void) => fn(),
+}));
+
+describe('transitionName helpers', () => {
+  it('emits a hashed name plus a view-transition-class for the tag', () => {
+    const subject = 'did:ad:example';
+    const name = getTransitionName(RESOURCE_PAGE_TRANSITION_TAG, subject);
+
+    expect(transitionName(RESOURCE_PAGE_TRANSITION_TAG, subject)).toBe(
+      `view-transition-name: ${name}; view-transition-class: ${RESOURCE_PAGE_TRANSITION_TAG}`,
+    );
+    expect(getTransitionStyle(PAGE_TITLE_TRANSITION_TAG, subject)).toEqual({
+      viewTransitionName: getTransitionName(PAGE_TITLE_TRANSITION_TAG, subject),
+      viewTransitionClass: PAGE_TITLE_TRANSITION_TAG,
+    });
+  });
+
+  it('falls back when there is no subject', () => {
+    expect(transitionName(RESOURCE_PAGE_TRANSITION_TAG, undefined)).toBe(
+      'view-transition-name: none',
+    );
+    expect(getTransitionStyle(RESOURCE_PAGE_TRANSITION_TAG, undefined)).toEqual(
+      {},
+    );
+  });
+});
+
+describe('wrapWithViewTransition', () => {
+  beforeEach(() => {
+    resetViewTransitionQueue();
+    vi.useFakeTimers();
+    vi.stubGlobal('navigator', { webdriver: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    resetViewTransitionQueue();
+  });
+
+  it('runs the callback directly when the API is missing', async () => {
+    vi.stubGlobal('document', {});
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(false, cb);
+
+    await wrapped();
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('runs the callback directly when transitions are disabled', async () => {
+    const startViewTransition = vi.fn();
+    vi.stubGlobal('document', { startViewTransition });
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(true, cb);
+
+    await wrapped();
+
+    expect(cb).toHaveBeenCalledOnce();
+    expect(startViewTransition).not.toHaveBeenCalled();
+  });
+
+  it('still navigates when startViewTransition throws before the update', async () => {
+    const startViewTransition = vi.fn(() => {
+      throw new TypeError('Duplicate view-transition-name value');
+    });
+    vi.stubGlobal('document', { startViewTransition });
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(false, cb);
+
+    await wrapped();
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('does not navigate twice when the throw happens after the update started', async () => {
+    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
+      void update();
+      throw new TypeError('Duplicate view-transition-name value');
+    });
+    vi.stubGlobal('document', { startViewTransition });
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(false, cb);
+
+    await wrapped();
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('skips a hung transition so the overlay cannot cover the page', async () => {
+    const skipTransition = vi.fn();
+    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
+      void update();
+
+      return {
+        skipTransition,
+        ready: Promise.resolve(),
+        finished: new Promise(() => undefined),
+        updateCallbackDone: Promise.resolve(),
+      };
+    });
+    vi.stubGlobal('document', { startViewTransition });
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(false, cb);
+
+    const done = wrapped();
+    await vi.advanceTimersByTimeAsync(1000);
+    await done;
+
+    expect(cb).toHaveBeenCalledOnce();
+    expect(skipTransition).toHaveBeenCalledOnce();
+  });
+
+  it('skips when ready rejects (Firefox duplicate-name / IB-split)', async () => {
+    const skipTransition = vi.fn();
+    let rejectReady: (reason?: unknown) => void = () => undefined;
+    let resolveFinished: () => void = () => undefined;
+    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
+      void update();
+
+      return {
+        skipTransition: () => {
+          skipTransition();
+          resolveFinished();
+        },
+        ready: new Promise<void>((_, reject) => {
+          rejectReady = reject;
+        }),
+        finished: new Promise<void>(resolve => {
+          resolveFinished = resolve;
+        }),
+        updateCallbackDone: Promise.resolve(),
+      };
+    });
+    vi.stubGlobal('document', { startViewTransition });
+    const cb = vi.fn(async () => undefined);
+    const wrapped = wrapWithViewTransition(false, cb);
+
+    const done = wrapped();
+    await vi.waitFor(() => expect(startViewTransition).toHaveBeenCalledOnce());
+    rejectReady(new Error('duplicate name'));
+    await done;
+
+    expect(cb).toHaveBeenCalledOnce();
+    expect(skipTransition).toHaveBeenCalledOnce();
+  });
+});

--- a/browser/data-browser/src/helpers/viewTransition.ts
+++ b/browser/data-browser/src/helpers/viewTransition.ts
@@ -1,0 +1,138 @@
+import { flushSync } from 'react-dom';
+
+/**
+ * Serializes concurrent view transitions. Without this, back-to-back navigate
+ * calls fire `document.startViewTransition()` while the previous transition
+ * is still animating — Chrome cancels the older one and logs
+ * "Skipped ViewTransition due to another transition starting" to the console.
+ * We wait for the prior transition's `finished` promise before starting the
+ * next one; failures still unblock the queue so a botched transition can't
+ * wedge the UI.
+ */
+let activeTransition: Promise<void> = Promise.resolve();
+
+const QUEUE_TIMEOUT_MS = 1000;
+
+/** Headless drivers don't paint, so `finished` can hang forever. */
+function isAutomated(): boolean {
+  if (typeof navigator === 'undefined' || navigator.webdriver !== true) {
+    return false;
+  }
+
+  try {
+    // Escape hatch for debugging transitions under automation:
+    // localStorage.setItem('forceViewTransitions', '1')
+    return localStorage.getItem('forceViewTransitions') !== '1';
+  } catch {
+    return true;
+  }
+}
+
+function swallow(promise: Promise<unknown> | undefined) {
+  promise?.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+function skipQuietly(transition: ViewTransition) {
+  try {
+    transition.skipTransition();
+  } catch {
+    // Already skipped, finished, or the UA does not implement skip.
+  }
+}
+
+/**
+ * Wrap an async navigation so it runs inside `document.startViewTransition`
+ * when the API exists and the user has not disabled animations.
+ *
+ * Firefox 144+ implements the API but is stricter than Chromium: duplicate
+ * `view-transition-name`s (including false duplicates from inline/block
+ * splits) reject `ready` / `updateCallbackDone`, and a hung `finished`
+ * promise leaves the `::view-transition` overlay on top of the page. We
+ * always run the navigation, skip a stuck overlay, and never leave those
+ * promises unhandled.
+ */
+export function wrapWithViewTransition<Args extends unknown[]>(
+  disabled: boolean,
+  cb: (...args: Args) => Promise<void>,
+): (...args: Args) => Promise<void> {
+  if (
+    disabled ||
+    typeof document === 'undefined' ||
+    !document.startViewTransition ||
+    isAutomated()
+  ) {
+    return cb;
+  }
+
+  const wrapped = async (...args: Args) => {
+    const previous = activeTransition;
+    const gate = Promise.race([
+      previous.then(
+        () => undefined,
+        () => undefined,
+      ),
+      new Promise<void>(resolve => setTimeout(resolve, QUEUE_TIMEOUT_MS)),
+    ]);
+
+    const next = gate.then(async () => {
+      let updateStarted = false;
+
+      try {
+        const transition = document.startViewTransition!(
+          () =>
+            new Promise<void>((innerResolve, innerReject) => {
+              updateStarted = true;
+              flushSync(() => {
+                cb(...args).then(innerResolve, innerReject);
+              });
+            }),
+        );
+
+        // Firefox creates these promises during error handling (duplicate
+        // names, IB splits) even before we read them — attach catches
+        // immediately so they are not unhandled rejections.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1999336
+        swallow(transition.updateCallbackDone);
+        transition.ready.then(undefined, () => skipQuietly(transition));
+        swallow(transition.finished);
+
+        await Promise.race([
+          transition.finished.then(
+            () => undefined,
+            () => undefined,
+          ),
+          new Promise<void>(resolve => {
+            setTimeout(() => {
+              skipQuietly(transition);
+              resolve();
+            }, QUEUE_TIMEOUT_MS);
+          }),
+        ]);
+      } catch {
+        // Synchronous throw from startViewTransition (Firefox reports some
+        // capture errors this way). Still navigate if the update callback
+        // never ran.
+        if (!updateStarted) {
+          await cb(...args);
+        }
+      }
+    });
+
+    activeTransition = next.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return next;
+  };
+
+  return wrapped;
+}
+
+/** Test-only: drop in-flight queue state between cases. */
+export function resetViewTransitionQueue() {
+  activeTransition = Promise.resolve();
+}

--- a/browser/data-browser/src/hooks/useNavigateWithTransition.ts
+++ b/browser/data-browser/src/hooks/useNavigateWithTransition.ts
@@ -1,87 +1,6 @@
-import { flushSync } from 'react-dom';
 import { useSettings } from '../helpers/AppSettings';
+import { wrapWithViewTransition } from '../helpers/viewTransition';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-
-/**
- * Serializes concurrent view transitions. Without this, back-to-back navigate
- * calls fire `document.startViewTransition()` while the previous transition
- * is still animating — Chrome cancels the older one and logs
- * "Skipped ViewTransition due to another transition starting" to the console.
- * We wait for the prior transition's `finished` promise before starting the
- * next one; failures still unblock the queue so a botched transition can't
- * wedge the UI.
- */
-let activeTransition: Promise<void> = Promise.resolve();
-
-// Headless test contexts (Playwright, Puppeteer) don't drive the
-// compositor, so `document.startViewTransition`'s update callback can hang
-// indefinitely — the navigation inside it never unblocks. Bypass the
-// transition wrap there. `navigator.webdriver` is the standard W3C signal
-// set by automation drivers.
-const IS_AUTOMATED =
-  typeof navigator !== 'undefined' &&
-  navigator.webdriver === true &&
-  // Escape hatch for debugging transitions under automation (e.g. a
-  // driven browser session): localStorage.setItem('forceViewTransitions', '1')
-  localStorage.getItem('forceViewTransitions') !== '1';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function wrapWithTransition<F extends (...args: any[]) => Promise<void>>(
-  disabled: boolean,
-  cb: F,
-) {
-  if (disabled || !document.startViewTransition || IS_AUTOMATED) {
-    return cb;
-  }
-
-  return async (...args: Parameters<F>) => {
-    // Wait for the previous transition to settle, but cap the wait at 1s.
-    // Headless test contexts (Playwright/Puppeteer) don't drive the
-    // compositor, so a transition's `finished` promise can hang
-    // indefinitely — without this cap, one hung transition wedges every
-    // subsequent navigation in the queue (the `gate.then(...)` callback
-    // would never fire). The new navigation still runs through
-    // `startViewTransition`'s update callback, so URL/state changes still
-    // happen; we just stop blocking on a previous hang.
-    const previous = activeTransition;
-    const gate = Promise.race([
-      previous.then(
-        () => undefined,
-        () => undefined,
-      ),
-      new Promise<void>(resolve => setTimeout(resolve, 1000)),
-    ]);
-    const next = gate.then(
-      () =>
-        new Promise<void>(resolve => {
-          const transition = document.startViewTransition!(
-            () =>
-              new Promise<void>(innerResolve => {
-                flushSync(() => {
-                  cb(...args).then(() => innerResolve());
-                });
-              }),
-          );
-          // `finished` resolves/rejects when the animation ends (or is
-          // skipped/cancelled). Either way we unblock the queue. Cap the
-          // wait so a hung transition can't permanently wedge the queue.
-          let settled = false;
-
-          const settle = () => {
-            if (settled) return;
-            settled = true;
-            resolve();
-          };
-
-          transition.finished.then(settle, settle);
-          setTimeout(settle, 1000);
-        }),
-    );
-    activeTransition = next;
-
-    return next;
-  };
-}
 
 /**
  * A wrapper around tanstack-router's navigate function that will trigger css view transitions if enabled.
@@ -90,7 +9,7 @@ export function useNavigateWithTransition() {
   const navigate = useNavigate();
   const { viewTransitionsDisabled } = useSettings();
 
-  const navigateWithTransition = wrapWithTransition(
+  const navigateWithTransition = wrapWithViewTransition(
     viewTransitionsDisabled,
     (options: Parameters<typeof navigate>[0] | string) => {
       const newOptions =
@@ -111,7 +30,7 @@ export function useBackForward() {
   const router = useRouter();
   const { viewTransitionsDisabled } = useSettings();
 
-  const back = wrapWithTransition(
+  const back = wrapWithViewTransition(
     viewTransitionsDisabled,
     () =>
       new Promise(resolve => {
@@ -120,7 +39,7 @@ export function useBackForward() {
       }),
   );
 
-  const forward = wrapWithTransition(
+  const forward = wrapWithViewTransition(
     viewTransitionsDisabled,
     () =>
       new Promise(resolve => {

--- a/browser/data-browser/src/styling.tsx
+++ b/browser/data-browser/src/styling.tsx
@@ -14,7 +14,12 @@ import './reset.css';
 import { useContext, type JSX } from 'react';
 import { SettingsContext } from './helpers/AppSettings';
 import { CurrentBackgroundColor } from './globalCssVars';
-import { BREADCRUMB_BAR_TRANSITION_TAG } from './helpers/transitionName';
+import {
+  BREADCRUMB_BAR_TRANSITION_TAG,
+  MEETING_PANEL_TITLE_TRANSITION_TAG,
+  PAGE_TITLE_TRANSITION_TAG,
+  RESOURCE_PAGE_TRANSITION_TAG,
+} from './helpers/transitionName';
 
 interface ThemeWrapperProps {
   children: React.ReactNode;
@@ -340,6 +345,13 @@ export const GlobalStyle = createGlobalStyle`
     --view-transition-duration: 150ms;
   }
 
+  /* Firefox 144 sizes the root view-transition snapshot from :root's
+     used height. Without an explicit height the snapshot stretches
+     (https://bugzilla.mozilla.org/show_bug.cgi?id=1962617). */
+  html {
+    height: 100%;
+  }
+
   * {
     box-sizing: border-box;
     scrollbar-color: ${p => p.theme.colors.bg2} transparent;
@@ -441,13 +453,29 @@ export const GlobalStyle = createGlobalStyle`
   ::view-transition-old(*),
   ::view-transition-new(*) {
     animation-duration: var(--view-transition-duration);
-    /* Scale snapshots by height, preserving aspect ratio. The UA default
-       (inline-size: 100%, block-size: auto) smears text horizontally when a
-       narrow snapshot morphs into a wide group (grid title → page H1) —
-       most visible in Firefox, which doesn't interpolate changing aspect
-       ratios as smoothly as Chromium. */
+  }
+
+  /* Title morphs: scale by height so a narrow grid label does not smear
+     horizontally into the page H1. Firefox does not interpolate changing
+     aspect ratios as smoothly as Chromium — scoped to titles via
+     view-transition-class so it does not apply to card→page morphs. */
+  ::view-transition-old(.${PAGE_TITLE_TRANSITION_TAG}),
+  ::view-transition-new(.${PAGE_TITLE_TRANSITION_TAG}),
+  ::view-transition-old(.${MEETING_PANEL_TITLE_TRANSITION_TAG}),
+  ::view-transition-new(.${MEETING_PANEL_TITLE_TRANSITION_TAG}) {
     block-size: 100%;
     inline-size: auto;
+  }
+
+  /* Card / main morphs: fill the animating group on both axes. Scaling by
+     height alone made a square card snapshot as wide as the page is tall —
+     a giant overlay, worst on Firefox. */
+  ::view-transition-old(.${RESOURCE_PAGE_TRANSITION_TAG}),
+  ::view-transition-new(.${RESOURCE_PAGE_TRANSITION_TAG}) {
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+    overflow: clip;
   }
 
   /* Keep geometry (group) animations on the same clock as the fades. The UA

--- a/browser/data-browser/src/views/Article/ArticleCard.tsx
+++ b/browser/data-browser/src/views/Article/ArticleCard.tsx
@@ -25,9 +25,9 @@ export function ArticleCard({ resource }: CardViewProps): JSX.Element {
 
   return (
     <div>
-      <AtomicLink subject={resource.subject}>
+      <TitleLink subject={resource.subject}>
         <Title subject={resource.subject}>{resource.title}</Title>
-      </AtomicLink>
+      </TitleLink>
       <p>
         {truncated}
         {truncationMark}
@@ -35,6 +35,12 @@ export function ArticleCard({ resource }: CardViewProps): JSX.Element {
     </div>
   );
 }
+
+const TitleLink = styled(AtomicLink)`
+  /* Firefox IB-split workaround: see ResourceCardTitle. */
+  display: inline-block;
+  max-width: 100%;
+`;
 
 const Title = styled.h2<ViewTransitionProps>`
   white-space: nowrap;

--- a/browser/data-browser/src/views/Card/ResourceCardTitle.tsx
+++ b/browser/data-browser/src/views/Card/ResourceCardTitle.tsx
@@ -22,16 +22,24 @@ export const ResourceCardTitle: FC<
     <TitleRow center gap='1ch' justify='space-between' wrapItems>
       <Row center gap='1ch'>
         <ResourceGlyph resource={resource} />
-        <AtomicLink subject={resource.subject}>
+        <TitleLink subject={resource.subject}>
           <Title subject={resource.subject}>
             {alternateTitle ?? resource.title}
           </Title>
-        </AtomicLink>
+        </TitleLink>
       </Row>
       {children}
     </TitleRow>
   );
 };
+
+const TitleLink = styled(AtomicLink)`
+  /* Firefox treats a block heading inside an inline <a> as an IB split and
+     reports a duplicate view-transition-name, skipping the whole page
+     transition. https://bugzilla.mozilla.org/show_bug.cgi?id=1999336 */
+  display: inline-block;
+  max-width: 100%;
+`;
 
 const Title = styled.h2<ViewTransitionProps>`
   font-size: 1.4rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Page transitions on Firefox were broken: card-to-page morphs exploded into a giant overlay that covered the sidebar, and a duplicate `view-transition-name` (including Firefox’s false duplicates from inline/block splits) could skip the whole transition or leave the overlay covering the page.

## What changed

- Snapshot sizing is scoped by `view-transition-class`: titles still scale by height (no horizontal smear), resource-page morphs fill the group with `object-fit: cover`.
- Title links that wrap a heading are `inline-block` so Firefox does not treat a named inline `<a>` as an IB-split duplicate ([bug 1999336](https://bugzilla.mozilla.org/show_bug.cgi?id=1999336)).
- `:root` gets an explicit height so Firefox’s root snapshot is not stretched ([bug 1962617](https://bugzilla.mozilla.org/show_bug.cgi?id=1962617)).
- `startViewTransition` failures and hung `finished` promises still navigate and call `skipTransition()`, so a Firefox capture error cannot freeze the UI.

## Firefox verification

Headed Firefox 150: a named inline `<a>` wrapping a heading rejects with `Duplicate view-transition-name value while capturing old state`; `display: inline-block` on the same link is `ready-ok`. The old global height-based snapshot rule overlaps the sidebar mid-morph; the new `resource-page` class keeps the morph in the main panel.

[Grid before the morph](https://cursor.com/agents/bc-58dc21da-3f9b-41f6-8a56-0476e0bccf21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox-grid-before.png)
[Broken CSS mid-morph overlapping the sidebar](https://cursor.com/agents/bc-58dc21da-3f9b-41f6-8a56-0476e0bccf21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox-morph-broken-mid.png)
[firefox-page-transitions.mp4](https://cursor.com/agents/bc-58dc21da-3f9b-41f6-8a56-0476e0bccf21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox-page-transitions.mp4)

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed (`TESTING_COVERAGE.md`)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58dc21da-3f9b-41f6-8a56-0476e0bccf21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58dc21da-3f9b-41f6-8a56-0476e0bccf21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




Rebase validation (2026-09-12): rebased onto develop `5c5d7794c`, preserving current coverage and changelog entries. All 861 frontend tests, workspace type checks and full frontend lint pass. Real Firefox against the rebuilt local app and an isolated AtomicServer navigated from the drive to a folder with forceViewTransitions enabled; startViewTransition ready and finished both resolved, with zero page errors. The final screenshot was inspected. This proves transition execution and navigation, not a full visual review of every card-to-page morph.
