### PR TITLE
fix(sync): fan out the server's stamp with a commit; keep the author's doc, cursor and history consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ By far most changes relate to `atomic-server`, so if not specified, assume the c
 **Changes to JS assets (including the front-end and JS libraries) are not shown here**, but in [`/browser/CHANGELOG`](/browser/CHANGELOG.md).
 See [STATUS.md](server/STATUS.md) to learn more about which features will remain stable.
 
+- Fix: live collaboration stopped for the author of a document after a peer
+  edited it. The server stamps `lastCommit` under its own Loro peer after
+  applying a commit; the fan-out only forwarded the author's own bytes and
+  never echoed to the author, so an edit built on the stored snapshot could
+  not apply there. The `UPDATE` now carries everything the apply added and
+  reaches the author too (`CommitResponse::fanout_delta`).
 - Commits are signed envelopes, not a queryable event log. Ordinary content
   commits are not stored as resources after apply (genesis and
   rights/parent/destroy stay). Loro binaries are not KV-index keys. The

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Fix: `Store.applyIncoming` imports the echo of this client's own commit before deduping it, so the server's `lastCommit` stamp lands locally and a collaborator's next edit applies instead of triggering a catch-up fetch that remounted the editor.
+- Fix: ops that arrive from the server are folded into the Loro save cursor as they are imported, and an ack keeps them there. Without this the echo made the resource look dirty again after every save and the client re-committed an empty delta every 130 ms until reload.
+- Fix: a pending edit that Loro has to seal early (an import, a snapshot export, a server response written into the doc) is committed under the token the next drain will use, so it stays in its own History version instead of collapsing into the base one.
 - Fix: automatic Cloud Vault backups failed in the browser with "Cannot convert 1 to a BigInt" — the checkpoint number is a 64-bit integer on the WASM side and must be handed over as a BigInt.
 - Fix: the recovery-code step of onboarding threw `_w_ctx_ is not defined` in the dev build (the i18n extractor emitted the nested-message form for one button label without its callback); the label is a script-scope string now.
 - Cmd+Up (go to parent) works in tables again: ArrowUp no longer matches

--- a/browser/lib/src/gap-recovery.test.ts
+++ b/browser/lib/src/gap-recovery.test.ts
@@ -214,3 +214,338 @@ describe('a delta that cannot apply triggers a catch-up fetch', () => {
     pending?.();
   });
 });
