### PR TITLE
Finish unified actions: ⌘K, hotkeys, shortcuts page, AI tools

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -322,6 +322,19 @@ is only kept in step by mirroring the tests, so do that deliberately.
 derivation (`personal_drive_subject` / `personalDriveSubject`). The cross-lang
 vector (`personal_drive_cross_lang_vector`) pins the nonce, signature, and DID.
 
+## Unified actions
+
+| Flow | Layer | Where |
+|---|---|---|
+| ⌘K action section: prefix/keyword match, cap, `available`/`disabled`, no mid-word / resource-name hits | glue | `browser/data-browser/src/actions/matchActions.test.ts` |
+| Shortcuts overlay / `/app/shortcuts` list equals `appActions` + `resourceActions` that carry a shortcut | glue | `browser/data-browser/src/actions/catalog.test.ts` |
+| `asTool` verbs derive AI tools; `execute` calls `run` and respects `available` | glue | `browser/data-browser/src/actions/deriveTools.test.ts` |
+| ⌘K shows a matching action and runs it; a resource-name query shows none | flow | `browser/e2e/tests/command-palette-actions.spec.ts` |
+| `?` overlay lists registry shortcuts; `\` toggles the sidebar | flow | `browser/e2e/tests/shortcuts.spec.ts` |
+| ⌘M searchable menu + ⌘↑ parent from the registry | flow | `browser/e2e/tests/resource-context-menu.spec.ts` |
+
+Not covered: derived AI tools invoked through a real model; MCP protocol projection (no Atomic MCP server yet); collapsing specialized `destroy()` call sites (table rows, views, tags) onto the resource delete action.
+
 ## Documents
 
 | Flow | Layer | Where |

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- [#1232](https://github.com/ontola/atomic-server/issues/1232) Unified
+  actions: the ⌘K palette shows a capped Actions section for the current
+  resource, hotkeys and the shortcuts overlay/page render from the action
+  registry, and simple verbs (`delete`, `favorite`, `share`, `history`)
+  derive in-app AI tools.
+
 ## [v0.41.0-beta.5] - 2026-09-04
 
 - `@tomic/lib`: `Store.search` uses the durable WASM/OPFS inverted index

--- a/browser/data-browser/src/actions/appActions.ts
+++ b/browser/data-browser/src/actions/appActions.ts
@@ -1,0 +1,96 @@
+import { paths } from '../routes/paths';
+import {
+  openSearchOverlay,
+  openShortcutsOverlay,
+} from '../components/overlayState';
+import { shortcuts } from './shortcuts';
+import type { ActionDefinition } from './types';
+
+/**
+ * App-level actions (no target resource). Their shortcuts used to live only
+ * in HotKeyWrapper; the help page and ⌘K now project this same list.
+ */
+export const appActions: ActionDefinition[] = [
+  {
+    id: 'search',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Open search',
+    helper: () => 'Open the command palette to find resources and run actions.',
+    keywords: ['find', 'palette', 'command'],
+    shortcut: shortcuts.search,
+    run: () => openSearchOverlay(),
+  },
+  {
+    id: 'keyboardShortcuts',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Show keyboard shortcuts',
+    helper: () => 'Open the list of keyboard shortcuts.',
+    keywords: ['hotkeys', 'keys', 'help'],
+    shortcut: shortcuts.keyboardShortcuts,
+    run: () => openShortcutsOverlay(),
+  },
+  {
+    id: 'home',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Go home',
+    helper: () => 'Open the home page.',
+    keywords: ['start', 'root'],
+    shortcut: shortcuts.home,
+    run: ctx => ctx.navigate('/'),
+  },
+  {
+    id: 'new',
+    scope: 'app',
+    section: 'action',
+    label: () => 'New resource',
+    helper: () => 'Create a new resource.',
+    keywords: ['create'],
+    shortcut: shortcuts.new,
+    run: ctx => ctx.navigate(paths.new),
+  },
+  {
+    id: 'menu',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Open menu',
+    helper: () => 'Open the actions menu for the current resource.',
+    keywords: ['more', 'actions'],
+    shortcut: shortcuts.menu,
+    // The main ResourceContextMenu binds this shortcut itself (focus + filter).
+    run: () => undefined,
+  },
+  {
+    id: 'userSettings',
+    scope: 'app',
+    section: 'action',
+    label: () => 'User settings',
+    helper: () => 'Open your agent / user settings.',
+    keywords: ['account', 'agent', 'profile'],
+    shortcut: shortcuts.userSettings,
+    run: ctx => ctx.navigate(paths.agentSettings),
+  },
+  {
+    id: 'themeSettings',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Theme settings',
+    helper: () => 'Open appearance and theme settings.',
+    keywords: ['appearance', 'dark', 'light'],
+    shortcut: shortcuts.themeSettings,
+    run: ctx => ctx.navigate(paths.appSettings),
+  },
+  {
+    id: 'sidebarToggle',
+    scope: 'app',
+    section: 'action',
+    label: () => 'Show or hide the sidebar',
+    helper: () => 'Lock or unlock the sidebar.',
+    keywords: ['nav', 'panel'],
+    shortcut: shortcuts.sidebarToggle,
+    available: ctx => !!ctx.toggleSidebar,
+    run: ctx => ctx.toggleSidebar?.(),
+  },
+];

--- a/browser/data-browser/src/actions/catalog.test.ts
+++ b/browser/data-browser/src/actions/catalog.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { listShortcutHelp } from './catalog';
+import { resourceActions } from './resourceActions';
+import { appActions } from './appActions';
+import { shortcuts } from './shortcuts';
+
+describe('listShortcutHelp', () => {
+  it('lists every action that carries a shortcut, from the registry', () => {
+    const entries = listShortcutHelp();
+    const ids = entries.map(entry => entry.id);
+
+    expect(ids).toContain('search');
+    expect(ids).toContain('keyboardShortcuts');
+    expect(ids).toContain('edit');
+    expect(ids).toContain('data');
+    expect(ids).toContain('parent');
+    expect(ids).toContain('menu');
+    expect(ids).toContain('sidebarToggle');
+
+    const parent = entries.find(entry => entry.id === 'parent');
+    expect(parent?.shortcut).toBe(shortcuts.parent);
+    expect(parent?.label).toBe('Go to parent');
+
+    const edit = entries.find(entry => entry.id === 'edit');
+    expect(edit?.label).toBe('Edit resource');
+  });
+
+  it('does not keep a parallel list — resource and app registries are the source', () => {
+    const fromRegistries = [...appActions, ...resourceActions]
+      .filter(action => action.shortcut)
+      .map(action => action.id)
+      .sort();
+    const fromCatalog = listShortcutHelp()
+      .map(entry => entry.id)
+      .sort();
+
+    expect(fromCatalog).toEqual(fromRegistries);
+  });
+});

--- a/browser/data-browser/src/actions/catalog.ts
+++ b/browser/data-browser/src/actions/catalog.ts
@@ -1,0 +1,42 @@
+import { appActions } from './appActions';
+import { resourceActions } from './resourceActions';
+import type { ActionContext, ActionDefinition } from './types';
+
+export interface ShortcutHelpEntry {
+  id: string;
+  shortcut: string;
+  label: string;
+}
+
+/** Stub for labels that ignore context (all shortcut-bearing actions do). */
+const LABEL_CTX = {} as ActionContext;
+
+function helpLabel(action: ActionDefinition): string {
+  try {
+    return action.shortcutLabel?.(LABEL_CTX) ?? action.label(LABEL_CTX);
+  } catch {
+    return action.id;
+  }
+}
+
+/**
+ * Every action that carries a shortcut, app-level first, then resource
+ * verbs. The shortcuts overlay and `/app/shortcuts` render this — they
+ * must not keep a parallel hand-written list.
+ */
+export function listShortcutHelp(): ShortcutHelpEntry[] {
+  return [...appActions, ...resourceActions]
+    .filter((action): action is ActionDefinition & { shortcut: string } =>
+      Boolean(action.shortcut),
+    )
+    .map(action => ({
+      id: action.id,
+      shortcut: action.shortcut,
+      label: helpLabel(action),
+    }));
+}
+
+export const allActions: ActionDefinition[] = [
+  ...appActions,
+  ...resourceActions,
+];

--- a/browser/data-browser/src/actions/deriveTools.test.ts
+++ b/browser/data-browser/src/actions/deriveTools.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { actionToolNames, executeDerivedAction } from './deriveTools';
+import { resourceActions } from './resourceActions';
+import type { ActionContext, ActionDefinition } from './types';
+
+const ctx = {
+  canWrite: true,
+  pathname: '/app/show',
+  isFavorite: false,
+  subject: 'did:ad:example',
+} as ActionContext;
+
+describe('deriveActionTools', () => {
+  it('derives tools only for asTool verbs, using helper as the description', () => {
+    const names = actionToolNames(resourceActions);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'delete_resource',
+        'favorite_resource',
+        'open_share_settings',
+        'show_history',
+      ]),
+    );
+    expect(names).not.toContain('edit');
+    expect(names).not.toContain('setEmoji');
+  });
+
+  it('execute builds context, gates on available, and calls run', async () => {
+    const run = vi.fn();
+    const action: ActionDefinition = {
+      id: 'delete',
+      scope: 'resource',
+      section: 'action',
+      label: () => 'Delete',
+      helper: () => 'Delete this resource.',
+      asTool: true,
+      toolName: 'delete_resource',
+      available: c => c.canWrite,
+      run,
+    };
+
+    const allowed = await executeDerivedAction(action, 'did:ad:example', {
+      buildContext: async () => ctx,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(allowed).toMatchObject({ success: true, action: 'delete' });
+
+    const blocked = await executeDerivedAction(action, 'did:ad:example', {
+      buildContext: async () => ({ ...ctx, canWrite: false }),
+    });
+
+    expect(blocked).toMatchObject({ success: false });
+  });
+});

--- a/browser/data-browser/src/actions/deriveTools.ts
+++ b/browser/data-browser/src/actions/deriveTools.ts
@@ -1,0 +1,99 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import type { ActionContext, ActionDefinition } from './types';
+
+export interface DeriveActionToolsOptions {
+  /**
+   * Build a real ActionContext for the target subject. Called once per
+   * tool invocation, after the subject is known.
+   */
+  buildContext: (subject: string) => Promise<ActionContext>;
+  /** Expand `#ref` / compact subjects before loading. */
+  expandSubject?: (subject: string) => string;
+}
+
+export async function executeDerivedAction(
+  action: ActionDefinition,
+  subjectOrRef: string,
+  options: DeriveActionToolsOptions,
+): Promise<
+  | string
+  | {
+      success: boolean;
+      message: string;
+      action?: string;
+      subject?: string;
+    }
+> {
+  const expand = options.expandSubject ?? ((subject: string) => subject);
+  const subject = expand(subjectOrRef);
+
+  try {
+    const ctx = await options.buildContext(subject);
+
+    if (action.available && !action.available(ctx)) {
+      return {
+        success: false,
+        message: `Cannot ${action.label(ctx)} this resource.`,
+      };
+    }
+
+    await action.run(ctx);
+
+    return {
+      success: true,
+      action: action.id,
+      subject,
+      message: `${action.label(ctx)} succeeded.`,
+    };
+  } catch (error) {
+    return `Error running ${action.toolName ?? action.id} on ${subject}: ${error}`;
+  }
+}
+
+/**
+ * Turn `asTool` action definitions into AI SDK tools. Rich tools (query,
+ * create_table, …) stay bespoke in `useAtomicTools`; this is only the
+ * simple verbs whose `run` is the whole implementation.
+ */
+export function deriveActionTools(
+  actions: ActionDefinition[],
+  options: DeriveActionToolsOptions,
+) {
+  const tools: Record<string, unknown> = {};
+
+  for (const action of actions) {
+    if (!action.asTool) {
+      continue;
+    }
+
+    const name = action.toolName ?? action.id;
+    let description = action.id;
+
+    try {
+      description = action.helper({} as ActionContext);
+    } catch {
+      // keep the id fallback
+    }
+
+    tools[name] = tool({
+      description,
+      inputSchema: z.object({
+        subject: z
+          .string()
+          .describe('The subject (URL or #ref) of the resource'),
+      }),
+      execute: async ({ subject }: { subject: string }) =>
+        executeDerivedAction(action, subject, options),
+      strict: true,
+    });
+  }
+
+  return tools as Record<string, ReturnType<typeof tool>>;
+}
+
+export function actionToolNames(actions: ActionDefinition[]): string[] {
+  return actions
+    .filter(action => action.asTool)
+    .map(action => action.toolName ?? action.id);
+}

--- a/browser/data-browser/src/actions/index.ts
+++ b/browser/data-browser/src/actions/index.ts
@@ -1,0 +1,24 @@
+export type {
+  ActionConfirmation,
+  ActionContext,
+  ActionDefinition,
+  ActionScope,
+  ActionSection,
+} from './types';
+export { resourceActions } from './resourceActions';
+export { appActions } from './appActions';
+export { allActions, listShortcutHelp } from './catalog';
+export type { ShortcutHelpEntry } from './catalog';
+export { useActionContext, buildActionContext } from './useActionContext';
+export type {
+  ActionContextOverrides,
+  BuildActionContextInput,
+} from './useActionContext';
+export { runAction, reportActionError } from './runAction';
+export {
+  matchActionsForPalette,
+  PALETTE_ACTION_CAP,
+  PALETTE_MIN_QUERY_LENGTH,
+} from './matchActions';
+export { deriveActionTools, actionToolNames } from './deriveTools';
+export { shortcuts, displayShortcut } from './shortcuts';

