### PR TITLE
fix(vault): deterministic agent vault proof + sign-in offer when restore needs a session

### DIFF
--- a/browser/data-browser/src/helpers/agentStorage.ts
+++ b/browser/data-browser/src/helpers/agentStorage.ts
@@ -31,6 +31,16 @@ interface StoredAgent {
    * still readable.
    */
   privateDrive?: string;
+  /**
+   * The agent's Cloud Vault proof (see `Agent.vaultProof`). Stored for the
+   * same reason as `privateDrive`: WebKit's WebCrypto signs the fixed proof
+   * message differently every call, so the keypair beside it cannot reproduce
+   * the signature the vault keys were wrapped under. Readable here, but it is
+   * one input of two — the wrapped drive keys live on the control plane, behind
+   * the account session — and any script on this origin could already ask the
+   * non-extractable key to sign.
+   */
+  vaultProof?: string;
 }
 
 /**
@@ -45,6 +55,8 @@ interface StoredAgentFallback {
   initialDrive?: string;
   /** See {@link StoredAgent}. */
   privateDrive?: string;
+  /** See {@link StoredAgent}. */
+  vaultProof?: string;
 }
 
 const AGENT_FALLBACK_KEY = 'atomic.agent.fallback';
@@ -79,6 +91,7 @@ export async function getAgentFromIDB(): Promise<Agent | undefined> {
         );
         agent.legacySubject = storedAgent.legacySubject;
         agent.privateDrive = storedAgent.privateDrive;
+        agent.vaultProof = storedAgent.vaultProof;
 
         // Heal installs written while the readable key was saved
         // unconditionally: a plaintext copy beside a non-extractable key hands
@@ -109,6 +122,7 @@ export async function getAgentFromIDB(): Promise<Agent | undefined> {
       );
       agent.legacySubject = fallback.legacySubject;
       agent.privateDrive = fallback.privateDrive;
+      agent.vaultProof = fallback.vaultProof;
 
       return agent;
     } catch (e) {
@@ -188,6 +202,7 @@ export async function saveAgentToIDB(
       previous?.subject === subject ? previous.initialDrive : undefined,
     privateDrive:
       previous?.subject === subject ? previous.privateDrive : undefined,
+    vaultProof: previous?.subject === subject ? previous.vaultProof : undefined,
   } satisfies StoredAgent);
 }
 
@@ -202,6 +217,7 @@ async function storeSecret(secret: string): Promise<void> {
   // Derived here, once, from the raw key — the stored keypair cannot
   // reproduce it. See `StoredAgent.privateDrive`.
   const privateDrive = await Agent.privateDriveSubjectFromSecret(secret);
+  const vaultProof = await Agent.vaultProofFromSecret(secret);
 
   {
     // Prefer the non-extractable keypair. Once stored this way the private key
@@ -217,6 +233,7 @@ async function storeSecret(secret: string): Promise<void> {
           legacySubject: legacySubjectFromSecret(secret),
           initialDrive: decoded.initialDrive,
           privateDrive,
+          vaultProof,
         } satisfies StoredAgent);
         await del(AGENT_FALLBACK_KEY);
 
@@ -238,6 +255,7 @@ async function storeSecret(secret: string): Promise<void> {
       legacySubject: legacySubjectFromSecret(secret),
       initialDrive: decoded.initialDrive,
       privateDrive,
+      vaultProof,
     } satisfies StoredAgentFallback);
     // Drop a keypair from a previous account, so it can't be loaded instead.
     await del(AGENT_IDB_KEY);

