### PR TITLE
chore(release): bump to v0.41.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+## [v0.41.0-beta.5] - 2026-09-04
+
 - **Local full-text search** in `atomic_lib` (`lib/src/search/`): a KV inverted
   index on the existing redb / sled / BTreeMap (OPFS) store. Indexes title,
   description, and Loro document body on every commit; queries AND tokens,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 dependencies = [
  "assert_cmd",
  "async-recursion",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 dependencies = [
  "actix",
  "actix-cors",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server-tauri"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 dependencies = [
  "actix-rt",
  "android_system_properties",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "atomic_lib"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 dependencies = [
  "anyhow",
  "argon2",

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+## [v0.41.0-beta.5] - 2026-09-04
+
 - `@tomic/lib`: `Store.search` uses the durable WASM/OPFS inverted index
   (`ClientDb.search`) for local hits, including `filters`. The MiniSearch
   in-memory index is removed. Online searches merge with hosted `/search`
@@ -11,6 +13,41 @@ This changelog covers all five packages, as they are (for now) updated as a whol
   `ClientDbWorker.search` / `NodeClientDb.search` added. Removed
   `escapeTantivyKey` — `filters=` is exact `property:"value"` pairs, no
   query language.
+- Fix: [#1358](https://github.com/atomicdata-dev/atomic-server/issues/1358)
+  Cloud Vault restore on Safari (and any WebCrypto signer) failed with "no
+  wrapper in this envelope accepted that credential". The agent vault proof
+  asked the signed-in agent's provider for a signature, which on WebKit is
+  WebCrypto with a randomized nonce — a different valid signature every
+  call, so the KEK never matched. The proof is now derived once with noble
+  (RFC 8032, matching the server) from the raw key at sign-in and persisted
+  beside the keypair. When no stored proof exists, a live signature is only
+  accepted if signing twice reproduces it.
+- Fix: signing in with a passkey or secret on a browser that has no
+  control-plane session no longer ends on "Your data is on another device"
+  with nothing to do. The connect-device step checks for a session first
+  and, when there is none, offers sign-in on the portal (or the device-link
+  panel in a webview that cannot hold the cookie).
+- Onboarding: the connect-device screen names one way in — restore from the
+  backup, sign in to the account that keeps it, or the second-device routes
+  — and folds the rest under "…or bring it over from another device".
+- Sidebar drive switcher is a two-part control: the drive's emoji or icon
+  (home for the private drive) plus its name, both halves bordered like a
+  segmented button.
+- Quick-create class shortcuts reveal on hover and stay hidden on touch
+  (the New page still has them).
+- [#1338](https://github.com/atomicdata-dev/atomic-server/issues/1338) Title
+  row on touch and narrow screens: the Add icon / Add cover ghost buttons
+  next to a page title only render where the viewport can hover and is at
+  least 600px wide; elsewhere they appear in the resource context menu.
+- Title editor wraps like the heading (a textarea that grows with the text)
+  instead of becoming a single-line input that scrolls sideways. Clicking a
+  title places the caret under the pointer instead of selecting the whole
+  title (a freshly created resource still selects its placeholder). The
+  go-to-parent arrow on narrow nav bars is gone.
+- The unsaved-changes asterisk is gone. Autosaving editors set the dirty
+  flag between every keystroke and its commit, so it blinked on every tap
+  and told the user nothing; the sidebar sync item already spins while
+  commits are in flight.
 - `@tomic/lib` live collaboration speaks binary `EPHEMERAL`. Edits in progress, cursors and drive presence are sent and received as `EPHEMERAL (0x40)` frames (`encodeEphemeral` / `decodeEphemeral`, `EphemeralKind`), raw bytes instead of base64 JSON in the `LORO_SYNC_UPDATE` / `LORO_EPHEMERAL_UPDATE` / `PRESENCE_UPDATE` text frames, which are gone. `WSClient.sendLoroSyncUpdate`, `sendLoroEphemeralUpdate` and `sendPresenceUpdate` now take `(subject, bytes)`; `Store.__handleLoroSyncMessage`, `__handleLoroEphemeralMessage` and `__handlePresenceMessage` take `(subject, bytes)`. The subscribe / unsubscribe frames are still text.
 - `@tomic/lib` drive sync speaks binary `SYNC`. The hash-first probe on connect and the reduced reconcile after the RBSR descent are sent as `SYNC (0x30)` with `"probe": true` / `"subjects": [...]` in the JSON tail, and a stale probe is answered with the new `SYNC_RESEND (0x38)` (`decodeSyncResend`, `Tag.SYNC_RESEND`). The text `SYNC_VV` request and text `SYNC_RESEND` answer are gone; the `RBSR_FP` / `RBSR_ITEMS` descent is still text. Servers advertise `sync-probe`; an older server ignores the two keys and runs a full reconcile.
 - `@tomic/lib` cleanup. Switching drives now `UNSUB`s the previous drive's fan-out (until now every drive opened in a session kept pushing its commits to the socket). `Store.waitForServerConnected(timeoutMs)` is public and is the one implementation of a wait that existed four times over (`Collection` and two data-browser helpers now use it). Removed: the write-only `serverHasCapability` / `getServerWsCapabilities` cache (the live list is `WSClient.serverCapabilities`), `Store.logIncomingCommit`, the `debugFrame` codec helper and the exported `supportsWebSockets` (all without callers), and a skipped integration test targeting APIs that no longer exist. Liveness constants moved to `liveness.ts`.

--- a/browser/cli/package.json
+++ b/browser/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/js-cli",
   "repository": {

--- a/browser/create-template/package.json
+++ b/browser/create-template/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/create-template/atomic-template",
   "repository": {

--- a/browser/create-template/templates/nextjs-site/package.json
+++ b/browser/create-template/templates/nextjs-site/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.11.1",
-    "@tomic/lib": "^0.41.0-beta.4",
-    "@tomic/react": "^0.41.0-beta.4",
+    "@tomic/lib": "^0.41.0-beta.5",
+    "@tomic/react": "^0.41.0-beta.5",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "loro-crdt": "^1.12.1",
@@ -25,7 +25,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@tomic/cli": "^0.41.0-beta.4",
+    "@tomic/cli": "^0.41.0-beta.5",
     "@types/node": "^20",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/browser/create-template/templates/sveltekit-site/package.json
+++ b/browser/create-template/templates/sveltekit-site/package.json
@@ -18,7 +18,7 @@
 		"@sveltejs/adapter-node": "^5.2.9",
 		"@sveltejs/kit": "^2.7.3",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
-		"@tomic/cli": "^0.41.0-beta.4",
+		"@tomic/cli": "^0.41.0-beta.5",
 		"@types/eslint": "^9.6.1",
 		"eslint": "^9.13.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -37,8 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@tomic/lib": "^0.41.0-beta.4",
-		"@tomic/svelte": "^0.41.0-beta.4",
+		"@tomic/lib": "^0.41.0-beta.5",
+		"@tomic/svelte": "^0.41.0-beta.5",
 		"loro-crdt": "^1.12.1",
 		"svelte-markdown": "^0.4.1"
 	},

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "author": {
     "email": "joep@ontola.io",
     "name": "Joep Meindertsma"

--- a/browser/e2e/package.json
+++ b/browser/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/e2e",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "private": true,
   "homepage": "https://atomicdata.dev/",
   "license": "MIT",

--- a/browser/edit-mode/package.json
+++ b/browser/edit-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/edit-mode",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "description": "Turn any page rendered from Atomic Data into an editable local-first clone: 'Edit this page' for visitors (guest agent + local-only drive, zero server writes) and inline-editing UI chrome.",
   "type": "module",
   "license": "MIT",

--- a/browser/lib/package.json
+++ b/browser/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/lib",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "author": "Joep Meindertsma",
   "homepage": "https://docs.atomicdata.dev/js",
   "repository": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -14,7 +14,7 @@
     "vitest": "^4.1.7"
   },
   "name": "@tomic/root",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/browser/plugin/package.json
+++ b/browser/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tomic/plugin",
   "type": "module",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "description": "Utils for building UI plugins for AtomicServer",
   "author": "Polle Pas <polle@ontola.io>",
   "license": "MIT",

--- a/browser/react/package.json
+++ b/browser/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/react",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "author": "Joep Meindertsma",
   "description": "Atomic Data React library",
   "homepage": "https://docs.atomicdata.dev/usecases/react",

--- a/browser/svelte/package.json
+++ b/browser/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ontola, Polle Pas",
   "name": "@tomic/svelte",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "license": "MIT",
   "homepage": "https://docs.atomicdata.dev/svelte",
   "repository": {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT"
 name = "atomic-cli"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 
 [dependencies]
 async-recursion = "1.1.1"
-atomic_lib = { version = "0.41.0-beta.4", path = "../lib", features = [
+atomic_lib = { version = "0.41.0-beta.5", path = "../lib", features = [
     "config",
     "rdf",
 ] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ name = "atomic-server-tauri"
 # crates.io forbids — see the note on `publish` in ../wasm/Cargo.toml.
 publish = false
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Atomic Server",
-  "version": "0.41.0-beta.4",
+  "version": "0.41.0-beta.5",
   "identifier": "io.ontola.atomicserver",
   "build": {
     "frontendDist": "../browser/data-browser/dist-tauri",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "atomic_lib"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "atomic-server"
 readme = "./README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 
 [[bin]]
 name = "atomic-server"
@@ -168,7 +168,7 @@ version = "4.13.0"
 # present, so it adds no runtime cost for fresh installs.
 features = ["config", "db-redb", "db-sled", "rdf", "discovery", "iroh", "ring", "ws"]
 path = "../lib"
-version = "0.41.0-beta.4"
+version = "0.41.0-beta.5"
 
 [dependencies.clap]
 features = ["derive", "env", "cargo"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Version bump across crates, `@tomic/*` packages and the Tauri config; changelog headings dated 2026-09-04.

This cut includes:

- **Local full-text search** — KV inverted index in `atomic_lib` (BM25 + 1-edit prefix fuzzy). Tantivy and MiniSearch are gone; hosted `/search` and the browser use the same engine.
- **Sync protocol** — binary `EPHEMERAL` and `SYNC` on both transports, one `SUB` frame, challenge-bound `AUTH`, slim `COMMIT_OK`, keepalive, capability advertisement.
- **Cloud Vault / onboarding** — deterministic agent vault proof (Safari restore, #1358), session offer when restore needs an account, one way in per connect-device screen.
- **Data-browser** — title editor caret/wrap/narrow-screen fixes (#1338), drive switcher, hover-only quick-create, no unsaved-changes asterisk.
- Tauri Android ships `arm64-v8a` only.

Tag `v0.41.0-beta.5` follows the merge. Pre-release tags do not deploy production or live docs.

## Checklist
- [x] Changelog entries for the version about to be tagged
- [x] All 15 version sites agree (`node scripts/bump-version.mjs --check 0.41.0-beta.5`)
- [x] `Cargo.lock` regenerated with `cargo update --workspace`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6981c818-316e-41bd-9ddc-bc88868efd8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6981c818-316e-41bd-9ddc-bc88868efd8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

