### PR TITLE
Fix develop CI: rename, Cmd+Up, table aria-busy

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -339,6 +339,7 @@ vector (`personal_drive_cross_lang_vector`) pins the nonce, signature, and DID.
 | ⌘K shows a matching action and runs it; a resource-name query shows none | flow | `browser/e2e/tests/command-palette-actions.spec.ts` |
 | `?` overlay lists registry shortcuts; `\` toggles the sidebar | flow | `browser/e2e/tests/shortcuts.spec.ts` |
 | ⌘M searchable menu + ⌘↑ parent from the registry | flow | `browser/e2e/tests/resource-context-menu.spec.ts` |
+| Parent action stays available on a non-drive stub and fetches parent at run | glue | `browser/data-browser/src/actions/resourceActions.parent.test.ts` |
 
 Not covered: derived AI tools invoked through a real model; MCP protocol projection (no Atomic MCP server yet); collapsing specialized `destroy()` call sites (table rows, views, tags) onto the resource delete action.
 

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Cmd+Up (go to parent) works in tables again: ArrowUp no longer matches
+  with Ctrl/Cmd held, and the parent action fetches the resource when a
+  stub has not yet materialized `parent`.
+- `useCollection` resets `ready` when the query changes, so the table
+  grid's `aria-busy` stays true until the new page lands.
+
 - Commits are signed envelopes: `CommitDetail` does not fetch `did:ad:commit:`
   resources; author and dates come from the resource. History no longer
   navigates to a commit DID, and the Sync page log no longer links commit ids.

--- a/browser/data-browser/src/actions/resourceActions.parent.test.ts
+++ b/browser/data-browser/src/actions/resourceActions.parent.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { core, server } from '@tomic/react';
+import { resourceActions } from './resourceActions';
+import type { ActionContext } from './types';
+
+const parent = resourceActions.find(action => action.id === 'parent')!;
+
+function ctx(
+  resource: {
+    loading?: boolean;
+    get: (prop: string) => unknown;
+    getClasses: () => string[];
+  },
+  extra: Partial<ActionContext> = {},
+): ActionContext {
+  return {
+    resource,
+    subject: 'did:ad:child',
+    ...extra,
+  } as unknown as ActionContext;
+}
+
+describe('parent action', () => {
+  it('is available when parent is already on the resource', () => {
+    expect(
+      parent.available?.(
+        ctx({
+          get: prop =>
+            prop === core.properties.parent ? 'did:ad:parent' : undefined,
+          getClasses: () => [],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('stays available on a non-drive even before parent has materialized', () => {
+    expect(
+      parent.available?.(
+        ctx({
+          get: () => undefined,
+          getClasses: () => [],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is hidden on a drive, which has no parent', () => {
+    expect(
+      parent.available?.(
+        ctx({
+          get: () => undefined,
+          getClasses: () => [server.classes.drive],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('fetches the resource when parent is not yet on the stub', async () => {
+    vi.stubGlobal('window', { location: { origin: 'http://localhost' } });
+
+    const navigate = vi.fn();
+    const getResource = vi.fn().mockResolvedValue({
+      get: (prop: string) =>
+        prop === core.properties.parent ? 'did:ad:parent' : undefined,
+    });
+
+    await parent.run(
+      ctx(
+        {
+          loading: true,
+          get: () => undefined,
+          getClasses: () => [],
+        },
+        {
+          subject: 'did:ad:child',
+          navigate,
+          store: { getResource } as unknown as ActionContext['store'],
+        },
+      ),
+    );
+
+    expect(getResource).toHaveBeenCalledWith('did:ad:child');
+    expect(navigate).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent('did:ad:parent')),
+    );
+  });
+});

--- a/browser/data-browser/src/actions/resourceActions.tsx
+++ b/browser/data-browser/src/actions/resourceActions.tsx
@@ -296,9 +296,19 @@ export const resourceActions: ActionDefinition[] = [
     icon: () => <FaTurnUp />,
     shortcut: shortcuts.parent,
     shortcutLabel: () => 'Go to parent',
-    available: ctx => !!getParent(ctx),
-    run: ctx => {
-      const parent = getParent(ctx);
+    // Not just `!!getParent`: a stub after goBack can lack `parent` while
+    // the table is already on screen. Dropping the action there ate Cmd+Up.
+    // Drives have no parent — hide it once we know that's what this is.
+    available: ctx =>
+      !!getParent(ctx) ||
+      !ctx.resource.getClasses().includes(server.classes.drive),
+    run: async ctx => {
+      let parent = getParent(ctx);
+
+      if (!parent) {
+        const resource = await ctx.store.getResource(ctx.subject);
+        parent = resource.get(core.properties.parent) as string | undefined;
+      }
 
       if (parent) {
         ctx.navigate(constructOpenURL(parent));

--- a/browser/data-browser/src/chunks/TableEditor/helpers/keyboardHandlers.mod.test.ts
+++ b/browser/data-browser/src/chunks/TableEditor/helpers/keyboardHandlers.mod.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { handlerMatchesModifier } from './keyboardHandlers';
+
+const noMod = { metaKey: false, ctrlKey: false };
+const ctrl = { metaKey: false, ctrlKey: true };
+const meta = { metaKey: true, ctrlKey: false };
+
+describe('handlerMatchesModifier', () => {
+  it('matches unmodified keys when mod is omitted, and ignores Ctrl/Cmd', () => {
+    expect(handlerMatchesModifier({}, noMod, false)).toBe(true);
+    expect(handlerMatchesModifier({}, ctrl, false)).toBe(false);
+    expect(handlerMatchesModifier({}, meta, true)).toBe(false);
+  });
+
+  it('matches Ctrl on non-Mac and Cmd on Mac when mod is true', () => {
+    expect(handlerMatchesModifier({ mod: true }, ctrl, false)).toBe(true);
+    expect(handlerMatchesModifier({ mod: true }, noMod, false)).toBe(false);
+    expect(handlerMatchesModifier({ mod: true }, meta, true)).toBe(true);
+    expect(handlerMatchesModifier({ mod: true }, ctrl, true)).toBe(false);
+  });
+});

--- a/browser/data-browser/src/chunks/TableEditor/helpers/keyboardHandlers.ts
+++ b/browser/data-browser/src/chunks/TableEditor/helpers/keyboardHandlers.ts
@@ -55,10 +55,25 @@ export interface KeyboardHandler {
   preventDefault?: boolean;
   disabledInReadOnly?: boolean;
   shift?: boolean;
+  /**
+   * When true, Ctrl/Cmd must be held. When false or omitted, the handler
+   * only matches *without* Ctrl/Cmd. Omitted used to mean "either", which
+   * made ArrowUp swallow Cmd/Ctrl+ArrowUp (go to parent).
+   */
   mod?: boolean;
   condition?: (context: HandlerContext) => boolean;
 
   handler: (context: HandlerContext) => void;
+}
+
+/** True when the handler's `mod` flag matches the event's Ctrl/Cmd state. */
+export function handlerMatchesModifier(
+  handler: Pick<KeyboardHandler, 'mod'>,
+  event: { metaKey: boolean; ctrlKey: boolean },
+  isMac = typeof navigator !== 'undefined' &&
+    navigator.platform.includes('Mac'),
+): boolean {
+  return (handler.mod ?? false) === (isMac ? event.metaKey : event.ctrlKey);
 }
 
 const getMultiSelectStartPosition = ({

--- a/browser/data-browser/src/chunks/TableEditor/hooks/useTableEditorKeyboardNavigation.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/hooks/useTableEditorKeyboardNavigation.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import {
   HandlerContext,
+  handlerMatchesModifier,
   KeyboardHandler,
   TableCommands,
   tableKeyboardHandlers,
@@ -16,12 +17,7 @@ const matchShift = (
 const matchModifier = (
   handler: KeyboardHandler,
   event: React.KeyboardEvent<HTMLDivElement> | KeyboardEvent,
-) =>
-  handler.mod === undefined ||
-  handler.mod ===
-    (navigator.platform.includes(/* @wc-ignore */ 'Mac')
-      ? event.metaKey
-      : event.ctrlKey);
+) => handlerMatchesModifier(handler, event);
 
 const matchCondition = (handler: KeyboardHandler, context: HandlerContext) =>
   handler.condition === undefined || handler.condition(context);

--- a/browser/data-browser/src/helpers/managed/vault.test.ts
+++ b/browser/data-browser/src/helpers/managed/vault.test.ts
@@ -23,13 +23,11 @@ import {
  */
 
 it('sends name and emoji as optional enrollment metadata', async () => {
-  const fetch = vi
-    .spyOn(globalThis, 'fetch')
-    .mockResolvedValue(
-      new Response(JSON.stringify({ enrollment: { id: '1' } }), {
-        status: 200,
-      }),
-    );
+  const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ enrollment: { id: '1' } }), {
+      status: 200,
+    }),
+  );
   await enrollVault('did:ad:drive', 'did:ad:agent:test', {
     name: 'Design',
     emoji: '🎨',

--- a/browser/e2e/tests/rename-regression.spec.ts
+++ b/browser/e2e/tests/rename-regression.spec.ts
@@ -14,7 +14,7 @@
  * concurrent-write commits with a clear error.
  */
 import { test, expect, Page } from '@playwright/test';
-import { before, editableTitle } from './test-utils';
+import { before, editableTitle, newDrive } from './test-utils';
 
 async function renameDrive(page: Page, text: string) {
   await editableTitle(page).click();
@@ -40,6 +40,9 @@ test.describe('drive rename regression', () => {
   test.beforeEach(before);
 
   test('multi-character rename persists across reload', async ({ page }) => {
+    // `/app/dev-drive` opens the agent's private drive, whose title is locked
+    // (it is derived from the key, not a project). Rename a project drive.
+    await newDrive(page);
     await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
 
     await renameDrive(page, 'Persistent Drive Name');
@@ -54,6 +57,7 @@ test.describe('drive rename regression', () => {
   test('two sequential renames both persist across reload', async ({
     page,
   }) => {
+    await newDrive(page);
     await expect(editableTitle(page)).toBeVisible({ timeout: 15000 });
 
     await renameDrive(page, 'First Name');

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1320,7 +1320,9 @@ export async function waitForGridMounted(page: Page, timeoutMs = 30_000) {
   // The empty entry row renders before the collection has answered, so a
   // visible row no longer means the data (and the ClientDb queue in front of
   // it) has settled. The grid says so itself: `aria-busy` while loading.
-  await expect(page.locator('[role="grid"][aria-busy="false"]')).toBeVisible({
+  // Treat anything other than `true` as settled — React/omitted `false` both
+  // mean not busy, and `[aria-busy="false"]` misses the omitted case.
+  await expect(page.locator('[role="grid"][aria-busy="true"]')).toHaveCount(0, {
     timeout: timeoutMs,
   });
   await expect(page.locator('[aria-rowindex="2"]')).toBeVisible({

--- a/browser/react/src/useCollection.ts
+++ b/browser/react/src/useCollection.ts
@@ -183,6 +183,10 @@ export function useCollection(
     }
 
     let cancelled = false;
+    // A query swap must not keep the previous collection's `ready`. The grid
+    // renders `aria-busy={!ready}`; leaving it true while the new fetch is
+    // in flight made tests (and AT) think a still-loading table had settled.
+    setReady(false);
 
     col.waitForReady().then(() => {
       if (cancelled) return;

--- a/browser/react/src/useCollection.ts
+++ b/browser/react/src/useCollection.ts
@@ -136,6 +136,29 @@ export function useCollection(
     return col;
   });
   const [ready, setReady] = useState(false);
+  // Reset `ready` during render when the query changes (not in the effect).
+  // The grid renders `aria-busy={!ready}`; keeping the previous collection's
+  // ready=true while the new fetch is in flight made tests (and AT) treat a
+  // still-loading table as settled. Same-render reset also avoids
+  // `react/set-state-in-effect`.
+  const queryIdentity = [
+    queryFilterMemo.property,
+    queryFilterMemo.value,
+    filtersDep,
+    queryFilterMemo.sort_by,
+    String(!!queryFilterMemo.sort_desc),
+    aggregationKey(queryFilterMemo.aggregation),
+    expressionFiltersKey(queryFilterMemo.expression_filters),
+    String(pageSize),
+    server ?? '',
+    String(includeNested),
+  ].join('\0');
+  const [readyFor, setReadyFor] = useState(queryIdentity);
+
+  if (readyFor !== queryIdentity) {
+    setReadyFor(queryIdentity);
+    setReady(false);
+  }
 
   const mapAll = useCallback(
     <T>(func: ({ index, collection }: CollectionItemProps) => T): T[] => {
@@ -183,10 +206,6 @@ export function useCollection(
     }
 
     let cancelled = false;
-    // A query swap must not keep the previous collection's `ready`. The grid
-    // renders `aria-busy={!ready}`; leaving it true while the new fetch is
-    // in flight made tests (and AT) think a still-loading table had settled.
-    setReady(false);
 
     col.waitForReady().then(() => {
       if (cancelled) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related Issues

Fixes develop CI. Latest `develop` Main (Mancave) / CI is red.

**Lint (current HEAD `77043818b`, vault metadata PR):** `data-browser` `format-check` fails on `src/helpers/managed/vault.test.ts`. Formatted that file so the pipeline can reach e2e.

**Playwright (previous HEAD `91d343cd1`, full suite, 3 retries):** three specs failed every retry:

1. **`rename-regression.spec.ts`** — `/app/dev-drive` lands on the personal/private drive, whose title is locked. Tests now create a project drive via `newDrive()` before renaming.
2. **`resource-context-menu.spec.ts` (`cmd+m` / `cmd+up`)** — Table ArrowUp handlers treated omitted `mod` as “match with or without Ctrl/Cmd”, so they swallowed Cmd+Up. The parent action also dropped when a stub lacked `parent`. ArrowUp now requires no modifier; the parent action stays available on non-drives and fetches the resource at run time.
3. **`tables.spec.ts` (`fast row entry`, Shift+Enter)** — `waitForGridMounted` waited for `[role="grid"][aria-busy="false"]`. The grid often omits the attribute when not busy, so the locator never matched. Wait for a visible grid and zero `[aria-busy="true"]` instead. `useCollection` resets `ready` during render when the query changes so `aria-busy` stays honest on the same paint.

**Local Playwright** (chromium, `SERVER_URL=http://localhost:9885`): rename, cmd+m/cmd+up, fast row entry, Shift+Enter, folder, sidebar subresource, saved-drives, server-only-fallback, and localized-text create-column all passed.

## Walkthrough

Project drive title is editable (not the locked private drive). After creating a table, Ctrl+ArrowUp returns to that drive.

[Project drive title after rename](https://cursor.com/agents/bc-03a346dd-4aea-4d48-be0a-7a25adae3805/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frename-title-saved.png)
[Widgets table on the renamed drive](https://cursor.com/agents/bc-03a346dd-4aea-4d48-be0a-7a25adae3805/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable-before-cmd-up.png)
[Drive page after Cmd+Up from the table](https://cursor.com/agents/bc-03a346dd-4aea-4d48-be0a-7a25adae3805/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdrive-after-cmd-up.png)

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [ ] Update docs if needed


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03a346dd-4aea-4d48-be0a-7a25adae3805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03a346dd-4aea-4d48-be0a-7a25adae3805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

