### PR TITLE
Share drive names and emoji with SaaS

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -351,3 +351,5 @@ Not covered: leftover Yjs-era DocumentV2 bodies end-to-end (needs a stored `{ ty
 Not covered: Flutter `create_drive` still mints a random DID (the Rust
 `ensure_personal_drive` helper exists for `setup()`). E2E sign-in on a second
 machine with the old machine offline.
+
+Cloud Vault display metadata: `vaultAutoBackup.test.ts` verifies name/emoji enrollment and refresh after edits; SaaS `enrollment_display_metadata_refreshes_and_survives_legacy_clients` verifies persistence and account ownership.

--- a/browser/data-browser/src/helpers/managed/vault.test.ts
+++ b/browser/data-browser/src/helpers/managed/vault.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   agentVaultProof,
+  enrollVault,
   vaultLaneId,
   backupDrive,
   restoreDrive,
@@ -20,6 +21,26 @@ import {
  * when storage rejects a PUT, whether restore replays segments in the right
  * order. Each of those is a data-integrity property, not a plumbing detail.
  */
+
+it('sends name and emoji as optional enrollment metadata', async () => {
+  const fetch = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(
+      new Response(JSON.stringify({ enrollment: { id: '1' } }), {
+        status: 200,
+      }),
+    );
+  await enrollVault('did:ad:drive', 'did:ad:agent:test', {
+    name: 'Design',
+    emoji: '🎨',
+  });
+  expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual({
+    drive_subject: 'did:ad:drive',
+    agent_subject: 'did:ad:agent:test',
+    drive_name: 'Design',
+    drive_emoji: '🎨',
+  });
+});
 
 const DEVICE = '03'.repeat(32);
 const PSEUDONYM = 'testpseudonym';

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -146,6 +146,8 @@ type DownloadUrl = {
 };
 
 export type VaultEnrollment = {
+  drive_name?: string | null;
+  drive_emoji?: string | null;
   id: string;
   drive_subject: string;
   /** The agent that enrolled it; an account may hold several agents' drives. */
@@ -235,6 +237,7 @@ async function api<T>(
 export async function enrollVault(
   driveSubject: string,
   agentSubject: string,
+  metadata?: { name?: string; emoji?: string },
 ): Promise<VaultEnrollment> {
   const created = await api<{ enrollment: VaultEnrollment }>(
     '/cloud-vault/enroll',
@@ -243,6 +246,8 @@ export async function enrollVault(
       body: JSON.stringify({
         drive_subject: driveSubject,
         agent_subject: agentSubject,
+        drive_name: metadata?.name,
+        drive_emoji: metadata?.emoji,
       }),
     },
   );
@@ -570,13 +575,15 @@ export async function setUpVaultForDrive({
   driveSubject,
   agentSubject,
   agentSecret,
+  metadata,
 }: {
+  metadata?: { name?: string; emoji?: string };
   keys: VaultKeyOps;
   driveSubject: string;
   agentSubject: string;
   agentSecret: Uint8Array;
 }): Promise<{ enrollment: VaultEnrollment; driveKey: Uint8Array }> {
-  const enrollment = await enrollVault(driveSubject, agentSubject);
+  const enrollment = await enrollVault(driveSubject, agentSubject, metadata);
   const existing = await getVaultKeyEnvelope(enrollment.drive_pseudonym);
 
   if (existing) {

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Agent, JSCryptoProvider, Store } from '@tomic/lib';
+import {
+  Agent,
+  JSCryptoProvider,
+  Store,
+  Resource,
+  core,
+  dataBrowser,
+} from '@tomic/lib';
 import {
   ensureVaultBackup,
   forgetEnrolledVaults,
@@ -96,6 +103,28 @@ afterEach(() => {
 });
 
 describe('ensureVaultBackup', () => {
+  it('shares the drive name and emoji and refreshes them after edits', async () => {
+    const store = await signedInStore();
+    const drive = new Resource(DRIVE);
+    await drive.set(core.properties.name, 'Design', false);
+    await drive.set(dataBrowser.properties.emoji, '🎨', false);
+    store.addResource(drive);
+    const deps = fakeDeps();
+    await ensureVaultBackup(store, DRIVE, deps);
+    expect(deps.setUpVaultForDrive).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        metadata: { name: 'Design', emoji: '🎨' },
+      }),
+    );
+    await drive.set(core.properties.name, 'Studio', false);
+    await ensureVaultBackup(store, DRIVE, deps);
+    expect(deps.setUpVaultForDrive).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        metadata: { name: 'Studio', emoji: '🎨' },
+      }),
+    );
+  });
+
   it('enrols and backs up a signed-in drive', async () => {
     const store = await signedInStore();
     const deps = fakeDeps();

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
@@ -1,4 +1,4 @@
-import { StoreEvents, type Store } from '@tomic/lib';
+import { core, dataBrowser, StoreEvents, type Store } from '@tomic/lib';
 import {
   agentVaultProof,
   getVaultState,
@@ -148,7 +148,7 @@ const defaultDeps: VaultAutoBackupDeps = {
  */
 const enrolled = new Map<
   string,
-  { drivePseudonym: string; driveKey: Uint8Array }
+  { drivePseudonym: string; driveKey: Uint8Array; metadata?: string }
 >();
 
 /** Only in tests. */
@@ -256,7 +256,22 @@ async function ensureVaultBackupOnce(
 
     let known = enrolled.get(driveSubject);
 
-    if (!known) {
+    // Display metadata is shared with SaaS; read it from the local drive.
+    const drive = store.resources.get(driveSubject);
+    const name = drive?.get(core.properties.name);
+    const emoji = drive?.get(dataBrowser.properties.emoji);
+    const metadata = {
+      name: typeof name === 'string' ? name : undefined,
+      emoji:
+        typeof emoji === 'string'
+          ? emoji
+          : typeof name === 'string'
+            ? ''
+            : undefined,
+    };
+    const metadataKey = JSON.stringify(metadata);
+
+    if (!known || (known.metadata ?? '{}') !== metadataKey) {
       if (!(await deps.hasAccount())) {
         return { status: 'skipped', reason: 'no account session' };
       }
@@ -265,12 +280,17 @@ async function ensureVaultBackupOnce(
       const { enrollment, driveKey } = await deps.setUpVaultForDrive({
         keys,
         driveSubject,
+        metadata,
         agentSubject: agent.subject,
         // The agent signs a fixed message; its key is never read. That is what
         // keeps non-extractable and hardware-backed keys usable here.
         agentSecret: await agentVaultProof(agent, keys.proofMessage),
       });
-      known = { drivePseudonym: enrollment.drive_pseudonym, driveKey };
+      known = {
+        drivePseudonym: enrollment.drive_pseudonym,
+        driveKey,
+        metadata: metadataKey,
+      };
       enrolled.set(driveSubject, known);
     }
 


### PR DESCRIPTION
Backup-only drives currently appear without a recognizable name in the SaaS portal. Send the local drive name and emoji as optional enrollment metadata, and refresh them when a later backup observes changes. Encrypted drive contents and key handling remain unchanged.

Older callers can omit the fields. Includes tests for the enrollment payload and metadata refresh, plus a coverage note.

Validation: 57 targeted Vitest tests pass in the isolated branch. Full frontend typecheck previously reported unrelated Node typings and document migration errors.

Companion SaaS PR https://github.com/ontola/atomic-saas/pull/52 adds metadata storage and the simplified drive overview; deploy that API before expecting names and emoji in the portal.
