### PR TITLE
Make Vault backups automatic across browser and Tauri

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -465,3 +465,9 @@ The node-type toolbar lifecycle is covered by `NodeSelectMenu.test.tsx` (destroy
 editors do not expose state/commands) and `oxc-react-compiler.test.ts` (production
 compilation does not hoist command getters into render). `sentry.test.ts` covers
 packaged WebView initialization without server-injected Sentry configuration.
+
+Automatic Vault scheduling (`vaultAutoBackup.test.ts`) covers sustained-edit
+maximum delay, queued edits across drive switches, late account availability,
+connectivity recovery, enrollment rediscovery after reload, and distinguishing
+Tauri embedded nodes from remote servers. Native background execution after OS
+suspension remains outside this scheduler's guarantees.

--- a/browser/data-browser/src/components/CloudVaultWatcher.tsx
+++ b/browser/data-browser/src/components/CloudVaultWatcher.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../helpers/AppSettings';
 import { deviceHasDriveData } from '../helpers/driveData';
 import { fetchPrivateDriveSubject } from '../helpers/privateDrive';
 import {
+  AUTO_BACKUP_RETRY_MS,
   ensureVaultBackup,
   watchForVaultBackups,
 } from '../helpers/managed/vaultAutoBackup';
@@ -16,8 +17,8 @@ import {
  * drive and backs it up once — which is how an account that predates automatic
  * backup, or that only ever signs in on this device, gets covered without
  * going through sign-in again. After that it backs the open drive up again a
- * while after each edit. Both are no-ops without a control-plane session, so
- * a self-hosted install pays one failed `/api/me` per sign-in and nothing else.
+ * while after each edit. Periodic retries cover late account linking and data
+ * arriving after startup. Both paths require an eligible account session.
  */
 export function CloudVaultWatcher() {
   const store = useStore();
@@ -31,22 +32,39 @@ export function CloudVaultWatcher() {
 
     let cancelled = false;
 
-    void (async () => {
-      const drive = await fetchPrivateDriveSubject(store, agent).catch(
-        () => undefined,
-      );
+    let checking = false;
 
-      if (cancelled || !drive) return;
+    const check = async () => {
+      if (checking || cancelled) return;
+      checking = true;
 
-      // Nothing to back up from a device that does not hold the drive — and
-      // sign-in handles that device by restoring instead.
-      if (!(await deviceHasDriveData(store, drive))) return;
+      try {
+        const drive = await fetchPrivateDriveSubject(store, agent).catch(
+          () => undefined,
+        );
 
-      if (!cancelled) void ensureVaultBackup(store, drive);
-    })();
+        if (cancelled || !drive) return;
+
+        // Nothing to back up from a device that does not hold the drive — and
+        // sign-in handles that device by restoring instead.
+        if (!(await deviceHasDriveData(store, drive))) return;
+
+        if (!cancelled) await ensureVaultBackup(store, drive);
+      } finally {
+        checking = false;
+      }
+    };
+
+    void check();
+    // Account linking, restored data and connectivity can arrive after mount.
+    const retry = setInterval(() => void check(), AUTO_BACKUP_RETRY_MS);
+    const onOnline = () => void check();
+    window.addEventListener('online', onOnline);
 
     return () => {
       cancelled = true;
+      clearInterval(retry);
+      window.removeEventListener('online', onOnline);
     };
     // `agent` is a new object on every settings render; its subject is what
     // identifies a sign-in.

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
@@ -8,6 +8,7 @@ import {
   dataBrowser,
 } from '@tomic/lib';
 import {
+  isEmbeddedVaultDrive,
   ensureVaultBackup,
   forgetEnrolledVaults,
   onVaultChanged,
@@ -439,6 +440,123 @@ describe('watchForVaultBackups', () => {
     return { win: win as unknown as Window, doc, listeners };
   }
 
+  it('backs up during continuous editing by the maximum delay', async () => {
+    vi.useFakeTimers();
+    const store = await signedInStore();
+    store.setDrive(DRIVE);
+    store.registerLocalOnlyDrive(DRIVE);
+    const deps = fakeDeps();
+    const stop = watchForVaultBackups(store, deps, {
+      idleMs: 1000,
+      maxWaitMs: 2000,
+      window: null,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      store.notifyResourceSaved(store.getResourceLoading(`${DRIVE}/doc`));
+      await vi.advanceTimersByTimeAsync(500);
+    }
+
+    expect(deps.runVaultBackup).toHaveBeenCalled();
+    stop();
+  });
+
+  it('retains pending backups when switching drives', async () => {
+    vi.useFakeTimers();
+    const store = await signedInStore();
+    const other = 'did:ad:drive:other';
+    store.registerLocalOnlyDrive(DRIVE);
+    store.registerLocalOnlyDrive(other);
+    store.setDrive(DRIVE);
+    const deps = fakeDeps();
+    const stop = watchForVaultBackups(store, deps, {
+      idleMs: 1000,
+      window: null,
+    });
+    store.notifyResourceSaved(store.getResourceLoading(`${DRIVE}/doc`));
+    store.setDrive(other);
+    store.notifyResourceSaved(store.getResourceLoading(`${other}/doc`));
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(
+      vi
+        .mocked(deps.runVaultBackup)
+        .mock.calls.map(([args]) => args.driveSubject),
+    ).toEqual(expect.arrayContaining([DRIVE, other]));
+    stop();
+  });
+
+  it('retries when the account becomes available without another edit', async () => {
+    vi.useFakeTimers();
+    const store = await signedInStore();
+    store.setDrive(DRIVE);
+    store.registerLocalOnlyDrive(DRIVE);
+    const deps = fakeDeps({ hasAccount: vi.fn(async () => false) });
+    const stop = watchForVaultBackups(store, deps, {
+      idleMs: 10,
+      retryMs: 100,
+      window: null,
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    expect(deps.runVaultBackup).not.toHaveBeenCalled();
+    vi.mocked(deps.hasAccount).mockResolvedValue(true);
+    await vi.advanceTimersByTimeAsync(110);
+    expect(deps.runVaultBackup).toHaveBeenCalled();
+    stop();
+  });
+
+  it('rediscovers an existing enrollment after reload without an edit', async () => {
+    vi.useFakeTimers();
+    const store = await signedInStore();
+    store.setDrive(DRIVE);
+    const deps = fakeDeps();
+    const stop = watchForVaultBackups(store, deps, {
+      idleMs: 10,
+      window: null,
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    expect(deps.listVaultDrives).toHaveBeenCalled();
+    expect(deps.runVaultBackup).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('recognizes Tauri embedded nodes but excludes external servers', async () => {
+    const local = new Store({
+      serverUrl: 'http://localhost:9883',
+      connect: false,
+    });
+    const remote = new Store({
+      serverUrl: 'https://example.com',
+      connect: false,
+    });
+    vi.stubGlobal('window', {
+      __TAURI_INTERNALS__: {},
+      location: { protocol: 'tauri:', hostname: 'localhost' },
+    });
+
+    try {
+      expect(isEmbeddedVaultDrive(local)).toBe(true);
+      expect(isEmbeddedVaultDrive(remote)).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('retries pending work immediately when connectivity returns', async () => {
+    vi.useFakeTimers();
+    const store = await signedInStore();
+    store.setDrive(DRIVE);
+    store.registerLocalOnlyDrive(DRIVE);
+    const deps = fakeDeps({ hasAccount: vi.fn(async () => false) });
+    const { win, listeners } = fakeWindow();
+    const stop = watchForVaultBackups(store, deps, { idleMs: 10, window: win });
+    await vi.advanceTimersByTimeAsync(20);
+    vi.mocked(deps.hasAccount).mockResolvedValue(true);
+    listeners.get('online')!();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deps.runVaultBackup).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
   it('backs the open local-only drive up once the edits stop', async () => {
     vi.useFakeTimers();
     const store = await signedInStore();
@@ -471,7 +589,7 @@ describe('watchForVaultBackups', () => {
     vi.useFakeTimers();
     const store = await signedInStore();
     store.setDrive(DRIVE);
-    const deps = fakeDeps();
+    const deps = fakeDeps({ listVaultDrives: vi.fn(async () => []) });
     const { win } = fakeWindow();
     const stop = watchForVaultBackups(store, deps, { idleMs: 10, window: win });
 

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
@@ -410,15 +410,10 @@ async function ensureVaultBackupOnce(
   }
 }
 
-/**
- * How long after the last edit a backup runs.
- *
- * Every pass currently seals the whole drive (incremental export is a
- * follow-up), so this is deliberately not "a few seconds": a burst of typing
- * should cost one upload, not one per pause. Going to the background flushes
- * it early, since a tab that is closing has no later.
- */
-export const AUTO_BACKUP_IDLE_MS = 60_000;
+/** Incremental packs make short idle backups cheap; unchanged drives upload nothing. */
+export const AUTO_BACKUP_IDLE_MS = 5_000;
+export const AUTO_BACKUP_MAX_WAIT_MS = 30_000;
+export const AUTO_BACKUP_RETRY_MS = 60_000;
 
 export type VaultRestoreOutcome =
   | { status: 'restored'; outcome: RestoreOutcome }
@@ -515,28 +510,32 @@ export async function restoreFromVault(
   }
 }
 
+/** Local Tauri data lives in its embedded node, not the browser's local-only registry. */
+export function isEmbeddedVaultDrive(store: Store): boolean {
+  if (!isRunningInTauri()) return false;
+
+  return ['localhost', '127.0.0.1', '[::1]'].includes(
+    new URL(store.getServerUrl()).hostname,
+  );
+}
+
 /**
- * Keep the open drive backed up as it changes.
- *
- * Listens for the store's own save/remove events — the user's edits, not
- * remote pushes — and runs {@link ensureVaultBackup} for the drive that is open
- * once the edits stop. That drive rather than the edited resource's, because a
- * resource's drive is the root of a parent chain that may not be loaded, and
- * edits happen in the drive on screen in all but contrived cases.
- *
- * Only drives that are local-only, or that this session already enrolled, are
- * backed up from here. A drive on a managed node is synced by that node and
- * needs no second copy; a drive on somebody else's server is not ours to back
- * up at all.
- *
- * Returns the unsubscribe function.
+ * Incremental backups while the app is running. Keep every edited drive queued,
+ * cap the debounce, and retry after account/network recovery without another edit.
+ * Remote drives are only backed up when already enrolled with this account.
  */
 export function watchForVaultBackups(
   store: Store,
   deps: VaultAutoBackupDeps = defaultDeps,
-  options: { idleMs?: number; window?: Window | null } = {},
+  options: {
+    idleMs?: number;
+    maxWaitMs?: number;
+    retryMs?: number;
+    window?: Window | null;
+  } = {},
 ): () => void {
   const idleMs = options.idleMs ?? AUTO_BACKUP_IDLE_MS;
+  const maxWaitMs = options.maxWaitMs ?? AUTO_BACKUP_MAX_WAIT_MS;
   const win =
     options.window === undefined
       ? typeof window === 'undefined'
@@ -544,53 +543,124 @@ export function watchForVaultBackups(
         : window
       : options.window;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let pending: string | undefined;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+  let generation = 0;
+  const pending = new Set<string>();
 
   const flush = () => {
-    if (timer) clearTimeout(timer);
+    clearTimeout(timer);
+    clearTimeout(deadline);
+    timer = deadline = undefined;
+    const drives = [...pending];
+    pending.clear();
+    const identity = store.getAgent()?.subject;
+    const passGeneration = generation;
 
-    timer = undefined;
-    const drive = pending;
-    pending = undefined;
+    if (!identity) return;
 
-    if (drive) void ensureVaultBackup(store, drive, deps);
+    void (async () => {
+      // Avoid enrollment discovery requests when signed out. Keep work queued
+      // so a reconnect or periodic retry can finish it later.
+      const retry = (drive: string) => {
+        if (
+          !stopped &&
+          passGeneration === generation &&
+          store.getAgent()?.subject === identity
+        )
+          pending.add(drive);
+      };
+
+      try {
+        if (!drives.length || stopped || !(await deps.hasAccount())) {
+          drives.forEach(retry);
+
+          return;
+        }
+
+        const remote = drives.filter(
+          drive =>
+            !store.isLocalOnlyDrive(drive) &&
+            !enrolled.has(drive) &&
+            !isEmbeddedVaultDrive(store),
+        );
+        const existing = remote.length ? await deps.listVaultDrives() : [];
+
+        for (const drive of drives) {
+          if (
+            stopped ||
+            passGeneration !== generation ||
+            store.getAgent()?.subject !== identity
+          )
+            return;
+          if (
+            remote.includes(drive) &&
+            !existing.some(item => item.drive_subject === drive)
+          )
+            continue;
+          const outcome = await ensureVaultBackup(store, drive, deps);
+          if (outcome.status === 'failed' || outcome.status === 'skipped')
+            retry(drive);
+        }
+      } catch {
+        // Discovery can fail offline; the next bounded retry rechecks it.
+        drives.forEach(retry);
+      }
+    })();
   };
 
   const schedule = () => {
     const drive = store.getDrive();
-
-    if (!drive) return;
-    if (!store.isLocalOnlyDrive(drive) && !enrolled.has(drive)) return;
-
-    pending = drive;
-
-    if (timer) clearTimeout(timer);
-
+    if (!drive || stopped) return;
+    pending.add(drive);
+    clearTimeout(timer);
     timer = setTimeout(flush, idleMs);
+    deadline ??= setTimeout(flush, maxWaitMs);
   };
 
-  // A tab going to the background may never come back. The upload is not
-  // guaranteed to finish, but a backup that starts has a chance; one scheduled
-  // for later has none.
-  const onHidden = () => {
+  const resume = () => {
+    schedule();
+    flush();
+  };
+
+  const onVisibility = () => {
     if (win?.document.visibilityState === 'hidden') flush();
+    else resume();
+  };
+
+  const reset = () => {
+    generation++;
+    enrolled.clear();
+    pending.clear();
+    clearTimeout(timer);
+    clearTimeout(deadline);
+    timer = deadline = undefined;
+    schedule();
   };
 
   const unsubscribe = [
     store.on(StoreEvents.ResourceSaved, schedule),
     store.on(StoreEvents.ResourceRemoved, schedule),
     store.on(StoreEvents.ResourceManuallyCreated, schedule),
+    store.on(StoreEvents.DriveChanged, schedule),
+    store.on(StoreEvents.AgentChanged, reset),
+    onManagedLogout(reset),
   ];
-  win?.document.addEventListener('visibilitychange', onHidden);
-  // A pagehide is too late to start an upload: navigation aborts its fetches.
-  // Visibility changes already give active backups their earlier opportunity.
+  // Also catches native-node changes that do not emit browser Store events,
+  // and accounts linked after the initial mount. No-change passes upload nothing.
+  const periodic = setInterval(resume, options.retryMs ?? AUTO_BACKUP_RETRY_MS);
+  win?.document.addEventListener('visibilitychange', onVisibility);
+  win?.addEventListener('online', resume);
+  schedule();
 
   return () => {
-    if (timer) clearTimeout(timer);
-
-    timer = undefined;
-    pending = undefined;
+    stopped = true;
+    clearTimeout(timer);
+    clearTimeout(deadline);
+    clearInterval(periodic);
+    pending.clear();
     unsubscribe.forEach(off => off());
-    win?.document.removeEventListener('visibilitychange', onHidden);
+    win?.document.removeEventListener('visibilitychange', onVisibility);
+    win?.removeEventListener('online', resume);
   };
 }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -110,3 +110,18 @@ by this browser SDK. Local builds can opt in with `VITE_SENTRY_DSN` and
 
 Android launcher images are generated from `brand/src/atomic-mark.svg` by
 `node brand/generate.mjs`, including adaptive foregrounds at every density.
+
+### Automatic Cloud Vault backup
+
+With a linked, eligible account, the open local drive is enrolled and backed up
+without a setup click. Tauri's embedded-node drives count as local data; unrelated
+remote drives are excluded unless already enrolled with this account. The personal
+drive is retried after startup too, so late account linking does not require a restart.
+Explicit backup opt-outs and account eligibility checks remain authoritative.
+
+The browser and Tauri watcher uses incremental packs: 5 seconds after editing
+stops, or at most 30 seconds during sustained editing. Switching drives preserves
+queued work. Foregrounding/reconnecting retries immediately; a 60-second check
+also catches native-node changes and late account availability. Unchanged drives
+upload no object. These timers run only while the app runtime can execute; they
+are not an Android/iOS OS background service. Manual backup remains a retry option.


### PR DESCRIPTION
Cloud Vault could remain off after late account linking or a reload, and continuous editing or switching drives could postpone or lose scheduled backups. Eligible local drives now enroll automatically, including Tauri embedded-node drives; existing remote enrollments are rediscovered after reload.

Incremental backups run after 5 seconds idle with a 30-second maximum delay. Pending drives survive navigation, with retries on reconnect/foreground and every 60 seconds. Personal-drive startup also retries. Explicit opt-outs, account eligibility and unrelated remote-drive exclusion remain intact. This runs while the app runtime is active; it does not provide OS scheduling after suspension.

Validation: three regression tests failed before the fix; 87 focused Vault tests now pass, including enrollment rediscovery and embedded-node checks. Typecheck, focused lint/format and frontend production build passed. Translation catalogs unchanged. Installed-device and suspended-app delivery are not claimed.
