### PR TITLE
fix(browser): vault backup BigInt argument; onboarding dev-build _w_ctx_ error

### DIFF
--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: automatic Cloud Vault backups failed in the browser with "Cannot convert 1 to a BigInt" — the checkpoint number is a 64-bit integer on the WASM side and must be handed over as a BigInt.
+- Fix: the recovery-code step of onboarding threw `_w_ctx_ is not defined` in the dev build (the i18n extractor emitted the nested-message form for one button label without its callback); the label is a script-scope string now.
 - Cmd+Up (go to parent) works in tables again: ArrowUp no longer matches
   with Ctrl/Cmd held, and the parent action fetches the resource when a
   stub has not yet materialized `parent`.

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -771,6 +771,12 @@ function RecoveryBackupStep({
   /** True after the user copies the recovery code — same "confirm you saved
    * it before continuing" idiom as {@link SecretStep}'s `secretBackedUp`. */
   const [codeSaved, setCodeSaved] = useState(false);
+  // A script-scope string rather than JSX text: as JSX text inside this
+  // ternary, the i18n extractor (wuchale) emitted the nested-message form
+  // without its enclosing callback, and the dev build threw
+  // `_w_ctx_ is not defined` on every onboarding run. See the CI note in
+  // atomic-saas's portal e2e.
+  const confirmSavedLabel = "Yes, I've stored it safely";
 
   if (confirmingSkip) {
     return (
@@ -829,7 +835,7 @@ function RecoveryBackupStep({
             </p>
             <Row key='confirm-row' gap='1rem' wrapItems>
               <ContinueButton onClick={onContinue}>
-                Yes, I&apos;ve stored it safely
+                {confirmSavedLabel}
               </ContinueButton>
             </Row>
           </React.Fragment>

--- a/browser/lib/src/client-db.worker.ts
+++ b/browser/lib/src/client-db.worker.ts
@@ -350,7 +350,10 @@ async function handleMessage(msg: WorkerRequest): Promise<unknown> {
         msg.drivePseudonym,
         msg.devicePubkey,
         msg.segment,
-        msg.checkpointN,
+        // `checkpoint_n` is a u64 on the Rust side; wasm-bindgen wants a
+        // BigInt for it and throws "Cannot convert 1 to a BigInt" for a
+        // Number, which failed every automatic backup in the browser.
+        BigInt(msg.checkpointN),
         msg.driveHasCheckpoint,
         msg.observedLanes,
       );


### PR DESCRIPTION
Two develop-head failures that atomic-saas's portal e2e surfaced once its CI stopped pinning atomic-server (ontola/atomic-saas#53).

- **`Cannot convert 1 to a BigInt`** on every automatic Cloud Vault backup: `client-db.worker.ts` passed `checkpointN` as a Number, but `vaultExport`'s `checkpoint_n` is a `u64` and wasm-bindgen requires a BigInt. Now `BigInt(msg.checkpointN)`.
- **`_w_ctx_ is not defined`** in `RecoveryBackupStep` in the vite dev build: for one button label the i18n extractor (wuchale) emitted the nested-message form `_w_runtime_.x(_w_ctx_)` without the enclosing callback. The label is a script-scope string now. Verified on the transformed module served by vite that the only remaining `_w_ctx_` references sit inside their callbacks.

Unblocks the portal e2e in ontola/atomic-saas#53, which in turn unblocks #1375.