### PR TITLE
Optional NextGraph mirror, as one imported component

### DIFF
--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -100,7 +100,8 @@
     "workbox-window": "^7.4.1",
     "wuchale": "^0.25.6",
     "yjs": "^13.6.30",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@tomic/ng-bridge-react": "link:../../../atomic-ng-bridge/packages/ui"
   },
   "devDependencies": {
     "@tanstack/router-devtools": "^1.167.0",

--- a/browser/data-browser/src/App.tsx
+++ b/browser/data-browser/src/App.tsx
@@ -205,6 +205,7 @@ bootstrap(store);
 // user explicitly opted out via the Sync page toggle.
 import { initClientDb } from './helpers/initClientDb';
 import { isClientDbEnabled } from './helpers/clientDbMode';
+import { NgBridgeBadge } from '@tomic/ng-bridge-react';
 
 if (isClientDbEnabled()) {
   initClientDb(store);
@@ -264,6 +265,10 @@ function App(): JSX.Element {
     <StoreContext.Provider value={store}>
       <PerformanceProfiler id='app'>
         <RouterProvider router={router}></RouterProvider>
+        {/* Mirrors a local-only drive into NextGraph. Renders nothing, and
+            loads nothing, unless enabled with `?ngbridge=1`. All NextGraph code
+            lives in @tomic/ng-bridge-react and its siblings, never here. */}
+        <NgBridgeBadge store={store} />
       </PerformanceProfiler>
     </StoreContext.Provider>
   );

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -100,6 +100,7 @@ import { appRoute } from './RootRoutes';
 import { pathNames, paths } from './paths';
 import { useSettings } from '../helpers/AppSettings';
 import { serverURLStorage } from '../helpers/serverURLStorage';
+import { NgSyncPanel } from '@tomic/ng-bridge-react';
 
 export const SyncRoute = createRoute({
   path: pathNames.sync,
@@ -1308,6 +1309,10 @@ function SyncPage() {
       <ContainerNarrow>
         <h1>Sync</h1>
         <Lead>{summaryLine()}</Lead>
+
+        {/* Where this workspace stands with NextGraph. Renders its own card and
+            reads its own state; this page knows nothing about NextGraph. */}
+        <NgSyncPanel store={store} />
 
         {/* Everything our paid services own, in one card.
 

--- a/browser/data-browser/vite.config.ts
+++ b/browser/data-browser/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { oxcReactCompiler } from './oxcReactCompilerPlugin';
@@ -17,6 +17,30 @@ import { execSync } from 'node:child_process';
 // outDir so the server build keeps its own nonce'd dist.
 const isTauri = process.env.TAURI === '1';
 const isVitest = process.env.VITEST === 'true';
+
+// Where the optional NextGraph mirror lives, when it is linked from a sibling
+// checkout rather than installed.
+//
+// It ships TypeScript sources and runs its wasm engine in a module worker.
+// Vite serves that worker entry over `/@fs/…` as a separate request, and
+// refuses any path outside the workspace root — so without this the worker
+// 403s, the mirror falls back to running the engine on the main thread, and
+// nothing says why. Installed from a registry it sits in `node_modules` and
+// none of this applies.
+function ngBridgeRoots(): string[] {
+  try {
+    // `<bridge>/packages/ui` → `<bridge>`, so the engine package beside it is
+    // covered too.
+    const linked = fs.realpathSync(
+      path.resolve(__dirname, 'node_modules/@tomic/ng-bridge-react'),
+    );
+
+    return [path.resolve(linked, '../..')];
+  } catch {
+    // Not installed, or not linked. Then there is no worker to serve.
+    return [];
+  }
+}
 
 // Source maps are 28MB of the 48MB dist -- and that dist is compiled into the
 // atomic-server binary by build.rs, so every user downloads ~60% debugging
@@ -314,6 +338,19 @@ export default defineConfig({
         theme: 'default',
       }),
   ],
+  // The optional NextGraph mirror runs its wasm engine in a module worker, so
+  // `vite-plugin-wasm` has to apply to worker builds too — `plugins` here is
+  // deliberately separate from the array above and does not inherit it.
+  // Without this the worker fails to build and the mirror silently falls back
+  // to running the engine on the main thread, where a long SPARQL call
+  // competes with rendering.
+  //
+  // Costs nothing when the mirror is not enabled: no worker is spawned, so no
+  // worker bundle is produced.
+  worker: {
+    format: 'es',
+    plugins: () => [wasm()],
+  },
   optimizeDeps: {
     // React Compiler emits `import { c as _c } from "react/compiler-runtime"`
     // in every memoised component. Without this hint, Vite only discovers
@@ -398,7 +435,15 @@ export default defineConfig({
     // directly, so every watch rebuild shows up on a plain reload (the documented
     // workspace-link workaround). They don't drag in WASM/ProseMirror, so there's
     // no single-instance concern like `loro-crdt` below.
-    exclude: ['loro-crdt', '@tomic/lib', '@tomic/react'],
+    exclude: [
+      'loro-crdt',
+      '@tomic/lib',
+      '@tomic/react',
+      // Same rule as `loro-crdt` above, for the same reason: a WASM dep that
+      // esbuild prebundles has its init hang forever rather than fail. Only
+      // reached when the NextGraph mirror is enabled.
+      '@ng-org/lib-wasm',
+    ],
     //
     // Vite's boot-time dep scan only follows static imports from index.html, so
     // it never sees the deps behind `React.lazy` chunks (RTE/tiptap, AI SDK,
@@ -448,6 +493,11 @@ export default defineConfig({
     strictPort: true,
     host: true,
     allowedHosts: ['.tunn.dev', 't-1sk9qbdw.tunn.dev'],
+    fs: {
+      // Setting this replaces Vite's default rather than extending it, so the
+      // workspace root has to be listed explicitly alongside the addition.
+      allow: [searchForWorkspaceRoot(process.cwd()), ...ngBridgeRoots()],
+    },
     // Pre-transform the lazy AI chunk's source graph in the background at
     // boot, so the first time the sidebar opens its modules are already
     // through the React Compiler pass instead of being transformed on-demand

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 9.1.7
       netlify-cli:
         specifier: 26.0.2
-        version: 26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.5)(rollup@4.60.4)
+        version: 26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.4)(rollup@4.60.4)
       oxfmt:
         specifier: ^0.51.0
         version: 0.51.0(svelte@5.55.9(@typescript-eslint/types@8.60.0))
@@ -240,6 +240,9 @@ importers:
       '@tomic/lib':
         specifier: workspace:*
         version: link:../lib
+      '@tomic/ng-bridge-react':
+        specifier: link:../../../atomic-ng-bridge/packages/ui
+        version: link:../../../atomic-ng-bridge/packages/ui
       '@tomic/plugin':
         specifier: workspace:*
         version: link:../plugin
@@ -11974,7 +11977,7 @@ snapshots:
       yaml: 2.9.0
       yargs: 17.7.2
 
-  '@netlify/build@35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.5)(rollup@4.60.4)':
+  '@netlify/build@35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.4)(rollup@4.60.4)':
     dependencies:
       '@bugsnag/js': 8.9.0
       '@netlify/blobs': 10.7.8(supports-color@10.2.2)
@@ -11993,7 +11996,7 @@ snapshots:
       ansis: 4.3.0
       clean-stack: 5.3.0
       execa: 8.0.1
-      fdir: 6.5.0(picomatch@4.0.5)
+      fdir: 6.5.0(picomatch@4.0.4)
       figures: 6.1.0
       filter-obj: 6.1.0
       hot-shots: 11.4.0
@@ -18022,13 +18025,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  netlify-cli@26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.5)(rollup@4.60.4):
+  netlify-cli@26.0.2(@swc/core@1.15.40)(@types/node@25.9.1)(idb-keyval@6.2.4)(picomatch@4.0.4)(rollup@4.60.4):
     dependencies:
       '@fastify/static': 9.1.3
       '@netlify/ai': 0.4.1
       '@netlify/api': 14.0.19
       '@netlify/blobs': 10.7.8(supports-color@10.2.2)
-      '@netlify/build': 35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.5)(rollup@4.60.4)
+      '@netlify/build': 35.13.6(@opentelemetry/api@1.9.1)(@swc/core@1.15.40)(@types/node@25.9.1)(picomatch@4.0.4)(rollup@4.60.4)
       '@netlify/build-info': 10.5.1
       '@netlify/config': 24.5.1
       '@netlify/dev': 4.18.6(@types/node@25.9.1)(idb-keyval@6.2.4)(rollup@4.60.4)


### PR DESCRIPTION
Adds @tomic/ng-bridge-react (from the sibling [atomic-ng-bridge](https://github.com/ontola/atomic-ng-bridge) repo) and mounts its badge next to the router, plus its panel on the Sync page. That component mirrors the current local-only drive into a NextGraph document, live, with no AtomicServer in the loop.

Deliberately the whole footprint in this repo: every piece of NextGraph code lives in the imported package. It renders nothing, and loads nothing, unless enabled with `?ngbridge=1`. Dropping the mirror is reverting this commit.

Vite needs three things for it, each found by running it rather than reading:

- `worker.plugins` applies `vite-plugin-wasm` to worker builds. It does not inherit from the main plugin array, and without it the worker fails to build and the mirror silently falls back to running its wasm on the main thread, where a long query competes with rendering.
- `server.fs.allow` includes the mirror's checkout when it is linked from a sibling directory. Vite serves the worker entry over `/@fs/` as its own request and refuses paths outside the workspace root, so the worker 403s. Installed from a registry it lives in node_modules and none of this applies.
- `@ng-org/lib-wasm` joins `optimizeDeps.exclude`, for the reason this file already documents for loro-crdt: a wasm dep that esbuild prebundles has its init hang forever rather than fail.

All three are inert when the mirror is not enabled.

## Related Issues

closes #number

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [ ] Update docs if needed