--- a/browser/data-browser/src/helpers/managed/useVaultBackup.ts
+++ b/browser/data-browser/src/helpers/managed/useVaultBackup.ts
@@ -41,6 +41,12 @@ export type UseVaultBackup = {
   restore: () => Promise<RestoreOutcome | null>;
   /** 0–1 while a restore is downloading, otherwise null. */
   restoreProgress: number | null;
+  /**
+   * Re-read the enrollment and vault state. For a screen that knows something
+   * changed on the control-plane side that no store event reports — a session
+   * that did not exist when the first read said `unavailable`.
+   */
+  refresh: () => Promise<void>;
 };
 
 /**
@@ -319,5 +325,6 @@ export function useVaultBackup({
     backupNow,
     restore,
     restoreProgress,
+    refresh,
   };
 }

--- a/browser/data-browser/src/helpers/managed/vault.test.ts
+++ b/browser/data-browser/src/helpers/managed/vault.test.ts
@@ -1016,6 +1016,67 @@ describe('agentVaultProof', () => {
       await agentVaultProof(signer, MESSAGE),
     );
   });
+
+  /**
+   * WebKit's WebCrypto randomizes Ed25519 nonces, so a live signature there is
+   * different every call — and a KEK derived from it never matches the one the
+   * envelope was wrapped under. The proof computed from the raw key at sign-in
+   * is the one that counts, and the live signer is not consulted at all.
+   */
+  it('prefers the proof stored at sign-in over a live signature', async () => {
+    const stored = new Uint8Array(64).fill(7);
+    const signBytes = vi.fn(async () => btoa(String.fromCharCode(...new Uint8Array(64).fill(1))));
+    const signer = {
+      signBytes,
+      vaultProof: btoa(String.fromCharCode(...stored)),
+      signsDeterministically: false,
+    };
+
+    expect(await agentVaultProof(signer, MESSAGE)).toEqual(stored);
+    expect(signBytes).not.toHaveBeenCalled();
+  });
+
+  /** The stored proof is only good for the message it was made over. */
+  it('ignores the stored proof for a different message', async () => {
+    const live = new Uint8Array(64).fill(2);
+    const signer = {
+      ...signerReturning(live),
+      vaultProof: btoa(String.fromCharCode(...new Uint8Array(64).fill(7))),
+    };
+
+    expect(
+      await agentVaultProof(signer, new TextEncoder().encode('other')),
+    ).toEqual(live);
+  });
+
+  /**
+   * No stored proof and a signer that admits it is non-deterministic: the only
+   * way to know whether its signature is usable is to ask twice. A signature
+   * that does not reproduce itself must not be turned into a wrapper.
+   */
+  it('refuses a live signature that does not reproduce itself', async () => {
+    let n = 0;
+    const signer = {
+      signBytes: async () =>
+        btoa(String.fromCharCode(...new Uint8Array(64).fill(++n))),
+      signsDeterministically: false,
+    };
+
+    await expect(agentVaultProof(signer, MESSAGE)).rejects.toThrow(
+      /signs differently every time/,
+    );
+  });
+
+  it('accepts a live signature that does reproduce itself', async () => {
+    const signer = {
+      ...signerReturning(new Uint8Array(64).fill(3)),
+      signsDeterministically: false,
+    };
+
+    expect(await agentVaultProof(signer, MESSAGE)).toEqual(
+      new Uint8Array(64).fill(3),
+    );
+  });
 });
 
 describe('vaultLaneId', () => {

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -1,4 +1,4 @@
-import { decodeB64 } from '@tomic/lib';
+import { AGENT_VAULT_PROOF_MESSAGE, decodeB64 } from '@tomic/lib';
 import { managedFetch } from './api';
 
 /**
@@ -19,6 +19,10 @@ import { managedFetch } from './api';
 /** Signs the fixed derivation message. Satisfied by `@tomic/lib`'s `Agent`. */
 export type VaultProofSigner = {
   signBytes(data: Uint8Array): Promise<string>;
+  /** The proof computed from the raw key at sign-in, if the agent carries it. */
+  vaultProof?: string;
+  /** Whether `signBytes` is reproducible. Absent means unknown. */
+  signsDeterministically?: boolean;
 };
 
 /**
@@ -26,9 +30,19 @@ export type VaultProofSigner = {
  *
  * A signature over a fixed message, not the private key. The browser's
  * `CryptoProvider` exposes signing rather than key bytes — deliberately, so
- * hardware-backed and non-extractable keys stay possible — and Ed25519
- * signatures are deterministic, so any device holding the agent reproduces the
- * same proof and therefore the same key.
+ * hardware-backed and non-extractable keys stay possible. RFC 8032 Ed25519
+ * signatures are deterministic, which is what lets every device holding the
+ * agent reproduce the same proof and therefore the same key — but that is a
+ * property of the implementation, and WebKit's WebCrypto randomizes the nonce.
+ * A Safari session signing live got a fresh proof every call: enrolling there
+ * wrote a wrapper no device could open, and restoring there failed with "no
+ * wrapper in this envelope accepted that credential" against a backup made
+ * anywhere else.
+ *
+ * So the proof the agent computed from its raw key at sign-in wins when it has
+ * one. Without it, a live signature is only trusted once it has reproduced
+ * itself; a signer that cannot is refused rather than handed a key it will
+ * never derive again.
  *
  * It also has exactly one representation, unlike "the agent secret", which in
  * this codebase means the base64 blob, the `privateKey` inside it, or the
@@ -39,9 +53,32 @@ export async function agentVaultProof(
   signer: VaultProofSigner,
   proofMessage: Uint8Array,
 ): Promise<Uint8Array> {
-  const signature = new Uint8Array(
-    decodeB64(await signer.signBytes(proofMessage)),
-  );
+  if (
+    signer.vaultProof &&
+    bytesEqual(proofMessage, AGENT_VAULT_PROOF_MESSAGE)
+  ) {
+    return checkedSignature(signer.vaultProof);
+  }
+
+  const first = await signer.signBytes(proofMessage);
+
+  if (signer.signsDeterministically === false) {
+    const second = await signer.signBytes(proofMessage);
+
+    if (second !== first) {
+      throw new Error(
+        'This browser signs differently every time, so it cannot reproduce ' +
+          'the credential your backups are wrapped under. Sign in with your ' +
+          'recovery code or secret again on this browser to fix that.',
+      );
+    }
+  }
+
+  return checkedSignature(first);
+}
+
+function checkedSignature(signatureB64: string): Uint8Array {
+  const signature = new Uint8Array(decodeB64(signatureB64));
 
   if (signature.length !== 64) {
     throw new Error(
@@ -50,6 +87,10 @@ export async function agentVaultProof(
   }
 
   return signature;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((byte, i) => byte === b[i]);
 }
 
 /**

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
@@ -287,6 +287,9 @@ describe('restoreFromVault', () => {
       'no-backup',
     );
     expect(deps.listVaultDrives).not.toHaveBeenCalled();
+    // The database wait is the long one (up to 20s); a device with no session
+    // must not sit through it to hear "no".
+    expect(deps.db).not.toHaveBeenCalled();
   });
 
   it('is no-backup for a drive the account never enrolled', async () => {

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
@@ -330,13 +330,18 @@ export async function restoreFromVault(
   if (!agent?.subject) return { status: 'no-backup', reason: 'not signed in' };
 
   try {
-    const db = await deps.db(store);
-
-    if (!db) return { status: 'no-backup', reason: 'no local database' };
-
+    // Session first: one quick request, against a database wait of up to
+    // `CLIENT_DB_WAIT_MS`. Sign-in calls this on every device that holds no
+    // data, and a browser that never signed in to the account — the common
+    // case for a fresh one — should not sit on "Restoring…" for twenty seconds
+    // to be told there was nothing to ask.
     if (!(await deps.hasAccount())) {
       return { status: 'no-backup', reason: 'no account session' };
     }
+
+    const db = await deps.db(store);
+
+    if (!db) return { status: 'no-backup', reason: 'no local database' };
 
     const enrollment = (await deps.listVaultDrives()).find(
       e => e.drive_subject === driveSubject && e.status === 'active',

--- a/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
+++ b/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
@@ -4,6 +4,11 @@ import { FaMobileScreenButton, FaLock } from 'react-icons/fa6';
 import { useStore } from '@tomic/react';
 import { useDriveVault } from '../../helpers/managed/useDriveVault';
 import { listVaultDrives } from '../../helpers/managed/vault';
+import { getManagedAccount } from '../../helpers/managed/session';
+import { canHoldProviderCookie } from '../../helpers/managed/deviceLink';
+import { openExternal } from '../../helpers/openExternal';
+import { PRODUCT_NAME } from '../../helpers/managed/product';
+import { LinkProviderPanel } from '../../components/Vault/LinkProviderPanel';
 import { Button } from '../../components/Button';
 import { Column, Row } from '../../components/Row';
 import { PairingCode } from '../../components/PairingCode';
@@ -53,6 +58,12 @@ interface ConnectDeviceStepProps {
    * "no backup" situations this is instead of a generic shrug.
    */
   vaultReason?: string;
+  /**
+   * The control plane that keeps this account's backups, if the build or a
+   * server has named one. Without it there is no vault to ask and no account
+   * to sign in to, so the restore offer stays off the screen.
+   */
+  portalUrl: string | null;
   /** Enter the app anyway, without its data. */
   onSkip: () => void;
   /** The drive's data arrived — open it. */
@@ -78,6 +89,7 @@ interface ConnectDeviceStepProps {
 export function ConnectDeviceStep({
   drive,
   vaultReason,
+  portalUrl,
   onSkip,
   onConnected,
 }: ConnectDeviceStepProps): JSX.Element {
@@ -115,6 +127,23 @@ export function ConnectDeviceStep({
    */
   const [vaultDrive, setVaultDrive] = useState<string | undefined>(drive);
 
+  /**
+   * Whether this client holds a session with the control plane; `undefined`
+   * until asked. The vault is behind that session, so without one the screen
+   * below cannot see the backup this device most likely came here for — and
+   * the sign-in that just happened does not create one. A passkey or secret
+   * proves the agent; the account is a separate login, and a browser that has
+   * never visited the portal (or cleared its cookies) has none. That case used
+   * to render as "your data is on another device" with no way to fix it.
+   */
+  const [hasSession, setHasSession] = useState<boolean>();
+
+  /**
+   * Bumped once the user has signed in or linked, so the vault lookup below
+   * runs again without leaving the step.
+   */
+  const [sessionAttempt, setSessionAttempt] = useState(0);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -124,6 +153,15 @@ export function ConnectDeviceStep({
       if (cancelled) return;
 
       if (local) setVaultDrive(local);
+
+      const account = await getManagedAccount().catch(() => null);
+
+      if (cancelled) return;
+
+      setHasSession(account !== null);
+
+      // Nothing below can answer without a session; asking would only fail.
+      if (account === null) return;
 
       // The control plane knows which drives this account has backed up, and
       // asking it matters in two cases. With no drive name at all: a device
@@ -166,7 +204,7 @@ export function ConnectDeviceStep({
     return () => {
       cancelled = true;
     };
-  }, [drive, agent?.subject]);
+  }, [drive, agent?.subject, sessionAttempt]);
 
   const vault = useDriveVault(vaultDrive ?? null);
   // Only offer this when there is something to restore. Backup being on with
@@ -174,6 +212,22 @@ export function ConnectDeviceStep({
   // resources and leave the screen looking like it failed.
   const canRestoreFromVault =
     vault.status.state === 'on' && vault.status.details.confirmed_objects > 0;
+
+  /**
+   * The account session appeared (signed in on the portal in another tab, or
+   * linked this device). Ask the control plane again, from here: the vault
+   * lookup above and the hook's own status both answered "no session" and
+   * nothing they watch changes when a cookie or a token does.
+   */
+  function sessionArrived() {
+    setSessionAttempt(n => n + 1);
+    void vault.refresh();
+  }
+
+  // Offered when the vault cannot be consulted for want of a session, and only
+  // when there is somewhere to get one. Not shown once the session is there
+  // and the vault simply has nothing — that is what `vaultReason` is for.
+  const needsSession = hasSession === false && !!portalUrl;
 
   async function restoreFromVault() {
     const outcome = await vault.restore();
@@ -398,10 +452,52 @@ export function ConnectDeviceStep({
               situations answer "no backup" — no session, never enrolled,
               enrolled but never uploaded, … — and they want different fixes
               on the other device, so name it. */}
-          {!canRestoreFromVault && vaultReason && (
+          {!canRestoreFromVault && vaultReason && !needsSession && (
             <Explainer data-testid='vault-no-backup-reason'>
               Cloud Vault had nothing for this workspace: {vaultReason}.
             </Explainer>
+          )}
+
+          {/* The backup is behind the account, and signing in as the agent did
+              not sign in to the account. Say so, and offer the way in — before
+              the second-device routes, because for someone who has a backup
+              this is the only route that needs nothing else. Two ways to get
+              a session, one per client (see the restore step): a page on the
+              portal's site signs in there and keeps the cookie; the apps and
+              a self-hosted origin cannot, and link this device instead. */}
+          {!canRestoreFromVault && needsSession && (
+            <VaultOffer data-testid='vault-needs-session'>
+              <Explainer>
+                {`Your backup, if you made one, is kept by your ${PRODUCT_NAME} account — and this browser isn’t signed in to it.`}
+              </Explainer>
+              {canHoldProviderCookie(portalUrl) ? (
+                <Row gap='0.5rem' justify='center' wrapItems>
+                  <Button
+                    type='button'
+                    data-testid='vault-sign-in'
+                    onClick={() => {
+                      // A new tab, not a redirect: the sign-in is a magic
+                      // link that lands on the portal, and this screen is
+                      // where the restore happens. Leaving it means finding
+                      // the way back through Sync.
+                      void openExternal(
+                        new URL('/signin', portalUrl!).toString(),
+                      );
+                    }}
+                  >
+                    {`Sign in to ${PRODUCT_NAME}`}
+                  </Button>
+                  <Button type='button' subtle onClick={sessionArrived}>
+                    I’ve signed in
+                  </Button>
+                </Row>
+              ) : (
+                <LinkProviderPanel
+                  portalUrl={portalUrl}
+                  onLinked={sessionArrived}
+                />
+              )}
+            </VaultOffer>
           )}
 
           {/* First, because it is the only route that needs nothing but this

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -1066,6 +1066,7 @@ export function GettingStartedFlow({
           <ConnectDeviceStep
             drive={missingDrive}
             vaultReason={missingDriveVaultReason}
+            portalUrl={knownPortalUrl}
             onConnected={target => {
               setDrive(target);
               navigate(constructOpenURL(target));

--- a/browser/lib/src/agent.test.ts
+++ b/browser/lib/src/agent.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import { Agent } from './agent.js';
 import { decodeB64 } from './base64.js';
 import { JSCryptoProvider, legacySubjectFromSecret } from './CryptoProvider.js';
-import { privateDriveSubject } from './genesis.js';
+import { AGENT_VAULT_PROOF_MESSAGE, privateDriveSubject } from './genesis.js';
 
 describe('Agent', () => {
   const validPrivateKey = 'CapMWIhFUT+w7ANv9oCPqrHrwZpkP2JhzF9JnyT6WcI=';
@@ -56,6 +56,26 @@ describe('Agent', () => {
     expect(first).toBe(await privateDriveSubject(decodeB64(validPrivateKey)));
     expect(first.startsWith('did:ad:')).toBe(true);
     expect(first.startsWith('did:ad:agent:')).toBe(false);
+  });
+
+  /**
+   * The vault proof is key material: `agent_secret_kek` on the server derives
+   * the key that wraps a drive's vault key from it. So it must be the RFC 8032
+   * deterministic signature — the one a `js` agent produces — regardless of
+   * which provider the agent ends up with, and it must survive re-derivation.
+   */
+  it('derives the vault proof deterministically from the secret', async ({
+    expect,
+  }) => {
+    const secret = Agent.buildSecret(validPrivateKey, validSubject);
+    const jsAgent = Agent.fromSecret(secret, 'js');
+
+    const fromSecret = await Agent.vaultProofFromSecret(secret);
+    expect(fromSecret).toBe(await Agent.vaultProofFromSecret(secret));
+    expect(fromSecret).toBe(
+      await jsAgent.signBytes(AGENT_VAULT_PROOF_MESSAGE),
+    );
+    expect(decodeB64(fromSecret)).toHaveLength(64);
   });
 });
 

--- a/browser/lib/src/agent.ts
+++ b/browser/lib/src/agent.ts
@@ -10,9 +10,11 @@ import {
 import { decodeB64 } from './base64.js';
 import { AtomicError, ErrorType } from './error.js';
 import {
+  AGENT_VAULT_PROOF_MESSAGE,
   encodeGenesisCert,
   privateDriveCert,
   privateDriveSubject as derivePrivateDriveSubject,
+  signBytesWithKey,
   subjectForSignature,
 } from './genesis.js';
 import { core } from './ontologies/core.js';
@@ -45,6 +47,15 @@ export class Agent implements AgentInterface {
    * session still knows which drive is its home.
    */
   public privateDrive?: string;
+  /**
+   * The agent's Cloud Vault proof: its signature over
+   * {@link AGENT_VAULT_PROOF_MESSAGE}, base64url. Same story as
+   * {@link privateDrive} — a key that wraps a vault key is derived from this
+   * signature, so it has to be the same bytes on every device and every day,
+   * and WebKit's WebCrypto produces a different signature each call. Computed
+   * once from the raw key at sign-in and carried with the agent.
+   */
+  public vaultProof?: string;
 
   #cryptoProvider: CryptoProvider;
 
@@ -96,6 +107,7 @@ export class Agent implements AgentInterface {
           // non-extractable, and this provider cannot reproduce the subject.
           agent.privateDrive =
             await Agent.privateDriveSubjectFromSecret(secretB64);
+          agent.vaultProof = await Agent.vaultProofFromSecret(secretB64);
 
           resolve(agent);
         })
@@ -222,6 +234,30 @@ export class Agent implements AgentInterface {
     const { privateKey } = decodeSecret(secretB64);
 
     return derivePrivateDriveSubject(new Uint8Array(decodeB64(privateKey)));
+  }
+
+  /**
+   * The vault proof implied by a raw private key: a deterministic (RFC 8032)
+   * signature over {@link AGENT_VAULT_PROOF_MESSAGE}. Like
+   * {@link privateDriveSubjectFromSecret}, only possible while the secret is in
+   * hand.
+   */
+  public static async vaultProofFromSecret(secretB64: string): Promise<string> {
+    const { privateKey } = decodeSecret(secretB64);
+
+    return signBytesWithKey(
+      AGENT_VAULT_PROOF_MESSAGE,
+      new Uint8Array(decodeB64(privateKey)),
+    );
+  }
+
+  /**
+   * Whether `signBytes` gives the same signature for the same bytes each time.
+   * False for WebCrypto providers (WebKit randomizes Ed25519 nonces); anything
+   * that derives a key or identity from a signature must not rely on one.
+   */
+  public get signsDeterministically(): boolean {
+    return this.#cryptoProvider.signsDeterministically;
   }
 
   public createSignature(subject: string, timestamp: number): Promise<string> {

--- a/browser/lib/src/genesis.ts
+++ b/browser/lib/src/genesis.ts
@@ -223,10 +223,28 @@ export async function signGenesisCert(
   cert: GenesisCert,
   privateKey: Uint8Array,
 ): Promise<string> {
-  const signature = await sign(encodeGenesisCert(cert), privateKey);
-
-  return encodeB64Url(signature);
+  return signBytesWithKey(encodeGenesisCert(cert), privateKey);
 }
+
+/** Sign `data` with a raw 32-byte Ed25519 private key, RFC 8032 deterministic.
+ *  Returns the base64url signature. */
+export async function signBytesWithKey(
+  data: Uint8Array,
+  privateKey: Uint8Array,
+): Promise<string> {
+  return encodeB64Url(await sign(data, privateKey));
+}
+
+/**
+ * The bytes an agent signs to prove itself to Cloud Vault; the signature is
+ * what its key-encryption key is derived from. Mirrors
+ * `atomic_lib::vault::secret_envelope::AGENT_VAULT_PROOF_MESSAGE` and must
+ * never change: every stored vault-key envelope was wrapped under a signature
+ * over exactly these bytes.
+ */
+export const AGENT_VAULT_PROOF_MESSAGE: Uint8Array = new TextEncoder().encode(
+  'atomic-vault-key-derivation-v1',
+);
 
 /** Verify a base64 `signature` against the certificate's signer pubkey. The
  *  caller separately confirms `subjectForSignature(signature)` equals the


### PR DESCRIPTION
## Problem

Restoring a drive with the key in Safari failed with *"no wrapper in this envelope accepted that credential"*, while the same envelope opened fine in Zen and on the phone.

The vault key envelope's `AgentSecret` wrapper is keyed by `agent_secret_kek(proof)`, where `proof` is the agent's Ed25519 signature over `atomic-vault-key-derivation-v1`. `agentVaultProof` obtained that signature from the signed-in agent's crypto provider — which, on WebKit, is WebCrypto with a randomized Ed25519 nonce. Every call yields a different valid signature, so the derived KEK never matches the one the envelope was wrapped under. Worse, a drive first enrolled from Safari got a wrapper nobody (Safari included) can ever open.

## Fix

Same pattern as `privateDrive`: the proof is computed **once from the raw key at sign-in** with noble (RFC 8032 deterministic, matching `ed25519_dalek` server-side) in `Agent.fromSecret`, persisted in IDB next to the non-extractable keypair (`StoredAgent.vaultProof`), and restored with the agent. `agentVaultProof` uses it when present.

Without a stored proof (a session signed in before this change) a live signature is trusted only if signing twice reproduces it; otherwise a clear error tells the user to sign in again on this browser rather than silently writing an unopenable wrapper.

- `@tomic/lib`: `AGENT_VAULT_PROOF_MESSAGE`, `signBytesWithKey`, `Agent.vaultProof` / `vaultProofFromSecret` / `signsDeterministically`.
- data-browser: `agentStorage` persists/loads the proof; `agentVaultProof` prefers it.

## Not in this PR

Envelopes already written by a WebKit session are unrecoverable (the drive key only lived in that session's memory). Those drives need a vault reset/re-key path; none of Joep's known enrollments (`0I5r…`, `OIHM…`) were made from Safari.

## Tests

- lib: `vaultProofFromSecret` is stable and equals the `js`-provider signature.
- data-browser: stored proof wins and the live signer is not called; stored proof ignored for another message; non-reproducing signer rejected; reproducing signer accepted.

https://claude.ai/code/session_019asLKBrBWY5ovyeCgtmdSd

---

## Second commit: no account session after passkey/secret sign-in

Joep's other observation on the same Safari session: signed in with the passkey, long wait, then *"Your data is on another device"* although backups exist — because Safari had no portal session. `ConnectDeviceStep` now checks the session first and, when none exists but a portal is known, offers to sign in on the portal (new tab + "I've signed in" re-check) or, where this origin cannot hold the cookie, the device-link panel. `restoreFromVault` checks the session before waiting up to 20s for the ClientDb.

Smoke-tested locally (`VITE_MANAGED_PORTAL_URL=https://staging.atomicserver.eu`, throwaway secret, no session): the step renders the link-panel branch in ~0.5s.

## Third commit: the connect-device screen, simplified

One way in per screen: restore from the backup when it is in reach, sign in to / link the account that keeps it when it is not, and only failing both the second-device routes — which now fold under "…or bring it over from another device". `LinkProviderPanel` gets a `compact` mode (button + code, no card) and a readable network error.

## Follow-up

Skipping the account step entirely would need the control plane to know the agent's public key at enrollment and accept a signed challenge for a session (agent-key sign-in). Not in this PR.