--- a/browser/data-browser/src/actions/matchActions.test.ts
+++ b/browser/data-browser/src/actions/matchActions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { matchActionsForPalette, PALETTE_ACTION_CAP } from './matchActions';
+import { resourceActions } from './resourceActions';
+import type { ActionContext, ActionDefinition } from './types';
+
+const ctx = {
+  canWrite: true,
+  pathname: '/app/show',
+  isFavorite: false,
+  resource: {
+    isFork: false,
+    title: 'Test',
+    get: (prop: string) =>
+      typeof prop === 'string' && prop.endsWith('/parent')
+        ? 'did:ad:parent'
+        : undefined,
+    getClasses: () => [],
+  },
+} as unknown as ActionContext;
+
+function def(
+  partial: Partial<ActionDefinition> & { id: string },
+): ActionDefinition {
+  return {
+    scope: 'resource',
+    section: 'action',
+    label: () => partial.id,
+    helper: () => partial.id,
+    run: () => undefined,
+    ...partial,
+  };
+}
+
+describe('matchActionsForPalette', () => {
+  it('hides the section for an empty or one-letter query', () => {
+    expect(matchActionsForPalette('', resourceActions, ctx)).toEqual([]);
+    expect(matchActionsForPalette('d', resourceActions, ctx)).toEqual([]);
+  });
+
+  it('matches a prefix of the action id or a keyword, not a mid-word substring', () => {
+    const ids = matchActionsForPalette('del', resourceActions, ctx).map(
+      action => action.id,
+    );
+
+    expect(ids).toContain('delete');
+    expect(ids).not.toContain('edit');
+
+    // "ete" is inside "delete" but is not a prefix of the vocabulary.
+    expect(
+      matchActionsForPalette('ete', resourceActions, ctx).map(a => a.id),
+    ).not.toContain('delete');
+  });
+
+  it('matches label words so "parent" finds "Go to parent"', () => {
+    const ids = matchActionsForPalette('parent', resourceActions, ctx).map(
+      action => action.id,
+    );
+
+    expect(ids).toContain('parent');
+  });
+
+  it('does not fire on ordinary resource-name queries', () => {
+    expect(
+      matchActionsForPalette('avocado', resourceActions, ctx),
+    ).toHaveLength(0);
+    expect(
+      matchActionsForPalette('Searchable-Folder', resourceActions, ctx),
+    ).toHaveLength(0);
+    expect(
+      matchActionsForPalette('tag:work', resourceActions, ctx),
+    ).toHaveLength(0);
+  });
+
+  it('caps the section and prefers exact / shorter remainder', () => {
+    const actions = [
+      def({ id: 'edit', keywords: ['change'] }),
+      def({ id: 'editAsFork', label: () => 'Edit as fork' }),
+      def({ id: 'editorial', keywords: ['edit'] }),
+      def({ id: 'history' }),
+    ];
+
+    const ids = matchActionsForPalette('edit', actions, ctx).map(a => a.id);
+
+    expect(ids[0]).toBe('edit');
+    expect(ids.length).toBeLessThanOrEqual(PALETTE_ACTION_CAP);
+  });
+
+  it('hides unavailable and disabled actions', () => {
+    const actions = [
+      def({ id: 'delete', available: () => false }),
+      def({ id: 'history', disabled: () => true }),
+      def({ id: 'share' }),
+    ];
+
+    expect(matchActionsForPalette('de', actions, ctx).map(a => a.id)).toEqual(
+      [],
+    );
+    expect(matchActionsForPalette('hi', actions, ctx).map(a => a.id)).toEqual(
+      [],
+    );
+    expect(matchActionsForPalette('sh', actions, ctx).map(a => a.id)).toEqual([
+      'share',
+    ]);
+  });
+
+  it('respects canWrite on the real delete action', () => {
+    const readOnly = { ...ctx, canWrite: false };
+
+    expect(
+      matchActionsForPalette('delete', resourceActions, readOnly).map(
+        a => a.id,
+      ),
+    ).not.toContain('delete');
+    expect(
+      matchActionsForPalette('delete', resourceActions, ctx).map(a => a.id),
+    ).toContain('delete');
+  });
+});

