### PR TITLE
fix(browser): recognise an own commit's echo by signature, before the ack [full-e2e]

### DIFF
--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 ## UNRELEASED
 
 - Fix: `Store.applyIncoming` imports the echo of this client's own commit before deduping it, so the server's `lastCommit` stamp lands locally and a collaborator's next edit applies instead of triggering a catch-up fetch that remounted the editor.
+- Fix: an own commit's echo is recognised by signature (registered at sign time), not only by the `lastCommit` the ack stamps, so an echo that lands before the ack no longer re-renders the page mid-edit (the tag picker in the tables e2e closed under load).
 - Fix: ops that arrive from the server are folded into the Loro save cursor as they are imported, and an ack keeps them there. Without this the echo made the resource look dirty again after every save and the client re-committed an empty delta every 130 ms until reload.
 - Fix: a pending edit that Loro has to seal early (an import, a snapshot export, a server response written into the doc) is committed under the token the next drain will use, so it stays in its own History version instead of collapsing into the base one.
 - Fix: automatic Cloud Vault backups failed in the browser with "Cannot convert 1 to a BigInt" — the checkpoint number is a 64-bit integer on the WASM side and must be handed over as a BigInt.

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1226,10 +1226,16 @@ export async function waitForClientDbFlush(
 }
 
 /**
- * Wait until nothing local is still waiting to reach the server.
+ * Wait until nothing local is still waiting to reach the server, and what
+ * reached it is also on disk here.
  *
  * Covers the outbox, in-flight `save()`s, and UI debounce timers
- * (`startScheduledSave`). `0` means a reload will not drop an edit.
+ * (`startScheduledSave`), then the ClientDb flush. `pendingDirtyCount === 0`
+ * alone means the server has the edit; the OPFS write that mirrors it is
+ * queued on a worker that a navigation destroys ("ClientDb worker
+ * destroyed" in CI logs), and a folder page loaded from OPFS then lacks the
+ * child that was just made. On a loaded runner the gap between ack and
+ * write is what made `folder @smoke` flap.
  */
 export async function waitForSynced(page: Page, timeoutMs = 30_000) {
   try {
@@ -1242,6 +1248,7 @@ export async function waitForSynced(page: Page, timeoutMs = 30_000) {
       undefined,
       { timeout: timeoutMs },
     );
+    await waitForClientDbFlush(page);
   } catch (cause) {
     const diag = await page
       .evaluate(() => {

--- a/browser/lib/src/gap-recovery.test.ts
+++ b/browser/lib/src/gap-recovery.test.ts
@@ -548,4 +548,51 @@ describe("the echo of a client's own commit", () => {
       .find(v => v.propvals.get(NAME) === 'First Title');
     expect(first?.token ?? '').toMatch(/^c-/);
   });
+  it('is recognised by signature when it lands before the ack', async ({
+    expect,
+  }) => {
+    // Under load the echo of an own commit arrives before COMMIT_OK, so
+    // `lastCommit` is not stamped yet. The signature was registered at sign
+    // time; the echo must import silently, not notify.
+    const store = await makeStore();
+    const { LoroDoc } = LoroLoader.Loro;
+    const authored = new LoroDoc();
+    authored
+      .getMap('properties')
+      .set(core.properties.isA, [core.classes.class]);
+    authored.commit();
+
+    const r = new Resource(subject);
+    r.setStore(store);
+    r.loading = true;
+    store.applyIncoming({
+      subject,
+      loroBytes: authored.export({ mode: 'snapshot' }),
+      source: 'ws-pending-get',
+      replaceLoroDocsFromRemote: true,
+    });
+    const resource = store.resources.get(subject)!;
+    resource.appliedCommitSignatures.add('sigAAA');
+
+    let notified = 0;
+    const off = store.subscribe(subject, () => {
+      notified += 1;
+    });
+
+    const { echo } = serverSide(
+      authored.export({ mode: 'snapshot' }),
+      'did:ad:commit:sigAAA',
+    );
+    const outcome = store.applyIncoming({
+      subject,
+      loroBytes: echo,
+      commitId: 'did:ad:commit:sigAAA',
+      source: 'ws-sub-push',
+    });
+    off();
+
+    expect(outcome).toBe('deduped');
+    expect(notified).toBe(0);
+    expect(resource.hasOpsPastSaveCursor()).toBe(false);
+  });
 });

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1166,6 +1166,15 @@ export class Store {
 
     if (entry.signedGenesis) {
       const genesis = entry.signedGenesis;
+
+      // Ours, from before the POST: the echo can land before the ack and
+      // must be recognised either way (see `applyIncoming`).
+      if (genesis.signature) {
+        this.resources
+          .get(subject)
+          ?.appliedCommitSignatures.add(genesis.signature);
+      }
+
       const created = await this.postCommit(genesis, endpoint);
       const commitId = commitIdOf(created);
       const resource = this.resources.get(subject);
@@ -1355,12 +1364,16 @@ export class Store {
     builder.setLoroUpdate(delta);
     const commit = await builder.sign(agent);
 
-    const created = await this.postCommit(commit, endpoint);
-    const commitId = commitIdOf(created);
-
+    // Registered before the POST, not after the ack: the server echoes the
+    // commit to this connection too, and under load that echo lands before
+    // `COMMIT_OK`. `applyIncoming` recognises it by signature and imports it
+    // without a notify, so an own save never re-renders the page mid-edit.
     if (commit.signature) {
       resource.appliedCommitSignatures.add(commit.signature);
     }
+
+    const created = await this.postCommit(commit, endpoint);
+    const commitId = commitIdOf(created);
 
     if (commitId) {
       resource.setLastCommitValue(commitId);
@@ -1797,20 +1810,29 @@ export class Store {
     const subject = this.normalizeSubject(change.subject);
     const existing = this.resources.get(this.aliases.get(subject) ?? subject);
 
-    // Echo dedup: same commitId as cached lastCommit ⇒ no notify. The bytes
-    // are still imported: the echo of this client's own commit carries the
-    // `lastCommit` stamp the server wrote under its own peer, and the next
-    // edit by anyone who loaded the stored snapshot depends on that op.
-    // Without it that edit parks as pending and the document stops being
-    // live for its author. Importing our own ops again is a no-op for Loro.
-    if (
-      !change.forceNotify &&
-      change.commitId &&
-      existing &&
-      !existing.loading &&
-      !existing.new &&
-      existing.get(commits.properties.lastCommit) === change.commitId
-    ) {
+    // Echo dedup ⇒ no notify. Two ways to recognise our own commit: the
+    // cached `lastCommit` matches (the ack already landed), or the id's
+    // signature is one this client signed (`appliedCommitSignatures`, added
+    // before the POST — the echo can arrive before the ack). The bytes are
+    // still imported: the echo carries the `lastCommit` stamp the server
+    // wrote under its own peer, and the next edit by anyone who loaded the
+    // stored snapshot depends on that op. Without it that edit parks as
+    // pending and the document stops being live for its author. Importing
+    // our own ops again is a no-op for Loro.
+    //
+    // Not notifying matters as much as importing: a notify re-renders the
+    // page, and an own save's echo lands right as the user opens the next
+    // cell's picker (tables e2e "create and fill" on a loaded runner).
+    const ownSignature = change.commitId?.startsWith('did:ad:commit:')
+      ? change.commitId.slice('did:ad:commit:'.length)
+      : undefined;
+    const isOwnCommit =
+      !!existing &&
+      !!change.commitId &&
+      (existing.get(commits.properties.lastCommit) === change.commitId ||
+        (!!ownSignature && existing.appliedCommitSignatures.has(ownSignature)));
+
+    if (!change.forceNotify && existing && !existing.loading && isOwnCommit) {
       if (!subject.startsWith('did:ad:commit:')) {
         existing.importLoroUpdate(change.loroBytes);
       }


### PR DESCRIPTION
Follow-up to #1377.

## What
The server now echoes a commit to its author. `Store.applyIncoming` recognised that echo only by the cached `lastCommit`, which the ack stamps; under load the echo arrives before `COMMIT_OK`, so it was handled as a peer's push: imported (correct) and **notified** (a re-render mid-edit). Develop's first full run after #1377 lost `tables › create and fill @smoke` on exactly that: the tag picker closed while the test was typing into it.

## How
- `drainOutboxSubject` adds the signature to `resource.appliedCommitSignatures` **before** the POST (genesis included).
- `applyIncoming` treats a commit id whose signature is in that set as its own: the bytes are imported (the server's `lastCommit` stamp must land), nothing is notified, `'deduped'` is returned. Works whichever of ack and echo lands first.

## Verification
- `@tomic/lib` vitest: 353 passed, including a new case for the echo-before-ack ordering.
- Locally, serial ×2: `tables › create and fill`, `fast row entry`, `documents` websockets + ephemeral cursor, `quick edit`, `history page`: 12/12.
- `[full-e2e]` in the title so this branch runs the whole suite.

## Full-e2e samples on this branch

Three `[full-e2e]` runs. The final failed lists: run 1 — folder, sidebar subresource, localized-text column, fast row entry, dashboard block, Cmd+M, saved-drives; run 2 — Cmd+M, fast row entry, dashboard block, documents websockets, folder; run 3 (with `waitForSynced` flushing the ClientDb) — sidebar subresource, dashboard block, Cmd+M (fast row entry and Shift+Enter flaky, passed on retry). Develop itself failed 6 of the same family before #1377 and 2 after it. Every one of these passes 3/3 serially on a Mac against the same build; the residual set is the runner-load family already documented, not this change.