### PR TITLE
Complete Cloud Server setup with consent, billing return and drive states

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -405,3 +405,9 @@ Cloud Vault display metadata: `vaultAutoBackup.test.ts` verifies name/emoji enro
   Server/Vault, disabled, paused and unknown states. Paired SaaS
   `drive-switcher-hosting.spec.ts` checks menu rendering and refresh/error
   behavior against mocked receipts in the running browser app.
+
+- Billing return: `enrollment.test.ts` checks the typed 402 response; paired
+  SaaS `server-billing-live.spec.ts` follows a free account through mock checkout,
+  back to the selected drive, then explicit consent, replication and an
+  authenticated read from the real managed node. Plan purchase alone creates
+  no enrollment. Real Stripe-hosted test-card checkout remains a deployment check.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -382,3 +382,26 @@ Not covered: Flutter `create_drive` still mints a random DID (the Rust
 machine with the old machine offline.
 
 Cloud Vault display metadata: `vaultAutoBackup.test.ts` verifies name/emoji enrollment and refresh after edits; SaaS `enrollment_display_metadata_refreshes_and_survives_legacy_clients` verifies persistence and account ownership.
+
+## Cloud Server setup
+
+- `data-browser/src/helpers/managed/cloudSync.setup.test.ts`: missing placement,
+  source-server replication and refusal, assigned-server connection ordering,
+  and failed connection without local-drive promotion.
+- `data-browser/src/helpers/managed/reconcile.test.ts`: pending/empty placements
+  do not switch the app away from its source.
+- Paired `atomic-saas/portal/e2e/server-setup.spec.ts`: setup opens the selected
+  existing drive, never creates a content-free enrollment in the portal.
+- Paired `atomic-saas/portal/e2e/server-hosting-live.spec.ts`: opt-in real sign-in,
+  grant, signed enrollment, setup UI, source replication and destination HTTP
+  read. Requires two isolated nodes and dev magic links (`ATOMIC_HOSTING_LIVE=1`).
+  Verified with plain and managed destinations. `ATOMIC_HOSTING_MANAGED=1`
+  additionally checks Active usage receipts and the switcher state. Production
+  deployment and Desktop/Tauri replication are not runtime-tested.
+
+- Hosting consent: `cloudSync.setup.test.ts` refuses transfer/enrollment without
+  an explicit agreement; paired SaaS HTTP tests enforce and record version 1.
+- `driveHostingState.test.ts` covers Local/Remote, empty placement, combined
+  Server/Vault, disabled, paused and unknown states. Paired SaaS
+  `drive-switcher-hosting.spec.ts` checks menu rendering and refresh/error
+  behavior against mocked receipts in the running browser app.

--- a/browser/data-browser/UI_COMPONENTS.md
+++ b/browser/data-browser/UI_COMPONENTS.md
@@ -49,7 +49,7 @@ These components help with rendering resources in different contexts.
 
 - `src/components/Dialog/index.tsx` - Dialog with title/content/action slots. Always use this instead of building your own dialog from scratch. Use in conjunction with `useDialog`
 - `src/components/ConfirmationDialog.tsx` - Standard confirm/cancel dialog built on `Dialog`, `useDialog`, and `Button`.
-- `src/components/Dropdown/index.tsx` - Menu dropdown with portal rendering, keyboard navigation, dividers, shortcut hints, and dialog-tree awareness.
+- `src/components/Dropdown/index.tsx` - Menu dropdown with portal rendering, keyboard navigation, dividers, shortcut hints, optional `suffix` metadata, and dialog-tree awareness.
 - `src/components/Popover.tsx` - Radix popover wrapper with optional modal behavior, arrow, control locking, and dialog-tree integration.
 - `src/components/CustomPopover.tsx` - Lighter popover pattern using local positioning and `usePopover`.
 

--- a/browser/data-browser/src/components/Dropdown/index.tsx
+++ b/browser/data-browser/src/components/Dropdown/index.tsx
@@ -36,6 +36,8 @@ export type MenuItemMinimial = {
   helper?: string;
   id: string;
   icon?: ReactNode;
+  /** Compact trailing metadata, such as a drive service state. */
+  suffix?: ReactNode;
   disabled?: boolean;
   header?: boolean;
   /**
@@ -506,6 +508,7 @@ export function DropdownMenu({
                 id,
                 disabled,
                 shortcut,
+                suffix,
                 icon,
                 header,
                 keepOpen,
@@ -529,6 +532,7 @@ export function DropdownMenu({
                   selected={useKeys && effectiveSelectedIndex === i}
                   icon={icon}
                   shortcut={shortcut}
+                  suffix={suffix}
                   header={header}
                   // In searchable mode focus stays in the filter input;
                   // selection is shown by highlight + scrolled into view.
@@ -574,6 +578,7 @@ export function MenuItem({
   helper,
   disabled,
   shortcut,
+  suffix,
   icon,
   label,
   header,
@@ -624,6 +629,7 @@ export function MenuItem({
     >
       {icon}
       <StyledLabel>{label}</StyledLabel>
+      {suffix}
       {shortcut && <StyledShortcut shortcut={shortcut} />}
     </MenuItemStyled>
   );

--- a/browser/data-browser/src/components/SideBar/DriveSwitcher.tsx
+++ b/browser/data-browser/src/components/SideBar/DriveSwitcher.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components';
+import { useDriveHostingStates } from '../../hooks/useDriveHostingStates';
 import { Resource, core, server, useResources } from '@tomic/react';
 import {
   FaCaretDown,
@@ -6,6 +8,7 @@ import {
   FaPlus,
   FaSquareCheck,
   FaRegCircle,
+  FaCloud,
 } from 'react-icons/fa6';
 import { useSettings } from '../../helpers/AppSettings';
 import { constructOpenURL } from '../../helpers/navigation';
@@ -34,6 +37,10 @@ export function DriveSwitcher({
 }: {
   Trigger?: DropdownTriggerComponent;
 }) {
+  const hosting = useDriveHostingStates();
+  const badge = (subject: string) => (
+    <HostingState>{hosting.states(subject)}</HostingState>
+  );
   const navigate = useNavigateWithTransition();
   const { drive, setDrive, agent } = useSettings();
   const { privateDrive } = usePrivateDrive();
@@ -61,7 +68,8 @@ export function DriveSwitcher({
           {
             id: privateDrive,
             label: 'Private drive',
-            helper: 'Your personal space — visible only to you.',
+            helper: 'Switch to your personal drive.',
+            suffix: badge(privateDrive),
             disabled: false,
             onClick: (): void => switchTo(privateDrive),
             icon: privateDrive === drive ? <FaSquareCheck /> : <FaHouse />,
@@ -72,6 +80,7 @@ export function DriveSwitcher({
       .filter(([_, resource]) => !resource.error)
       .map(([subject, resource]) => ({
         id: subject,
+        suffix: badge(subject),
         label: getTitle(resource),
         helper: `Switch to ${getTitle(resource)}`,
         disabled: false,
@@ -91,12 +100,22 @@ export function DriveSwitcher({
     ...Array.from(recentDrivesMap.entries()).map(([subject, resource]) => ({
       label: getTitle(resource),
       id: subject,
+      suffix: badge(subject),
       helper: `Switch to ${getTitle(resource)}`,
       icon: subject === drive ? <FaSquareCheck /> : <FaRegCircle />,
       onClick: (): void => switchTo(subject),
       disabled: false,
     })),
     DIVIDER,
+    {
+      id: 'drive-hosting',
+      label: 'Storage and hosting',
+      icon: <FaCloud />,
+      helper:
+        'Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server.',
+      onClick: () =>
+        navigate(`/app/sync?drive=${encodeURIComponent(drive ?? '')}`),
+    },
     {
       id: 'manage-drives',
       label: 'Manage drives',
@@ -108,5 +127,20 @@ export function DriveSwitcher({
     },
   ];
 
-  return <DropdownMenu Trigger={Trigger} items={items} />;
+  return (
+    <DropdownMenu
+      Trigger={Trigger}
+      items={items}
+      bindActive={active => {
+        if (active) void hosting.refresh();
+      }}
+    />
+  );
 }
+
+const HostingState = styled.span`
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: ${p => p.theme.colors.textLight};
+  white-space: nowrap;
+`;

--- a/browser/data-browser/src/helpers/managed/cloudSync.setup.test.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.setup.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { enableCloudSyncForDrive } from './cloudSync';
+
+vi.mock('./session', () => ({
+  getManagedAccount: vi.fn(async () => ({ email: 'owner@example.com' })),
+}));
+vi.mock('./enrollment', () => ({
+  createManagedSyncEnrollment: vi.fn(),
+  genesisCertOf: vi.fn(() => undefined),
+}));
+vi.mock('@tomic/react', () => ({
+  signRequest: vi.fn(async () => ({ Authorization: 'signed' })),
+}));
+import { createManagedSyncEnrollment } from './enrollment';
+
+const drive = 'did:ad:existing-drive';
+const agentSubject = 'did:ad:agent:owner';
+
+function setup(local = true) {
+  const store = {
+    isLocalOnlyDrive: vi.fn((subject: string) => local && subject === drive),
+    getAgent: vi.fn(() => ({ subject: agentSubject })),
+    setServerUrl: vi.fn(),
+    getResource: vi.fn(async () => ({})),
+    waitForServerConnected: vi.fn(async () => true),
+    promoteLocalDrive: vi.fn(async () => {}),
+    getSyncStatus: vi.fn(() => ({ serverConnected: true })),
+  };
+  const setServer = vi.fn();
+
+  return {
+    store,
+    setServer,
+    args: {
+      store: store as never,
+      drive,
+      agentSubject,
+      setServer,
+      hostingConsentAccepted: true,
+    },
+  };
+}
+
+describe('Cloud Server setup', () => {
+  afterEach(() => vi.unstubAllGlobals());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true })),
+    );
+    vi.mocked(createManagedSyncEnrollment).mockResolvedValue({
+      drive,
+      node: null,
+      http_origin: 'https://cloud.example',
+    });
+  });
+
+  it('does not enroll or transfer data without explicit agreement', async () => {
+    const { args, store } = setup();
+    await expect(
+      enableCloudSyncForDrive({ ...args, hostingConsentAccepted: false }),
+    ).rejects.toThrow(/Agree/);
+    expect(createManagedSyncEnrollment).not.toHaveBeenCalled();
+    expect(store.promoteLocalDrive).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('waits for the assigned server rather than the old React connection', async () => {
+    const { args, store } = setup();
+    let actualOrigin = 'https://old.example';
+    store.setServerUrl.mockImplementation((url: string) => {
+      actualOrigin = url;
+    });
+    store.waitForServerConnected.mockImplementation(async () => {
+      expect(actualOrigin).toBe('https://cloud.example');
+
+      return true;
+    });
+    await enableCloudSyncForDrive(args);
+    expect(store.promoteLocalDrive).toHaveBeenCalledWith(drive);
+  });
+
+  it('leaves a local drive unpromoted when connection fails', async () => {
+    const { args, store } = setup();
+    store.waitForServerConnected.mockResolvedValue(false);
+    await expect(enableCloudSyncForDrive(args)).rejects.toThrow(/Timed out/);
+    expect(store.promoteLocalDrive).not.toHaveBeenCalled();
+  });
+
+  it('does not claim success or promote against an unrelated server without placement', async () => {
+    vi.mocked(createManagedSyncEnrollment).mockResolvedValue({
+      drive,
+      node: null,
+      http_origin: null,
+    });
+    const { args, store, setServer } = setup();
+    await expect(enableCloudSyncForDrive(args)).rejects.toThrow(
+      /server address/i,
+    );
+    expect(setServer).not.toHaveBeenCalled();
+    expect(store.promoteLocalDrive).not.toHaveBeenCalled();
+  });
+
+  it('replicates an existing remote drive from its source without switching the app', async () => {
+    const { args, store, setServer } = setup(false);
+    await enableCloudSyncForDrive({
+      ...args,
+      sourceServer: 'https://source.example',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://source.example/replicate-drive',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ drive, target: 'https://cloud.example' }),
+      }),
+    );
+    expect(setServer).not.toHaveBeenCalled();
+    expect(store.promoteLocalDrive).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a refused replication without switching away from the source', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 403 } as Response);
+    const { args, setServer } = setup(false);
+    await expect(
+      enableCloudSyncForDrive({
+        ...args,
+        sourceServer: 'https://source.example',
+      }),
+    ).rejects.toThrow(/replicat/i);
+    expect(setServer).not.toHaveBeenCalled();
+  });
+});

--- a/browser/data-browser/src/helpers/managed/cloudSync.test.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.test.ts
@@ -129,6 +129,7 @@ describe('enableCloudSyncForDrive', () => {
     const result = await enableCloudSyncForDrive({
       store: store as never,
       drive: 'did:ad:somedrive',
+      hostingConsentAccepted: true,
       agentSubject: 'did:ad:agent:abc',
       setServer,
       managedInfo: { managed: true, portalUrl: 'https://portal.example' },

--- a/browser/data-browser/src/helpers/managed/cloudSync.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.ts
@@ -1,4 +1,4 @@
-// Turning on hosted sync for a drive the user already has locally — the
+// Turning on hosted sync for a local or server-hosted drive —
 // the Cloud Server action on the /sync page. This is the bridge between
 // the open-core connection layer (connect a server, promote a local drive) and
 // the SaaS control plane (account + per-drive enrollment that assigns a node).
@@ -14,15 +14,15 @@
 //      picks an available node and returns its `http_origin`; only after the
 //      enrollment exists will that node ACCEPT the drive's pushed commits
 //      (open nodes admit anything; a managed node checks the enrollment first).
-//   3. Point the app at that node and, if the drive was local-only, promote it
-//      so the sync engine actually pushes it up.
+//   3. A remote drive is copied by its source server, with verified receipt.
+//      A local-only drive connects to the assigned node before promotion.
 
 import { getManagedAccount } from './session';
 import { createManagedSyncEnrollment, genesisCertOf } from './enrollment';
 import { getManagedEnrollments } from './enrollmentApi';
 import type { ManagedInfo } from '../managedServer';
 import { isRunningInTauri } from '../tauri';
-import type { Store } from '@tomic/react';
+import { signRequest, type Store } from '@tomic/react';
 
 /**
  * Where to send a user to create a hosted-sync account, or null when no portal
@@ -155,7 +155,7 @@ export async function ensureManagedSession(
 }
 
 export type EnableCloudSyncResult =
-  | { ok: true; httpOrigin: string | null }
+  | { ok: true; httpOrigin: string; replicated: boolean }
   | { ok: false; reason: 'no-account'; portalUrl: string | null };
 
 /**
@@ -170,8 +170,15 @@ export async function enableCloudSyncForDrive(params: {
   agentSubject: string;
   setServer: (url: string) => void;
   managedInfo?: ManagedInfo | null;
+  /** Server holding the complete drive, when this is not a local-only drive. */
+  sourceServer?: string;
+  hostingConsentAccepted?: boolean;
 }): Promise<EnableCloudSyncResult> {
   const { store, drive, agentSubject, setServer, managedInfo } = params;
+
+  if (params.hostingConsentAccepted !== true) {
+    throw new Error('Agree to Cloud Server hosting before continuing.');
+  }
 
   const account = await getManagedAccount().catch(() => null);
 
@@ -206,31 +213,64 @@ export async function enableCloudSyncForDrive(params: {
     agentSubject,
     agent: agent?.subject === agentSubject ? agent : undefined,
     genesisCert,
+    hostingConsentVersion: 1,
   });
 
-  const httpOrigin = enrollment.http_origin ?? null;
+  const httpOrigin = enrollment.http_origin;
 
-  if (httpOrigin) {
-    // Point the app at the assigned node. A local-only drive then needs an
-    // explicit promote (it was excluded from sync); a drive already on this
-    // node's origin resyncs through the normal reconnect.
-    setServer(httpOrigin);
-
-    if (wasLocalOnly || agentWasLocalOnly) {
-      if (!(await store.waitForServerConnected(20_000))) {
-        throw new Error('Timed out connecting to the Cloud Server node.');
-      }
-
-      await promoteLocalOnly();
-    }
-  } else if (
-    (wasLocalOnly || agentWasLocalOnly) &&
-    store.getSyncStatus().serverConnected
-  ) {
-    // No origin came back (older control plane) — best effort against whatever
-    // node is currently connected.
-    await promoteLocalOnly();
+  if (!httpOrigin) {
+    throw new Error(
+      'Cloud Server did not return a server address. Retry setup shortly.',
+    );
   }
+
+  // A browser may only have a partial cache. Have the source server push its
+  // complete drive and verify the remote hash before reporting success.
+  // Keep reading from the source, which also retains the replication target.
+  if (
+    !wasLocalOnly &&
+    params.sourceServer &&
+    new URL(params.sourceServer).origin !== new URL(httpOrigin).origin
+  ) {
+    if (!agent || agent.subject !== agentSubject) {
+      throw new Error(
+        'Sign in with the identity that owns this drive to set up hosting.',
+      );
+    }
+
+    const url = new URL('/replicate-drive', params.sourceServer).toString();
+    const headers = await signRequest(url, agent, {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ drive, target: httpOrigin }),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Could not replicate this drive to Cloud Server (HTTP ${response.status}). Your source server is still connected. Retry setup after checking that it supports replication and can reach the cloud server.`,
+      );
+    }
+
+    return { ok: true, httpOrigin, replicated: true };
+  }
+
+  // React's setting update is asynchronous. Reset the store connection now,
+  // or the wait below may see the old server as connected and push there.
+  store.setServerUrl(httpOrigin);
+  setServer(httpOrigin);
+
+  if (!(await store.waitForServerConnected(20_000))) {
+    throw new Error(
+      'Timed out connecting to the Cloud Server node. Retry setup.',
+    );
+  }
+
+  await promoteLocalOnly();
 
   async function promoteLocalOnly() {
     // Agent first: the drive's commits are signed by it, and a node that can
@@ -239,5 +279,5 @@ export async function enableCloudSyncForDrive(params: {
     if (wasLocalOnly) await store.promoteLocalDrive(drive);
   }
 
-  return { ok: true, httpOrigin };
+  return { ok: true, httpOrigin, replicated: false };
 }

--- a/browser/data-browser/src/helpers/managed/driveHostingState.test.ts
+++ b/browser/data-browser/src/helpers/managed/driveHostingState.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { driveHostingState } from './driveHostingState';
+
+describe('drive hosting states', () => {
+  it('only labels explicit device-only storage Local', () => {
+    expect(driveHostingState(true)).toEqual(['Local']);
+    expect(driveHostingState(false)).toEqual(['Remote']);
+  });
+  it.each(['Pending', 'Active'])(
+    'does not claim an empty %s placement is hosted',
+    status => {
+      expect(driveHostingState(false, { status, resource_count: 0 })).toEqual([
+        'Server setup',
+      ]);
+    },
+  );
+  it('shows readable hosting and encrypted backup as separate services', () => {
+    expect(
+      driveHostingState(
+        false,
+        { status: 'Active', resource_count: 5 },
+        { status: 'active', last_backup_at: 123 },
+      ),
+    ).toEqual(['Server', 'Vault']);
+    expect(
+      driveHostingState(true, undefined, {
+        status: 'active',
+        last_backup_at: null,
+      }),
+    ).toEqual(['Local', 'Vault setup']);
+  });
+  it.each([
+    ['Suspended', 'Server paused'],
+    ['Error', 'Server error'],
+    ['unrecognized', 'Server unknown'],
+  ])('preserves %s instead of showing a healthy server', (status, label) => {
+    expect(driveHostingState(false, { status, resource_count: 5 })).toEqual([
+      label,
+    ]);
+  });
+  it('does not show disabled services as enabled', () => {
+    expect(
+      driveHostingState(
+        true,
+        { status: 'Disabled' },
+        { status: 'disabled', last_backup_at: 123 },
+      ),
+    ).toEqual(['Local']);
+  });
+});

--- a/browser/data-browser/src/helpers/managed/driveHostingState.ts
+++ b/browser/data-browser/src/helpers/managed/driveHostingState.ts
@@ -1,0 +1,41 @@
+import type { ManagedEnrollmentSummary } from './enrollmentApi';
+import type { VaultEnrollment } from './vault';
+
+/** Service receipts describe copies, not this device's current connection. */
+export function driveHostingState(
+  local: boolean,
+  server?: Pick<ManagedEnrollmentSummary, 'status' | 'resource_count'>,
+  vault?: Pick<VaultEnrollment, 'status' | 'last_backup_at'>,
+): string[] {
+  const states: string[] = [];
+
+  switch (server?.status) {
+    case /* @wc-ignore */ 'Active':
+      states.push((server.resource_count ?? 0) > 0 ? 'Server' : 'Server setup');
+      break;
+    case /* @wc-ignore */ 'Pending':
+      states.push('Server setup');
+      break;
+    case /* @wc-ignore */ 'Suspended':
+      states.push('Server paused');
+      break;
+    case /* @wc-ignore */ 'Error':
+      states.push('Server error');
+      break;
+    case undefined:
+    case /* @wc-ignore */ 'Disabled':
+      break;
+    default:
+      states.push('Server unknown');
+  }
+
+  if (!states.length) states.push(local ? 'Local' : 'Remote');
+
+  if (vault?.status === /* @wc-ignore */ 'active') {
+    states.push(vault.last_backup_at ? 'Vault' : 'Vault setup');
+  } else if (vault && vault.status !== /* @wc-ignore */ 'disabled') {
+    states.push('Vault paused');
+  }
+
+  return states;
+}

--- a/browser/data-browser/src/helpers/managed/enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.test.ts
@@ -261,6 +261,7 @@ describe('createManagedSyncEnrollment with an agent', () => {
       agentSubject: agent.subject!,
       agent,
       genesisCert: 'AQID',
+      hostingConsentVersion: 1,
     });
 
     expect(managedFetch).toHaveBeenCalledTimes(2);
@@ -272,6 +273,7 @@ describe('createManagedSyncEnrollment with an agent', () => {
 
     expect(managedFetch.mock.calls[1][0]).toBe('/sync-enrollments');
     const body = bodyOf(managedFetch.mock.calls[1]);
+    expect(body.hosting_consent_version).toBe(1);
     const proof = body.proof as Record<string, unknown>;
     expect(proof.nonce).toBe('nonce-1');
     expect(proof.genesis_cert).toBe('AQID');

--- a/browser/data-browser/src/helpers/managed/enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.test.ts
@@ -50,15 +50,15 @@ const failureOf = async (promise: Promise<unknown>): Promise<Error> => {
  * fleet in production read as a mysterious backup failure with no next step.
  */
 describe('createManagedSyncEnrollment failures', () => {
-  it('passes on the reason the server gave, with the upgrade link', async () => {
+  it('returns a typed payment requirement for the hosting handoff', async () => {
     failWith(402, {
       error: 'Cloud Server requires a subscription',
       upgrade_url: 'https://portal.example/billing',
     });
 
-    await expect(enroll()).rejects.toThrow(
-      /Cloud Server requires a subscription.*portal\.example\/billing/,
-    );
+    await expect(enroll()).rejects.toMatchObject({
+      name: 'HostingPaymentRequiredError',
+    });
   });
 
   /** Actionable, and distinct from "we are broken". */

--- a/browser/data-browser/src/helpers/managed/enrollment.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.ts
@@ -236,6 +236,7 @@ export async function createManagedSyncEnrollment({
   agentSubject,
   agent,
   genesisCert,
+  hostingConsentVersion,
 }: {
   driveSubject: string;
   agentSubject: string;
@@ -243,6 +244,7 @@ export async function createManagedSyncEnrollment({
   agent?: Agent;
   /** The drive's `genesis` propval, for a drive that is not the agent's personal drive. */
   genesisCert?: string;
+  hostingConsentVersion?: number;
 }): Promise<ManagedSyncEnrollmentResult> {
   // Identity convergence happens silently at app boot (IdentityReconcileGate);
   // by the time we enroll, the active agent is the account's agent. Enrolling
@@ -268,6 +270,7 @@ export async function createManagedSyncEnrollment({
     body: JSON.stringify({
       drive_subject: driveSubject,
       agent_subject: agentSubject,
+      hosting_consent_version: hostingConsentVersion,
       ...(proof ? { proof } : {}),
     }),
   });

--- a/browser/data-browser/src/helpers/managed/enrollment.ts
+++ b/browser/data-browser/src/helpers/managed/enrollment.ts
@@ -61,6 +61,14 @@ const PROOF_ERROR_MESSAGES: Record<string, string> = {
     'your workspace, sign in with the identity that created it and retry.',
 };
 
+export class HostingPaymentRequiredError extends Error {
+  constructor() {
+    // This exception is a control signal; the route renders translated copy.
+    super(/* @wc-ignore */ 'Hosting payment required');
+    this.name = /* @wc-ignore */ 'HostingPaymentRequiredError';
+  }
+}
+
 /**
  * Say what actually went wrong.
  *
@@ -84,6 +92,10 @@ async function enrollmentError(response: Response): Promise<Error> {
     return new Error(
       `Your ${PRODUCT_NAME} session expired. Sign in and retry.`,
     );
+  }
+
+  if (response.status === 402) {
+    return new HostingPaymentRequiredError();
   }
 
   // A refused proof gets a sentence that says what the user can do about it;

--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -167,6 +167,19 @@ describe('evaluateServerReconciliation', () => {
     expect(result).toEqual({ ok: true });
   });
 
+  it('keeps the source server when placement exists but no data has arrived', async () => {
+    mockFetch({
+      account: { email: 'a@example.com' },
+      enrollments: [enrollment({ status: 'Pending', resource_count: 0 })],
+    });
+    expect(
+      await evaluateServerReconciliation(
+        'https://source.example',
+        'did:ad:drive1',
+      ),
+    ).toEqual({ ok: true });
+  });
+
   it('is ok when the matching enrollment has no http_origin yet', async () => {
     mockFetch({
       account: { email: 'a@example.com' },

--- a/browser/data-browser/src/helpers/managed/reconcile.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.ts
@@ -171,7 +171,13 @@ export async function evaluateServerReconciliation(
   );
 
   const withOrigin = enrollments.filter(
-    e => e.status !== 'Disabled' && e.http_origin,
+    // A placement is not a hosted copy. Keep the source until the node
+    // reports data, including after an interrupted setup.
+    e =>
+      e.status !== 'Disabled' &&
+      e.status !== /* @wc-ignore */ 'Pending' &&
+      e.resource_count !== 0 &&
+      e.http_origin,
   );
 
   // Match by the drive currently in view; with no drive in view yet, only

--- a/browser/data-browser/src/hooks/useDriveHostingStates.ts
+++ b/browser/data-browser/src/hooks/useDriveHostingStates.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '@tomic/react';
+import {
+  managedFetch,
+  getRememberedManagedPortalUrl,
+} from '../helpers/managed/api';
+import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
+import type { ManagedEnrollmentSummary } from '../helpers/managed/enrollmentApi';
+import {
+  listVaultDrives,
+  type VaultEnrollment,
+} from '../helpers/managed/vault';
+import { driveHostingState } from '../helpers/managed/driveHostingState';
+
+type Services = {
+  agent: string | undefined;
+  servers: ManagedEnrollmentSummary[];
+  vaults: VaultEnrollment[];
+};
+
+/** Fetch once per menu opening, never once per drive. Unknown is not Off. */
+export function useDriveHostingStates() {
+  const store = useStore();
+  const agent = store.getAgent()?.subject;
+  const [services, setServices] = useState<Services | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const generation = useRef(0);
+  const offered = !!(getManagedPortalUrl() || getRememberedManagedPortalUrl());
+  const refresh = useCallback(async () => {
+    if (!offered) return;
+
+    const request = ++generation.current;
+
+    try {
+      const [response, vaults] = await Promise.all([
+        managedFetch('/sync-enrollments', {}),
+        listVaultDrives(),
+      ]);
+
+      if (!response.ok) throw new Error('Hosting status unavailable');
+
+      const body = await response.json();
+      const servers = Array.isArray(body) ? body : body.enrollments;
+
+      if (!Array.isArray(servers)) throw new Error('Invalid hosting status');
+      if (request !== generation.current) return;
+
+      setServices({ servers, vaults, agent });
+      setUnavailable(false);
+    } catch {
+      if (request !== generation.current) return;
+
+      setServices(null);
+      setUnavailable(true);
+    }
+  }, [offered, agent]);
+
+  useEffect(() => {
+    void refresh();
+    window.addEventListener('focus', refresh);
+
+    return () => {
+      generation.current++;
+      window.removeEventListener('focus', refresh);
+    };
+  }, [refresh, agent]);
+
+  const current = services?.agent === agent ? services : null;
+
+  return {
+    refresh,
+    states: (subject: string) => {
+      const labels = driveHostingState(
+        store.isLocalOnlyDrive(subject),
+        current?.servers.find(e => e.drive_subject === subject),
+        current?.vaults.find(e => e.drive_subject === subject),
+      );
+
+      if (offered && !current)
+        labels.push(unavailable ? 'Cloud unknown' : 'Checking cloud…');
+
+      return labels.join(' · ');
+    },
+  };
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4812,9 +4812,8 @@ msgstr ""
 msgid "Private drive"
 msgstr ""
 
-#: src/components/SideBar/DriveSwitcher.tsx
-msgid "Your personal space — visible only to you."
-msgstr ""
+#~ msgid "Your personal space — visible only to you."
+#~ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Manage drives"
@@ -5056,10 +5055,8 @@ msgstr ""
 msgid "No {0} portal is configured for this server."
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Backing up this workspace to {0}…"
-msgstr ""
+#~ msgid "Backing up this workspace to {0}…"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/Vault/VaultPanel.tsx
@@ -5067,14 +5064,11 @@ msgstr ""
 msgid "Setting up…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Sign-in wasn’t completed — nothing was backed up."
-msgstr ""
+#~ msgid "Sign-in wasn’t completed — nothing was backed up."
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Could not enable {0} backup."
-msgstr ""
+#~ msgid "Could not enable {0} backup."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
@@ -6526,6 +6520,7 @@ msgid "Bearer {0}"
 msgstr ""
 
 #: src/routes/SyncRoute.tsx
+#: src/routes/SyncRoute.tsx
 msgid "Set up Cloud Server"
 msgstr ""
 
@@ -6787,10 +6782,8 @@ msgstr ""
 msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "Already set up for this workspace. This app is reading from {0} instead."
-msgstr ""
+#~ msgid "Already set up for this workspace. This app is reading from {0} instead."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "This server"
@@ -6805,10 +6798,8 @@ msgstr ""
 msgid "Checking whether this workspace is hosted…"
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
-msgstr ""
+#~ msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Checking this workspace’s backup…"
@@ -7290,4 +7281,133 @@ msgstr ""
 #. 0: shortPeer; 1: ' '
 #: src/routes/History/VersionTitle.tsx
 msgid "by peer {0}{1} <0>Unattributed</0>"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive uses a legacy server address. Cloud Server requires a portable DID drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign-in wasn’t completed — hosting setup was cancelled."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not set up Cloud Server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server received this workspace. Your source server is still connected."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Connected to Cloud Server. Syncing this workspace…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server is on"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sync again"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Finish Cloud Server setup"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This workspace has been copied to Cloud Server. You’re still using the source server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use Cloud Server"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "See plans"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Local:</0> data stays on your devices unless you connect a service or share it."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Vault:</0> an encrypted backup that the provider cannot read. It does not host your workspace."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Server:</0> you agree to us storing and processing a readable copy of this drive to provide hosting. Your sharing permissions still control other users’ access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Agree and enable Cloud Server"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Switch to your personal drive."
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Cloud unknown"
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Checking cloud…"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server paused"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server error"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server unknown"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Local"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Remote"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault paused"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Storage and hosting"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
 msgstr ""

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7307,9 +7307,8 @@ msgstr ""
 msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Cloud Server is on"
@@ -7410,4 +7409,16 @@ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Hosting needs a Server plan. After payment, return here to finish setup."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Choose Server plan"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4846,9 +4846,8 @@ msgstr "<0/> and{0} <1/> are typing"
 msgid "Private drive"
 msgstr "Private drive"
 
-#: src/components/SideBar/DriveSwitcher.tsx
-msgid "Your personal space — visible only to you."
-msgstr "Your personal space — visible only to you."
+#~ msgid "Your personal space — visible only to you."
+#~ msgstr "Your personal space — visible only to you."
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Manage drives"
@@ -5090,10 +5089,8 @@ msgstr "Your workspace hasn’t opened here yet. It may still be settling — re
 msgid "No {0} portal is configured for this server."
 msgstr "No {0} portal is configured for this server."
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Backing up this workspace to {0}…"
-msgstr "Backing up this workspace to {0}…"
+#~ msgid "Backing up this workspace to {0}…"
+#~ msgstr "Backing up this workspace to {0}…"
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/Vault/VaultPanel.tsx
@@ -5101,14 +5098,11 @@ msgstr "Backing up this workspace to {0}…"
 msgid "Setting up…"
 msgstr "Setting up…"
 
-#: src/routes/SyncRoute.tsx
-msgid "Sign-in wasn’t completed — nothing was backed up."
-msgstr "Sign-in wasn’t completed — nothing was backed up."
+#~ msgid "Sign-in wasn’t completed — nothing was backed up."
+#~ msgstr "Sign-in wasn’t completed — nothing was backed up."
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Could not enable {0} backup."
-msgstr "Could not enable {0} backup."
+#~ msgid "Could not enable {0} backup."
+#~ msgstr "Could not enable {0} backup."
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
@@ -6560,6 +6554,7 @@ msgid "Bearer {0}"
 msgstr "Bearer {0}"
 
 #: src/routes/SyncRoute.tsx
+#: src/routes/SyncRoute.tsx
 msgid "Set up Cloud Server"
 msgstr "Set up Cloud Server"
 
@@ -6821,10 +6816,8 @@ msgstr "Open a workspace to see whether it can be hosted."
 msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
 msgstr "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "Already set up for this workspace. This app is reading from {0} instead."
-msgstr "Already set up for this workspace. This app is reading from {0} instead."
+#~ msgid "Already set up for this workspace. This app is reading from {0} instead."
+#~ msgstr "Already set up for this workspace. This app is reading from {0} instead."
 
 #: src/routes/SyncRoute.tsx
 msgid "This server"
@@ -6839,10 +6832,8 @@ msgstr "{0} doesn’t offer hosting, so it can’t be switched on from here."
 msgid "Checking whether this workspace is hosted…"
 msgstr "Checking whether this workspace is hosted…"
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
-msgstr "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+#~ msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+#~ msgstr "This workspace already lives on {0}. Moving it here is a migration, not a backup."
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Checking this workspace’s backup…"
@@ -7325,3 +7316,132 @@ msgstr "by <0/>{0} <1/>"
 #: src/routes/History/VersionTitle.tsx
 msgid "by peer {0}{1} <0>Unattributed</0>"
 msgstr "by peer {0}{1} <0>Unattributed</0>"
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive uses a legacy server address. Cloud Server requires a portable DID drive."
+msgstr "This drive uses a legacy server address. Cloud Server requires a portable DID drive."
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign-in wasn’t completed — hosting setup was cancelled."
+msgstr "Sign-in wasn’t completed — hosting setup was cancelled."
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not set up Cloud Server."
+msgstr "Could not set up Cloud Server."
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server received this workspace. Your source server is still connected."
+msgstr "Cloud Server received this workspace. Your source server is still connected."
+
+#: src/routes/SyncRoute.tsx
+msgid "Connected to Cloud Server. Syncing this workspace…"
+msgstr "Connected to Cloud Server. Syncing this workspace…"
+
+#: src/routes/SyncRoute.tsx
+msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
+msgstr "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+msgstr "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server is on"
+msgstr "Cloud Server is on"
+
+#: src/routes/SyncRoute.tsx
+msgid "Sync again"
+msgstr "Sync again"
+
+#: src/routes/SyncRoute.tsx
+msgid "Finish Cloud Server setup"
+msgstr "Finish Cloud Server setup"
+
+#: src/routes/SyncRoute.tsx
+msgid "This workspace has been copied to Cloud Server. You’re still using the source server."
+msgstr "This workspace has been copied to Cloud Server. You’re still using the source server."
+
+#: src/routes/SyncRoute.tsx
+msgid "Use Cloud Server"
+msgstr "Use Cloud Server"
+
+#: src/routes/SyncRoute.tsx
+msgid "See plans"
+msgstr "See plans"
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Local:</0> data stays on your devices unless you connect a service or share it."
+msgstr "<0>Local:</0> data stays on your devices unless you connect a service or share it."
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Vault:</0> an encrypted backup that the provider cannot read. It does not host your workspace."
+msgstr "<0>Cloud Vault:</0> an encrypted backup that the provider cannot read. It does not host your workspace."
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Server:</0> you agree to us storing and processing a readable copy of this drive to provide hosting. Your sharing permissions still control other users’ access."
+msgstr "<0>Cloud Server:</0> you agree to us storing and processing a readable copy of this drive to provide hosting. Your sharing permissions still control other users’ access."
+
+#: src/routes/SyncRoute.tsx
+msgid "Agree and enable Cloud Server"
+msgstr "Agree and enable Cloud Server"
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Switch to your personal drive."
+msgstr "Switch to your personal drive."
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Cloud unknown"
+msgstr "Cloud unknown"
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Checking cloud…"
+msgstr "Checking cloud…"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server"
+msgstr "Server"
+
+#: src/helpers/managed/driveHostingState.ts
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server setup"
+msgstr "Server setup"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server paused"
+msgstr "Server paused"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server error"
+msgstr "Server error"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server unknown"
+msgstr "Server unknown"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Local"
+msgstr "Local"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Remote"
+msgstr "Remote"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault"
+msgstr "Vault"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault setup"
+msgstr "Vault setup"
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault paused"
+msgstr "Vault paused"
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Storage and hosting"
+msgstr "Storage and hosting"
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
+msgstr "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7341,9 +7341,8 @@ msgstr "Connected to Cloud Server. Syncing this workspace…"
 msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
 msgstr "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
-msgstr "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+#~ msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+#~ msgstr "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
 
 #: src/routes/SyncRoute.tsx
 msgid "Cloud Server is on"
@@ -7445,3 +7444,15 @@ msgstr "Storage and hosting"
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
 msgstr "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
+
+#: src/routes/SyncRoute.tsx
+msgid "Hosting needs a Server plan. After payment, return here to finish setup."
+msgstr "Hosting needs a Server plan. After payment, return here to finish setup."
+
+#: src/routes/SyncRoute.tsx
+msgid "Choose Server plan"
+msgstr "Choose Server plan"
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4812,9 +4812,8 @@ msgstr ""
 msgid "Private drive"
 msgstr ""
 
-#: src/components/SideBar/DriveSwitcher.tsx
-msgid "Your personal space — visible only to you."
-msgstr ""
+#~ msgid "Your personal space — visible only to you."
+#~ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Manage drives"
@@ -5056,10 +5055,8 @@ msgstr ""
 msgid "No {0} portal is configured for this server."
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Backing up this workspace to {0}…"
-msgstr ""
+#~ msgid "Backing up this workspace to {0}…"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/Vault/VaultPanel.tsx
@@ -5067,14 +5064,11 @@ msgstr ""
 msgid "Setting up…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Sign-in wasn’t completed — nothing was backed up."
-msgstr ""
+#~ msgid "Sign-in wasn’t completed — nothing was backed up."
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Could not enable {0} backup."
-msgstr ""
+#~ msgid "Could not enable {0} backup."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
@@ -6526,6 +6520,7 @@ msgid "Bearer {0}"
 msgstr ""
 
 #: src/routes/SyncRoute.tsx
+#: src/routes/SyncRoute.tsx
 msgid "Set up Cloud Server"
 msgstr ""
 
@@ -6787,10 +6782,8 @@ msgstr ""
 msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "Already set up for this workspace. This app is reading from {0} instead."
-msgstr ""
+#~ msgid "Already set up for this workspace. This app is reading from {0} instead."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "This server"
@@ -6805,10 +6798,8 @@ msgstr ""
 msgid "Checking whether this workspace is hosted…"
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
-msgstr ""
+#~ msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Checking this workspace’s backup…"
@@ -7290,4 +7281,133 @@ msgstr ""
 #. 0: shortPeer; 1: ' '
 #: src/routes/History/VersionTitle.tsx
 msgid "by peer {0}{1} <0>Unattributed</0>"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive uses a legacy server address. Cloud Server requires a portable DID drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign-in wasn’t completed — hosting setup was cancelled."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not set up Cloud Server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server received this workspace. Your source server is still connected."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Connected to Cloud Server. Syncing this workspace…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server is on"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sync again"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Finish Cloud Server setup"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This workspace has been copied to Cloud Server. You’re still using the source server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use Cloud Server"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "See plans"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Local:</0> data stays on your devices unless you connect a service or share it."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Vault:</0> an encrypted backup that the provider cannot read. It does not host your workspace."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Server:</0> you agree to us storing and processing a readable copy of this drive to provide hosting. Your sharing permissions still control other users’ access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Agree and enable Cloud Server"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Switch to your personal drive."
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Cloud unknown"
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Checking cloud…"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server paused"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server error"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server unknown"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Local"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Remote"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault paused"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Storage and hosting"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
 msgstr ""

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7307,9 +7307,8 @@ msgstr ""
 msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Cloud Server is on"
@@ -7410,4 +7409,16 @@ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Hosting needs a Server plan. After payment, return here to finish setup."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Choose Server plan"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4812,9 +4812,8 @@ msgstr ""
 msgid "Private drive"
 msgstr ""
 
-#: src/components/SideBar/DriveSwitcher.tsx
-msgid "Your personal space — visible only to you."
-msgstr ""
+#~ msgid "Your personal space — visible only to you."
+#~ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Manage drives"
@@ -5056,10 +5055,8 @@ msgstr ""
 msgid "No {0} portal is configured for this server."
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Backing up this workspace to {0}…"
-msgstr ""
+#~ msgid "Backing up this workspace to {0}…"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 #: src/components/Vault/VaultPanel.tsx
@@ -5067,14 +5064,11 @@ msgstr ""
 msgid "Setting up…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Sign-in wasn’t completed — nothing was backed up."
-msgstr ""
+#~ msgid "Sign-in wasn’t completed — nothing was backed up."
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Could not enable {0} backup."
-msgstr ""
+#~ msgid "Could not enable {0} backup."
+#~ msgstr ""
 
 #: src/components/NewIdentitySection.tsx
 msgid "Skip anyway"
@@ -6526,6 +6520,7 @@ msgid "Bearer {0}"
 msgstr ""
 
 #: src/routes/SyncRoute.tsx
+#: src/routes/SyncRoute.tsx
 msgid "Set up Cloud Server"
 msgstr ""
 
@@ -6787,10 +6782,8 @@ msgstr ""
 msgid "This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here."
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "Already set up for this workspace. This app is reading from {0} instead."
-msgstr ""
+#~ msgid "Already set up for this workspace. This app is reading from {0} instead."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "This server"
@@ -6805,10 +6798,8 @@ msgstr ""
 msgid "Checking whether this workspace is hosted…"
 msgstr ""
 
-#. 0: serverHostname ?? 'another server'
-#: src/routes/SyncRoute.tsx
-msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
-msgstr ""
+#~ msgid "This workspace already lives on {0}. Moving it here is a migration, not a backup."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Checking this workspace’s backup…"
@@ -7290,4 +7281,133 @@ msgstr ""
 #. 0: shortPeer; 1: ' '
 #: src/routes/History/VersionTitle.tsx
 msgid "by peer {0}{1} <0>Unattributed</0>"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive uses a legacy server address. Cloud Server requires a portable DID drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign-in wasn’t completed — hosting setup was cancelled."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not set up Cloud Server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server received this workspace. Your source server is still connected."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Connected to Cloud Server. Syncing this workspace…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Cloud Server is on"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sync again"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Finish Cloud Server setup"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This workspace has been copied to Cloud Server. You’re still using the source server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use Cloud Server"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "See plans"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Local:</0> data stays on your devices unless you connect a service or share it."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Vault:</0> an encrypted backup that the provider cannot read. It does not host your workspace."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "<0>Cloud Server:</0> you agree to us storing and processing a readable copy of this drive to provide hosting. Your sharing permissions still control other users’ access."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Agree and enable Cloud Server"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Switch to your personal drive."
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Cloud unknown"
+msgstr ""
+
+#: src/hooks/useDriveHostingStates.ts
+msgid "Checking cloud…"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server paused"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server error"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Server unknown"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Local"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Remote"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault setup"
+msgstr ""
+
+#: src/helpers/managed/driveHostingState.ts
+msgid "Vault paused"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Storage and hosting"
+msgstr ""
+
+#: src/components/SideBar/DriveSwitcher.tsx
+msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7307,9 +7307,8 @@ msgstr ""
 msgid "Keep this workspace available when your devices are offline, with shareable links, search, and API access."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting currently requires an invitation for this drive."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Cloud Server is on"
@@ -7410,4 +7409,16 @@ msgstr ""
 
 #: src/components/SideBar/DriveSwitcher.tsx
 msgid "Local stays on your devices. Vault is encrypted backup. Server hosts a readable copy. Remote is another connected server."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Hosting needs a Server plan. After payment, return here to finish setup."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Choose Server plan"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -38,6 +38,7 @@ import {
   FaKey,
 } from 'react-icons/fa6';
 import { Button } from '../components/Button';
+import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { VaultPanel } from '../components/Vault/VaultPanel';
 import { LinkProviderPanel } from '../components/Vault/LinkProviderPanel';
 import { isDeviceLinked } from '../helpers/managed/deviceLink';
@@ -103,6 +104,12 @@ import { serverURLStorage } from '../helpers/serverURLStorage';
 
 export const SyncRoute = createRoute({
   path: pathNames.sync,
+  validateSearch: (search): { drive?: string } => ({
+    drive:
+      typeof search.drive === 'string' && search.drive.startsWith('did:ad:')
+        ? search.drive
+        : undefined,
+  }),
   component: () => <SyncPage />,
   getParentRoute: () => appRoute,
 });
@@ -543,7 +550,19 @@ function SyncPage() {
     () => localStorage.getItem('ws-debug') === '1',
   );
   const [clientDbOn, setClientDbOn] = useState(() => isClientDbEnabled());
-  const { setServer, baseURL } = useSettings();
+  const { setServer, setDrive, baseURL } = useSettings();
+  const { drive: requestedDrive } = SyncRoute.useSearch();
+  const [confirmCloud, setConfirmCloud] = useState(false);
+  const [hostedCopy, setHostedCopy] = useState<{
+    drive: string;
+    origin: string;
+  } | null>(null);
+  const hostedCopyOrigin =
+    hostedCopy && hostedCopy.drive === status.drive ? hostedCopy.origin : null;
+  useEffect(() => {
+    if (requestedDrive && requestedDrive !== store.getDrive())
+      setDrive(requestedDrive);
+  }, [requestedDrive, setDrive, store]);
   const [knownServers, setKnownServers] = useState<string[]>(() =>
     serverURLStorage.getKnownServers(),
   );
@@ -968,16 +987,10 @@ function SyncPage() {
     }
   });
 
-  // Offer Cloud Server only for a drive that lives on this device (a
-  // local-only drive, or the embedded node with no remote server) and isn't
-  // already enrolled. A drive already homed on a remote server is a migration,
-  // not a backup — out of scope for this action.
-  const deviceLocalDrive =
-    !!status.drive && (localOnlyDrive || !showServerConn);
+  // The source server copies remote drives in full; enrollment alone is not sync.
   const showCloudBackup =
     isCloudSyncAvailable(managedInfo) &&
-    cloudEnrolled === false &&
-    deviceLocalDrive &&
+    cloudEnrolled !== null &&
     !driveMissing;
 
   /**
@@ -1002,10 +1015,6 @@ function SyncPage() {
       return 'This device doesn’t have this workspace yet. Pair the device that does, and you can host it from here.';
     }
 
-    if (cloudEnrolled === true) {
-      return `Already set up for this workspace. This app is reading from ${serverHostname ?? 'another server'} instead.`;
-    }
-
     if (!isCloudSyncAvailable(managedInfo)) {
       return `${serverHostname ?? 'This server'} doesn’t offer hosting, so it can’t be switched on from here.`;
     }
@@ -1014,8 +1023,8 @@ function SyncPage() {
       return 'Checking whether this workspace is hosted…';
     }
 
-    if (!deviceLocalDrive) {
-      return `This workspace already lives on ${serverHostname ?? 'another server'}. Moving it here is a migration, not a backup.`;
+    if (!status.drive.startsWith('did:ad:')) {
+      return 'This drive uses a legacy server address. Cloud Server requires a portable DID drive.';
     }
 
     return null;
@@ -1121,6 +1130,13 @@ function SyncPage() {
         agentSubject,
         setServer,
         managedInfo,
+        hostingConsentAccepted: true,
+        sourceServer:
+          !localOnlyDrive &&
+          status.serverUrl &&
+          !isOriginWithoutNode(status.serverUrl)
+            ? status.serverUrl
+            : undefined,
       };
       let result = await enableCloudSyncForDrive(args);
 
@@ -1139,7 +1155,7 @@ function SyncPage() {
         const signedIn = await ensureManagedSession(result.portalUrl);
 
         if (!signedIn) {
-          toast(`Sign-in wasn’t completed — nothing was backed up.`);
+          toast(`Sign-in wasn’t completed — hosting setup was cancelled.`);
 
           return;
         }
@@ -1147,14 +1163,20 @@ function SyncPage() {
         result = await enableCloudSyncForDrive(args);
 
         if (!result.ok) {
-          toast.error(`Could not enable ${PRODUCT_NAME} backup.`);
+          toast.error(`Could not set up Cloud Server.`);
 
           return;
         }
       }
 
       setCloudEnrolled(true);
-      toast.success(`Backing up this workspace to ${PRODUCT_NAME}…`);
+      if (result.replicated)
+        setHostedCopy({ drive, origin: result.httpOrigin });
+      toast.success(
+        result.replicated
+          ? 'Cloud Server received this workspace. Your source server is still connected.'
+          : 'Connected to Cloud Server. Syncing this workspace…',
+      );
     } catch (e) {
       store.notifyError(e as Error);
     } finally {
@@ -1478,24 +1500,46 @@ function SyncPage() {
                     one of ours, but the reader scans this column to find out
                     what they have, and the header above already says whose
                     services these are. */}
-                <CardIcon>
+                <CardIcon $tone={hostedCopyOrigin ? 'provider' : 'neutral'}>
                   <FaCloud />
                 </CardIcon>
                 <ConnBody>
-                  <ConnTitle>Cloud Server</ConnTitle>
+                  <ConnTitle>
+                    {hostedCopyOrigin ? 'Cloud Server is on' : 'Cloud Server'}
+                  </ConnTitle>
                   <ConnSub>
                     A hosted workspace on {PRODUCT_NAME}: shareable links,
                     search across everything, API access, and no waiting on
                     another device to be awake. Unlike Cloud Vault, our servers
                     process what you put here.
                   </ConnSub>
+                  {hostedCopyOrigin && (
+                    <ConnMeta>
+                      This workspace has been copied to Cloud Server. You’re
+                      still using the source server.
+                    </ConnMeta>
+                  )}
                   {cloudServerBlocked && (
                     <ConnMeta>{cloudServerBlocked}</ConnMeta>
                   )}
                   <ConnActions>
+                    {hostedCopyOrigin && (
+                      <Button onClick={() => switchToServer(hostedCopyOrigin)}>
+                        Use Cloud Server
+                      </Button>
+                    )}
                     {!cloudServerBlocked && (
-                      <Button onClick={backupToCloud} disabled={cloudBusy}>
-                        {cloudBusy ? 'Setting up…' : 'Set up Cloud Server'}
+                      <Button
+                        onClick={() => setConfirmCloud(true)}
+                        disabled={cloudBusy}
+                      >
+                        {cloudBusy
+                          ? 'Setting up…'
+                          : hostedCopyOrigin
+                            ? 'Sync again'
+                            : cloudEnrolled
+                              ? 'Finish Cloud Server setup'
+                              : 'Set up Cloud Server'}
                       </Button>
                     )}
                     {/* This tier costs money and reads our copy of your data,
@@ -1520,6 +1564,36 @@ function SyncPage() {
             )}
           </ProviderCard>
         )}
+
+        <ConfirmationDialog
+          title='Set up Cloud Server'
+          confirmLabel='Agree and enable Cloud Server'
+          show={confirmCloud}
+          bindShow={setConfirmCloud}
+          onConfirm={() => void backupToCloud()}
+        >
+          <p>
+            Keep this workspace available when your devices are offline, with
+            shareable links, search, and API access.
+          </p>
+          <p>
+            <strong>Local:</strong> data stays on your devices unless you
+            connect a service or share it.
+          </p>
+          <p>
+            <strong>Cloud Vault:</strong> an encrypted backup that the provider
+            cannot read. It does not host your workspace.
+          </p>
+          <p>
+            <strong>Cloud Server:</strong> you agree to us storing and
+            processing a readable copy of this drive to provide hosting. Your
+            sharing permissions still control other users’ access.
+          </p>
+          <p>
+            Existing content stays in this drive. Hosting currently requires an
+            invitation for this drive.
+          </p>
+        </ConfirmationDialog>
 
         {/* Signed in, but this device holds none of the account's data — it's
             still on whatever device created it. Pairing is the way across, so

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1,3 +1,4 @@
+import { HostingPaymentRequiredError } from '../helpers/managed/enrollment';
 import {
   useEffect,
   useState,
@@ -588,6 +589,9 @@ function SyncPage() {
   // known / not applicable; `false` = eligible but not enrolled (show the CTA);
   // `true` = already enrolled (hide it).
   const [cloudEnrolled, setCloudEnrolled] = useState<boolean | null>(null);
+  const [paymentRequiredDrive, setPaymentRequiredDrive] = useState<
+    string | null
+  >(null);
   const [cloudBusy, setCloudBusy] = useState(false);
   // Resolved in an effect rather than read off a Resource during render: the
   // React Compiler memoizes on the proxy identity, so a resource that finishes
@@ -1122,6 +1126,7 @@ function SyncPage() {
     if (!drive || !agentSubject || cloudBusy) return;
 
     setCloudBusy(true);
+    setPaymentRequiredDrive(null);
 
     try {
       const args = {
@@ -1178,7 +1183,11 @@ function SyncPage() {
           : 'Connected to Cloud Server. Syncing this workspace…',
       );
     } catch (e) {
-      store.notifyError(e as Error);
+      if (e instanceof HostingPaymentRequiredError) {
+        setPaymentRequiredDrive(drive);
+      } else {
+        store.notifyError(e as Error);
+      }
     } finally {
       setCloudBusy(false);
     }
@@ -1522,6 +1531,21 @@ function SyncPage() {
                   {cloudServerBlocked && (
                     <ConnMeta>{cloudServerBlocked}</ConnMeta>
                   )}
+                  {paymentRequiredDrive !== null &&
+                    paymentRequiredDrive === status.drive &&
+                    accountPortalUrl && (
+                      <ConnMeta>
+                        Hosting needs a Server plan. After payment, return here
+                        to finish setup.
+                        <LearnMore
+                          {...externalLinkProps(
+                            `${accountPortalUrl}/billing?${new URLSearchParams({ drive: status.drive ?? '' })}`,
+                          )}
+                        >
+                          Choose Server plan
+                        </LearnMore>
+                      </ConnMeta>
+                    )}
                   <ConnActions>
                     {hostedCopyOrigin && (
                       <Button onClick={() => switchToServer(hostedCopyOrigin)}>
@@ -1590,8 +1614,8 @@ function SyncPage() {
             sharing permissions still control other users’ access.
           </p>
           <p>
-            Existing content stays in this drive. Hosting currently requires an
-            invitation for this drive.
+            Existing content stays in this drive. Hosting requires a Server plan
+            or an invitation for this drive.
           </p>
         </ConfirmationDialog>
 

--- a/planning/sync-onboarding-ux.md
+++ b/planning/sync-onboarding-ux.md
@@ -165,3 +165,28 @@ Gaps worth knowing, rather than rediscovering:
 *If you change vocabulary or a flow here, change it in both clients and update
 this table. A person moving from the phone to the laptop should not notice
 they moved.*
+
+## Cloud Server setup (2026-09-07)
+
+The hosted browser now offers setup for existing portable drives on another
+server. The source's `/replicate-drive` copies its complete data and verifies
+receipt; the browser keeps its source connection and offers “Use Cloud Server”
+only after that copy succeeds. Local-only drives connect to the assigned node
+before promotion. Enrollment alone is not a successful transfer: pending or
+empty placements must not override the source on the next app launch.
+
+The account portal hands setup to `/app/sync?drive=…`, preserving the selected
+drive. It shows hosting beside each drive and keeps unfinished setup actionable.
+The confirmation explains that hosting is a readable copy, distinct from Vault.
+Flutter has no equivalent managed-hosting setup action; its generic device
+connections are unchanged. The browser's source-server path also applies to an
+embedded node, but native runtime verification remains separate.
+
+### Hosting consent and drive switcher (2026-09-07)
+
+The hosting action explains Local, Vault and Server before an explicit “Agree
+and enable Cloud Server” action. The paired control plane requires consent
+version 1 and persists account, agent and server timestamp on the enrollment.
+Existing records retain unknown consent; no consent is inferred from a drive
+being present. Browser switcher rows carry compact service state labels, with
+one Storage and hosting action for details. Unknown cloud status stays explicit.


### PR DESCRIPTION
Cloud Server setup now handles an existing portable drive without switching the app to an empty destination. The app obtains owner proof, records explicit hosting consent through the control plane, copies from the source server, and offers switching only after the destination confirms receipt. Local drives retain their promotion path with corrected connection ordering.

A payment-required response opens billing for the selected drive. Returning from payment resumes setup and still requires consent; purchasing a plan does not copy data. The drive switcher shows compact Local/Remote, Server/Vault, setup, paused/error and unknown states.

Paired with https://github.com/ontola/atomic-saas/pull/54 on the same `codex/server-proposition` branch, which integrates and fixes SaaS PR #20. Merge this server side first, as required by the paired deployment workflow.

Validation:
- 52 focused browser unit tests passed.
- Five real-server replication tests passed earlier in this work.
- Six paired Playwright scenarios passed, including payment return and existing-drive copy to an actual managed node with an authenticated read and Active usage receipt.
- Data-browser production build passed; translation diffs reviewed.

Limits: billing end-to-end uses the explicit mock provider, not a Stripe-hosted test-card transaction. No production deployment or native/Tauri runtime validation. Full browser typecheck still reports the three baseline errors in `upgradeDocument.ts` and `loro-loader.ts`. Legacy HTTP-subject drives receive an explicit portable-DID requirement.
