### PR TITLE
Fix desktop workspace discovery and restore feedback

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -487,3 +487,12 @@ updates without a reload and verifies a second change after the reader reloads.
 multiple-reader cleanup through both Store unsubscribe APIs, and retaining
 ordinary document drive-wide fan-out. Profiles no longer depend on being inside
 the reader's active drive to receive live updates.
+
+## Desktop workspace discovery (2026-09-08)
+
+`sync::discover::tests::inspection_checks_access_without_importing_or_pairing`
+uses real Iroh endpoints: an authorized identity sees a peer name without importing
+the drive or pairing; a stranger is rejected. The local Tauri debug build connected
+to staging's advertised Iroh node and received a no-readable-data response for its
+test identity. Live drive and node PKARR signatures were verified separately.
+This does not yet prove restoration of the user's private staging workspace.

--- a/browser/data-browser/src/components/AI/LocalOllamaDiscovery.tsx
+++ b/browser/data-browser/src/components/AI/LocalOllamaDiscovery.tsx
@@ -21,6 +21,7 @@ export function LocalOllamaDiscovery() {
       .then(async response => {
         if (!response.ok) throw new Error('Ollama discovery failed');
         const data = await response.json();
+
         if (active) {
           setStatus(Array.isArray(data?.models) ? 'found' : 'unavailable');
         }

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7587,3 +7587,86 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Find your workspace"
+msgstr ""
+
+#~ msgid "Looking for your workspace on your other devices…"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We couldn’t find a reachable device with your workspace."
+msgstr ""
+
+#~ msgid "We found your workspace on {0}."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Fetch a copy to this device so you can open it here."
+msgstr ""
+
+#~ msgid "Fetching workspace…"
+#~ msgstr ""
+
+#~ msgid "Fetch workspace"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Look here"
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Address where your workspace lives"
+msgstr ""
+
+#~ msgid "We found your workspace on {0} ."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "A device was found, but this account cannot read the workspace there."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We could not check your workspace. Try again or enter its address below."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Connection details"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Your secret was accepted. Preparing this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking for your workspace on this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking whether your account has a backup to restore…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Looking for a device that has your workspace…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Fetching your workspace to this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Opening your workspace"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "This may take a little while. Please keep this window open."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We found your workspace"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device does not have this workspace yet. Fetch it from a device that has it."
+msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7621,3 +7621,86 @@ msgstr "Use local Ollama"
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr "Connect local Ollama"
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Find your workspace"
+msgstr "Find your workspace"
+
+#~ msgid "Looking for your workspace on your other devices…"
+#~ msgstr "Looking for your workspace on your other devices…"
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We couldn’t find a reachable device with your workspace."
+msgstr "We couldn’t find a reachable device with your workspace."
+
+#~ msgid "We found your workspace on {0}."
+#~ msgstr "We found your workspace on {0}."
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Fetch a copy to this device so you can open it here."
+msgstr "Fetch a copy to this device so you can open it here."
+
+#~ msgid "Fetching workspace…"
+#~ msgstr "Fetching workspace…"
+
+#~ msgid "Fetch workspace"
+#~ msgstr "Fetch workspace"
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Look here"
+msgstr "Look here"
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Address where your workspace lives"
+msgstr "Address where your workspace lives"
+
+#~ msgid "We found your workspace on {0} ."
+#~ msgstr "We found your workspace on {0} ."
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "A device was found, but this account cannot read the workspace there."
+msgstr "A device was found, but this account cannot read the workspace there."
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We could not check your workspace. Try again or enter its address below."
+msgstr "We could not check your workspace. Try again or enter its address below."
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Connection details"
+msgstr "Connection details"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Your secret was accepted. Preparing this device…"
+msgstr "Your secret was accepted. Preparing this device…"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking for your workspace on this device…"
+msgstr "Checking for your workspace on this device…"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking whether your account has a backup to restore…"
+msgstr "Checking whether your account has a backup to restore…"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Looking for a device that has your workspace…"
+msgstr "Looking for a device that has your workspace…"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Fetching your workspace to this device…"
+msgstr "Fetching your workspace to this device…"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Opening your workspace"
+msgstr "Opening your workspace"
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "This may take a little while. Please keep this window open."
+msgstr "This may take a little while. Please keep this window open."
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We found your workspace"
+msgstr "We found your workspace"
+
+#: src/routes/SyncRoute.tsx
+msgid "This device does not have this workspace yet. Fetch it from a device that has it."
+msgstr "This device does not have this workspace yet. Fetch it from a device that has it."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7587,3 +7587,86 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Find your workspace"
+msgstr ""
+
+#~ msgid "Looking for your workspace on your other devices…"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We couldn’t find a reachable device with your workspace."
+msgstr ""
+
+#~ msgid "We found your workspace on {0}."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Fetch a copy to this device so you can open it here."
+msgstr ""
+
+#~ msgid "Fetching workspace…"
+#~ msgstr ""
+
+#~ msgid "Fetch workspace"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Look here"
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Address where your workspace lives"
+msgstr ""
+
+#~ msgid "We found your workspace on {0} ."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "A device was found, but this account cannot read the workspace there."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We could not check your workspace. Try again or enter its address below."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Connection details"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Your secret was accepted. Preparing this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking for your workspace on this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking whether your account has a backup to restore…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Looking for a device that has your workspace…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Fetching your workspace to this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Opening your workspace"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "This may take a little while. Please keep this window open."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We found your workspace"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device does not have this workspace yet. Fetch it from a device that has it."
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7587,3 +7587,86 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/views/getting-started/ConnectDeviceStep.tsx
+msgid "Find your workspace"
+msgstr ""
+
+#~ msgid "Looking for your workspace on your other devices…"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We couldn’t find a reachable device with your workspace."
+msgstr ""
+
+#~ msgid "We found your workspace on {0}."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Fetch a copy to this device so you can open it here."
+msgstr ""
+
+#~ msgid "Fetching workspace…"
+#~ msgstr ""
+
+#~ msgid "Fetch workspace"
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Look here"
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Address where your workspace lives"
+msgstr ""
+
+#~ msgid "We found your workspace on {0} ."
+#~ msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "A device was found, but this account cannot read the workspace there."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We could not check your workspace. Try again or enter its address below."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "Connection details"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Your secret was accepted. Preparing this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking for your workspace on this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Checking whether your account has a backup to restore…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Looking for a device that has your workspace…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Fetching your workspace to this device…"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "Opening your workspace"
+msgstr ""
+
+#: src/views/getting-started/WorkspaceLoading.tsx
+msgid "This may take a little while. Please keep this window open."
+msgstr ""
+
+#: src/views/getting-started/DiscoverWorkspace.tsx
+msgid "We found your workspace"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This device does not have this workspace yet. Fetch it from a device that has it."
+msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1,4 +1,5 @@
 import { HostingPaymentRequiredError } from '../helpers/managed/enrollment';
+import { DiscoverWorkspace } from '../views/getting-started/DiscoverWorkspace';
 import {
   useEffect,
   useState,
@@ -1035,6 +1036,10 @@ function SyncPage() {
   const cloudServerBlocked = cloudServerBlocker();
 
   function summaryLine(): string {
+    if (driveMissing) {
+      return 'This device does not have this workspace yet. Fetch it from a device that has it.';
+    }
+
     if (localOnlyDrive) {
       return 'This workspace is stored only on this device — it isn’t backed up or synced anywhere.';
     }
@@ -1628,21 +1633,31 @@ function SyncPage() {
             </CardIcon>
             <ConnBody>
               <ConnTitle>Your data is on another device</ConnTitle>
-              <ConnSub>
-                {/* Either code below brings it over: this device's when it is a
+              {isNode && status.drive ? (
+                <DiscoverWorkspace
+                  key={status.drive}
+                  drive={status.drive}
+                  onConnected={() => setDriveMissing(false)}
+                />
+              ) : (
+                <>
+                  <ConnSub>
+                    {/* Either code below brings it over: this device's when it is a
                     node, otherwise the server's — the other device scans it and
                     syncs the drive somewhere this one can read. */}
-                {pairNodeId
-                  ? 'You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it.'
-                  : 'You’re signed in, but this device doesn’t have your workspace yet. Connect a device that has it.'}
-              </ConnSub>
-              <ConnActions>
-                {!pairNodeId && (
-                  <Button onClick={() => setShowAddServer(true)}>
-                    Connect a device
-                  </Button>
-                )}
-              </ConnActions>
+                    {pairNodeId
+                      ? 'You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it.'
+                      : 'You’re signed in, but this device doesn’t have your workspace yet. Connect a device that has it.'}
+                  </ConnSub>
+                  <ConnActions>
+                    {!pairNodeId && (
+                      <Button onClick={() => setShowAddServer(true)}>
+                        Connect a device
+                      </Button>
+                    )}
+                  </ConnActions>
+                </>
+              )}
             </ConnBody>
           </LocalDriveNotice>
         )}
@@ -1735,16 +1750,18 @@ function SyncPage() {
           {/* About *other* devices specifically. This device and any cloud
               services are listed above, so the old "not syncing anywhere"
               wording now sat under entries proving otherwise. */}
-          {connectionCount === 0 && connectionServers.length === 0 && (
-            <EmptyConnections>
-              <p>No other devices yet — your data is safe on this one.</p>
-              <p>
-                {isNode
-                  ? 'Pair another device to sync directly, or connect an always-on one to reach your data from anywhere.'
-                  : 'Connect an always-on device to back up your data and reach it from anywhere.'}
-              </p>
-            </EmptyConnections>
-          )}
+          {!driveMissing &&
+            connectionCount === 0 &&
+            connectionServers.length === 0 && (
+              <EmptyConnections>
+                <p>No other devices yet — your data is safe on this one.</p>
+                <p>
+                  {isNode
+                    ? 'Pair another device to sync directly, or connect an always-on one to reach your data from anywhere.'
+                    : 'Connect an always-on device to back up your data and reach it from anywhere.'}
+                </p>
+              </EmptyConnections>
+            )}
 
           {/* Servers we do not own — one stable list; the active one is marked,
               not moved. A managed node is deliberately absent: it moved up into

--- a/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
+++ b/browser/data-browser/src/views/getting-started/ConnectDeviceStep.tsx
@@ -1,3 +1,4 @@
+import { DiscoverWorkspace } from './DiscoverWorkspace';
 import React, { useEffect, useState, type JSX } from 'react';
 import { styled } from 'styled-components';
 import { FaMobileScreenButton, FaLock } from 'react-icons/fa6';
@@ -456,8 +457,13 @@ export function ConnectDeviceStep({
               <FaLock aria-hidden />
             )}
           </Badge>
-          <CardTitle>{title}</CardTitle>
-          <CardSubtitle>{subtitle}</CardSubtitle>
+          <CardTitle>
+            {isNode && drive ? 'Find your workspace' : title}
+          </CardTitle>
+          {!(isNode && drive) && <CardSubtitle>{subtitle}</CardSubtitle>}
+          {isNode && drive && (
+            <DiscoverWorkspace drive={drive} onConnected={onConnected} />
+          )}
 
           {/* The vault's own account of why there is nothing to restore. Five
               situations answer "no backup" — never enrolled, enrolled but

--- a/browser/data-browser/src/views/getting-started/DiscoverWorkspace.tsx
+++ b/browser/data-browser/src/views/getting-started/DiscoverWorkspace.tsx
@@ -1,0 +1,199 @@
+import { WorkspaceLoading } from './WorkspaceLoading';
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import { invoke } from '@tauri-apps/api/core';
+import { useStore } from '@tomic/react';
+import { Button } from '../../components/Button';
+import { Column, Row } from '../../components/Row';
+import { InputStyled } from '../../components/forms/InputStyles';
+import { normalizeServerUrl } from '../../helpers/serverUrl';
+import { fetchManagedInfo } from '../../helpers/managedServer';
+import {
+  reopenRestoredDrive,
+  deviceHasDriveData,
+} from '../../helpers/driveData';
+
+const UNAUTHORIZED = 'Unauthorized';
+
+interface WorkspacePeer {
+  nodeId: string;
+  name?: string;
+}
+
+/** Discovery inspects access; fetching requires the button below. */
+export function DiscoverWorkspace({
+  drive,
+  onConnected,
+}: {
+  drive: string;
+  onConnected: (drive: string) => void;
+}) {
+  const store = useStore();
+  const [peer, setPeer] = useState<WorkspacePeer>();
+  const [phase, setPhase] = useState<'searching' | 'ready' | 'fetching'>(
+    'searching',
+  );
+  const [error, setError] = useState('');
+  const [address, setAddress] = useState('');
+  const [attempt, setAttempt] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    setPeer(undefined);
+    setError('');
+    setPhase('searching');
+    void invoke<WorkspacePeer>('discover_workspace', { drive })
+      .then(found => {
+        if (!cancelled) {
+          setPeer(found);
+          setPhase('ready');
+        }
+      })
+      .catch(e => {
+        if (!cancelled) {
+          setError(String(e));
+          setPhase('ready');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [drive, attempt]);
+
+  async function findAtAddress() {
+    const url = normalizeServerUrl(address);
+    if (!url) return;
+    setPhase('searching');
+    setPeer(undefined);
+    setError('');
+    try {
+      const info = await fetchManagedInfo(url);
+      if (!info.nodeId)
+        throw new Error('That address did not return a device pairing ID.');
+      setPeer(
+        await invoke<WorkspacePeer>('discover_workspace', {
+          drive,
+          nodeId: info.nodeId,
+        }),
+      );
+    } catch (e) {
+      setError(String(e));
+    }
+    setPhase('ready');
+  }
+
+  async function fetchWorkspace() {
+    if (!peer) return;
+    setPhase('fetching');
+    setError('');
+    try {
+      await invoke('fetch_workspace', { drive, nodeId: peer.nodeId });
+      if (!(await deviceHasDriveData(store, drive, { refresh: true }))) {
+        throw new Error(
+          'The connection finished, but your workspace is not available here yet.',
+        );
+      }
+      await reopenRestoredDrive(store, drive);
+      onConnected(drive);
+    } catch (e) {
+      setError(String(e));
+      setPhase('ready');
+    }
+  }
+
+  return phase === 'searching' || phase === 'fetching' ? (
+    <WorkspaceLoading stage={phase === 'searching' ? 'discovery' : 'fetch'} />
+  ) : (
+    <Panel>
+      <div role='status' aria-live='polite'>
+        {peer ? (
+          <>
+            <h3>We found your workspace</h3>
+            <p>
+              <strong>{peer.name || peer.nodeId.slice(0, 12)}</strong>
+            </p>
+            <p>Fetch a copy to this device so you can open it here.</p>
+          </>
+        ) : (
+          <p>We couldn’t find a reachable device with your workspace.</p>
+        )}
+      </div>
+      {error && (
+        <div role='alert'>
+          <p>
+            {error.includes(UNAUTHORIZED)
+              ? 'A device was found, but this account cannot read the workspace there.'
+              : 'We could not check your workspace. Try again or enter its address below.'}
+          </p>
+          <details>
+            <summary>Connection details</summary>
+            <p>{error}</p>
+          </details>
+        </div>
+      )}
+      {peer ? (
+        <Button
+          type='button'
+          onClick={fetchWorkspace}
+          disabled={phase !== 'ready'}
+        >
+          Fetch workspace
+        </Button>
+      ) : (
+        <Button subtle onClick={() => setAttempt(n => n + 1)}>
+          Search again
+        </Button>
+      )}
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          void findAtAddress();
+        }}
+      >
+        <Column gap='0.5rem'>
+          <label htmlFor='workspace-address'>
+            Address where your workspace lives
+          </label>
+          <Row gap='0.5rem'>
+            <InputStyled
+              id='workspace-address'
+              placeholder='your-server.example'
+              value={address}
+              onChange={e => setAddress(e.target.value)}
+            />
+            <Button
+              type='submit'
+              subtle
+              disabled={!address.trim() || phase !== 'ready'}
+            >
+              Look here
+            </Button>
+          </Row>
+        </Column>
+      </form>
+    </Panel>
+  );
+}
+
+const Panel = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  p,
+  h3 {
+    margin: 0;
+  }
+  h3 {
+    font-size: 1rem;
+  }
+  details {
+    color: ${p => p.theme.colors.textLight};
+  }
+  summary {
+    cursor: pointer;
+  }
+  input {
+    min-width: 0;
+    width: 100%;
+  }
+`;

--- a/browser/data-browser/src/views/getting-started/DiscoverWorkspace.tsx
+++ b/browser/data-browser/src/views/getting-started/DiscoverWorkspace.tsx
@@ -54,6 +54,7 @@ export function DiscoverWorkspace({
           setPhase('ready');
         }
       });
+
     return () => {
       cancelled = true;
     };
@@ -65,6 +66,7 @@ export function DiscoverWorkspace({
     setPhase('searching');
     setPeer(undefined);
     setError('');
+
     try {
       const info = await fetchManagedInfo(url);
       if (!info.nodeId)
@@ -78,6 +80,7 @@ export function DiscoverWorkspace({
     } catch (e) {
       setError(String(e));
     }
+
     setPhase('ready');
   }
 
@@ -85,13 +88,16 @@ export function DiscoverWorkspace({
     if (!peer) return;
     setPhase('fetching');
     setError('');
+
     try {
       await invoke('fetch_workspace', { drive, nodeId: peer.nodeId });
+
       if (!(await deviceHasDriveData(store, drive, { refresh: true }))) {
         throw new Error(
           'The connection finished, but your workspace is not available here yet.',
         );
       }
+
       await reopenRestoredDrive(store, drive);
       onConnected(drive);
     } catch (e) {

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -1,3 +1,4 @@
+import { WorkspaceLoading } from './WorkspaceLoading';
 import {
   PRODUCT_NAME,
   clearManagedAccountBinding,
@@ -75,7 +76,8 @@ type Step =
   | 'create'
   | 'restore'
   | 'restore-upgraded'
-  | 'connect-device';
+  | 'connect-device'
+  | 'opening-workspace';
 
 type RestoreState =
   | { phase: 'checking' }
@@ -182,6 +184,9 @@ export function GettingStartedFlow({
     fromManaged ? 'create' : nextDrive ? 'signin' : initialStep,
   );
   const [loading, setLoading] = useState(false);
+  const [workspaceStage, setWorkspaceStage] = useState<
+    'identity' | 'local' | 'backup'
+  >('identity');
   const [error, setError] = useState<Error | undefined>();
   // The drive a freshly signed-in device is missing, handed to the
   // connect-device step. Undefined when no drive resolved at all.
@@ -561,6 +566,8 @@ export function GettingStartedFlow({
 
     try {
       const newAgent = await Agent.fromSecret(secret);
+      setWorkspaceStage('identity');
+      setStep('opening-workspace');
       setAgent(newAgent);
       await saveAgentToIDB(secret);
       // However they got in — passkey, code, or secret — the device is open
@@ -589,6 +596,7 @@ export function GettingStartedFlow({
       // it lands on the connect-device step, which is the screen for a device
       // holding none of your data — including its offer to restore from the
       // vault.
+      setWorkspaceStage('local');
       const target =
         nextDrive ??
         (await withDeadline(
@@ -642,6 +650,7 @@ export function GettingStartedFlow({
       let vaultReason: string | undefined;
 
       if (!hasData && target) {
+        setWorkspaceStage('backup');
         const restored = await withDeadline(
           restoreFromVault(store, target),
           VAULT_RESTORE_TIMEOUT_MS,
@@ -715,6 +724,7 @@ export function GettingStartedFlow({
       setError(
         err instanceof Error ? err : new Error('Could not parse that secret.'),
       );
+      setStep('signin');
     } finally {
       setLoading(false);
     }
@@ -764,7 +774,15 @@ export function GettingStartedFlow({
 
   return (
     <Shell>
-      {step === 'welcome' ? (
+      {step === 'opening-workspace' ? (
+        <Swap key='opening-workspace'>
+          <OnboardingWrap>
+            <OnboardingCard>
+              <WorkspaceLoading stage={workspaceStage} />
+            </OnboardingCard>
+          </OnboardingWrap>
+        </Swap>
+      ) : step === 'welcome' ? (
         <Swap key='welcome'>
           <WelcomeStack>
             <VisuallyHiddenH1 key='heading'>AtomicServer</VisuallyHiddenH1>

--- a/browser/data-browser/src/views/getting-started/WorkspaceLoading.tsx
+++ b/browser/data-browser/src/views/getting-started/WorkspaceLoading.tsx
@@ -1,0 +1,32 @@
+import { Spinner } from '../../components/Spinner';
+import { Column } from '../../components/Row';
+import { CardSubtitle, CardTitle } from './chrome';
+
+export function WorkspaceLoading({
+  stage,
+}: {
+  stage: 'identity' | 'local' | 'backup' | 'discovery' | 'fetch';
+}) {
+  return (
+    <Column gap='1rem' role='status' aria-live='polite' aria-busy='true'>
+      <div style={{ alignSelf: 'center' }}>
+        <Spinner size='2.5rem' />
+      </div>
+      <CardTitle>Opening your workspace</CardTitle>
+      <CardSubtitle>
+        {stage === 'identity'
+          ? 'Your secret was accepted. Preparing this device…'
+          : stage === 'local'
+            ? 'Checking for your workspace on this device…'
+            : stage === 'backup'
+              ? 'Checking whether your account has a backup to restore…'
+              : stage === 'discovery'
+                ? 'Looking for a device that has your workspace…'
+                : 'Fetching your workspace to this device…'}
+      </CardSubtitle>
+      <CardSubtitle>
+        This may take a little while. Please keep this window open.
+      </CardSubtitle>
+    </Column>
+  );
+}

--- a/browser/e2e/tests/ollama-feedback.spec.ts
+++ b/browser/e2e/tests/ollama-feedback.spec.ts
@@ -29,12 +29,14 @@ test('settings detects local Ollama and accepts it with one click', async ({
   if (!process.env.TEST_REAL_OLLAMA)
     await page.route('http://localhost:11434/api/tags', route => {
       probes++;
+
       return route.fulfill({
         json: { models: [{ name: 'qwen:test', model: 'qwen:test' }] },
       });
     });
   await page.goto(`${FRONTEND_URL}/app/settings`);
   expect(probes).toBe(0);
+
   if (await page.locator('script[src*="/@vite/client"]').count()) {
     browserDiagnostics.expect(
       'error',
@@ -43,6 +45,7 @@ test('settings detects local Ollama and accepts it with one click', async ({
       1,
     );
   }
+
   await page.getByText('AI', { exact: true }).click();
   await expect(
     page.getByText('Local Ollama detected', { exact: true }),
@@ -58,6 +61,7 @@ test('settings detects local Ollama and accepts it with one click', async ({
     'http://localhost:11434',
   );
   await page.reload();
+
   if (await page.locator('script[src*="/@vite/client"]').count()) {
     browserDiagnostics.expect(
       'error',
@@ -66,6 +70,7 @@ test('settings detects local Ollama and accepts it with one click', async ({
       1,
     );
   }
+
   await page.getByText('AI', { exact: true }).click();
   await expect(page.locator('#ollama-url')).toHaveValue(
     'http://localhost:11434',

--- a/browser/e2e/tests/username-live.spec.ts
+++ b/browser/e2e/tests/username-live.spec.ts
@@ -15,6 +15,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 test.beforeEach(before);
+
 async function collaborator(
   page: import('@playwright/test').Page,
   browser: import('@playwright/test').Browser,
@@ -26,10 +27,11 @@ async function collaborator(
     route.fulfill({ status: 204 }),
   );
   await devDrive(peer);
-  const agent = await peer.evaluate(() => window.store.getAgent()!.subject);
-  const drive = await page.evaluate(async agent => {
+  const peerAgent = await peer.evaluate(() => window.store.getAgent()!.subject);
+  const sharedDrive = await page.evaluate(async agent => {
     const store = window.store;
     const drive = await store.getResource(store.getDrive()!);
+
     for (const property of [
       'https://atomicdata.dev/properties/read',
       'https://atomicdata.dev/properties/write',
@@ -39,16 +41,20 @@ async function collaborator(
         agent,
       ]);
     }
+
     await drive.save();
+
     return drive.subject;
-  }, agent);
+  }, peerAgent);
   await page.waitForFunction(
     () => window.store.getSyncStatus().pendingDirtyCount === 0,
   );
-  await peer.evaluate(drive => window.store.setDrive(drive), drive);
+  await peer.evaluate(drive => window.store.setDrive(drive), sharedDrive);
   await openSubject(peer, subject);
+
   return peer;
 }
+
 test('remote username change updates existing chat author', async ({
   page,
   browser,

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -1376,6 +1376,7 @@ export class WSClient {
     // Drive-wide live subscription. Previously sent only inside
     // `authenticate()`, so an anonymous session never subscribed at all.
     this.subscribeToDrive();
+
     for (const subject of this.store.subscribers.keys()) {
       if (this.store.getWebSocketForSubject(subject) === this) {
         this.subscribeAgentProfile(subject);

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -77,7 +77,7 @@ path = "../server"
 
 [dependencies.atomic_lib]
 path = "../lib"
-features = ["db-redb", "iroh"]
+features = ["db-redb", "iroh", "discovery"]
 
 [dependencies.serde]
 features = ["derive"]

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -180,6 +180,42 @@ async fn adopt_agent(
   Ok(())
 }
 
+/// Look up and inspect a workspace without importing it or starting live sync.
+#[tauri::command]
+async fn discover_workspace(
+  drive: String,
+  node_id: Option<String>,
+  node: tauri::State<'_, std::sync::Arc<EmbeddedNode>>,
+) -> Result<atomic_lib::sync::discover::WorkspacePeer, String> {
+  let store = node.require_store()?;
+  let peer = match node_id {
+    Some(id) => id.trim_start_matches("did:ad:node:").to_string(),
+    None => tokio::time::timeout(
+      std::time::Duration::from_secs(10),
+      atomic_lib::discovery::resolve_node_id(&drive),
+    )
+    .await
+    .map_err(|_| "Peer lookup timed out")?
+    .map_err(|e| e.to_string())?,
+  };
+  atomic_lib::sync::peer::inspect_workspace_peer(&peer, &drive, &store)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn fetch_workspace(
+  drive: String,
+  node_id: String,
+  node: tauri::State<'_, std::sync::Arc<EmbeddedNode>>,
+) -> Result<usize, String> {
+  let store = node.require_store()?;
+  atomic_lib::sync::peer::sync_drive_with_peer_outcome(&node_id, &drive, &store)
+    .await
+    .map(|outcome| outcome.count)
+    .map_err(|e| e.to_string())
+}
+
 /// Cloud Vault, against the embedded node's own store.
 ///
 /// In a browser the vault runs inside the WASM ClientDb, because that *is* the
@@ -528,6 +564,8 @@ pub fn run() {
     .manage(std::sync::Arc::new(vfs::VfsController::default()))
     .invoke_handler(tauri::generate_handler![
       adopt_agent,
+      discover_workspace,
+      fetch_workspace,
       vault_export,
       vault_commit_segment,
       vault_import,
@@ -539,6 +577,8 @@ pub fn run() {
   #[cfg(not(all(desktop, unix)))]
   let builder = builder.invoke_handler(tauri::generate_handler![
     adopt_agent,
+    discover_workspace,
+    fetch_workspace,
     vault_export,
     vault_commit_segment,
     vault_import

--- a/lib/src/sync/discover.rs
+++ b/lib/src/sync/discover.rs
@@ -1,0 +1,146 @@
+//! Read-only peer inspection before the user chooses to fetch a workspace.
+use super::{peer, protocol};
+use crate::{errors::AtomicResult, Db, Storelike};
+use iroh::Endpoint;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacePeer {
+    pub node_id: String,
+    pub name: Option<String>,
+}
+
+/// Authenticate and request just the workspace resource to check read access.
+/// Discard its snapshot: no import, SYNC, subscription or remembered pairing.
+pub async fn inspect_workspace(
+    endpoint: &Endpoint,
+    node_id: &str,
+    drive: &str,
+    store: &Db,
+) -> AtomicResult<WorkspacePeer> {
+    tokio::time::timeout(std::time::Duration::from_secs(20), async {
+        let remote: iroh::NodeId = node_id.parse::<iroh::NodeId>().map_err(|e| e.to_string())?;
+        let conn = endpoint
+            .connect(remote, peer::ATOMIC_ALPN)
+            .await
+            .map_err(|e| e.to_string())?;
+        let result = async {
+            let (mut send, mut recv) = conn.open_bi().await.map_err(|e| e.to_string())?;
+            let auth = protocol::encode_auth(&store.get_default_agent()?, drive)?;
+            send.write_u32(auth.len() as u32)
+                .await
+                .map_err(|e| e.to_string())?;
+            send.write_all(&auth).await.map_err(|e| e.to_string())?;
+            let mut authenticated = false;
+            let mut name = None;
+            loop {
+                let len = recv.read_u32().await? as usize;
+                if len == 0 || len > protocol::IROH_PREAUTH_FRAME_MAX_BYTES {
+                    return Err("Invalid discovery response size".into());
+                }
+                let mut frame = vec![0; len];
+                recv.read_exact(&mut frame)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                match frame[0] {
+                    protocol::tag::ERROR => {
+                        let error =
+                            protocol::decode_error(&frame[1..]).ok_or("Invalid discovery error")?;
+                        return Err(error.message.into());
+                    }
+                    protocol::tag::AUTH_OK if !authenticated => {
+                        authenticated = true;
+                        let get = protocol::encode_get(1, drive);
+                        send.write_u32(get.len() as u32)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        send.write_all(&get).await.map_err(|e| e.to_string())?;
+                    }
+                    protocol::tag::HELLO if authenticated => {
+                        name = protocol::decode_hello(&frame[1..]);
+                    }
+                    protocol::tag::UPDATE if authenticated => {
+                        let update = protocol::decode_update(&frame[1..])
+                            .ok_or("Invalid workspace response")?;
+                        if update.request_id != 1
+                            || update.subject != drive
+                            || update.loro_bytes.is_empty()
+                        {
+                            return Err("Unexpected workspace response".into());
+                        }
+                        return Ok(WorkspacePeer {
+                            node_id: node_id.to_string(),
+                            name,
+                        });
+                    }
+                    protocol::tag::AUTH if authenticated => {} // No data is served back.
+                    _ => return Err("Unexpected discovery frame".into()),
+                }
+            }
+        }
+        .await;
+        conn.close(0u32.into(), b"workspace inspection complete");
+        result
+    })
+    .await
+    .map_err(|_| "Workspace discovery timed out")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn inspection_checks_access_without_importing_or_pairing() {
+        let source = Db::init_temp("inspect_source").await.unwrap();
+        let (alice, drive) = source.setup("Alice").await.unwrap();
+        let (node_id, router) = peer::start(source.clone()).await.unwrap();
+        let client = Db::init_temp("inspect_client").await.unwrap();
+        client.set_default_agent(alice.clone());
+        let endpoint = Endpoint::builder().bind().await.unwrap();
+        endpoint
+            .add_node_addr(router.endpoint().node_addr().await.unwrap())
+            .unwrap();
+        let found = inspect_workspace(&endpoint, &node_id.to_string(), &drive, &client)
+            .await
+            .unwrap();
+        assert_eq!(found.node_id, node_id.to_string());
+        assert!(found.name.is_some());
+        assert!(
+            peer::get_known_peers(&client).is_empty(),
+            "inspection must not pair"
+        );
+        assert!(
+            client
+                .get_resource(&crate::Subject::from_raw(&drive, None))
+                .await
+                .is_err(),
+            "inspection must not import the drive"
+        );
+        let stranger = crate::agents::Agent::new(Some("Stranger")).unwrap();
+        client.set_default_agent(stranger);
+        assert!(
+            inspect_workspace(&endpoint, &node_id.to_string(), &drive, &client)
+                .await
+                .is_err()
+        );
+        client.set_default_agent(alice);
+        let imported = peer::sync_drive_with_peer_using(
+            &endpoint,
+            &node_id.to_string(),
+            &drive,
+            &client,
+            true,
+        )
+        .await
+        .unwrap();
+        assert!(imported > 0, "explicit fetch imports data");
+        assert!(client
+            .get_resource(&crate::Subject::from_raw(&drive, None))
+            .await
+            .is_ok());
+        endpoint.close().await;
+        router.shutdown().await.unwrap();
+    }
+}

--- a/lib/src/sync/mod.rs
+++ b/lib/src/sync/mod.rs
@@ -6,12 +6,12 @@
 // `policy`, `protocol`, and `rbsr` are std-only; the rest needs the `db`
 // feature. The module itself stays ungated so `Storelike::sync_policy`
 // (always compiled) can reference `sync::policy` in a no-features build.
+#[cfg(feature = "iroh")]
+pub mod discover;
 #[cfg(feature = "db")]
 pub mod engine;
 #[cfg(all(test, feature = "iroh", feature = "db-redb"))]
 mod iroh_e2e;
-#[cfg(feature = "iroh")]
-pub mod discover;
 #[cfg(feature = "iroh")]
 pub mod peer;
 pub mod policy;

--- a/lib/src/sync/mod.rs
+++ b/lib/src/sync/mod.rs
@@ -11,6 +11,8 @@ pub mod engine;
 #[cfg(all(test, feature = "iroh", feature = "db-redb"))]
 mod iroh_e2e;
 #[cfg(feature = "iroh")]
+pub mod discover;
+#[cfg(feature = "iroh")]
 pub mod peer;
 pub mod policy;
 pub mod protocol;

--- a/lib/src/sync/peer.rs
+++ b/lib/src/sync/peer.rs
@@ -1356,6 +1356,16 @@ pub async fn wait_for_peer_count_change(current: usize) -> usize {
     }
 }
 
+/// Inspect access and the device name without importing or pairing.
+pub async fn inspect_workspace_peer(
+    node_id: &str,
+    drive: &str,
+    store: &Db,
+) -> crate::errors::AtomicResult<super::discover::WorkspacePeer> {
+    let endpoint = ENDPOINT.get().ok_or("Iroh peer has not started")?;
+    super::discover::inspect_workspace(endpoint, node_id, drive, store).await
+}
+
 /// Sync a drive with a remote peer over the global endpoint (set by
 /// `start()`), replacing an existing live connection (QR pair / manual
 /// sync). Returns the rich [`PeerSyncOutcome`].

--- a/planning/desktop-pkarr-restore.md
+++ b/planning/desktop-pkarr-restore.md
@@ -1,0 +1,24 @@
+# Desktop PKARR restore
+
+- [x] Verify staging announcement: personal drive resolves to staging NodeID; node advertises Iroh relay.
+- [x] Create isolated codex/desktop-pkarr-restore worktree from origin/develop.
+- [x] Run isolated local Tauri build: Iroh connects; restore had no PKARR lookup.
+- [x] Add native inspection regression and wire discovery plus explicit fetch to desktop.
+- [x] Verify real staging connection, public-profile inspection and private-workspace denial for test identity.
+- [ ] Verify user private-workspace fetch after user signs in.
+- [x] Compare actual browser, staging and desktop child resources: restoration is NOT complete.
+- [x] Reproduce staging rejection with the browser's existing resyncDrive path: private drive is not enrolled for sync.
+- [ ] Resolve private-drive hosting policy/enrollment without bypassing managed admission.
+- [ ] Reconcile browser changes to staging, then verify desktop content matches.
+- [x] Add explicit loading stages after secret acceptance; offer discovery from missing-drive Sync screen.
+- [x] Render full recovery screen in native WebKit with a fresh test sign-in; new copy and manual node address fallback are visible.
+- [ ] Reproduce the beta.5 packaged-build missing text; dev rendering alone does not establish its cause.
+
+User agent: did:ad:agent:Th4BIsoBJHrL3Wo9E_h9hI3tRs5yQFsVGDgJGg0ZyZ0
+Drive: did:ad:0I5rRjyMDYOaRKAPYbesoGG7cJuoVFYskbhePk9MIXZSQZWvNoOUHPAm37UfIrSFwZRMej9tzWoXbLDkxu-0Bw
+Staging node: 60720a76f65b7861fdb110af3b3232983df0063058690f0a68d9df2c46481243
+No user data or secrets modified during live read-only discovery checks.
+
+Live follow-up: browser and desktop use the same private drive DID. Browser document `did:ad:57wrjINk9xcY5RXaJJI9hEQPsoxPAwfYtaU3hh8btqxsj5x7oUdvF1knplnwxaHwufaq0JqH2i-O5I2fcI_gBg` is named `What s this!@?`, while authenticated staging HTTP GET and desktop return `Document`. Browser computeDriveSyncState contains 6 resources, including that document; staging parent query contains 3 children. Explicit browser reconciliation at 21:43 returned SYNC_PUSH rejected: drive is not enrolled for sync on this node. Linked desktop GET /api/sync-enrollments confirms only the OIHM... team drive is active, not the private drive. Browser had incorrectly shown In sync with its lastDriveSync belonging to YcXy... instead. Do not report restoration success from the drive resource or PKARR connection alone. User product-policy question is pending.
+
+Native probe returns name `atomic-staging`. Unit test also explicitly fetches after inspection and confirms imported data. Typecheck passes. Debug app uses /tmp/atomic-desktop-pkarr, separate bundle identifier and staging portal override. No commit or push.

--- a/planning/sync-onboarding-ux.md
+++ b/planning/sync-onboarding-ux.md
@@ -190,3 +190,17 @@ version 1 and persists account, agent and server timestamp on the enrollment.
 Existing records retain unknown consent; no consent is inferred from a drive
 being present. Browser switcher rows carry compact service state labels, with
 one Storage and hosting action for details. Unknown cloud status stays explicit.
+
+## Desktop workspace discovery (2026-09-08)
+
+A restored Tauri identity now inspects its personal drive's PKARR peer before
+asking the user to fetch. The inspection authenticates, reads only the drive
+resource to check access, and discards the snapshot. It imports no data and
+creates no remembered pairing. A successful result names the device from HELLO;
+only “Fetch workspace” starts sync, followed by a fresh local readability check.
+An address can supply a node ID when PKARR discovery fails. Device names are
+self-reported display labels, never identity or authorization evidence.
+
+Flutter already attempts PKARR through `syncConnectivityNow`; its automatic
+fetch behavior is unchanged in this desktop debugging change. The new shared
+Rust inspection is available for a future matching confirmation step there.


### PR DESCRIPTION
Desktop sign-in could leave a missing workspace without checking its PKARR announcement. Add authenticated, read-only Iroh inspection that shows the discovered node name, followed by an explicit fetch action and a manual server-address fallback. Offer the same flow from Sync when the selected drive is missing.

Show a dedicated loading screen after secret acceptance and during discovery/fetch, fix the discovery heading rendering, and avoid claiming that an absent workspace is safe locally.

Validation: TypeScript typecheck passed; native Iroh regression verifies access checks, no import or pairing during inspection, and data import after explicit fetch. A local Tauri build connected to staging and inspected its announced node.

End-to-end restoration remains unresolved: staging rejects the private drive's browser updates because that drive is not enrolled for sync. This PR does not change managed enrollment policy. The original beta.5 packaged-build blank screen also remains unconfirmed; development rendering is not proof of its cause.

## Related Issues

No linked issue. Investigation and remaining checks are tracked in planning/desktop-pkarr-restore.md.

## Checklist
- [ ] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [x] Update docs if needed