+
+describe("the echo of a client's own commit", () => {
+  const subject = 'did:ad:ownCommitEchoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==';
+
+  /** What the server does with a commit: import it, then stamp `lastCommit`
+   *  under its own peer. The echo it fans out is both. A peer that boots
+   *  from the stored snapshot builds its next edit on top of the stamp. */
+  function serverSide(
+    authorSnapshot: Uint8Array,
+    commitId: string,
+  ): {
+    echo: Uint8Array;
+    peerEdit: Uint8Array;
+  } {
+    const { LoroDoc } = LoroLoader.Loro;
+    const server = new LoroDoc();
+    const before = server.version();
+    server.import(authorSnapshot);
+    server.getMap('properties').set(commits.properties.lastCommit, commitId);
+    server.commit();
+    const echo = server.export({ mode: 'update', from: before } as never);
+
+    const peer = new LoroDoc();
+    peer.import(server.export({ mode: 'snapshot' }));
+    const peerBefore = peer.version();
+    peer.getMap('properties').set(NAME, 'typed by the peer');
+    peer.commit();
+    const peerEdit = peer.export({
+      mode: 'update',
+      from: peerBefore,
+    } as never);
+
+    return { echo, peerEdit };
+  }
+
+  it('is imported, not dropped, so a peer edit built on the stored snapshot applies', async ({
+    expect,
+  }) => {
+    const store = await makeStore();
+    const commitId = 'did:ad:commit:mine';
+
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.getMap('properties').set(NAME, 'mine');
+    authored.commit();
+
+    // The author's resource, already stamped with its own commit id — the
+    // state right after COMMIT_OK.
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    store.resources.get(subject)!.setLastCommitValue(commitId);
+
+    const { echo, peerEdit } = serverSide(
+      authored.export({ mode: 'snapshot' }),
+      commitId,
+    );
+
+    let fetched = 0;
+
+    (
+      store as unknown as { fetchResourceFromServer: () => Promise<unknown> }
+    ).fetchResourceFromServer = async () => {
+      fetched += 1;
+
+      return undefined;
+    };
+
+    expect(
+      store.applyIncoming({
+        subject,
+        loroBytes: echo,
+        commitId,
+        source: 'ws-sub-push',
+      }),
+    ).toBe('deduped');
+
+    expect(
+      store.applyIncoming({
+        subject,
+        loroBytes: peerEdit,
+        commitId: 'did:ad:commit:theirs',
+        source: 'ws-sub-push',
+      }),
+    ).toBe('applied');
+    expect(store.resources.get(subject)!.get(NAME)).toBe('typed by the peer');
+    expect(fetched).toBe(0);
+  });
+
+  it('does not leave the author looking unsaved, which would re-commit forever', async ({
+    expect,
+  }) => {
+    const store = await makeStore();
+    const commitId = 'did:ad:commit:mine';
+
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.getMap('properties').set(NAME, 'mine');
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+    resource.setLastCommitValue(commitId);
+    // Hydrated clean: the cursor sits at everything the server has.
+    expect(resource.hasOpsPastSaveCursor()).toBe(false);
+
+    const { echo, peerEdit } = serverSide(
+      authored.export({ mode: 'snapshot' }),
+      commitId,
+    );
+
+    store.applyIncoming({
+      subject,
+      loroBytes: echo,
+      commitId,
+      source: 'ws-sub-push',
+    });
+    expect(
+      resource.hasOpsPastSaveCursor(),
+      "the server's stamp is not local work to sign",
+    ).toBe(false);
+
+    store.applyIncoming({
+      subject,
+      loroBytes: peerEdit,
+      commitId: 'did:ad:commit:theirs',
+      source: 'ws-sub-push',
+    });
+    expect(
+      resource.hasOpsPastSaveCursor(),
+      "a collaborator's edit is not local work to sign either",
+    ).toBe(false);
+    expect(resource.hasUnsavedChanges()).toBe(false);
+
+    // A real local edit still counts.
+    await resource.set(NAME, 'edited here');
+    expect(resource.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('stays absorbed when the echo lands before the ack advances the cursor', async ({
+    expect,
+  }) => {
+    // The drain captures the version at export time and moves the cursor
+    // there once the server acks. Under load the echo of that very commit
+    // arrives first; the ack must not throw its absorbed ops away.
+    const store = await makeStore();
+    const commitId = 'did:ad:commit:mine';
+
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.getMap('properties').set(NAME, 'mine');
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+    resource.setLastCommitValue(commitId);
+    const versionAtExport = resource.getLoroDoc()!.oplogVersion();
+
+    const { echo } = serverSide(
+      authored.export({ mode: 'snapshot' }),
+      commitId,
+    );
+    store.applyIncoming({
+      subject,
+      loroBytes: echo,
+      commitId,
+      source: 'ws-sub-push',
+    });
+    expect(resource.hasOpsPastSaveCursor()).toBe(false);
+
+    // The ack, arriving second.
+    resource.markLoroSavedAt(versionAtExport);
+    expect(
+      resource.hasOpsPastSaveCursor(),
+      'the ack must keep the absorbed server ops',
+    ).toBe(false);
+  });
+
+  it('does not strip the history token off an edit that was pending when it landed', async ({
+    expect,
+  }) => {
+    // A Loro import commits pending local ops, without a message. The echo
+    // now lands while the user is still typing, so without care the title
+    // edit is sealed untagged, falls into the base bucket of the history,
+    // and the version that should show "First Title" shows the later state.
+    const store = await makeStore();
+    const commitId = 'did:ad:commit:mine';
+
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+    resource.setLastCommitValue(commitId);
+
+    // Pending, not yet drained.
+    await resource.set(NAME, 'First Title');
+
+    const { echo } = serverSide(
+      authored.export({ mode: 'snapshot' }),
+      commitId,
+    );
+    store.applyIncoming({
+      subject,
+      loroBytes: echo,
+      commitId,
+      source: 'ws-sub-push',
+    });
+
+    // The drain comes round.
+    const exported = resource.exportLoroDeltaForDrain(false, 'c-drain');
+    expect(exported).toBeDefined();
+
+    const first = resource
+      .getLoroHistory()
+      .find(v => v.propvals.get(NAME) === 'First Title');
+    expect(first, 'a version must show the first title').toBeDefined();
+    expect(first!.token ?? '').toMatch(/^c-/);
+  });
+
+  it('keeps the token when a server response is written into the doc mid-edit', async ({
+    expect,
+  }) => {
+    // `applyHydratedValues` runs on every acked save. It used to close the
+    // pending edit with a bare commit — the exact shape the history e2e
+    // caught once the author started receiving its own echoes.
+    const store = await makeStore();
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+
+    await resource.set(NAME, 'First Title');
+    resource.applyHydratedValues([
+      [commits.properties.lastCommit, 'did:ad:commit:acked'],
+    ]);
+    expect(resource.exportLoroDeltaForDrain(false, 'c-drain')).toBeDefined();
+
+    const first = resource
+      .getLoroHistory()
+      .find(v => v.propvals.get(NAME) === 'First Title');
+    expect(first?.token ?? '').toMatch(/^c-/);
+  });
+  it('keeps the token when third-party code commits the doc mid-edit', async ({
+    expect,
+  }) => {
+    // loro-prosemirror commits the shared doc from its own plugin, with no
+    // message. That is what sealed the title ops untagged in the history
+    // e2e once the echo started re-rendering the page between keystrokes.
+    const store = await makeStore();
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+
+    await resource.set(NAME, 'First Title');
+    // Someone else's bare commit.
+    resource.getLoroDoc()!.commit();
+    expect(resource.exportLoroDeltaForDrain(false, 'c-drain')).toBeDefined();
+
+    const first = resource
+      .getLoroHistory()
+      .find(v => v.propvals.get(NAME) === 'First Title');
+    expect(first?.token ?? '').toMatch(/^c-/);
+  });
+});

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -1,9 +1,11 @@
 import type {
+  ImportStatus,
   LoroDoc,
   LoroList,
   UndoManager as LoroUndoManager,
   VersionVector,
 } from 'loro-crdt';
+import { ulid } from 'ulidx';
 import { enableLoro, LoroLoader } from './loro-loader.js';
 import { decodeB64, encodeB64 } from './base64.js';
 import { EventManager } from './EventManager.js';
@@ -681,6 +683,9 @@ export class Resource<C extends OptionalClass = any> {
           val instanceof Uint8Array ? val : decodeB64(val as string);
 
         try {
+          // An import seals pending ops without a message; keep the
+          // user's edit under its history token (see `stagedCommitToken`).
+          this.sealPendingEdits();
           this._loroDoc.import(bytes);
           this.rebuildCacheFromLoro();
           this.#cacheDirty = false;
@@ -874,6 +879,10 @@ export class Resource<C extends OptionalClass = any> {
   private loroSetProperty(prop: string, value: JSONValue): void {
     const map = this.getLoroMap();
 
+    if (map) {
+      this.armStagedCommitToken();
+    }
+
     if (!map) {
       // Loro not loaded yet — write to cache as fallback.
       // getLoroDoc() will seed Loro from cache when it initializes.
@@ -1054,6 +1063,54 @@ export class Resource<C extends OptionalClass = any> {
    *
    * @internal store-level drain only — not part of the public API.
    */
+  /**
+   * The Loro change message the next drain export will carry, created on
+   * first use. It exists because a Loro import commits whatever local ops
+   * are still pending, and does so without a message. Since the server
+   * echoes every commit back to its author, an import now routinely lands
+   * while the user is mid-edit; sealed untagged, those ops fall into the
+   * base ('') bucket of `getLoroHistory` and the version they belong to
+   * shows the wrong state (history e2e: both versions read "Second Title").
+   * Sealing them under the token the drain will use keeps one bucket per
+   * Atomic commit.
+   */
+  private _stagedCommitToken?: string;
+
+  private stagedCommitToken(): string {
+    this._stagedCommitToken ??= `c-${ulid().toLowerCase()}`;
+
+    return this._stagedCommitToken;
+  }
+
+  /**
+   * Tell Loro which message the next commit carries, whoever makes it. Not
+   * every commit goes through this class: loro-prosemirror commits the doc
+   * from its plugin `init` and on body edits, and a re-render triggered by a
+   * server response can put that init right between two keystrokes. Arming
+   * the message at write time means a pending edit keeps its history token
+   * no matter who seals it. Loro clears the message after one commit, so
+   * this is re-armed on every write.
+   */
+  private armStagedCommitToken(): void {
+    this._loroDoc?.setNextCommitMessage(this.stagedCommitToken());
+  }
+
+  /**
+   * Commit pending local ops under the staged token. Call it wherever Loro
+   * would otherwise seal them itself without a message: before an import,
+   * before a snapshot export, and where a server response is written into
+   * the doc mid-edit (`applyHydratedValues`).
+   *
+   * @internal store-level persistence only — not part of the public API.
+   */
+  public sealPendingEdits(): void {
+    const doc = this._loroDoc;
+
+    if (!doc || doc.getPendingTxnLength() === 0) return;
+
+    doc.commit({ timestamp: Date.now(), message: this.stagedCommitToken() });
+  }
+
   public exportLoroDeltaForDrain(
     isFirstCommit: boolean,
     commitMessage?: string,
@@ -1089,9 +1146,47 @@ export class Resource<C extends OptionalClass = any> {
    * @internal store-level drain only — not part of the public API.
    */
   public markLoroSavedAt(version: VersionVector): void {
-    if (this._loroDoc) {
+    const doc = this._loroDoc;
+
+    if (!doc) return;
+
+    // `version` was captured at export time, so it is exact for this doc's
+    // own peer: local ops typed during the round-trip must stay past the
+    // cursor. Remote peers are a different matter — the echo of the commit
+    // just acked can land BEFORE the ack and be absorbed into the previous
+    // cursor (`absorbImportedOpsIntoSaveCursor`); replacing the cursor
+    // outright would forget that and re-open the re-commit loop that
+    // method exists to close. Keep whichever is further for every peer
+    // that is not us.
+    const previous = this._loroVersionAtLastSave;
+
+    if (!previous) {
       this._loroVersionAtLastSave = version;
+
+      return;
     }
+
+    const own = doc.peerIdStr;
+    const merged = new Map(version.toJSON());
+    let changed = false;
+
+    for (const [peer, counter] of previous.toJSON()) {
+      if (peer === own) continue;
+
+      if ((merged.get(peer) ?? 0) < counter) {
+        merged.set(peer, counter);
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      this._loroVersionAtLastSave = version;
+
+      return;
+    }
+
+    const { VersionVector: VersionVectorClass } = LoroLoader.Loro;
+    this._loroVersionAtLastSave = new VersionVectorClass(merged);
   }
 
   /** Base64-encode the current save cursor (last-synced Loro version) for
@@ -1142,6 +1237,51 @@ export class Resource<C extends OptionalClass = any> {
       this._loroDoc.oplogVersion(),
       this._loroVersionAtLastSave,
     );
+  }
+
+  /**
+   * Ops that just arrived from the server are, by definition, already on
+   * the server. Fold them into the save cursor so they never read as
+   * unsaved local work.
+   *
+   * Without this, the echo of this client's own commit — which carries the
+   * `lastCommit` stamp the server wrote under its own peer — lands past the
+   * cursor, `hasOpsPastSaveCursor` reports the resource dirty again, the
+   * drain re-signs a delta holding nothing but the server's stamp, the
+   * server stamps that too, and the client commits every 130 ms forever
+   * (quick-edit e2e: `syncInProgress` never clears). A collaborator's push
+   * landing during the `postCommit` round-trip used to trigger the same
+   * loop, only rarely.
+   *
+   * Ops under this doc's own peer are left alone: those are the local edits
+   * the cursor exists to track, and the import status never reports them
+   * as new anyway.
+   */
+  private absorbImportedOpsIntoSaveCursor(
+    imported: ImportStatus['success'],
+  ): void {
+    const doc = this._loroDoc;
+    const cursor = this._loroVersionAtLastSave;
+
+    if (!doc || !cursor || imported.size === 0) return;
+
+    const own = doc.peerIdStr;
+    const merged = new Map(cursor.toJSON());
+    let changed = false;
+
+    for (const [peer, span] of imported) {
+      if (peer === own) continue;
+
+      if ((merged.get(peer) ?? 0) < span.end) {
+        merged.set(peer, span.end);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      const { VersionVector: VersionVectorClass } = LoroLoader.Loro;
+      this._loroVersionAtLastSave = new VersionVectorClass(merged);
+    }
   }
 
   /** The resource's last applied commit id (`did:ad:commit:{sig}`).
@@ -1205,10 +1345,14 @@ export class Resource<C extends OptionalClass = any> {
     // from the genesis change's timestamp). Loro orders changes by lamport,
     // not timestamp, so a finer timestamp is safe metadata; readers normalise
     // mixed-unit oplogs via `normalizeLoroChangeTimestampMs`.
+    // Ops a remote import already sealed carry the staged token; use the
+    // same one here so everything in this export forms one bucket.
+    const message = this._stagedCommitToken ?? commitMessage;
     this._loroDoc.commit({
       timestamp: Date.now(),
-      ...(commitMessage ? { message: commitMessage } : {}),
+      ...(message ? { message } : {}),
     });
+    this._stagedCommitToken = undefined;
 
     // If it's the first commit, we must export a full snapshot.
     if (isFirstCommit || !this._loroVersionAtLastSave) {
@@ -1271,6 +1415,11 @@ export class Resource<C extends OptionalClass = any> {
   private static extractLoroSnapshot(
     resource: Resource,
   ): Uint8Array | undefined {
+    // The export seals pending ops untagged; `merge` reaches here with the
+    // live doc while the user is mid-edit (the drain's `applyToStore` after
+    // an ack), so keep that edit under its history token.
+    resource.sealPendingEdits();
+
     return resource._loroDoc
       ? resource._loroDoc.export({ mode: 'snapshot' })
       : Resource.decodeStoredSnapshot(resource._loroSnapshotBytes);
@@ -1462,8 +1611,11 @@ export class Resource<C extends OptionalClass = any> {
             structuredClone(Array.from(resourceB._auxValues.entries())),
           );
         } else {
-          // Import the incoming state — Loro merges via CRDT
+          // Import the incoming state — Loro merges via CRDT. Seal any
+          // pending edit under its history token first: the import would
+          // otherwise commit it bare (see `stagedCommitToken`).
           try {
+            this.sealPendingEdits();
             localDoc.import(incomingSnapshot);
           } catch (e) {
             // Import can fail if the snapshot is from an incompatible version.
@@ -1719,6 +1871,7 @@ export class Resource<C extends OptionalClass = any> {
    *  resource's LoroDoc directly without going through `set()`. */
   public markDirty(): void {
     this._dirty = true;
+    this.armStagedCommitToken();
     this.eventManager.emit(ResourceEvents.LocalChange, '', undefined);
   }
 
@@ -2194,10 +2347,11 @@ export class Resource<C extends OptionalClass = any> {
     // response landing between a keystroke and the next commit boundary
     // would otherwise be flushed by the system-origin commit below —
     // folding the user's edit into a change the outbox is told to ignore,
-    // which loses it silently.
-    if (this._loroDoc && this._loroDoc.getPendingTxnLength() > 0) {
-      this._loroDoc.commit({ timestamp: Date.now() });
-    }
+    // which loses it silently. Sealed under the staged commit token, not
+    // bare: the server answers every save, so this runs mid-edit all the
+    // time, and an untagged change drops the edit out of its history
+    // version (see `stagedCommitToken`).
+    this.sealPendingEdits();
 
     for (const [key, value] of values) {
       this.applyRawValue(key, value);
@@ -3329,6 +3483,8 @@ export class Resource<C extends OptionalClass = any> {
       if (!(v instanceof Uint8Array)) obj[k] = v;
     }
 
+    // The export seals pending ops; keep them under their history token.
+    this.sealPendingEdits();
     const snapshot = this._loroDoc?.export({ mode: 'snapshot' });
 
     // Await the OPFS write — when `save()` resolves the edit MUST survive a
@@ -3523,7 +3679,9 @@ export class Resource<C extends OptionalClass = any> {
         return { complete: true };
       }
 
+      this.sealPendingEdits();
       const status = doc.import(loroUpdate);
+      this.absorbImportedOpsIntoSaveCursor(status.success);
       this.rebuildCacheFromLoro();
       this.#cacheDirty = false;
       this.initLoroSaveCursorIfFresh();

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1797,7 +1797,12 @@ export class Store {
     const subject = this.normalizeSubject(change.subject);
     const existing = this.resources.get(this.aliases.get(subject) ?? subject);
 
-    // Echo dedup: same commitId as cached lastCommit ⇒ no-op.
+    // Echo dedup: same commitId as cached lastCommit ⇒ no notify. The bytes
+    // are still imported: the echo of this client's own commit carries the
+    // `lastCommit` stamp the server wrote under its own peer, and the next
+    // edit by anyone who loaded the stored snapshot depends on that op.
+    // Without it that edit parks as pending and the document stops being
+    // live for its author. Importing our own ops again is a no-op for Loro.
     if (
       !change.forceNotify &&
       change.commitId &&
@@ -1806,6 +1811,10 @@ export class Store {
       !existing.new &&
       existing.get(commits.properties.lastCommit) === change.commitId
     ) {
+      if (!subject.startsWith('did:ad:commit:')) {
+        existing.importLoroUpdate(change.loroBytes);
+      }
+
       return 'deduped';
     }
 
@@ -2012,6 +2021,9 @@ export class Store {
 
         if (jsonAd) {
           const doc = resource.getLoroDoc?.();
+          // A snapshot export commits pending ops, untagged; keep a
+          // mid-edit persist from stripping the edit's history token.
+          resource.sealPendingEdits();
           const snapshot = doc?.export({ mode: 'snapshot' });
 
           // One local-DB write costs ~9ms, three quarters of it rebuilding

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -479,12 +479,20 @@ deterministic signing and commit parsing are unaffected by the transport.
 answers `ERROR` with the matching `request_id` and a classified code. HTTP
 `POST /commit` remains the fallback path.
 
-**Echo suppression.** Each WebSocket connection has a per-process id
-(`ws-<n>`). The server threads it through as the commit's `source_id`, stamps
-it on the emitted database events, and the commit monitor skips subscribers
-registered under the same id, so the client never sees its own write return
-as a push. Other connections, including other tabs of the same agent, do
-receive it. An HTTP commit has no source id and reaches everyone.
+**The echo carries the server's stamp.** The `UPDATE` a commit fans out is
+not the commit's own bytes: it is every op the stored doc gained during the
+apply, which is the author's ops plus the `lastCommit` stamp the server
+writes afterwards under its own peer. Anyone who loads the stored snapshot
+builds their next edit on top of that stamp, so a subscriber without it parks
+that edit as pending and every later delta parks behind it. For the same
+reason the author's own connection receives the echo too; the client dedups
+it by commit id and imports it without notifying.
+
+**Echo suppression** applies to non-commit changes only. Each WebSocket
+connection has a per-process id (`ws-<n>`). The server threads it through as
+the change's `source_id`, stamps it on the emitted database events, and the
+commit monitor skips subscribers registered under the same id for external
+changes (sync imports, internal writes). An HTTP commit has no source id.
 
 **The peer `COMMIT` arm differs deliberately** (`engine::handle_frame`, via
 `apply_peer_commit`):
@@ -496,7 +504,7 @@ receive it. An HTTP commit has no source id and reaches everyone.
 | `validate_loro_causality` | on | **off**: concurrent writes between peers are expected |
 | Subject ownership | enforced | **off**: hosting subjects it does not own is what a replica is |
 | `previousCommit` | not validated | not validated |
-| `source_id` echo suppression | yes | none: peers do not fan out through the commit monitor |
+| `source_id` echo suppression | non-commit changes only; a commit's `UPDATE` reaches its author with the server's stamp | none: peers do not fan out through the commit monitor |
 | Live-echo suppression | no | yes, so the live push loop does not bounce the commit back |
 
 Both roles auto-create the signer's agent resource when it is absent and the
@@ -855,7 +863,8 @@ unrecognized text frame is logged and ignored.
 -> COMMIT (0x13) request_id 1
 -> COMMIT (0x13) request_id 2                    (pipelined, same tier)
 <- COMMIT_OK (0x14) 2 [commit_id]                (slim; acks in completion order)
-<- COMMIT_OK (0x14) 1 [commit_id]                (no UPDATE echoed back)
+<- COMMIT_OK (0x14) 1 [commit_id]
+<- UPDATE (0x11) delta | HAS_COMMIT_ID | PUSH    (own commit echoed with the server's stamp; deduped by id)
 <- UPDATE (0x11) delta | HAS_COMMIT_ID | PUSH    (someone else's commit)
 -> GET (0x10)
 <- UPDATE (0x11) SNAPSHOT | HAS_COMMIT_ID

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -26,9 +26,29 @@ pub struct CommitResponse {
     pub changed_props: HashSet<String>,
     /// Optional transport/source identity for echo suppression.
     pub source_id: Option<String>,
+    /// Every op the stored doc gained while applying this commit: the
+    /// author's own ops plus what the server wrote on top (the `lastCommit`
+    /// stamp, `createdAt` at genesis). This, not `commit.loro_update`, is
+    /// what live subscribers must receive — see [`Self::fanout_delta`].
+    pub broadcast_update: Option<Vec<u8>>,
 }
 
 impl CommitResponse {
+    /// The delta to push to live subscribers.
+    ///
+    /// The server stamps `lastCommit` on the resource after importing the
+    /// author's update. That stamp is a Loro op under the server's own peer,
+    /// and the next edit by anyone who loaded a snapshot depends on it. A
+    /// subscriber that only ever received `commit.loro_update` lacks the
+    /// stamp, parks that edit as pending, and every later delta parks behind
+    /// it: the document quietly stops being live. Falls back to the commit's
+    /// own bytes when the apply did not go through a Loro doc.
+    pub fn fanout_delta(&self) -> Option<&[u8]> {
+        self.broadcast_update
+            .as_deref()
+            .or(self.commit.loro_update.as_deref())
+    }
+
     /// The authorization relevance of this commit — which authority-defining
     /// facts it establishes or mutates. See [`crate::hierarchy::AuthImpact`].
     pub fn auth_impact(&self) -> crate::hierarchy::AuthImpact {
@@ -61,6 +81,10 @@ pub struct CommitApplied {
     /// present (an idempotent replay), so producing no state change is
     /// expected and correct, not a silent LWW loss.
     pub imported_new_ops: bool,
+    /// The doc's version before the commit's `loroUpdate` was imported, so
+    /// the caller can export everything the apply added — including what
+    /// the server writes afterwards — as one delta for live subscribers.
+    pub vv_before: Option<loro::VersionVector>,
 }
 
 #[derive(Clone, Debug)]
@@ -954,6 +978,13 @@ impl Commit {
 
         let destroyed = commit.destroy.unwrap_or(false);
 
+        // Export what the doc gained during this apply — the author's ops and
+        // the stamp above — for the live fan-out (`CommitResponse::fanout_delta`).
+        let broadcast_update = applied
+            .vv_before
+            .as_ref()
+            .and_then(|vv| applied.resource_new.export_updates_since(vv));
+
         Ok(CommitResponse {
             commit,
             add_atoms: applied.add_atoms,
@@ -971,6 +1002,7 @@ impl Commit {
             },
             changed_props: applied.changed_props,
             source_id: opts.source_id.clone(),
+            broadcast_update,
         })
     }
 
@@ -1010,6 +1042,7 @@ impl Commit {
         let mut add_atoms: Vec<Atom> = Vec::new();
         let mut changed_props: HashSet<String> = HashSet::new();
         let mut imported_new_ops = false;
+        let mut vv_before: Option<loro::VersionVector> = None;
 
         if let Some(loro_update_bytes) = &self.loro_update {
             // Seed from the current resource state when no snapshot exists yet so
@@ -1019,12 +1052,13 @@ impl Commit {
             // Whether the import actually advances the oplog tells idempotent
             // replay (every op already present → VV unchanged) apart from a
             // genuine new write. See the causality guard in `apply_commit`.
-            let vv_before = loro_doc.oplog_vv_map();
+            let vv_map_before = loro_doc.oplog_vv_map();
+            vv_before = Some(loro_doc.oplog_vv());
 
             // Import the update and compute the property-level diff for indexing
             let diff = loro_doc
                 .import_update_with_diff(loro_update_bytes, &resource.get_subject().to_string())?;
-            imported_new_ops = loro_doc.oplog_vv_map() != vv_before;
+            imported_new_ops = loro_doc.oplog_vv_map() != vv_map_before;
 
             // Track which properties changed
             for atom in &diff.add_atoms {
@@ -1058,6 +1092,7 @@ impl Commit {
             remove_atoms,
             changed_props,
             imported_new_ops,
+            vv_before,
         })
     }
 
@@ -2180,6 +2215,69 @@ mod test {
         assert_eq!(
             updated.get(crate::urls::DESCRIPTION).unwrap().to_string(),
             "v2"
+        );
+    }
+
+    /// The server stamps `lastCommit` after importing a commit. That stamp is
+    /// an op under the server's own peer, and a peer that boots from the
+    /// stored snapshot builds its next edit on top of it. The author only
+    /// ever gets its own commit echoed back; if that echo is the commit's raw
+    /// bytes, the author lacks the stamp, the peer's edit parks as pending
+    /// and the document stops being live for the author. `fanout_delta` is
+    /// what the echo must carry.
+    #[tokio::test]
+    async fn fanout_delta_lets_the_author_apply_a_peer_edit_built_on_the_stored_snapshot() {
+        let (store, agent) = store_with_known_agent().await;
+        let agent_subject: Subject = format!("did:ad:agent:{}", agent.public_key).into();
+
+        let author = crate::loro::AtomicLoroDoc::new();
+        author
+            .set_property(urls::PUBLIC_KEY, &Value::String(agent.public_key.clone()))
+            .unwrap();
+        author
+            .set_property(urls::IS_A, &Value::ResourceArray(vec![urls::AGENT.into()]))
+            .unwrap();
+
+        let mut builder = CommitBuilder::new(agent_subject.clone());
+        builder.set_loro_update(author.export_snapshot());
+        builder.is_genesis = true;
+        let empty_resource = Resource::new(agent_subject.to_string());
+        let genesis = builder.sign(&agent, &store, &empty_resource).await.unwrap();
+
+        let opts = CommitOpts {
+            validate_signature: true,
+            validate_timestamp: false,
+            validate_rights: false,
+            update_index: true,
+            ..CommitOpts::no_validations_no_index()
+        };
+        let response = store.apply_commit(genesis, &opts).await.unwrap();
+
+        // The echo of the author's own commit, as the live channel fans it out.
+        let echo = response
+            .fanout_delta()
+            .expect("a Loro commit fans out a delta")
+            .to_vec();
+        assert_ne!(
+            Some(echo.as_slice()),
+            response.commit.loro_update.as_deref(),
+            "the fan-out must carry more than the author's own bytes: the server's stamp"
+        );
+        author.import_update(&echo).unwrap();
+
+        // A second peer boots from what the server stored and edits on top.
+        let stored = store.get_resource(&agent_subject).await.unwrap();
+        let peer = stored.build_state_doc().unwrap();
+        let peer_before = peer.oplog_vv();
+        peer.set_property(urls::NAME, &Value::String("typed by the peer".into()))
+            .unwrap();
+        let peer_delta = peer.export_updates_since(&peer_before);
+
+        author.import_update(&peer_delta).unwrap();
+        assert_eq!(
+            author.get_string_property(urls::NAME),
+            Some("typed by the peer".into()),
+            "the author must apply the peer's edit without a catch-up fetch"
         );
     }
 

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -3280,7 +3280,7 @@ impl Storelike for Db {
         } else {
             DbEvent::Changed {
                 subject,
-                delta: commit_response.commit.loro_update.clone(),
+                delta: commit_response.fanout_delta().map(<[u8]>::to_vec),
                 source_id: commit_response.source_id.clone(),
                 is_new: commit_response.resource_old.is_none(),
                 from_commit: true,

--- a/lib/src/resources.rs
+++ b/lib/src/resources.rs
@@ -254,6 +254,15 @@ impl Resource {
         Ok(doc)
     }
 
+    /// Every op the live doc gained since `since`, or `None` when this
+    /// resource has no materialized doc. Used to fan out a commit together
+    /// with what the server wrote on top of it.
+    pub fn export_updates_since(&self, since: &loro::VersionVector) -> Option<Vec<u8>> {
+        self.loro
+            .as_ref()
+            .map(|doc| doc.export_updates_since(since))
+    }
+
     /// Replace property state from a materialized versioned doc (sync / import).
     pub fn apply_state_doc(&mut self, doc: crate::loro::AtomicLoroDoc) -> AtomicResult<()> {
         let snapshot = doc.export_snapshot();
@@ -1146,6 +1155,7 @@ impl Resource {
             remove_atoms: Vec::new(),
             changed_props: std::collections::HashSet::new(),
             source_id: None,
+            broadcast_update: None,
         }
     }
 

--- a/lib/src/sync/iroh_e2e.rs
+++ b/lib/src/sync/iroh_e2e.rs
@@ -407,8 +407,14 @@ async fn e2e_canvas_folder_assignment_syncs() {
     );
 }
 
-/// New `did:ad:` resources (genesis commits) reach B via a follow-up bulk sync.
-/// Edits to existing resources may arrive live; genesis creation often needs nudge/resync.
+/// New `did:ad:` resources (genesis commits) reach B live while the link is
+/// up, and via a follow-up bulk sync otherwise.
+///
+/// The live delta used to be the commit's own bytes, which a peer could not
+/// always apply for a genesis, so this test once asserted that B did NOT have
+/// the canvas until a resync. `CommitResponse::fanout_delta` now carries
+/// everything the apply added and B usually has it before anyone asks for a
+/// resync; the bulk path is the fallback, not the rule.
 #[tokio::test]
 async fn e2e_new_resource_after_bulk_resync() {
     let pair = setup_pair("e2e_new_res").await;
@@ -436,16 +442,21 @@ async fn e2e_new_resource_after_bulk_resync() {
         .await
         .unwrap();
 
-    assert!(
+    let live_ok = wait_until(std::time::Duration::from_secs(3), || async {
         pair.db_b
             .get_resource(&new_canvas.as_str().into())
             .await
-            .is_err(),
-        "B should not have the canvas before resync"
-    );
+            .is_ok()
+    })
+    .await;
 
-    let imported = sync_b_from_a(&pair).await;
-    assert!(imported > 0, "second bulk sync should import new canvas");
+    if !live_ok {
+        let imported = sync_b_from_a(&pair).await;
+        assert!(
+            imported > 0,
+            "bulk resync must import the canvas when live delivery did not"
+        );
+    }
 
     let on_b = pair
         .db_b

--- a/server/src/commit_monitor.rs
+++ b/server/src/commit_monitor.rs
@@ -23,8 +23,9 @@ use std::sync::Arc;
 /// One connection's registration on a subject, drive or filter.
 #[derive(Debug, Clone)]
 pub struct Subscriber {
-    /// Connection id; a change this connection originated is not echoed back
-    /// to it (see [`skip_same_source`]).
+    /// Connection id. A non-commit change this connection originated is not
+    /// echoed back to it (see [`skip_same_source`]); its own commits are,
+    /// because the echo carries the server's stamp on top of them.
     source_id: String,
     /// The identity the subscription was admitted under, as a subject
     /// string. Kept so [`Handler<RebindAgent>`] can re-evaluate the
@@ -326,12 +327,18 @@ impl Handler<Unsubscribe> for CommitMonitor {
     }
 }
 
-/// True iff a `DbEvent`/`CommitResponse` with `event_source` should NOT be
+/// True iff a non-commit `DbEvent` with `event_source` should NOT be
 /// delivered to a subscriber registered with `subscriber_source`. Same
 /// connection on both sides means the client originated this change and
 /// already has it locally — sending it back is the self-echo we want to
 /// suppress. Missing event source (`None`) means a non-WS origin (HTTP
 /// commit, internal write) and we deliver to everyone.
+///
+/// Commit fan-out deliberately does not use this: the frame carries
+/// `CommitResponse::fanout_delta`, which includes the `lastCommit` stamp the
+/// server wrote under its own peer. The author needs that stamp too — the
+/// next edit by anyone who loaded the stored snapshot depends on it — and the
+/// client dedups the echo by commit id, so it costs one silent import.
 fn skip_same_source(event_source: Option<&str>, subscriber_source: &str) -> bool {
     event_source.is_some_and(|s| s == subscriber_source)
 }
@@ -602,8 +609,6 @@ impl Handler<CommitMessage> for CommitMonitor {
             self.store.get_base_domain().as_deref(),
         );
 
-        let event_source = msg.commit_response.source_id.as_deref();
-
         // Encode the wire frame ONCE up front, wrap in `Arc`. Each
         // subscriber `do_send` then clones only the Arc pointer (O(1))
         // instead of cloning the full `CommitMessage` and re-encoding
@@ -618,10 +623,9 @@ impl Handler<CommitMessage> for CommitMonitor {
                     target_subject,
                     subscribers.len()
                 );
-                for (connection, subscriber) in subscribers {
-                    if skip_same_source(event_source, &subscriber.source_id) {
-                        continue;
-                    }
+                // The author's own connection is included on purpose: see
+                // `skip_same_source`.
+                for connection in subscribers.keys() {
                     connection.do_send(SendFrame {
                         frame: frame.clone(),
                     });
@@ -655,10 +659,7 @@ impl Handler<CommitMessage> for CommitMonitor {
                 if !owner.is_within_drive(&drive_subject) {
                     continue;
                 }
-                for (connection, subscriber) in subscribers {
-                    if skip_same_source(event_source, &subscriber.source_id) {
-                        continue;
-                    }
+                for connection in subscribers.keys() {
                     connection.do_send(SendFrame {
                         frame: frame.clone(),
                     });
@@ -746,7 +747,7 @@ impl Handler<CommitMessage> for CommitMonitor {
 fn encode_commit_frame(store: &Db, msg: &CommitMessage) -> Option<Arc<[u8]>> {
     let commit = &msg.commit_response.commit;
 
-    if let Some(loro_update) = &commit.loro_update {
+    if let Some(loro_update) = msg.commit_response.fanout_delta() {
         // The wire `commit_id` becomes the client's `lastCommit`
         // propval and, on its next commit, its `previousCommit`. The
         // latter is parsed as an AtomicURL by the server's JSON-AD


### PR DESCRIPTION
## What broke

Live collaboration stopped for the **author** of a document once a collaborator edited it. The server stamps `lastCommit` on the resource after applying a commit; `Resource::set_unsafe` is doc-first, so the stamp is a Loro op under the server's own peer. The websocket fan-out forwarded only `commit.loro_update` and skipped the author's connection, so no live subscriber ever got the stamp. A collaborator who loaded the stored snapshot built the next edit on top of it; the author parked that edit as pending and every later delta parked behind it. `recoverFromIncompleteImport` then refetched a snapshot and replaced the doc under loro-prosemirror, which threw `Unreachable code` from its cursor mapping.

This is the "ephemeral cursor" spec that has been red on CI since 2026-09-02, and locally `documents › create document, edit, page title, websockets` as well.

## Server

- `CommitResponse::broadcast_update`: everything the stored doc gained during the apply (author ops plus the stamp), exported from the version captured before the import. `fanout_delta()` is what `DbEvent::Changed` and `commit_monitor::encode_commit_frame` send.
- Commit frames reach the author's connection too. `skip_same_source` stays for non-commit changes.
- Regression test: `fanout_delta_lets_the_author_apply_a_peer_edit_built_on_the_stored_snapshot`.

## Client (`@tomic/lib`)

Delivering the echo exposed three assumptions, each with a unit test in `gap-recovery.test.ts`:

1. **Echo dedup still imports.** `applyIncoming` dedups by commit id but imports the bytes so the stamp lands.
2. **Remote ops are not unsaved work.** `absorbImportedOpsIntoSaveCursor` folds imported peers into the save cursor and `markLoroSavedAt` merges rather than replaces. Without this the drain re-committed an empty delta every 130 ms (`syncInProgress` never cleared; the quick-edit spec).
3. **A pending edit keeps its history token whoever seals it.** Loro commits pending ops without a message on import, export, and from loro-prosemirror's plugin `init`, which a re-render can trigger between two keystrokes. The staged token is armed as `setNextCommitMessage` on every write and used by `sealPendingEdits()` before imports and exports, and the drain reuses it. Without this the History page showed "Second Title" for both versions.

## Verification

- `cargo test -p atomic_lib --lib`: 247 passed. `cargo test -p atomic-server`: 65 + 43 passed. `cargo fmt` clean.
- `@tomic/lib` vitest: 352 passed. lint, format, typecheck clean.
- Local e2e against this branch (server + vite dev): 174 passed, 4 failed, all four environmental on this machine (macOS `ControlOrMeta+m`, the sveltekit template port, and two Cloud Vault specs that talk to a stale control plane on :3030). `history page`, `quick edit text typing ux`, `documents` ×3, `rename-regression` re-run serially ×5: green.

## Notes

- `docs/src/websockets.md` echo section updated.
- `cargo clippy -p atomic_lib --all-targets -- -D warnings` reports two pre-existing lints on develop (`insert_propval_raw` never used, an unused `Result` in `expression.rs`), untouched here.
- `browser/data-browser` `typecheck` has a pre-existing error in `upgradeDocument.ts:221` on develop, untouched here.

## CI follow-up

The first run failed only `sync::iroh_e2e::e2e_new_resource_after_bulk_resync`, which asserted that a new resource does **not** reach the other peer until a bulk resync. With the fan-out delta the live push now applies for a genesis too, so the test treats the bulk path as the fallback. The whole `iroh_e2e` module passes locally with `--features iroh,db-redb` (15 tests).