### PR TITLE
fix: update collaborator usernames live

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -479,3 +479,11 @@ successfully against local Ollama on 2026-09-08. The shared setup-panel componen
 is not separately covered by this probe. The existing Vite-only Wuchale/React
 key warning when expanding AI settings is explicitly expected; other console
 errors remain failures.
+
+`username-live.spec.ts` changes the owner's display name through user settings
+while a different agent reads an existing chat message. It asserts the author
+updates without a reload and verifies a second change after the reader reloads.
+`websockets.test.ts` checks targeted profile SUB frames, subscription replay,
+multiple-reader cleanup through both Store unsubscribe APIs, and retaining
+ordinary document drive-wide fan-out. Profiles no longer depend on being inside
+the reader's active drive to receive live updates.

--- a/browser/e2e/tests/username-live.spec.ts
+++ b/browser/e2e/tests/username-live.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from './fixtures';
+import {
+  before,
+  newResource,
+  editTitle,
+  getCurrentSubject,
+  devDrive,
+  openSubject,
+  FRONTEND_URL,
+} from './test-utils';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('http://localhost:3030/api/me', route =>
+    route.fulfill({ status: 204 }),
+  );
+});
+test.beforeEach(before);
+async function collaborator(
+  page: import('@playwright/test').Page,
+  browser: import('@playwright/test').Browser,
+  subject: string,
+) {
+  const context = await browser.newContext();
+  const peer = await context.newPage();
+  await peer.route('http://localhost:3030/api/me', route =>
+    route.fulfill({ status: 204 }),
+  );
+  await devDrive(peer);
+  const agent = await peer.evaluate(() => window.store.getAgent()!.subject);
+  const drive = await page.evaluate(async agent => {
+    const store = window.store;
+    const drive = await store.getResource(store.getDrive()!);
+    for (const property of [
+      'https://atomicdata.dev/properties/read',
+      'https://atomicdata.dev/properties/write',
+    ]) {
+      await drive.set(property, [
+        ...((drive.get(property) as string[]) ?? []),
+        agent,
+      ]);
+    }
+    await drive.save();
+    return drive.subject;
+  }, agent);
+  await page.waitForFunction(
+    () => window.store.getSyncStatus().pendingDirtyCount === 0,
+  );
+  await peer.evaluate(drive => window.store.setDrive(drive), drive);
+  await openSubject(peer, subject);
+  return peer;
+}
+test('remote username change updates existing chat author', async ({
+  page,
+  browser,
+}) => {
+  test.slow();
+  await newResource('chatroom', page);
+  await editTitle('Author name reproduction', page);
+  await page.getByLabel('Chat input').fill('Message from renamed author');
+  await page.getByLabel('Chat input').press('Enter');
+  await expect(
+    page.getByText('Message from renamed author', { exact: true }),
+  ).toBeVisible();
+  const subject = await getCurrentSubject(page);
+  const peer = await collaborator(page, browser, subject!);
+  const message = peer
+    .getByText('Message from renamed author', { exact: true })
+    .locator('xpath=ancestor::*[@about][1]');
+  await expect(message).toContainText('Dev User');
+  await page.goto(`${FRONTEND_URL}/app/agent`);
+  await page
+    .getByLabel('Your name', { exact: true })
+    .fill('Renamed Collaborator');
+  await page.getByLabel('Your name', { exact: true }).press('Enter');
+  await page.waitForFunction(
+    () => window.store.getSyncStatus().pendingDirtyCount === 0,
+  );
+  await expect(message).toContainText('Renamed Collaborator', {
+    timeout: 15000,
+  });
+  // A fresh connection must restore the profile subscription as well.
+  await peer.reload();
+  await expect(message).toContainText('Renamed Collaborator');
+  await page.getByLabel('Your name', { exact: true }).fill('Renamed Again');
+  await page.getByLabel('Your name', { exact: true }).press('Enter');
+  await expect(message).toContainText('Renamed Again', { timeout: 15000 });
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -4697,18 +4697,20 @@ export class Store {
 
     const normalized = this.normalizeSubject(subject);
 
-    return this.addLoroSubscriber(this.subscribers, normalized, callback, () =>
-      this.subscribeWebSocket(normalized),
+    return this.addLoroSubscriber(
+      this.subscribers,
+      normalized,
+      callback,
+      () => this.subscribeWebSocket(normalized),
+      () =>
+        this.getWebSocketForSubject(normalized)?.unsubscribeAgentProfile(
+          normalized,
+        ),
     );
   }
 
-  /** v2 uses drive-level WS subscriptions — every resource in the drive
-   *  is delivered through the single `SUB <drive>` sent in
-   *  {@link WSClient.handleOpen}. The server's `CommitMonitor` fans
-   *  CommitMessages out to drive subscribers when the commit's target
-   *  lives under that drive. This per-resource entry-point is kept as
-   *  a no-op for API stability — callers don't need to gate themselves.
-   *  The lookup confirms the origin's WS exists. */
+  /** Drive resources use drive-wide fan-out. Mounted agent profiles also need
+   * a targeted subscription: another user's profile is outside our drive. */
   public subscribeWebSocket(subject: string): void {
     if (!this._serverConnected) return;
     const normalized = this.normalizeSubject(subject);
@@ -4723,7 +4725,9 @@ export class Store {
     }
 
     try {
-      this.getWebSocketForSubject(subject);
+      const ws = this.getWebSocketForSubject(subject);
+      if (this.subscribers.has(normalized))
+        ws?.subscribeAgentProfile(normalized);
     } catch (e) {
       console.error(e);
     }
@@ -4976,8 +4980,12 @@ export class Store {
     const subs = this.subscribers.get(normalized);
     if (!subs) return;
     const filtered = subs.filter(cb => cb !== callback);
-    if (filtered.length === 0) this.subscribers.delete(normalized);
-    else this.subscribers.set(normalized, filtered);
+    if (filtered.length === 0) {
+      this.subscribers.delete(normalized);
+      this.getWebSocketForSubject(normalized)?.unsubscribeAgentProfile(
+        normalized,
+      );
+    } else this.subscribers.set(normalized, filtered);
   }
 
   /**

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -425,6 +425,49 @@ describe('WSClient drive subscription', () => {
     vi.restoreAllMocks();
   });
 
+  it('subscribes mounted agent profiles, restores them on reconnect, and releases the last reader', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('profile-subscription'));
+    const auth = client.authenticate();
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await auth;
+    vi.spyOn(store, 'getWebSocketForSubject').mockReturnValue(client);
+    store.setServerConnected(true);
+    const subject = 'did:ad:agent:other-user';
+    const changed = vi.fn();
+    const stopFirst = store.subscribe(subject, changed);
+    const stopSecond = store.subscribe(subject, vi.fn());
+    const subjects = (tag: number) =>
+      framesWithTag(socket, tag).map(frame =>
+        new TextDecoder().decode(frame.subarray(1)),
+      );
+    expect(subjects(Tag.SUB)).toEqual([subject]);
+    stopFirst();
+    expect(subjects(Tag.UNSUB)).toEqual([]);
+    // Connection-open/auth replay restores mounted profiles as well as drives.
+    (client as unknown as { reSubscribeAll(): void }).reSubscribeAll();
+    expect(subjects(Tag.SUB)).toEqual([subject, subject]);
+    stopSecond();
+    expect(subjects(Tag.UNSUB)).toEqual([subject]);
+    (client as unknown as { reSubscribeAll(): void }).reSubscribeAll();
+    expect(subjects(Tag.SUB)).toHaveLength(2);
+    // Legacy callers release through Store.unsubscribe rather than the disposer.
+    store.subscribe(subject, changed);
+    store.unsubscribe(subject, changed);
+    expect(subjects(Tag.UNSUB)).toEqual([subject, subject]);
+    // Ordinary resources continue using drive-wide fan-out.
+    const stopDocument = store.subscribe('did:ad:document', vi.fn());
+    expect(subjects(Tag.SUB)).toEqual([subject, subject, subject]);
+    stopDocument();
+    expect(subjects(Tag.UNSUB)).toEqual([subject, subject]);
+    client.close();
+  });
+
   it('UNSUBs the previous drive when the store switches drives', async ({
     expect,
   }) => {

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -1340,10 +1340,47 @@ export class WSClient {
     }
   }
 
+  /** Agent profiles are public resources outside the reader's active drive. */
+  public subscribeAgentProfile(subject: string): void {
+    if (
+      !subject.startsWith('did:ad:agent:') ||
+      this.readyState !== WebSocket.OPEN
+    )
+      return;
+    if (this.store.isLocalOnlySubject(subject)) return;
+    if (
+      this.store.getAgent()?.subject &&
+      this.authenticatedWith !== this.store.getAgent()?.subject
+    )
+      return;
+    const resource = this.store.resources.get(subject);
+    if (
+      resource?.new ||
+      isNotFound(resource?.error) ||
+      isUnauthorized(resource?.error)
+    )
+      return;
+    this.sendBinary(encodeSub(subject));
+  }
+
+  public unsubscribeAgentProfile(subject: string): void {
+    if (
+      !subject.startsWith('did:ad:agent:') ||
+      this.readyState !== WebSocket.OPEN
+    )
+      return;
+    this.sendBinary(encodeUnsub(subject));
+  }
+
   private reSubscribeAll(): void {
     // Drive-wide live subscription. Previously sent only inside
     // `authenticate()`, so an anonymous session never subscribed at all.
     this.subscribeToDrive();
+    for (const subject of this.store.subscribers.keys()) {
+      if (this.store.getWebSocketForSubject(subject) === this) {
+        this.subscribeAgentProfile(subject);
+      }
+    }
 
     // Loro and presence subscriptions carry an identity (peers see who
     // is editing), so the server refuses them before AUTH with


### PR DESCRIPTION
Changing a display name left collaborators seeing the old chat author because agent profiles live outside the shared drive and received no targeted subscription. Subscribe to mounted agent profiles, restore those subscriptions on reconnect, and release them when the final reader unmounts.

Validation: 39 Store/WebSocket tests, library and frontend typechecks, and a two-agent Chromium test that changes the name through settings and repeats after the reader reloads. The cherry-picked tree is identical to the locally verified tree. Ollama and feedback fixes are already on develop via #1389.