--- a/browser/data-browser/src/actions/matchActions.ts
+++ b/browser/data-browser/src/actions/matchActions.ts
@@ -1,0 +1,120 @@
+import type { ActionContext, ActionDefinition } from './types';
+
+/** ⌘K shows at most this many actions, and never interleaves them with hits. */
+export const PALETTE_ACTION_CAP = 3;
+
+/** Shorter queries match too much of an open noun search; require a prefix. */
+export const PALETTE_MIN_QUERY_LENGTH = 2;
+
+export interface ActionMatch {
+  action: ActionDefinition;
+  /** Lower is a tighter match (exact beat prefix; shorter remainder wins). */
+  score: number;
+}
+
+function words(text: string): string[] {
+  return text.split(/[\s/&]+/).filter(Boolean);
+}
+
+function prefixScore(candidate: string, query: string): number | undefined {
+  if (!candidate.startsWith(query)) {
+    return undefined;
+  }
+
+  // Exact vocabulary hit first, then how much of the word is still unmatched.
+  return candidate === query ? 0 : candidate.length - query.length + 1;
+}
+
+function bestScore(
+  action: ActionDefinition,
+  query: string,
+  ctx: ActionContext,
+): number | undefined {
+  let label = '';
+
+  try {
+    label = action.label(ctx).toLowerCase();
+  } catch {
+    // A label that can't resolve (missing resource) still matches on id/keywords.
+  }
+
+  const haystacks = [
+    action.id.toLowerCase(),
+    label,
+    ...words(label),
+    ...(action.keywords ?? []).map(keyword => keyword.toLowerCase()),
+  ];
+
+  let best: number | undefined;
+
+  for (const haystack of haystacks) {
+    const score = prefixScore(haystack, query);
+
+    if (score === undefined) {
+      continue;
+    }
+
+    if (best === undefined || score < best) {
+      best = score;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Actions shown in the ⌘K palette for `query`.
+ *
+ * Placement policy (planning/actions.md): a closed verb set next to an open
+ * noun search, never ranked together. A hit is a *prefix* of the action id or
+ * a keyword — not a substring of the human label, which would fire on ordinary
+ * resource queries ("edit" inside "Editable title"). Capped, and hidden when
+ * the action is unavailable.
+ */
+export function matchActionsForPalette(
+  query: string,
+  actions: ActionDefinition[],
+  ctx: ActionContext,
+  cap = PALETTE_ACTION_CAP,
+): ActionDefinition[] {
+  const needle = query.trim().toLowerCase();
+
+  if (needle.length < PALETTE_MIN_QUERY_LENGTH) {
+    return [];
+  }
+
+  const matches: ActionMatch[] = [];
+
+  for (const action of actions) {
+    try {
+      if (!(action.available?.(ctx) ?? true)) {
+        continue;
+      }
+
+      if (action.disabled?.(ctx)) {
+        continue;
+      }
+    } catch {
+      // Incomplete context (tests, or a resource still loading) — skip.
+      continue;
+    }
+
+    const score = bestScore(action, needle, ctx);
+
+    if (score === undefined) {
+      continue;
+    }
+
+    matches.push({ action, score });
+  }
+
+  matches.sort((a, b) => {
+    if (a.score !== b.score) {
+      return a.score - b.score;
+    }
+
+    return a.action.id.localeCompare(b.action.id);
+  });
+
+  return matches.slice(0, cap).map(match => match.action);
+}

--- a/browser/data-browser/src/actions/resourceActions.tsx
+++ b/browser/data-browser/src/actions/resourceActions.tsx
@@ -30,9 +30,7 @@ import {
   shareURL,
 } from '../helpers/navigation';
 import { paths } from '../routes/paths';
-import { shortcuts } from '../components/HotKeyWrapper';
-import { ResourceInline } from '../views/ResourceInline';
-import { ResourceUsage } from '../components/ResourceUsage';
+import { shortcuts } from './shortcuts';
 import type { ActionContext, ActionDefinition } from './types';
 
 const getParent = (ctx: ActionContext): string | undefined =>
@@ -62,6 +60,7 @@ export const resourceActions: ActionDefinition[] = [
     helper: () => 'View the resource and its properties in the Data View.',
     keywords: ['json', 'raw', 'properties'],
     shortcut: shortcuts.data,
+    shortcutLabel: () => 'Show data view',
     disabled: ctx => ctx.pathname.startsWith(paths.data),
     run: ctx => ctx.navigate(dataURL(ctx.subject)),
   },
@@ -74,6 +73,8 @@ export const resourceActions: ActionDefinition[] = [
     helper: () => 'Toggle whether this resource appears in your Favorites.',
     keywords: ['star', 'bookmark', 'pin'],
     icon: ctx => (ctx.isFavorite ? <FaStar /> : <FaRegStar />),
+    asTool: true,
+    toolName: 'favorite_resource',
     run: ctx =>
       ctx.isFavorite
         ? ctx.removeFavorite(ctx.subject)
@@ -98,6 +99,7 @@ export const resourceActions: ActionDefinition[] = [
     keywords: ['change', 'modify', 'form'],
     icon: () => <FaPencil />,
     shortcut: shortcuts.edit,
+    shortcutLabel: () => 'Edit resource',
     available: ctx => ctx.canWrite,
     run: ctx => ctx.navigate(editURL(ctx.subject)),
   },
@@ -268,6 +270,8 @@ export const resourceActions: ActionDefinition[] = [
     helper: () => 'Edit permissions and create invites.',
     keywords: ['share', 'access', 'rights', 'invite'],
     icon: () => <FaShare />,
+    asTool: true,
+    toolName: 'open_share_settings',
     run: ctx => ctx.navigate(shareURL(ctx.subject)),
   },
   {
@@ -278,6 +282,8 @@ export const resourceActions: ActionDefinition[] = [
     helper: () => 'Show the history of this resource',
     keywords: ['versions', 'changes', 'undo'],
     icon: () => <FaClock />,
+    asTool: true,
+    toolName: 'show_history',
     run: ctx => ctx.navigate(historyURL(ctx.subject)),
   },
   {
@@ -289,6 +295,7 @@ export const resourceActions: ActionDefinition[] = [
     keywords: ['up', 'back', 'enclosing', 'folder'],
     icon: () => <FaTurnUp />,
     shortcut: shortcuts.parent,
+    shortcutLabel: () => 'Go to parent',
     available: ctx => !!getParent(ctx),
     run: ctx => {
       const parent = getParent(ctx);
@@ -318,19 +325,17 @@ export const resourceActions: ActionDefinition[] = [
     keywords: ['remove', 'destroy', 'trash'],
     icon: () => <FaTrash />,
     available: ctx => ctx.canWrite,
+    asTool: true,
+    toolName: 'delete_resource',
     danger: true,
     dangerLabel: () => 'Confirm Delete',
     confirmation: {
       title: () => 'Delete resource',
       confirmLabel: () => 'Delete',
       body: ctx => (
-        <>
-          <p>
-            Are you sure you want to delete{' '}
-            <ResourceInline subject={ctx.subject} />
-          </p>
-          <ResourceUsage resource={ctx.resource} />
-        </>
+        <p>
+          Are you sure you want to delete {ctx.resource.title || ctx.subject}?
+        </p>
       ),
     },
     run: async ctx => {

--- a/browser/data-browser/src/actions/runAction.ts
+++ b/browser/data-browser/src/actions/runAction.ts
@@ -1,0 +1,56 @@
+import toast from 'react-hot-toast';
+import type { ActionContext, ActionDefinition } from './types';
+
+/**
+ * Run an action, and never let its failure disappear.
+ *
+ * `run` is async and most call sites invoke it without awaiting, so a rejection
+ * used to become an unhandled promise — the menu closed, nothing happened, and
+ * the only trace was in a console nobody had open. That is what a failed delete
+ * looked like: the row stayed, and no error was ever shown.
+ *
+ * Actions that report their own failures still do; this is the net under them.
+ */
+export function runAction(action: ActionDefinition, ctx: ActionContext): void {
+  try {
+    const result = action.run(ctx) as unknown;
+
+    if (result instanceof Promise) {
+      void result.catch((e: unknown) => reportActionError(action, ctx, e));
+    }
+  } catch (e) {
+    // A synchronous throw, before the promise even exists.
+    reportActionError(action, ctx, e);
+  }
+}
+
+export function reportActionError(
+  action: ActionDefinition,
+  ctx: ActionContext,
+  e: unknown,
+): void {
+  const detail =
+    e instanceof Error && e.message
+      ? e.message
+      : typeof e === 'string' && e
+        ? e
+        : 'unknown error';
+
+  // `label` is `(ctx) => string`, not a string. Interpolating it directly put
+  // the function's source in the toast — so the net added to surface a failed
+  // action named it as `(ctx) => ...` instead of "Delete". Resolving it can
+  // itself throw (it reads the resource), and a label that fails must not
+  // swallow the error it was meant to report.
+  let label = 'Action';
+
+  try {
+    label = action.label(ctx);
+  } catch {
+    // keep the fallback
+  }
+
+  // Logged as well as shown: the toast is necessarily short, and a server's
+  // parse error is the kind of thing worth having in full.
+  console.error(`[action] "${label}" failed:`, e);
+  toast.error(`${label} failed: ${detail}`);
+}

--- a/browser/data-browser/src/actions/shortcuts.ts
+++ b/browser/data-browser/src/actions/shortcuts.ts
@@ -1,0 +1,66 @@
+/** List of used keyboard shortcuts, mapped for OS. */
+export const shortcuts = {
+  /** Edit current resource */
+  edit: osCtrl('e'),
+  /** Show data view for current resource */
+  data: osCtrl('d'),
+  /** Show home page */
+  home: osCtrl('h'),
+  /** Create a new resource */
+  new: osCtrl('n'),
+  /** Open user settings page */
+  userSettings: osCtrl('u'),
+  /** Open theme settings page */
+  themeSettings: osCtrl('t'),
+  // react-hotkeys-hook v5 matches on `event.code` (mapped through its key
+  // table), so punctuation must be written as code names: pressing `?` gives
+  // code "Slash", never "/". `shift+/` and `\` silently stopped matching in
+  // the v4 → v5 upgrade, like the `cmd+` alias below.
+  /** Open keyboard shortcuts page */
+  keyboardShortcuts: 'shift+slash',
+  /** Open command palette / search */
+  search: osCtrl('k'),
+  /** Open resource menu */
+  menu: osCtrl('m'),
+  /** Go to the parent of the current resource */
+  parent: osCtrl('up'),
+  /** Locks the sidebar menu */
+  sidebarToggle: 'backslash',
+  /** Move line up (documents) */
+  moveLineUp: osAlt('up'),
+  /** Move line down (documents) */
+  moveLineDown: osAlt('down'),
+  /** Delete line (documents) */
+  deleteLine: osAlt('backspace'),
+};
+
+function osCtrl(key: string): string {
+  // react-hotkeys-hook v5 dropped the `cmd` modifier alias that v4 accepted —
+  // it only recognizes `meta`/`mod`/`ctrl`/`control`. Emitting `cmd+…` meant
+  // EVERY Cmd shortcut silently stopped matching on macOS (search, edit, new,
+  // menu, …). Use `meta` for the Mac Cmd key.
+  return navigator.platform.includes('Mac') ? `meta+${key}` : `ctrl+${key}`;
+}
+
+function osAlt(key: string): string {
+  return navigator.platform.includes('Mac') ? `option+${key}` : `alt+${key}`;
+}
+
+export function displayShortcut(shortcut: string): string {
+  // Code names → the character users see on their keyboard.
+  const readable = shortcut
+    .replace('shift+slash', '?')
+    .replace('backslash', '\\');
+
+  if (navigator.platform.includes('Mac')) {
+    return readable
+      .replace('meta+', '⌘')
+      .replace('option+', '⌥')
+      .replace('shift+', '⇧')
+      .replace('backspace', '⌫')
+      .replace('up', '↑')
+      .replace('down', '↓');
+  }
+
+  return readable;
+}

--- a/browser/data-browser/src/actions/types.ts
+++ b/browser/data-browser/src/actions/types.ts
@@ -52,6 +52,8 @@ export interface ActionContext {
   /** Opens the pick-or-upload dialog for this resource's cover image. */
   openCoverPicker?: () => void;
   onAfterDelete?: () => void;
+  /** App-level: lock or unlock the sidebar. */
+  toggleSidebar?: () => void;
 }
 
 /** What the confirmation dialog for a `danger` action shows. */
@@ -76,6 +78,18 @@ export interface ActionDefinition {
   icon?: (ctx: ActionContext) => ReactNode;
   /** From the `shortcuts` registry; rendered as a chip wherever listed. */
   shortcut?: string;
+  /**
+   * Help-page wording when the menu label is too terse (e.g. menu says
+   * "Edit", the shortcuts list says "Edit resource").
+   */
+  shortcutLabel?: (ctx: ActionContext) => string;
+  /**
+   * When true, the in-app AI tools (and a future MCP server) derive a tool
+   * from this definition: `description` is `helper`, `execute` is `run`.
+   */
+  asTool?: boolean;
+  /** Tool name when `asTool` is set. Defaults to the action id. */
+  toolName?: string;
   /** Extra search terms for searchable surfaces (⌘M filter, ⌘K palette). */
   keywords?: string[];
   /**

--- a/browser/data-browser/src/actions/useActionContext.ts
+++ b/browser/data-browser/src/actions/useActionContext.ts
@@ -1,4 +1,10 @@
-import { useCanWrite, useDrive, useResource, useStore } from '@tomic/react';
+import {
+  useCanWrite,
+  useDrive,
+  useResource,
+  useStore,
+  type Store,
+} from '@tomic/react';
 import { useCurrentSubject } from '../helpers/useCurrentSubject';
 import { useNavigateWithTransition } from '../hooks/useNavigateWithTransition';
 import { useQueryScopeHandler } from '../hooks/useQueryScope';
@@ -19,6 +25,66 @@ export interface ActionContextOverrides {
   openEmojiPicker?: () => void;
   openCoverPicker?: () => void;
   onAfterDelete?: () => void;
+  toggleSidebar?: () => void;
+}
+
+/** Fields needed to assemble an ActionContext outside a React render. */
+export interface BuildActionContextInput {
+  subject: string;
+  store: Store;
+  navigate: (to: string) => void;
+  favorites: string[];
+  addFavorite: (subject: string) => void;
+  removeFavorite: (subject: string) => void;
+  currentSubject?: string;
+  drive?: string;
+  addToChat?: () => void;
+  enableScope?: () => void;
+  addChild?: () => void;
+  toggleSidebar?: () => void;
+}
+
+/**
+ * Build an {@link ActionContext} from already-resolved store state — used by
+ * AI tools, which run after the subject is known.
+ */
+export async function buildActionContext(
+  input: BuildActionContextInput,
+): Promise<ActionContext> {
+  const resource = await input.store.getResource(input.subject);
+  const agent = input.store.getAgent();
+  let canWrite = false;
+
+  if (agent?.subject) {
+    if (resource.new) {
+      canWrite = true;
+    } else {
+      const [allowed] = await resource.canWrite(agent.subject);
+      canWrite =
+        !!allowed ||
+        (input.subject.startsWith('did:ad:') &&
+          agent.subject.startsWith('did:ad:'));
+    }
+  }
+
+  return {
+    store: input.store,
+    navigate: input.navigate,
+    subject: input.subject,
+    resource,
+    canWrite,
+    currentSubject: input.currentSubject,
+    pathname: typeof window === 'undefined' ? '' : window.location.pathname,
+    isFavorite: input.favorites.includes(input.subject),
+    addFavorite: input.addFavorite,
+    removeFavorite: input.removeFavorite,
+    addToChat: input.addToChat ?? (() => undefined),
+    enableScope: input.enableScope ?? (() => undefined),
+    addChild: input.addChild ?? (() => undefined),
+    drive: input.drive,
+    titleAffordancesInline: false,
+    toggleSidebar: input.toggleSidebar,
+  };
 }
 
 /**

--- a/browser/data-browser/src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+++ b/browser/data-browser/src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
@@ -185,6 +185,22 @@ const ToolTitle = ({
     );
   }
 
+  if (toolName === TOOL_NAMES.DELETE_RESOURCE) {
+    return <span>Deleting resource</span>;
+  }
+
+  if (toolName === TOOL_NAMES.FAVORITE_RESOURCE) {
+    return <span>Toggling favorite</span>;
+  }
+
+  if (toolName === TOOL_NAMES.OPEN_SHARE_SETTINGS) {
+    return <span>Opening share settings</span>;
+  }
+
+  if (toolName === TOOL_NAMES.SHOW_HISTORY) {
+    return <span>Opening history</span>;
+  }
+
   return <span>{toolName}</span>;
 };
 

--- a/browser/data-browser/src/chunks/AI/useAtomicTools.ts
+++ b/browser/data-browser/src/chunks/AI/useAtomicTools.ts
@@ -52,6 +52,11 @@ import {
   describeDashboard,
   resolveBlock,
 } from '../DashboardPage/dashboardOps';
+import { resourceActions } from '../../actions/resourceActions';
+import { deriveActionTools } from '../../actions/deriveTools';
+import { buildActionContext } from '../../actions/useActionContext';
+import { useFavorites } from '../../hooks/useFavorites';
+import { useCurrentSubject } from '../../helpers/useCurrentSubject';
 
 export const TOOL_NAMES = {
   SEMANTIC_SEARCH: 'semantic_search',
@@ -77,6 +82,12 @@ export const TOOL_NAMES = {
   CREATE_DASHBOARD: 'create_dashboard',
   DESCRIBE_DASHBOARD: 'describe_dashboard',
   CONFIGURE_BLOCK: 'configure_block',
+  // Derived from `resourceActions` (`asTool`). Keep names in sync with
+  // `toolName` on those definitions.
+  DELETE_RESOURCE: 'delete_resource',
+  FAVORITE_RESOURCE: 'favorite_resource',
+  OPEN_SHARE_SETTINGS: 'open_share_settings',
+  SHOW_HISTORY: 'show_history',
 } as const;
 
 /** One column of a table, in the compact vocabulary `create_table` uses. */
@@ -409,6 +420,50 @@ export function useAtomicMCPTools({
   const addToOntology = useAddToOntology();
   const { drive } = useSettings();
   const runDocumentEdit = useDocumentEditAgent(editModel);
+  const [favorites, addFavorite, removeFavorite] = useFavorites();
+  const [currentSubject] = useCurrentSubject();
+  const derivedActionTools = deriveActionTools(resourceActions, {
+    expandSubject,
+    buildContext: subject =>
+      buildActionContext({
+        subject,
+        store,
+        navigate,
+        favorites,
+        addFavorite,
+        removeFavorite,
+        currentSubject,
+        drive,
+      }),
+  });
+  const derivedWriteTools = {
+    ...(derivedActionTools[TOOL_NAMES.DELETE_RESOURCE]
+      ? {
+          [TOOL_NAMES.DELETE_RESOURCE]:
+            derivedActionTools[TOOL_NAMES.DELETE_RESOURCE],
+        }
+      : {}),
+    ...(derivedActionTools[TOOL_NAMES.FAVORITE_RESOURCE]
+      ? {
+          [TOOL_NAMES.FAVORITE_RESOURCE]:
+            derivedActionTools[TOOL_NAMES.FAVORITE_RESOURCE],
+        }
+      : {}),
+  };
+  const derivedReadTools = {
+    ...(derivedActionTools[TOOL_NAMES.OPEN_SHARE_SETTINGS]
+      ? {
+          [TOOL_NAMES.OPEN_SHARE_SETTINGS]:
+            derivedActionTools[TOOL_NAMES.OPEN_SHARE_SETTINGS],
+        }
+      : {}),
+    ...(derivedActionTools[TOOL_NAMES.SHOW_HISTORY]
+      ? {
+          [TOOL_NAMES.SHOW_HISTORY]:
+            derivedActionTools[TOOL_NAMES.SHOW_HISTORY],
+        }
+      : {}),
+  };
 
   /** Resolves a `@class` shortname (or title) to a class subject on the
    *  current drive. Full URLs and `#refs` pass through/expand. */
@@ -475,6 +530,7 @@ export function useAtomicMCPTools({
 
   const tools = {
     read: {
+      ...derivedReadTools,
       [TOOL_NAMES.SEMANTIC_SEARCH]: tool({
         description:
           'Perform a hybrid semantic and/or text search for resources in the AtomicServer Database. This is more powerful than regular search as it understands the meaning of the query. The results only include the **first** relevant chunk of the resource that matches the query. To get a complete picture you might need to fetch the full resource. If your search requires more specific results use the optional text_query parameter to bias the results towards the text',
@@ -901,6 +957,7 @@ export function useAtomicMCPTools({
       }),
     },
     write: {
+      ...derivedWriteTools,
       [TOOL_NAMES.EDIT_ATOMIC_RESOURCE]: tool({
         description:
           'Change a property on a resource. The property accepts a compact shortname (resolved against the resource\'s class, e.g. "status") or a full property URL. Select/tag values accept tag names.',

--- a/browser/data-browser/src/components/HotKeyWrapper.tsx
+++ b/browser/data-browser/src/components/HotKeyWrapper.tsx
@@ -1,124 +1,40 @@
 // @wc-ignore-file
 import * as React from 'react';
-import { constructOpenURL, dataURL, editURL } from '../helpers/navigation';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { useCurrentSubject } from '../helpers/useCurrentSubject';
-import { Client, core, useStore } from '@tomic/react';
+import { Client } from '@tomic/react';
 import { useSettings } from '../helpers/AppSettings';
-import { paths } from '../routes/paths';
-import { openSearchOverlay, openShortcutsOverlay } from './OverlayContainer';
+import { useCurrentSubject } from '../helpers/useCurrentSubject';
+import { appActions } from '../actions/appActions';
+import { resourceActions } from '../actions/resourceActions';
+import { runAction } from '../actions/runAction';
+import { useActionContext } from '../actions/useActionContext';
+import { shortcuts } from '../actions/shortcuts';
+import { openSearchOverlay, openShortcutsOverlay } from './overlayState';
 
 import type { JSX } from 'react';
-import { useNavigateWithTransition } from '../hooks/useNavigateWithTransition';
+
+export { shortcuts, displayShortcut } from '../actions/shortcuts';
 
 type Props = {
   children: React.ReactNode;
 };
 
-/** List of used keyboard shortcuts, mapped for OS */
-export const shortcuts = {
-  /** Edit current resource */
-  edit: osCtrl('e'),
-  /** Show data view for current resource */
-  data: osCtrl('d'),
-  /** Show home page */
-  home: osCtrl('h'),
-  /** Create a new resource */
-  new: osCtrl('n'),
-  /** Open user settings page */
-  userSettings: osCtrl('u'),
-  /** Open theme settings page */
-  themeSettings: osCtrl('t'),
-  // react-hotkeys-hook v5 matches on `event.code` (mapped through its key
-  // table), so punctuation must be written as code names: pressing `?` gives
-  // code "Slash", never "/". `shift+/` and `\` silently stopped matching in
-  // the v4 → v5 upgrade, like the `cmd+` alias below.
-  /** Open keyboard shortcuts page */
-  keyboardShortcuts: 'shift+slash',
-  /** Open command palette / search */
-  search: osCtrl('k'),
-  /** Open resource menu */
-  menu: osCtrl('m'),
-  /** Go to the parent of the current resource */
-  parent: osCtrl('up'),
-  /** Locks the sidebar menu */
-  sidebarToggle: 'backslash',
-  /** Move line up (documents) */
-  moveLineUp: osAlt('up'),
-  /** Move line down (documents) */
-  moveLineDown: osAlt('down'),
-  /** Delete line (documents) */
-  deleteLine: osAlt('backspace'),
-};
+const resourceHotkeys = resourceActions.filter(
+  (action): action is (typeof resourceActions)[number] & { shortcut: string } =>
+    Boolean(action.shortcut),
+);
 
-function osCtrl(key: string): string {
-  // react-hotkeys-hook v5 dropped the `cmd` modifier alias that v4 accepted —
-  // it only recognizes `meta`/`mod`/`ctrl`/`control`. Emitting `cmd+…` meant
-  // EVERY Cmd shortcut silently stopped matching on macOS (search, edit, new,
-  // menu, …). Use `meta` for the Mac Cmd key.
-  return navigator.platform.includes('Mac') ? `meta+${key}` : `ctrl+${key}`;
-}
-
-function osAlt(key: string): string {
-  return navigator.platform.includes('Mac') ? `option+${key}` : `alt+${key}`;
-}
-
-export function displayShortcut(shortcut: string): string {
-  // Code names → the character users see on their keyboard.
-  const readable = shortcut
-    .replace('shift+slash', '?')
-    .replace('backslash', '\\');
-
-  if (navigator.platform.includes('Mac')) {
-    return readable
-      .replace('meta+', '⌘')
-      .replace('option+', '⌥')
-      .replace('shift+', '⇧')
-      .replace('backspace', '⌫')
-      .replace('up', '↑')
-      .replace('down', '↓');
-  }
-
-  return readable;
-}
-
-/** App-wide keyboard events handler. */
-function HotKeysWrapper({ children }: Props): JSX.Element {
-  const navigate = useNavigateWithTransition();
-  const [subject] = useCurrentSubject();
-  const { sideBarLocked, setSideBarLocked } = useSettings();
-  const store = useStore();
-
+function ResourceActionHotkey({
+  action,
+  subject,
+  ctx,
+}: {
+  action: (typeof resourceHotkeys)[number];
+  subject: string | undefined;
+  ctx: ReturnType<typeof useActionContext>;
+}): null {
   useHotkeys(
-    shortcuts.edit,
-    e => {
-      e.preventDefault();
-
-      if (Client.isValidSubject(subject)) {
-        navigate(editURL(subject!));
-      }
-    },
-    {},
-    [subject],
-  );
-  useHotkeys(
-    shortcuts.data,
-    e => {
-      e.preventDefault();
-
-      if (Client.isValidSubject(subject)) {
-        navigate(dataURL(subject!));
-      }
-    },
-    {},
-    [subject],
-  );
-  useHotkeys(shortcuts.home, e => {
-    e.preventDefault();
-    navigate('/');
-  });
-  useHotkeys(
-    shortcuts.parent,
+    action.shortcut,
     e => {
       e.preventDefault();
 
@@ -126,30 +42,53 @@ function HotKeysWrapper({ children }: Props): JSX.Element {
         return;
       }
 
-      store.getResource(subject!).then(resource => {
-        const parent = resource.get(core.properties.parent) as
-          | string
-          | undefined;
+      if (!(action.available?.(ctx) ?? true)) {
+        return;
+      }
 
-        if (parent) {
-          navigate(constructOpenURL(parent));
-        }
-      });
+      if (action.disabled?.(ctx)) {
+        return;
+      }
+
+      runAction(action, ctx);
     },
     {},
-    [subject],
+    [subject, ctx, action],
   );
-  useHotkeys(shortcuts.new, e => {
-    e.preventDefault();
-    navigate(paths.new);
+
+  return null;
+}
+
+/** App-wide keyboard events handler. Resource verbs run the registry action. */
+function HotKeysWrapper({ children }: Props): JSX.Element {
+  const [subject] = useCurrentSubject();
+  const { sideBarLocked, setSideBarLocked } = useSettings();
+  const ctx = useActionContext(subject ?? '', {
+    toggleSidebar: () => setSideBarLocked(!sideBarLocked),
   });
-  useHotkeys(shortcuts.userSettings, e => {
+
+  const home = appActions.find(action => action.id === 'home')!;
+  const createNew = appActions.find(action => action.id === 'new')!;
+  const userSettings = appActions.find(action => action.id === 'userSettings')!;
+  const themeSettings = appActions.find(
+    action => action.id === 'themeSettings',
+  )!;
+
+  useHotkeys(home.shortcut!, e => {
     e.preventDefault();
-    navigate(paths.agentSettings);
+    runAction(home, ctx);
   });
-  useHotkeys(shortcuts.themeSettings, e => {
+  useHotkeys(createNew.shortcut!, e => {
     e.preventDefault();
-    navigate(paths.appSettings);
+    runAction(createNew, ctx);
+  });
+  useHotkeys(userSettings.shortcut!, e => {
+    e.preventDefault();
+    runAction(userSettings, ctx);
+  });
+  useHotkeys(themeSettings.shortcut!, e => {
+    e.preventDefault();
+    runAction(themeSettings, ctx);
   });
   useHotkeys(shortcuts.search, e => {
     e.preventDefault();
@@ -169,7 +108,19 @@ function HotKeysWrapper({ children }: Props): JSX.Element {
     [sideBarLocked],
   );
 
-  return <>{children}</>;
+  return (
+    <>
+      {resourceHotkeys.map(action => (
+        <ResourceActionHotkey
+          key={action.id}
+          action={action}
+          subject={subject}
+          ctx={ctx}
+        />
+      ))}
+      {children}
+    </>
+  );
 }
 
 export default HotKeysWrapper;

--- a/browser/data-browser/src/components/OverlayContainer.tsx
+++ b/browser/data-browser/src/components/OverlayContainer.tsx
@@ -1,10 +1,22 @@
 import { useEffect, useRef, useState, type JSX, useMemo } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { styled } from 'styled-components';
-import { displayShortcut, shortcuts } from './HotKeyWrapper';
+import { displayShortcut, shortcuts } from '../actions/shortcuts';
+import { listShortcutHelp } from '../actions/catalog';
+import { matchActionsForPalette } from '../actions/matchActions';
+import { resourceActions } from '../actions/resourceActions';
+import { runAction } from '../actions/runAction';
+import { useActionContext } from '../actions/useActionContext';
+import type { ActionDefinition } from '../actions/types';
 import { useNavigateWithTransition } from '../hooks/useNavigateWithTransition';
 import { constructOpenURL } from '../helpers/navigation';
 import { useCurrentSubject } from '../helpers/useCurrentSubject';
+import {
+  ConfirmationDialog,
+  ConfirmationDialogTheme,
+} from './ConfirmationDialog';
+import { ResourceInline } from '../views/ResourceInline';
+import { ResourceUsage } from './ResourceUsage';
 import {
   useServerSearch,
   useStore,
@@ -31,28 +43,16 @@ import ResourceCard from '../views/Card/ResourceCard';
 import ResourceRow from '@views/ResourceRow';
 import { DEFAULT_AICHAT_NAME } from './AI/aiContstants';
 import { setPendingFirstMessage } from '@chunks/AI/pendingFirstMessage';
+import {
+  closeOverlay,
+  openSearchOverlay,
+  openShortcutsOverlay,
+  setOverlay,
+  subscribeOverlay,
+  type OverlayType,
+} from './overlayState';
 
-// ─── Module-level overlay state ────────────────────────────────────────────────
-
-type OverlayType = 'search' | 'shortcuts' | null;
-
-const overlayListeners = new Set<(overlay: OverlayType) => void>();
-
-function setOverlay(overlay: OverlayType): void {
-  overlayListeners.forEach(listener => listener(overlay));
-}
-
-export function openSearchOverlay(_query?: string): void {
-  setOverlay('search');
-}
-
-export function openShortcutsOverlay(): void {
-  setOverlay('shortcuts');
-}
-
-export function closeOverlay(): void {
-  setOverlay(null);
-}
+export { closeOverlay, openSearchOverlay, openShortcutsOverlay };
 
 // ─── Module-level search state (shared between SearchOverlay and PreviewPane) ───
 
@@ -211,6 +211,54 @@ const PreviewFloat = styled.div`
   overflow-y: auto;
 `;
 
+const SectionHeading = styled.div`
+  padding: 0.5rem 1rem 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: ${p => p.theme.colors.textLight};
+`;
+
+const ActionRow = styled.button<{ $selected?: boolean }>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border: none;
+  border-bottom: 1px solid ${p => p.theme.colors.bg2};
+  background: ${p => (p.$selected ? p.theme.colors.bg1 : 'transparent')};
+  color: ${p => p.theme.colors.text};
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background 80ms;
+
+  &:hover {
+    background: ${p => p.theme.colors.bg1};
+  }
+
+  svg {
+    color: ${p => p.theme.colors.textLight};
+    flex-shrink: 0;
+  }
+
+  span {
+    flex: 1;
+  }
+`;
+
+const ActionShortcut = styled.kbd`
+  background: ${p => p.theme.colors.bg1};
+  border: 1px solid ${p => p.theme.colors.bg2};
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.3rem;
+  font-size: 0.7rem;
+  color: ${p => p.theme.colors.textLight};
+  font-family: inherit;
+`;
+
 const AIChatRow = styled.button<{ $selected?: boolean }>`
   display: flex;
   align-items: center;
@@ -267,6 +315,11 @@ function parseSearchTags(
   };
 }
 
+type PaletteRow =
+  | { kind: 'action'; action: ActionDefinition }
+  | { kind: 'result'; subject: string }
+  | { kind: 'aiChat' };
+
 function SearchOverlay(): JSX.Element {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { drive } = useSettings();
@@ -274,6 +327,9 @@ function SearchOverlay(): JSX.Element {
   const { scope } = useQueryScopeHandler();
   const navigate = useNavigateWithTransition();
   const store = useStore();
+  const [currentSubject] = useCurrentSubject();
+  const actionCtx = useActionContext(currentSubject ?? '');
+  const [confirmingAction, setConfirmingAction] = useState<ActionDefinition>();
   const driveResource = useResource<Server.Drive>(drive);
   const [driveTags] = useArray(driveResource, dataBrowser.properties.tagList);
   const tagResources = useResources(driveTags);
@@ -331,8 +387,16 @@ function SearchOverlay(): JSX.Element {
     allowEmptyQuery: !filterIsEmpty,
   });
 
+  const actionHits = currentSubject
+    ? matchActionsForPalette(query, resourceActions, actionCtx)
+    : [];
   const showAIChatRow = !!privateDrive && query && results.length === 0;
-  const totalItemCount = results.length + (showAIChatRow ? 1 : 0);
+  const rows: PaletteRow[] = [
+    ...actionHits.map(action => ({ kind: 'action' as const, action })),
+    ...results.map(subject => ({ kind: 'result' as const, subject })),
+    ...(showAIChatRow ? [{ kind: 'aiChat' as const }] : []),
+  ];
+  const totalItemCount = rows.length;
 
   useEffect(() => {
     const timer = setTimeout(() => inputRef.current?.focus(), 50);
@@ -343,6 +407,37 @@ function SearchOverlay(): JSX.Element {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
     setSelected(0);
+  };
+
+  const activateRow = async (row: PaletteRow | undefined): Promise<void> => {
+    if (!row) {
+      return;
+    }
+
+    if (row.kind === 'action') {
+      if (row.action.danger && row.action.confirmation) {
+        setConfirmingAction(row.action);
+
+        return;
+      }
+
+      runAction(row.action, actionCtx);
+      closeOverlay();
+
+      return;
+    }
+
+    if (row.kind === 'result') {
+      navigate(constructOpenURL(row.subject));
+      closeOverlay();
+
+      return;
+    }
+
+    if (privateDrive) {
+      await handleStartAIChat(query, store, privateDrive, navigate);
+      closeOverlay();
+    }
   };
 
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -357,19 +452,7 @@ function SearchOverlay(): JSX.Element {
         break;
       case 'Enter':
         e.preventDefault();
-
-        if (results[selectedIndex]) {
-          const openURL = constructOpenURL(results[selectedIndex]);
-          navigate(openURL);
-          closeOverlay();
-        } else if (showAIChatRow && selectedIndex === results.length) {
-          // AI Chat row selected
-          if (privateDrive) {
-            await handleStartAIChat(query, store, privateDrive, navigate);
-            closeOverlay();
-          }
-        }
-
+        await activateRow(rows[selectedIndex]);
         break;
       case 'Escape':
         e.preventDefault();
@@ -406,10 +489,17 @@ function SearchOverlay(): JSX.Element {
     }
   }, [selectedIndex]);
 
-  // Sync results + index to module state for the preview
+  // Sync results + index to module state for the preview. Actions are not
+  // previewed — an action at selectedIndex 0 must not show results[0].
   useEffect(() => {
-    setSearchResults(results, selectedIndex);
-  }, [results, selectedIndex]);
+    const actionCount = actionHits.length;
+    const resultIndex =
+      selectedIndex >= actionCount &&
+      selectedIndex < actionCount + results.length
+        ? selectedIndex - actionCount
+        : -1;
+    setSearchResults(results, resultIndex);
+  }, [results, selectedIndex, actionHits.length]);
 
   return (
     <ErrorBoundary>
@@ -452,26 +542,56 @@ function SearchOverlay(): JSX.Element {
             <ResultsList>
               <ResultsArea ref={resultsRef}>
                 <Column gap='0'>
-                  {results.map((subject, index) => (
-                    <ResultCard
-                      key={subject}
-                      subject={subject}
-                      index={index}
-                      selected={index === selectedIndex}
-                      onSelect={() => {
+                  {actionHits.length > 0 && (
+                    <SectionHeading>Actions</SectionHeading>
+                  )}
+                  {actionHits.map((action, index) => (
+                    <ActionRow
+                      key={action.id}
+                      data-index={index}
+                      data-testid={`palette-action-${action.id}`}
+                      $selected={index === selectedIndex}
+                      onClick={() => {
                         setSelected(index);
-                        setTimeout(() => {
-                          const openURL = constructOpenURL(subject);
-                          navigate(openURL);
-                          closeOverlay();
-                        }, 80);
+                        void activateRow({ kind: 'action', action });
                       }}
-                    />
+                    >
+                      {action.icon?.(actionCtx)}
+                      <span>{action.label(actionCtx)}</span>
+                      {action.shortcut && (
+                        <ActionShortcut>
+                          {displayShortcut(action.shortcut)}
+                        </ActionShortcut>
+                      )}
+                    </ActionRow>
                   ))}
+                  {results.length > 0 && actionHits.length > 0 && (
+                    <SectionHeading>Resources</SectionHeading>
+                  )}
+                  {results.map((subject, resultIndex) => {
+                    const index = actionHits.length + resultIndex;
+
+                    return (
+                      <ResultCard
+                        key={subject}
+                        subject={subject}
+                        index={index}
+                        selected={index === selectedIndex}
+                        onSelect={() => {
+                          setSelected(index);
+                          setTimeout(() => {
+                            void activateRow({ kind: 'result', subject });
+                          }, 80);
+                        }}
+                      />
+                    );
+                  })}
                   {showAIChatRow && (
                     <AIChatRow
-                      data-index={results.length}
-                      $selected={selectedIndex === results.length}
+                      data-index={actionHits.length + results.length}
+                      $selected={
+                        selectedIndex === actionHits.length + results.length
+                      }
                       onClick={async () => {
                         if (!privateDrive) {
                           return;
@@ -501,7 +621,7 @@ function SearchOverlay(): JSX.Element {
                 <kbd>↑</kbd> <kbd>↓</kbd> navigate
               </span>
               <span>
-                <kbd>↵</kbd> open / chat
+                <kbd>↵</kbd> open / run
               </span>
               <span>
                 <kbd>⇧↵</kbd> chat
@@ -518,6 +638,35 @@ function SearchOverlay(): JSX.Element {
           </FooterRow>
         </>
       )}
+      <ConfirmationDialog
+        title={confirmingAction?.confirmation?.title(actionCtx) ?? ''}
+        show={confirmingAction !== undefined}
+        bindShow={show => {
+          if (!show) {
+            setConfirmingAction(undefined);
+          }
+        }}
+        theme={ConfirmationDialogTheme.Alert}
+        confirmLabel={confirmingAction?.confirmation?.confirmLabel(actionCtx)}
+        onConfirm={() => {
+          if (confirmingAction) {
+            runAction(confirmingAction, actionCtx);
+            closeOverlay();
+          }
+        }}
+      >
+        {confirmingAction?.id === 'delete' ? (
+          <>
+            <p>
+              Are you sure you want to delete{' '}
+              <ResourceInline subject={actionCtx.subject} />
+            </p>
+            <ResourceUsage resource={actionCtx.resource} />
+          </>
+        ) : (
+          confirmingAction?.confirmation?.body(actionCtx)
+        )}
+      </ConfirmationDialog>
     </ErrorBoundary>
   );
 }
@@ -615,27 +764,15 @@ function ShortcutsOverlay(): JSX.Element {
     }
   };
 
-  // Rendered from the central `shortcuts` registry so this overlay can't
-  // drift from the actual bindings.
-  const shortcuts_list = [
-    { key: shortcuts.search, label: 'Open search' },
-    { key: shortcuts.keyboardShortcuts, label: 'Show keyboard shortcuts' },
-    { key: shortcuts.edit, label: 'Edit resource' },
-    { key: shortcuts.data, label: 'Show data view' },
-    { key: shortcuts.home, label: 'Go home' },
-    { key: shortcuts.parent, label: 'Go to parent' },
-    { key: shortcuts.new, label: 'New resource' },
-    { key: shortcuts.menu, label: 'Open menu' },
-    { key: shortcuts.userSettings, label: 'User settings' },
-    { key: shortcuts.themeSettings, label: 'Theme settings' },
-    { key: shortcuts.sidebarToggle, label: 'Show or hide the sidebar' },
-  ];
+  // Rendered from the action registry so this overlay can't drift from
+  // the actual bindings or the `/app/shortcuts` page.
+  const shortcuts_list = listShortcutHelp();
 
   const search = query.trim().toLowerCase();
   const visibleShortcuts = shortcuts_list.filter(
-    ({ key, label }) =>
+    ({ shortcut, label }) =>
       label.toLowerCase().includes(search) ||
-      displayShortcut(key).toLowerCase().includes(search),
+      displayShortcut(shortcut).toLowerCase().includes(search),
   );
 
   return (
@@ -655,10 +792,10 @@ function ShortcutsOverlay(): JSX.Element {
         <ShortcutHint onClick={closeOverlay}>esc</ShortcutHint>
       </OverlayInputWrapper>
       <ShortcutsList>
-        {visibleShortcuts.map(({ key, label }) => (
-          <ShortcutRow key={key}>
+        {visibleShortcuts.map(({ id, shortcut, label }) => (
+          <ShortcutRow key={id}>
             <ShortcutLabel>{label}</ShortcutLabel>
-            <ShortcutKey>{displayShortcut(key)}</ShortcutKey>
+            <ShortcutKey>{displayShortcut(shortcut)}</ShortcutKey>
           </ShortcutRow>
         ))}
         {visibleShortcuts.length === 0 && (
@@ -691,13 +828,7 @@ export function OverlayContainer(): JSX.Element | null {
     index: 0,
   });
 
-  useEffect(() => {
-    overlayListeners.add(setOverlayState);
-
-    return () => {
-      overlayListeners.delete(setOverlayState);
-    };
-  }, []);
+  useEffect(() => subscribeOverlay(setOverlayState), []);
 
   useEffect(() => {
     const handler = (isOpen: boolean, results: string[], index: number) => {

--- a/browser/data-browser/src/components/ResourceContextMenu/index.tsx
+++ b/browser/data-browser/src/components/ResourceContextMenu/index.tsx
@@ -13,10 +13,12 @@ import { ResourceCodeUsageDialog } from '../../views/CodeUsage/ResourceCodeUsage
 import { addIf } from '../../helpers/addIf';
 import { resourceActions } from '../../actions/resourceActions';
 import { useActionContext } from '../../actions/useActionContext';
-import toast from 'react-hot-toast';
-import type { ActionContext, ActionDefinition } from '../../actions/types';
+import { runAction } from '../../actions/runAction';
+import type { ActionDefinition } from '../../actions/types';
 import { useCustomContextItemsContext } from './CustomContextItemsContext';
 import { CoverPickerDialog, EmojiPickerDialog } from '../ResourceDecorations';
+import { ResourceInline } from '../../views/ResourceInline';
+import { ResourceUsage } from '../ResourceUsage';
 
 export {
   CustomContextItemsProvider,
@@ -28,60 +30,6 @@ export { ResourceContextMenuHost } from './ResourceContextMenuHost';
 export { useResourceContextMenu } from './ResourceContextMenuContext';
 
 export { DIVIDER, type DropdownItem } from '../Dropdown';
-
-/**
- * Run a menu action, and never let its failure disappear.
- *
- * `run` is async and both call sites invoke it without awaiting, so a rejection
- * used to become an unhandled promise — the menu closed, nothing happened, and
- * the only trace was in a console nobody had open. That is what a failed delete
- * looked like: the row stayed, and no error was ever shown.
- *
- * Actions that report their own failures still do; this is the net under them.
- */
-function runAction(action: ActionDefinition, ctx: ActionContext): void {
-  try {
-    const result = action.run(ctx) as unknown;
-
-    if (result instanceof Promise) {
-      void result.catch((e: unknown) => reportActionError(action, ctx, e));
-    }
-  } catch (e) {
-    // A synchronous throw, before the promise even exists.
-    reportActionError(action, ctx, e);
-  }
-}
-
-function reportActionError(
-  action: ActionDefinition,
-  ctx: ActionContext,
-  e: unknown,
-): void {
-  const detail =
-    e instanceof Error && e.message
-      ? e.message
-      : typeof e === 'string' && e
-        ? e
-        : 'unknown error';
-
-  // `label` is `(ctx) => string`, not a string. Interpolating it directly put
-  // the function's source in the toast — so the net added to surface a failed
-  // action named it as `(ctx) => ...` instead of "Delete". Resolving it can
-  // itself throw (it reads the resource), and a label that fails must not
-  // swallow the error it was meant to report.
-  let label = 'Action';
-
-  try {
-    label = action.label(ctx);
-  } catch {
-    // keep the fallback
-  }
-
-  // Logged as well as shown: the toast is necessarily short, and a server's
-  // parse error is the kind of thing worth having in full.
-  console.error(`[action] "${label}" failed:`, e);
-  toast.error(`${label} failed: ${detail}`);
-}
 
 /** Ids of the actions in the registry (`actions/resourceActions.tsx`). */
 export const ContextMenuOptions = {
@@ -303,7 +251,17 @@ export function ResourceContextMenu({
           if (confirmingAction) runAction(confirmingAction, ctx);
         }}
       >
-        {confirmation?.body(ctx)}
+        {confirmingAction?.id === 'delete' ? (
+          <>
+            <p>
+              Are you sure you want to delete{' '}
+              <ResourceInline subject={ctx.subject} />
+            </p>
+            <ResourceUsage resource={ctx.resource} />
+          </>
+        ) : (
+          confirmation?.body(ctx)
+        )}
       </ConfirmationDialog>
       {/* Use the menu's own subject, not the current page's — a right-click can
        * target a resource other than the one being viewed. */}

--- a/browser/data-browser/src/components/overlayState.ts
+++ b/browser/data-browser/src/components/overlayState.ts
@@ -1,0 +1,35 @@
+/**
+ * Module-level overlay switch. Lives outside OverlayContainer so action
+ * definitions can open search / shortcuts without importing the React tree
+ * (that would cycle: OverlayContainer → catalog → appActions → Overlay).
+ */
+
+export type OverlayType = 'search' | 'shortcuts' | null;
+
+const overlayListeners = new Set<(overlay: OverlayType) => void>();
+
+export function setOverlay(overlay: OverlayType): void {
+  overlayListeners.forEach(listener => listener(overlay));
+}
+
+export function openSearchOverlay(_query?: string): void {
+  setOverlay('search');
+}
+
+export function openShortcutsOverlay(): void {
+  setOverlay('shortcuts');
+}
+
+export function closeOverlay(): void {
+  setOverlay(null);
+}
+
+export function subscribeOverlay(
+  listener: (overlay: OverlayType) => void,
+): () => void {
+  overlayListeners.add(listener);
+
+  return () => {
+    overlayListeners.delete(listener);
+  };
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -964,7 +964,7 @@ msgstr ""
 msgid "Not found!"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 #: src/routes/Router.tsx
 msgid "Go home"
 msgstr ""
@@ -1104,6 +1104,7 @@ msgstr ""
 msgid "Add description"
 msgstr ""
 
+#: src/components/OverlayContainer.tsx
 #: src/views/Drive/DrivePage.tsx
 msgid "Resources"
 msgstr ""
@@ -1351,9 +1352,8 @@ msgstr ""
 msgid "<0/> <1/> navigate"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
-msgid "<0/> open / chat"
-msgstr ""
+#~ msgid "<0/> open / chat"
+#~ msgstr ""
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> chat"
@@ -1364,37 +1364,37 @@ msgstr ""
 msgid "<0>esc</0> close"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open search"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show keyboard shortcuts"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
 msgid "Edit resource"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Show data view"
 msgstr ""
 
+#: src/actions/appActions.ts
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
-#: src/components/OverlayContainer.tsx
 msgid "New resource"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open menu"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "User settings"
 msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Theme settings"
 msgstr ""
 
@@ -1706,45 +1706,35 @@ msgstr ""
 msgid "Global"
 msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Search"
-msgstr ""
+#~ msgid "<0/> Search"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show or hide the sidebar"
-msgstr ""
+#~ msgid "<0/> Show or hide the sidebar"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show these keyboard shortcuts"
-msgstr ""
+#~ msgid "<0/> Show these keyboard shortcuts"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>dit resource"
-msgstr ""
+#~ msgid "<0/> <1/>dit resource"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>d</1>ata for resource"
-msgstr ""
+#~ msgid "<0/> Show <1>d</1>ata for resource"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>h</1>ome page"
-msgstr ""
+#~ msgid "<0/> Show <1>h</1>ome page"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ew resource"
-msgstr ""
+#~ msgid "<0/> <1/>ew resource"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Open <1>m</1>enu"
-msgstr ""
+#~ msgid "<0/> Open <1>m</1>enu"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ser settings"
-msgstr ""
+#~ msgid "<0/> <1/>ser settings"
+#~ msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>heme settings"
-msgstr ""
+#~ msgid "<0/> <1/>heme settings"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "In sync"
@@ -4665,7 +4655,7 @@ msgid "No matching actions"
 msgstr ""
 
 #: src/actions/resourceActions.tsx
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Go to parent"
 msgstr ""
 
@@ -4674,15 +4664,16 @@ msgid "Open the parent of this resource."
 msgstr ""
 
 #. 0: ' '
-#: src/actions/resourceActions.tsx
+#. 0: ' '
+#: src/components/OverlayContainer.tsx
+#: src/components/ResourceContextMenu/index.tsx
 msgid "Are you sure you want to delete{0} <0/>"
 msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Go to parent resource"
-msgstr ""
+#~ msgid "<0/> Go to parent resource"
+#~ msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4977,17 +4968,14 @@ msgstr ""
 msgid "Connect to that device"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+#~ msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or let it scan this device"
-msgstr ""
+#~ msgid "…or let it scan this device"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+#~ msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
@@ -4997,9 +4985,8 @@ msgstr ""
 msgid "Paste a pairing code or did:ad:node:…"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+#~ msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
+#~ msgstr ""
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5330,18 +5317,14 @@ msgstr ""
 msgid "Scan this from that device"
 msgstr ""
 
-#. 0: serverLabel(baseURL)
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+#~ msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Connect a device that has it"
-msgstr ""
+#~ msgid "Connect a device that has it"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+#~ msgid "An always-on device has an address — add it and your workspace appears."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -6320,8 +6303,8 @@ msgstr ""
 msgid "Button says"
 msgstr ""
 
+#: src/actions/runAction.ts
 #: src/chunks/TablePage/NewColumnButton.tsx
-#: src/components/ResourceContextMenu/index.tsx
 msgid "Action"
 msgstr ""
 
@@ -6557,9 +6540,8 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#: src/helpers/managed/cloudSync.ts
-msgid "Timed out connecting to the Cloud Server node."
-msgstr ""
+#~ msgid "Timed out connecting to the Cloud Server node."
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6610,10 +6592,8 @@ msgstr ""
 msgid "Waiting for you to approve it…"
 msgstr ""
 
-#. 0: providerName(portalUrl)
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Getting a code…"
@@ -6627,6 +6607,9 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
 #: src/helpers/managed/deviceLink.ts
 msgid "Mac"
 msgstr ""
@@ -6658,21 +6641,18 @@ msgstr ""
 #~ msgid "Use my own secret"
 #~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Restore this workspace"
-msgstr ""
+#~ msgid "Restore this workspace"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
-msgstr ""
+#~ msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore my workspace"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or bring it from another device instead"
-msgstr ""
+#~ msgid "…or bring it from another device instead"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6864,7 +6844,7 @@ msgid "Not synced yet"
 msgstr ""
 
 #. 0: label; 1: detail
-#: src/components/ResourceContextMenu/index.tsx
+#: src/actions/runAction.ts
 msgid "{0} failed: {1}"
 msgstr ""
 
@@ -7132,4 +7112,153 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "Cannot {0} this resource."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "{0} succeeded."
+msgstr ""
+
+#. 0: action.toolName ?? action.id; 1: subject; 2: error
+#: src/actions/deriveTools.ts
+msgid "Error running {0} on {1}: {2}"
+msgstr ""
+
+#: src/actions/deriveTools.ts
+msgid "The subject (URL or #ref) of the resource"
+msgstr ""
+
+#. 0: ctx.resource.title || ctx.subject
+#: src/actions/resourceActions.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Deleting resource"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Toggling favorite"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening share settings"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening history"
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the command palette to find resources and run actions."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the list of keyboard shortcuts."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the home page."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Create a new resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the actions menu for the current resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open your agent / user settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open appearance and theme settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Lock or unlock the sidebar."
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "Actions"
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "<0/> open / run"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Open <0>Sync</0> there and scan or paste its code here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or let it scan this one"
+msgstr ""
+
+#. 0: serverLabel(baseURL)
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "It syncs your workspace to {0}, which this browser reads from."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Connect a server that has it"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Restore your workspace"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Bring your data back"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "There’s an encrypted backup, sealed so only you can open it."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Your backup is kept by your {0} account. Sign in to it and it comes back here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Signing in restores who you are. Your workspace still lives on the device you made it with."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Sign in to {0}"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "I’ve signed in — check again"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or bring it over from another device"
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Couldn’t reach {0}. Check your connection and try again."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect to {0}"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "stores it without being able to read it."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -964,7 +964,7 @@ msgstr "Stack trace:"
 msgid "Not found!"
 msgstr "Not found!"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 #: src/routes/Router.tsx
 msgid "Go home"
 msgstr "Go home"
@@ -1104,6 +1104,7 @@ msgstr "Set as current drive"
 msgid "Add description"
 msgstr "Add description"
 
+#: src/components/OverlayContainer.tsx
 #: src/views/Drive/DrivePage.tsx
 msgid "Resources"
 msgstr "Resources"
@@ -1351,9 +1352,8 @@ msgstr "Start AI Chat with \"{0}\""
 msgid "<0/> <1/> navigate"
 msgstr "<0/> <1/> navigate"
 
-#: src/components/OverlayContainer.tsx
-msgid "<0/> open / chat"
-msgstr "<0/> open / chat"
+#~ msgid "<0/> open / chat"
+#~ msgstr "<0/> open / chat"
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> chat"
@@ -1364,37 +1364,37 @@ msgstr "<0/> chat"
 msgid "<0>esc</0> close"
 msgstr "<0>esc</0> close"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open search"
 msgstr "Open search"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show keyboard shortcuts"
 msgstr "Show keyboard shortcuts"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
 msgid "Edit resource"
 msgstr "Edit resource"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Show data view"
 msgstr "Show data view"
 
+#: src/actions/appActions.ts
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
-#: src/components/OverlayContainer.tsx
 msgid "New resource"
 msgstr "New resource"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open menu"
 msgstr "Open menu"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "User settings"
 msgstr "User settings"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Theme settings"
 msgstr "Theme settings"
 
@@ -1706,45 +1706,35 @@ msgstr "You're using a local Agent, which cannot authenticate on other domains, 
 msgid "Global"
 msgstr "Global"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Search"
-msgstr "<0/> Search"
+#~ msgid "<0/> Search"
+#~ msgstr "<0/> Search"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show or hide the sidebar"
-msgstr "<0/> Show or hide the sidebar"
+#~ msgid "<0/> Show or hide the sidebar"
+#~ msgstr "<0/> Show or hide the sidebar"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show these keyboard shortcuts"
-msgstr "<0/> Show these keyboard shortcuts"
+#~ msgid "<0/> Show these keyboard shortcuts"
+#~ msgstr "<0/> Show these keyboard shortcuts"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>dit resource"
-msgstr "<0/> <1/>dit resource"
+#~ msgid "<0/> <1/>dit resource"
+#~ msgstr "<0/> <1/>dit resource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>d</1>ata for resource"
-msgstr "<0/> Show <1>d</1>ata for resource"
+#~ msgid "<0/> Show <1>d</1>ata for resource"
+#~ msgstr "<0/> Show <1>d</1>ata for resource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>h</1>ome page"
-msgstr "<0/> Show <1>h</1>ome page"
+#~ msgid "<0/> Show <1>h</1>ome page"
+#~ msgstr "<0/> Show <1>h</1>ome page"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ew resource"
-msgstr "<0/> <1/>ew resource"
+#~ msgid "<0/> <1/>ew resource"
+#~ msgstr "<0/> <1/>ew resource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Open <1>m</1>enu"
-msgstr "<0/> Open <1>m</1>enu"
+#~ msgid "<0/> Open <1>m</1>enu"
+#~ msgstr "<0/> Open <1>m</1>enu"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ser settings"
-msgstr "<0/> <1/>ser settings"
+#~ msgid "<0/> <1/>ser settings"
+#~ msgstr "<0/> <1/>ser settings"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>heme settings"
-msgstr "<0/> <1/>heme settings"
+#~ msgid "<0/> <1/>heme settings"
+#~ msgstr "<0/> <1/>heme settings"
 
 #: src/routes/SyncRoute.tsx
 msgid "In sync"
@@ -4699,7 +4689,7 @@ msgid "No matching actions"
 msgstr "No matching actions"
 
 #: src/actions/resourceActions.tsx
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Go to parent"
 msgstr "Go to parent"
 
@@ -4708,15 +4698,16 @@ msgid "Open the parent of this resource."
 msgstr "Open the parent of this resource."
 
 #. 0: ' '
-#: src/actions/resourceActions.tsx
+#. 0: ' '
+#: src/components/OverlayContainer.tsx
+#: src/components/ResourceContextMenu/index.tsx
 msgid "Are you sure you want to delete{0} <0/>"
 msgstr "Are you sure you want to delete{0} <0/>"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Go to parent resource"
-msgstr "<0/> Go to parent resource"
+#~ msgid "<0/> Go to parent resource"
+#~ msgstr "<0/> Go to parent resource"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show or hide the sidebar"
 msgstr "Show or hide the sidebar"
 
@@ -5011,17 +5002,14 @@ msgstr "Switch to"
 msgid "Connect to that device"
 msgstr "Connect to that device"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
+#~ msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
+#~ msgstr "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or let it scan this device"
-msgstr "…or let it scan this device"
+#~ msgid "…or let it scan this device"
+#~ msgstr "…or let it scan this device"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
+#~ msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
+#~ msgstr "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
@@ -5031,9 +5019,8 @@ msgstr "Skip for now"
 msgid "Paste a pairing code or did:ad:node:…"
 msgstr "Paste a pairing code or did:ad:node:…"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr "Open <0>Sync</0> there to show its code, then scan or paste it here."
+#~ msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
+#~ msgstr "Open <0>Sync</0> there to show its code, then scan or paste it here."
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5364,18 +5351,14 @@ msgstr "Or paste theirs"
 msgid "Scan this from that device"
 msgstr "Scan this from that device"
 
-#. 0: serverLabel(baseURL)
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
+#~ msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
+#~ msgstr "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Connect a device that has it"
-msgstr "Connect a device that has it"
+#~ msgid "Connect a device that has it"
+#~ msgstr "Connect a device that has it"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "An always-on device has an address — add it and your workspace appears."
-msgstr "An always-on device has an address — add it and your workspace appears."
+#~ msgid "An always-on device has an address — add it and your workspace appears."
+#~ msgstr "An always-on device has an address — add it and your workspace appears."
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -6354,8 +6337,8 @@ msgstr "Pick an option…"
 msgid "Button says"
 msgstr "Button says"
 
+#: src/actions/runAction.ts
 #: src/chunks/TablePage/NewColumnButton.tsx
-#: src/components/ResourceContextMenu/index.tsx
 msgid "Action"
 msgstr "Action"
 
@@ -6591,9 +6574,8 @@ msgstr "Set up Cloud Server"
 msgid "Cloud Server"
 msgstr "Cloud Server"
 
-#: src/helpers/managed/cloudSync.ts
-msgid "Timed out connecting to the Cloud Server node."
-msgstr "Timed out connecting to the Cloud Server node."
+#~ msgid "Timed out connecting to the Cloud Server node."
+#~ msgstr "Timed out connecting to the Cloud Server node."
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6644,10 +6626,8 @@ msgstr "Open{0} <0>{0}/link</0>{1} on a device where you are signed in, and ente
 msgid "Waiting for you to approve it…"
 msgstr "Waiting for you to approve it…"
 
-#. 0: providerName(portalUrl)
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
-msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
+#~ msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Getting a code…"
@@ -6661,6 +6641,9 @@ msgstr "Connect this device"
 msgid "Android"
 msgstr "Android"
 
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
 #: src/helpers/managed/deviceLink.ts
 msgid "Mac"
 msgstr "Mac"
@@ -6692,21 +6675,18 @@ msgstr "Safari"
 #~ msgid "Use my own secret"
 #~ msgstr "Use my own secret"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Restore this workspace"
-msgstr "Restore this workspace"
+#~ msgid "Restore this workspace"
+#~ msgstr "Restore this workspace"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
-msgstr "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
+#~ msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
+#~ msgstr "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore my workspace"
 msgstr "Restore my workspace"
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or bring it from another device instead"
-msgstr "…or bring it from another device instead"
+#~ msgid "…or bring it from another device instead"
+#~ msgstr "…or bring it from another device instead"
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6898,7 +6878,7 @@ msgid "Not synced yet"
 msgstr "Not synced yet"
 
 #. 0: label; 1: detail
-#: src/components/ResourceContextMenu/index.tsx
+#: src/actions/runAction.ts
 msgid "{0} failed: {1}"
 msgstr "{0} failed: {1}"
 
@@ -7167,3 +7147,152 @@ msgstr "Forgot it? Restore from {0}"
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
 msgstr "Your backup is kept by your {0} account. Connect this device to it to restore."
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "Cannot {0} this resource."
+msgstr "Cannot {0} this resource."
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "{0} succeeded."
+msgstr "{0} succeeded."
+
+#. 0: action.toolName ?? action.id; 1: subject; 2: error
+#: src/actions/deriveTools.ts
+msgid "Error running {0} on {1}: {2}"
+msgstr "Error running {0} on {1}: {2}"
+
+#: src/actions/deriveTools.ts
+msgid "The subject (URL or #ref) of the resource"
+msgstr "The subject (URL or #ref) of the resource"
+
+#. 0: ctx.resource.title || ctx.subject
+#: src/actions/resourceActions.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr "Are you sure you want to delete {0}?"
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Deleting resource"
+msgstr "Deleting resource"
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Toggling favorite"
+msgstr "Toggling favorite"
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening share settings"
+msgstr "Opening share settings"
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening history"
+msgstr "Opening history"
+
+#: src/actions/appActions.ts
+msgid "Open the command palette to find resources and run actions."
+msgstr "Open the command palette to find resources and run actions."
+
+#: src/actions/appActions.ts
+msgid "Open the list of keyboard shortcuts."
+msgstr "Open the list of keyboard shortcuts."
+
+#: src/actions/appActions.ts
+msgid "Open the home page."
+msgstr "Open the home page."
+
+#: src/actions/appActions.ts
+msgid "Create a new resource."
+msgstr "Create a new resource."
+
+#: src/actions/appActions.ts
+msgid "Open the actions menu for the current resource."
+msgstr "Open the actions menu for the current resource."
+
+#: src/actions/appActions.ts
+msgid "Open your agent / user settings."
+msgstr "Open your agent / user settings."
+
+#: src/actions/appActions.ts
+msgid "Open appearance and theme settings."
+msgstr "Open appearance and theme settings."
+
+#: src/actions/appActions.ts
+msgid "Lock or unlock the sidebar."
+msgstr "Lock or unlock the sidebar."
+
+#: src/components/OverlayContainer.tsx
+msgid "Actions"
+msgstr "Actions"
+
+#: src/components/OverlayContainer.tsx
+msgid "<0/> open / run"
+msgstr "<0/> open / run"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Open <0>Sync</0> there and scan or paste its code here."
+msgstr "Open <0>Sync</0> there and scan or paste its code here."
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or let it scan this one"
+msgstr "…or let it scan this one"
+
+#. 0: serverLabel(baseURL)
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "It syncs your workspace to {0}, which this browser reads from."
+msgstr "It syncs your workspace to {0}, which this browser reads from."
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Connect a server that has it"
+msgstr "Connect a server that has it"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Restore your workspace"
+msgstr "Restore your workspace"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Bring your data back"
+msgstr "Bring your data back"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "There’s an encrypted backup, sealed so only you can open it."
+msgstr "There’s an encrypted backup, sealed so only you can open it."
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Your backup is kept by your {0} account. Sign in to it and it comes back here."
+msgstr "Your backup is kept by your {0} account. Sign in to it and it comes back here."
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Signing in restores who you are. Your workspace still lives on the device you made it with."
+msgstr "Signing in restores who you are. Your workspace still lives on the device you made it with."
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Sign in to {0}"
+msgstr "Sign in to {0}"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "I’ve signed in — check again"
+msgstr "I’ve signed in — check again"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or bring it over from another device"
+msgstr "…or bring it over from another device"
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Couldn’t reach {0}. Check your connection and try again."
+msgstr "Couldn’t reach {0}. Check your connection and try again."
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect to {0}"
+msgstr "Connect to {0}"
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "stores it without being able to read it."
+msgstr "stores it without being able to read it."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -964,7 +964,7 @@ msgstr "Traza de la pila:"
 msgid "Not found!"
 msgstr "¡No encontrado!"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 #: src/routes/Router.tsx
 msgid "Go home"
 msgstr "Ir a la página principal"
@@ -1104,6 +1104,7 @@ msgstr "Establecer como unidad actual"
 msgid "Add description"
 msgstr "Añadir descripción"
 
+#: src/components/OverlayContainer.tsx
 #: src/views/Drive/DrivePage.tsx
 msgid "Resources"
 msgstr "Recursos"
@@ -1351,9 +1352,8 @@ msgstr "Iniciar chat de IA con \"{0}\""
 msgid "<0/> <1/> navigate"
 msgstr "<0/> <1/> navegar"
 
-#: src/components/OverlayContainer.tsx
-msgid "<0/> open / chat"
-msgstr "<0/> abrir / chatear"
+#~ msgid "<0/> open / chat"
+#~ msgstr "<0/> abrir / chatear"
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> chat"
@@ -1364,37 +1364,37 @@ msgstr "<0/> chatear"
 msgid "<0>esc</0> close"
 msgstr "<0>esc</0> cerrar"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open search"
 msgstr "Abrir búsqueda"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show keyboard shortcuts"
 msgstr "Mostrar atajos de teclado"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
 msgid "Edit resource"
 msgstr "Editar recurso"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Show data view"
 msgstr "Mostrar vista de datos"
 
+#: src/actions/appActions.ts
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
-#: src/components/OverlayContainer.tsx
 msgid "New resource"
 msgstr "Nuevo recurso"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open menu"
 msgstr "Abrir menú"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "User settings"
 msgstr "Configuración de usuario"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Theme settings"
 msgstr "Configuración de tema"
 
@@ -1706,45 +1706,35 @@ msgstr "Estás utilizando un Agente local, que no puede autenticarse en otros do
 msgid "Global"
 msgstr "Global"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Search"
-msgstr "<0/> Buscar"
+#~ msgid "<0/> Search"
+#~ msgstr "<0/> Buscar"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show or hide the sidebar"
-msgstr "<0/> Mostrar u ocultar la barra lateral"
+#~ msgid "<0/> Show or hide the sidebar"
+#~ msgstr "<0/> Mostrar u ocultar la barra lateral"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show these keyboard shortcuts"
-msgstr "<0/> Mostrar estos atajos de teclado"
+#~ msgid "<0/> Show these keyboard shortcuts"
+#~ msgstr "<0/> Mostrar estos atajos de teclado"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>dit resource"
-msgstr "<0/> <1/>ditar recurso"
+#~ msgid "<0/> <1/>dit resource"
+#~ msgstr "<0/> <1/>ditar recurso"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>d</1>ata for resource"
-msgstr "<0/> Mostrar <1>d</1>atos del recurso"
+#~ msgid "<0/> Show <1>d</1>ata for resource"
+#~ msgstr "<0/> Mostrar <1>d</1>atos del recurso"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>h</1>ome page"
-msgstr "<0/> Mostrar página de <1>i</1>nicio"
+#~ msgid "<0/> Show <1>h</1>ome page"
+#~ msgstr "<0/> Mostrar página de <1>i</1>nicio"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ew resource"
-msgstr "<0/> <1/>uevo recurso"
+#~ msgid "<0/> <1/>ew resource"
+#~ msgstr "<0/> <1/>uevo recurso"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Open <1>m</1>enu"
-msgstr "<0/> Abrir <1>m</1>enú"
+#~ msgid "<0/> Open <1>m</1>enu"
+#~ msgstr "<0/> Abrir <1>m</1>enú"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ser settings"
-msgstr "<0/> <1/>justes de usuario"
+#~ msgid "<0/> <1/>ser settings"
+#~ msgstr "<0/> <1/>justes de usuario"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>heme settings"
-msgstr "<0/> <1/>justes de tema"
+#~ msgid "<0/> <1/>heme settings"
+#~ msgstr "<0/> <1/>justes de tema"
 
 #: src/routes/SyncRoute.tsx
 msgid "In sync"
@@ -4665,7 +4655,7 @@ msgid "No matching actions"
 msgstr ""
 
 #: src/actions/resourceActions.tsx
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Go to parent"
 msgstr ""
 
@@ -4674,15 +4664,16 @@ msgid "Open the parent of this resource."
 msgstr ""
 
 #. 0: ' '
-#: src/actions/resourceActions.tsx
+#. 0: ' '
+#: src/components/OverlayContainer.tsx
+#: src/components/ResourceContextMenu/index.tsx
 msgid "Are you sure you want to delete{0} <0/>"
 msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Go to parent resource"
-msgstr ""
+#~ msgid "<0/> Go to parent resource"
+#~ msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4977,17 +4968,14 @@ msgstr ""
 msgid "Connect to that device"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+#~ msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or let it scan this device"
-msgstr ""
+#~ msgid "…or let it scan this device"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+#~ msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
@@ -4997,9 +4985,8 @@ msgstr ""
 msgid "Paste a pairing code or did:ad:node:…"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+#~ msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
+#~ msgstr ""
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5330,18 +5317,14 @@ msgstr ""
 msgid "Scan this from that device"
 msgstr ""
 
-#. 0: serverLabel(baseURL)
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+#~ msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Connect a device that has it"
-msgstr ""
+#~ msgid "Connect a device that has it"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+#~ msgid "An always-on device has an address — add it and your workspace appears."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -6320,8 +6303,8 @@ msgstr ""
 msgid "Button says"
 msgstr ""
 
+#: src/actions/runAction.ts
 #: src/chunks/TablePage/NewColumnButton.tsx
-#: src/components/ResourceContextMenu/index.tsx
 msgid "Action"
 msgstr ""
 
@@ -6557,9 +6540,8 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#: src/helpers/managed/cloudSync.ts
-msgid "Timed out connecting to the Cloud Server node."
-msgstr ""
+#~ msgid "Timed out connecting to the Cloud Server node."
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6610,10 +6592,8 @@ msgstr ""
 msgid "Waiting for you to approve it…"
 msgstr ""
 
-#. 0: providerName(portalUrl)
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Getting a code…"
@@ -6627,6 +6607,9 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
 #: src/helpers/managed/deviceLink.ts
 msgid "Mac"
 msgstr ""
@@ -6658,21 +6641,18 @@ msgstr ""
 #~ msgid "Use my own secret"
 #~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Restore this workspace"
-msgstr ""
+#~ msgid "Restore this workspace"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
-msgstr ""
+#~ msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore my workspace"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or bring it from another device instead"
-msgstr ""
+#~ msgid "…or bring it from another device instead"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6864,7 +6844,7 @@ msgid "Not synced yet"
 msgstr ""
 
 #. 0: label; 1: detail
-#: src/components/ResourceContextMenu/index.tsx
+#: src/actions/runAction.ts
 msgid "{0} failed: {1}"
 msgstr ""
 
@@ -7132,4 +7112,153 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "Cannot {0} this resource."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "{0} succeeded."
+msgstr ""
+
+#. 0: action.toolName ?? action.id; 1: subject; 2: error
+#: src/actions/deriveTools.ts
+msgid "Error running {0} on {1}: {2}"
+msgstr ""
+
+#: src/actions/deriveTools.ts
+msgid "The subject (URL or #ref) of the resource"
+msgstr ""
+
+#. 0: ctx.resource.title || ctx.subject
+#: src/actions/resourceActions.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Deleting resource"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Toggling favorite"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening share settings"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening history"
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the command palette to find resources and run actions."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the list of keyboard shortcuts."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the home page."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Create a new resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the actions menu for the current resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open your agent / user settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open appearance and theme settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Lock or unlock the sidebar."
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "Actions"
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "<0/> open / run"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Open <0>Sync</0> there and scan or paste its code here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or let it scan this one"
+msgstr ""
+
+#. 0: serverLabel(baseURL)
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "It syncs your workspace to {0}, which this browser reads from."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Connect a server that has it"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Restore your workspace"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Bring your data back"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "There’s an encrypted backup, sealed so only you can open it."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Your backup is kept by your {0} account. Sign in to it and it comes back here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Signing in restores who you are. Your workspace still lives on the device you made it with."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Sign in to {0}"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "I’ve signed in — check again"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or bring it over from another device"
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Couldn’t reach {0}. Check your connection and try again."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect to {0}"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "stores it without being able to read it."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -964,7 +964,7 @@ msgstr "Trace de la pile :"
 msgid "Not found!"
 msgstr "Pas trouvé !"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 #: src/routes/Router.tsx
 msgid "Go home"
 msgstr "Aller à l'accueil"
@@ -1104,6 +1104,7 @@ msgstr "Définir comme lecteur actuel"
 msgid "Add description"
 msgstr "Ajouter une description"
 
+#: src/components/OverlayContainer.tsx
 #: src/views/Drive/DrivePage.tsx
 msgid "Resources"
 msgstr "Ressources"
@@ -1351,9 +1352,8 @@ msgstr "Lancer une discussion IA avec « {0} »"
 msgid "<0/> <1/> navigate"
 msgstr "<0/> <1/> naviguer"
 
-#: src/components/OverlayContainer.tsx
-msgid "<0/> open / chat"
-msgstr "<0/> ouvrir / discuter"
+#~ msgid "<0/> open / chat"
+#~ msgstr "<0/> ouvrir / discuter"
 
 #: src/components/OverlayContainer.tsx
 msgid "<0/> chat"
@@ -1364,37 +1364,37 @@ msgstr "<0/> discuter"
 msgid "<0>esc</0> close"
 msgstr "<0>échap</0> fermer"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open search"
 msgstr "Ouvrir la recherche"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show keyboard shortcuts"
 msgstr "Afficher les raccourcis clavier"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 #: src/components/forms/ResourceSelector/ResourceSelector.tsx
 msgid "Edit resource"
 msgstr "Modifier la ressource"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Show data view"
 msgstr "Afficher la vue des données"
 
+#: src/actions/appActions.ts
 #: src/components/NewInstanceButton/QuickCreateRow.tsx
-#: src/components/OverlayContainer.tsx
 msgid "New resource"
 msgstr "Nouvelle ressource"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Open menu"
 msgstr "Ouvrir le menu"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "User settings"
 msgstr "Paramètres utilisateur"
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Theme settings"
 msgstr "Paramètres du thème"
 
@@ -1706,45 +1706,35 @@ msgstr "Vous utilisez un Agent local, qui ne peut pas s'authentifier sur d'autre
 msgid "Global"
 msgstr "Global"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Search"
-msgstr "<0/> Rechercher"
+#~ msgid "<0/> Search"
+#~ msgstr "<0/> Rechercher"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show or hide the sidebar"
-msgstr "<0/> Afficher ou masquer la barre latérale"
+#~ msgid "<0/> Show or hide the sidebar"
+#~ msgstr "<0/> Afficher ou masquer la barre latérale"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show these keyboard shortcuts"
-msgstr "<0/> Afficher ces raccourcis clavier"
+#~ msgid "<0/> Show these keyboard shortcuts"
+#~ msgstr "<0/> Afficher ces raccourcis clavier"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>dit resource"
-msgstr "<0/> <1/>Modifier la ressource"
+#~ msgid "<0/> <1/>dit resource"
+#~ msgstr "<0/> <1/>Modifier la ressource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>d</1>ata for resource"
-msgstr "<0/> Afficher les <1>d</1>onnées de la ressource"
+#~ msgid "<0/> Show <1>d</1>ata for resource"
+#~ msgstr "<0/> Afficher les <1>d</1>onnées de la ressource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Show <1>h</1>ome page"
-msgstr "<0/> Afficher la page d'<1>a</1>ccueil"
+#~ msgid "<0/> Show <1>h</1>ome page"
+#~ msgstr "<0/> Afficher la page d'<1>a</1>ccueil"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ew resource"
-msgstr "<0/> <1/>Nouvelle ressource"
+#~ msgid "<0/> <1/>ew resource"
+#~ msgstr "<0/> <1/>Nouvelle ressource"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Open <1>m</1>enu"
-msgstr "<0/> Ouvrir le <1>m</1>enu"
+#~ msgid "<0/> Open <1>m</1>enu"
+#~ msgstr "<0/> Ouvrir le <1>m</1>enu"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>ser settings"
-msgstr "<0/> <1/>Paramètres utilisateur"
+#~ msgid "<0/> <1/>ser settings"
+#~ msgstr "<0/> <1/>Paramètres utilisateur"
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> <1/>heme settings"
-msgstr "<0/> <1/>Paramètres du thème"
+#~ msgid "<0/> <1/>heme settings"
+#~ msgstr "<0/> <1/>Paramètres du thème"
 
 #: src/routes/SyncRoute.tsx
 msgid "In sync"
@@ -4665,7 +4655,7 @@ msgid "No matching actions"
 msgstr ""
 
 #: src/actions/resourceActions.tsx
-#: src/components/OverlayContainer.tsx
+#: src/actions/resourceActions.tsx
 msgid "Go to parent"
 msgstr ""
 
@@ -4674,15 +4664,16 @@ msgid "Open the parent of this resource."
 msgstr ""
 
 #. 0: ' '
-#: src/actions/resourceActions.tsx
+#. 0: ' '
+#: src/components/OverlayContainer.tsx
+#: src/components/ResourceContextMenu/index.tsx
 msgid "Are you sure you want to delete{0} <0/>"
 msgstr ""
 
-#: src/routes/ShortcutsRoute.tsx
-msgid "<0/> Go to parent resource"
-msgstr ""
+#~ msgid "<0/> Go to parent resource"
+#~ msgstr ""
 
-#: src/components/OverlayContainer.tsx
+#: src/actions/appActions.ts
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4977,17 +4968,14 @@ msgstr ""
 msgid "Connect to that device"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
-msgstr ""
+#~ msgid "You’re signed in, but this device doesn’t have your workspace yet. Signing in restores who you are — your data stays where you made it."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or let it scan this device"
-msgstr ""
+#~ msgid "…or let it scan this device"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
-msgstr ""
+#~ msgid "Scan this code from your other device instead. It only says where to reach this one — the other side still proves it holds your key."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Skip for now"
@@ -4997,9 +4985,8 @@ msgstr ""
 msgid "Paste a pairing code or did:ad:node:…"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
-msgstr ""
+#~ msgid "Open <0>Sync</0> there to show its code, then scan or paste it here."
+#~ msgstr ""
 
 #: src/components/pairing/PairingFlowProvider.tsx
 msgid "Pairing device"
@@ -5330,18 +5317,14 @@ msgstr ""
 msgid "Scan this from that device"
 msgstr ""
 
-#. 0: serverLabel(baseURL)
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
-msgstr ""
+#~ msgid "Syncs your workspace with {0}, which this browser reads from. Safe to show: a code only routes."
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Connect a device that has it"
-msgstr ""
+#~ msgid "Connect a device that has it"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "An always-on device has an address — add it and your workspace appears."
-msgstr ""
+#~ msgid "An always-on device has an address — add it and your workspace appears."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Error: could not disconnect that device"
@@ -6320,8 +6303,8 @@ msgstr ""
 msgid "Button says"
 msgstr ""
 
+#: src/actions/runAction.ts
 #: src/chunks/TablePage/NewColumnButton.tsx
-#: src/components/ResourceContextMenu/index.tsx
 msgid "Action"
 msgstr ""
 
@@ -6557,9 +6540,8 @@ msgstr ""
 msgid "Cloud Server"
 msgstr ""
 
-#: src/helpers/managed/cloudSync.ts
-msgid "Timed out connecting to the Cloud Server node."
-msgstr ""
+#~ msgid "Timed out connecting to the Cloud Server node."
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6610,10 +6592,8 @@ msgstr ""
 msgid "Waiting for you to approve it…"
 msgstr ""
 
-#. 0: providerName(portalUrl)
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so {0} stores it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Getting a code…"
@@ -6627,6 +6607,9 @@ msgstr ""
 msgid "Android"
 msgstr ""
 
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
+#: src/actions/shortcuts.ts
 #: src/helpers/managed/deviceLink.ts
 msgid "Mac"
 msgstr ""
@@ -6658,21 +6641,18 @@ msgstr ""
 #~ msgid "Use my own secret"
 #~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "Restore this workspace"
-msgstr ""
+#~ msgid "Restore this workspace"
+#~ msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
-msgstr ""
+#~ msgid "You’re signed in, and this workspace has an encrypted backup. We stored it sealed, so only this device can open it."
+#~ msgstr ""
 
 #: src/views/getting-started/ConnectDeviceStep.tsx
 msgid "Restore my workspace"
 msgstr ""
 
-#: src/views/getting-started/ConnectDeviceStep.tsx
-msgid "…or bring it from another device instead"
-msgstr ""
+#~ msgid "…or bring it from another device instead"
+#~ msgstr ""
 
 #. 0: PRODUCT_NAME
 #: src/components/Vault/VaultPanel.tsx
@@ -6864,7 +6844,7 @@ msgid "Not synced yet"
 msgstr ""
 
 #. 0: label; 1: detail
-#: src/components/ResourceContextMenu/index.tsx
+#: src/actions/runAction.ts
 msgid "{0} failed: {1}"
 msgstr ""
 
@@ -7132,4 +7112,153 @@ msgstr ""
 #. 0: PRODUCT_NAME
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Your backup is kept by your {0} account. Connect this device to it to restore."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "Cannot {0} this resource."
+msgstr ""
+
+#. 0: action.label(ctx)
+#: src/actions/deriveTools.ts
+msgid "{0} succeeded."
+msgstr ""
+
+#. 0: action.toolName ?? action.id; 1: subject; 2: error
+#: src/actions/deriveTools.ts
+msgid "Error running {0} on {1}: {2}"
+msgstr ""
+
+#: src/actions/deriveTools.ts
+msgid "The subject (URL or #ref) of the resource"
+msgstr ""
+
+#. 0: ctx.resource.title || ctx.subject
+#: src/actions/resourceActions.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Deleting resource"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Toggling favorite"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening share settings"
+msgstr ""
+
+#: src/chunks/AI/AIChatMessageParts/MessageToolPart.tsx
+msgid "Opening history"
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the command palette to find resources and run actions."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the list of keyboard shortcuts."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the home page."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Create a new resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open the actions menu for the current resource."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open your agent / user settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Open appearance and theme settings."
+msgstr ""
+
+#: src/actions/appActions.ts
+msgid "Lock or unlock the sidebar."
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "Actions"
+msgstr ""
+
+#: src/components/OverlayContainer.tsx
+msgid "<0/> open / run"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Open <0>Sync</0> there and scan or paste its code here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or let it scan this one"
+msgstr ""
+
+#. 0: serverLabel(baseURL)
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "It syncs your workspace to {0}, which this browser reads from."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Connect a server that has it"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Restore your workspace"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Bring your data back"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "There’s an encrypted backup, sealed so only you can open it."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Your backup is kept by your {0} account. Sign in to it and it comes back here."
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Signing in restores who you are. Your workspace still lives on the device you made it with."
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Sign in to {0}"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "I’ve signed in — check again"
+msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "…or bring it over from another device"
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Couldn’t reach {0}. Check your connection and try again."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect to {0}"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+msgstr ""
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "stores it without being able to read it."
 msgstr ""

--- a/browser/data-browser/src/routes/ShortcutsRoute.tsx
+++ b/browser/data-browser/src/routes/ShortcutsRoute.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { styled } from 'styled-components';
 import { ContainerNarrow } from '../components/Containers';
-import { shortcuts } from '../components/HotKeyWrapper';
+import { listShortcutHelp } from '../actions/catalog';
 import { Shortcut } from '../components/Shortcut';
 import { Main } from '../components/Main';
 import { createRoute } from '@tanstack/react-router';
@@ -14,47 +14,20 @@ export const ShortcutsRoute = createRoute({
   getParentRoute: () => appRoute,
 });
 
-/** List of all the keyboard shorcuts */
+/** List of all the keyboard shortcuts, rendered from the action registry. */
 const Shortcuts: React.FunctionComponent = () => {
+  const entries = listShortcutHelp();
+
   return (
     <Main>
       <ContainerNarrow>
         <h1>Keyboard shortcuts</h1>
         <h3>Global</h3>
-        <p>
-          <Key shortcut={shortcuts.search} /> Search
-        </p>
-        <p>
-          <Key shortcut={shortcuts.sidebarToggle} /> Show or hide the sidebar
-        </p>
-        <p>
-          <Key shortcut={shortcuts.keyboardShortcuts} /> Show these keyboard
-          shortcuts
-        </p>
-        <p>
-          <Key shortcut={shortcuts.edit} /> <b>E</b>dit resource
-        </p>
-        <p>
-          <Key shortcut={shortcuts.data} /> Show <b>d</b>ata for resource
-        </p>
-        <p>
-          <Key shortcut={shortcuts.home} /> Show <b>h</b>ome page
-        </p>
-        <p>
-          <Key shortcut={shortcuts.parent} /> Go to parent resource
-        </p>
-        <p>
-          <Key shortcut={shortcuts.new} /> <b>N</b>ew resource
-        </p>
-        <p>
-          <Key shortcut={shortcuts.menu} /> Open <b>m</b>enu
-        </p>
-        <p>
-          <Key shortcut={shortcuts.userSettings} /> <b>U</b>ser settings
-        </p>
-        <p>
-          <Key shortcut={shortcuts.themeSettings} /> <b>T</b>heme settings
-        </p>
+        {entries.map(entry => (
+          <p key={entry.id}>
+            <Key shortcut={entry.shortcut} /> {entry.label}
+          </p>
+        ))}
       </ContainerNarrow>
     </Main>
   );

--- a/browser/e2e/tests/command-palette-actions.spec.ts
+++ b/browser/e2e/tests/command-palette-actions.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { before, newResource, setTitle, typeInSearch } from './test-utils';
+
+test.describe('command palette actions', () => {
+  test.beforeEach(before);
+
+  test('cmd+k shows matching registry actions and runs one', async ({
+    page,
+  }) => {
+    await newResource('folder', page);
+    await setTitle(page, 'PaletteFolder');
+    await page.keyboard.press('Escape');
+
+    await typeInSearch(page, 'history');
+    const historyAction = page.getByTestId('palette-action-history');
+    await expect(historyAction).toBeVisible();
+    await expect(page.getByText('Actions', { exact: true })).toBeVisible();
+
+    await historyAction.click();
+    await expect(page).toHaveURL(/history/);
+  });
+
+  test('cmd+k does not interleave actions into a resource-name query', async ({
+    page,
+  }) => {
+    await typeInSearch(page, 'avocado');
+    await expect(page.getByTestId('palette-action-history')).toHaveCount(0);
+    await expect(page.getByTestId('palette-action-delete')).toHaveCount(0);
+    await expect(page.getByTestId('palette-action-edit')).toHaveCount(0);
+  });
+});

--- a/planning/README.md
+++ b/planning/README.md
@@ -89,7 +89,7 @@ Not top-level plans. Indexed so they do not go missing.
 | [`arc-actor-message-payloads.md`](./arc-actor-message-payloads.md) | Partial. WS encode-once shipped; `CommitMessage` Arc-wrap deferred. |
 | [`sync-onboarding-ux.md`](./sync-onboarding-ux.md) | Reference. Cross-client copy for what can reach what. Companion to [`device-pairing.md`](./device-pairing.md). |
 | [`main-drive-and-paths.md`](./main-drive-and-paths.md) | Strategy. DID-branch deployment: root drive, legacy URLs, human-readable paths. |
-| [`actions.md`](./actions.md) | **Step 1 shipped** (registry + ⌘M menu, 2026-07-08). Remaining: ⌘K section, hotkeys/shortcuts page derived from the registry, AI-tool derivation. |
+| [`actions.md`](./actions.md) | **Steps 1–4 shipped.** Registry drives ⌘M, ⌘K (capped prefix match), hotkeys, the shortcuts overlay/page, and simple AI tools. Remaining: MCP projection when a server exists. |
 | [`silent-failures.md`](./silent-failures.md) | Living log of error-handling failures that reported success (2026-08-21). Carries M8 from the pairing field test. |
 
 Closed decisions, as-built records, closed explorations and fixed notes live

--- a/planning/actions.md
+++ b/planning/actions.md
@@ -1,33 +1,21 @@
 # Unified Actions
 
-**Status:** Rollout step 1 shipped (2026-07-08, `30574b93b`): the registry in
+**Status:** Steps 1–4 shipped. The registry in
 `browser/data-browser/src/actions/` (`ActionDefinition`, `resourceActions`,
-`useActionContext`) and the searchable ⌘M menu; `ResourceContextMenu` renders
-from it, and the fork verbs from
+`appActions`, `useActionContext`) is the source for the searchable ⌘M menu,
+`ResourceContextMenu`, the ⌘K actions section, hotkeys, the shortcuts overlay
+and `/app/shortcuts` page, and simple AI tools. Fork verbs from
 [`drafts-and-suggestions.md`](./drafts-and-suggestions.md) already land there.
-Remaining: steps 2–4 — the ⌘K actions section (`SearchOverlay` still only
-navigates), hotkeys and the shortcuts page derived from the registry (today
-`resourceActions` imports `shortcuts` from `HotKeyWrapper`, the reverse of the
-plan), and AI-tool / MCP derivation.
 
-Corrected 2026-09-01; the previous "Nothing built" line predated step 1.
+Remaining: a future MCP server can reuse `deriveActionTools`; specialized
+`destroy()` call sites (table rows, views, tags) stay local — they are not
+the resource-delete verb.
 
 ## Problem
 
 Resource actions (view, edit, delete, share, history, favorite, …) are invocable
 from many surfaces — context menus, keyboard shortcuts, the ⌘K overlay, AI tools,
-the JS API — but each surface enumerates and implements them independently:
-
-- Four parallel registries enumerate overlapping verbs: `ContextMenuOptions`
-  (ResourceContextMenu), the `shortcuts` object (HotKeyWrapper), `TOOL_NAMES`
-  (useAtomicTools), and the URL builders in `helpers/navigation.tsx`.
-- `resource.destroy()` is wired up independently in 5+ places, each
-  re-implementing confirmation + toast + cleanup.
-- The shortcuts help page (`ShortcutsRoute.tsx`) is hand-synced prose.
-- The ⌘K overlay exposes exactly one verb (navigate to search result).
-- Coverage is inconsistent: Delete has no hotkey and no AI tool; Share/History/
-  Favorite exist only in the context menu.
-- There is no MCP server yet; when one exists it would be a fifth enumeration.
+the JS API — but each surface used to enumerate and implement them independently.
 
 ## Design
 
@@ -38,57 +26,37 @@ surface is a *projection* of it.
 interface ActionDefinition {
   id: string;                  // stable; matches old ContextMenuOptions values
   scope: 'resource' | 'app';   // takes a target subject vs. app-level
-  section: 'view' | 'action' | 'danger'; // menus render dividers between sections
-  label: string | ((ctx) => string);      // menu label / palette title
-  helper: string;              // tooltip today; AI/MCP tool description later
-  icon?: (ctx) => ReactNode;
-  shortcut?: string;           // from the `shortcuts` registry; shown as chip
-  keywords?: string[];         // extra search terms for searchable surfaces
-  danger?: boolean;            // surface must confirm before running
-  confirmation?: { title; confirmLabel; body(ctx) }; // what the dialog shows
-  available?: (ctx) => boolean; // hidden when false (e.g. needs canWrite)
-  disabled?: (ctx) => boolean;  // shown greyed (e.g. already on that route)
-  run: (ctx) => void | Promise<void>; // THE one implementation
+  section: 'view' | 'action';  // menus render dividers between sections
+  label: string | ((ctx) => string);
+  helper: string;              // tooltip; AI/MCP tool description
+  shortcut?: string;           // from `actions/shortcuts.ts`
+  asTool?: boolean;            // derive an AI tool from helper + run
+  run: (ctx) => void | Promise<void>;
 }
 ```
 
-`ActionContext` is assembled once per target by the `useActionContext(subject,
-overrides)` hook: store, navigate, resource, canWrite, favorites, AI-sidebar
-add-to-chat, scope/new-child navigation, current subject/pathname, plus
-surface-provided capabilities (`showCodeUsageDialog`, `onAfterDelete`,
-`external`). **Capability gating**: an action that needs a capability declares
-it via `available`, so surfaces that can't provide it simply don't list it.
-
-Three kinds of actions, modeled by what `run` does:
-- **navigation** (view, data, edit, share, history, import, move-to-parent):
-  `run` = `navigate(xURL(subject))`; safe on every surface.
-- **mutation** (delete, favorite): the duplication hotspot; `danger` +
-  `confirmation` live on the definition so confirm-wiring is uniform.
-- **UI effects** (add to chat, use in code, search children): gated on
-  capabilities, only listed where they make sense.
+`ActionContext` is assembled by `useActionContext` (React) or
+`buildActionContext` (AI tools). Surfaces that cannot provide a capability
+simply do not list the action (`available`).
 
 ## Surfaces
 
 | Surface | How it projects the registry |
 |---|---|
-| Right-click / kebab menus | `ResourceContextMenu` builds `DropdownItem[]` from definitions; `showOnly` keeps filtering by id (17 call sites unchanged) |
-| ⌘M "more" menu | Same menu, `searchable`: filter input at top, type-to-filter over label+keywords, arrows+enter. Only the main menu is searchable; right-click stays a plain instant dropdown (mouse intent) |
-| ⌘K overlay | Actions appear as a section next to search results. **Placement policy, not unified ranking**: actions section capped at ~3, shown only on a strong prefix/synonym match against the action vocabulary, never interleaved with resource results |
+| Right-click / kebab menus | `ResourceContextMenu` builds `DropdownItem[]` from definitions |
+| ⌘M "more" menu | Same menu, `searchable` |
+| ⌘K overlay | Actions section, capped at 3, prefix/synonym match only, never interleaved with resource results |
 | Hotkeys | `HotKeyWrapper` registers definitions that carry `shortcut` |
-| Shortcuts help page | Rendered from the registry (kills the hand-synced prose) |
-| AI tools | Simple verbs derive `tool({ description: helper, execute: run })`; rich tools (query, create_table) stay bespoke |
+| Shortcuts help | `listShortcutHelp()` — overlay and `/app/shortcuts` |
+| AI tools | `deriveActionTools` for `asTool` verbs; rich tools stay bespoke |
 | MCP server (future) | Same derivation, different protocol |
 
 ## Rollout
 
-1. **Registry + searchable ⌘M menu** (this slice): `src/actions/` with all
-   current context-menu actions + move-to-parent (⌘↑, Finder convention);
-   `ResourceContextMenu` renders from the registry; `DropdownMenu` gains a
-   `searchable` mode used by the main menu.
-2. **⌘K**: actions section in `SearchOverlay` per the placement policy.
-3. **Hotkeys + shortcuts page** derived from the registry; collapse the
-   remaining scattered delete implementations onto the delete action.
-4. **AI tools / MCP** derivation for simple verbs.
+1. **Registry + searchable ⌘M menu** (2026-07-08): shipped.
+2. **⌘K**: actions section in `OverlayContainer` `SearchOverlay` per the placement policy.
+3. **Hotkeys + shortcuts page** derived from the registry. Shortcut strings live in `actions/shortcuts.ts`; `HotKeyWrapper` re-exports them.
+4. **AI tools**: `delete_resource`, `favorite_resource`, `open_share_settings`, `show_history` derive from the matching verbs.
 
 ## Non-goals
 
@@ -108,3 +76,6 @@ Three kinds of actions, modeled by what `run` does:
   call sites and `menu-item-<id>` test ids don't churn.
 - **Right-click menus are not searchable**; ⌘M and the navbar kebab are.
 - **Move to parent** gets ⌘↑, matching Finder's "go to enclosing folder".
+- **⌘K match is a prefix of id / label word / keyword**, never a mid-word
+  substring, and ignored below 2 characters — so a resource-name query does
+  not grow an Actions section.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

closes #1232

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed

## What this does

Issue #1232 asked for one place to describe resource actions so menus, shortcuts, the command palette, and AI tools stop enumerating the same verbs independently. Step 1 (registry + ⌘M) already shipped. This finishes steps 2–4 from `planning/actions.md`:

- **⌘K** (`OverlayContainer` search overlay) shows a separate **Actions** section for the current resource. Matches are a prefix of the action id, a label word, or a keyword; the section is capped at 3 and never interleaved with resource hits. Danger verbs still confirm.
- **Hotkeys** for edit / data / parent run the registry action instead of a parallel `navigate()` in `HotKeyWrapper`. Shortcut strings live in `actions/shortcuts.ts`.
- **Shortcuts overlay and `/app/shortcuts`** render `listShortcutHelp()` — the same list as the bindings.
- **AI tools** `delete_resource`, `favorite_resource`, `open_share_settings`, and `show_history` are derived from `asTool` verbs (`helper` → description, `run` → execute). Rich tools stay bespoke.

## Still out of scope (as planned)

- No Atomic MCP server yet — `deriveActionTools` is the hook a future MCP adapter can reuse.
- The registry stays in `data-browser` (not `@tomic/lib`); almost every verb touches navigation, dialogs, or toasts.
- Specialized `destroy()` call sites (table rows, views, tags) stay local — they are not the resource-delete verb.

## Testing

- Unit: `matchActions.test.ts`, `catalog.test.ts`, `deriveTools.test.ts` (11/11)
- E2E: `command-palette-actions.spec.ts` — 2/2 passed locally against Vite `:6747` + server `:9885` (not `@smoke`, so feature-branch CI does not run it)
- Manual: ⌘K `history` opens History; ⌘K `avocado` has no Actions section; `?` overlay lists registry shortcuts including Go to parent / Edit resource

[cmdk-actions-and-shortcuts-overlay.mp4](https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcmdk-actions-and-shortcuts-overlay.mp4)

[⌘K Actions section matching History](https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcmdk_history_actions_section.webp)
[History page after running the palette action](https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_page_after_palette_action.webp)
[⌘K avocado query with no Actions section](https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcmdk_avocado_no_actions.webp)
[Shortcuts overlay rendered from the action registry](https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshortcuts_overlay_from_registry.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1158e44-08ac-4ae6-aedb-6ffb2138735e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

