### PR TITLE
Fix recovery-code fallback and add passkey enrollment

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -487,3 +487,7 @@ updates without a reload and verifies a second change after the reader reloads.
 multiple-reader cleanup through both Store unsubscribe APIs, and retaining
 ordinary document drive-wide fan-out. Profiles no longer depend on being inside
 the reader's active drive to receive live updates.
+
+## Recovery-code passkey enrollment
+
+`browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts` verifies code-only reveal without WebAuthn, preservation of ciphertext and existing wrappers when adding a passkey, unlocking with either passkey, and no writes on wrong-code, account-mismatch or cancelled registration. Tests use WebCrypto, Argon2id and a simulated authenticator; physical mobile PRF support remains a device acceptance check.

--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -15,6 +15,7 @@ import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
 import { getRememberedManagedPortalUrl } from '../helpers/managed/api';
 import {
   addRecoveryCodeWrapper,
+  addPasskeyWrapper,
   buildEnvelopeV2,
   buildEnvelopeWithPasskeyAndCode,
   envelopeWrapperKinds,
@@ -65,6 +66,7 @@ export function AccountRecoveryCard({
   const [newCode, setNewCode] = useState<string | null>(null);
   const [codeInput, setCodeInput] = useState('');
   const [needsCode, setNeedsCode] = useState(false);
+  const [passkeyAdded, setPasskeyAdded] = useState(false);
   /**
    * The secret being enrolled, typed by the user.
    *
@@ -188,6 +190,8 @@ export function AccountRecoveryCard({
   }, [agentSubject, hasSession]);
 
   async function handleReveal() {
+    if (needsCode && !codeInput.trim()) return;
+
     setLoading(true);
     setError(undefined);
 
@@ -207,17 +211,28 @@ export function AccountRecoveryCard({
       }
 
       setSecret(revealed);
+      setCodeInput('');
       setNeedsCode(false);
     } catch (e) {
       const message =
         e instanceof Error ? e.message : 'Could not show your secret.';
 
       // The helper asks for a code when that's the only way in.
-      if (message.toLowerCase().includes('enter your recovery')) {
+      if (
+        message.toLowerCase().includes('enter your recovery') ||
+        (backup.phase === 'ready' &&
+          envelopeWrapperKinds(backup.secret).hasCode)
+      ) {
         setNeedsCode(true);
       }
 
-      setError(message);
+      setError(
+        !needsCode &&
+          backup.phase === 'ready' &&
+          envelopeWrapperKinds(backup.secret).hasCode
+          ? 'Could not unlock with a passkey. Use your recovery code instead.'
+          : message,
+      );
     } finally {
       setLoading(false);
     }
@@ -379,6 +394,37 @@ export function AccountRecoveryCard({
     }
   }
 
+  async function handleAddPasskey() {
+    if (!needsCode || !codeInput.trim()) {
+      setNeedsCode(true);
+      setError(undefined);
+
+      return;
+    }
+
+    if (!agentSubject) return;
+
+    setLoading(true);
+    setError(undefined);
+    setPasskeyAdded(false);
+
+    try {
+      const saved = await addPasskeyWrapper(
+        codeInput.trim(),
+        agentSubject,
+        accountEmail ?? 'Atomic account',
+      );
+      setBackup({ phase: 'ready', secret: saved, onServer: true });
+      setCodeInput('');
+      setNeedsCode(false);
+      setPasskeyAdded(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not add a passkey.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   if (backup.phase === 'loading') return null;
 
   if (backup.phase === 'none') {
@@ -481,6 +527,61 @@ export function AccountRecoveryCard({
         </Column>
       ) : null}
 
+      {needsCode ? (
+        <InputWrapper hasPrefix>
+          <FaKey />
+          <InputStyled
+            value={codeInput}
+            onChange={e => setCodeInput(e.target.value)}
+            type='password'
+            placeholder='Recovery code'
+            aria-label='Recovery code'
+          />
+        </InputWrapper>
+      ) : null}
+      {hasCode ? (
+        <Column gap='0.5rem'>
+          <Row gap='1rem' wrapItems>
+            <Button
+              subtle
+              disabled={loading}
+              onClick={() => {
+                setNeedsCode(true);
+                setError(undefined);
+              }}
+            >
+              Use recovery code
+            </Button>
+            {hasSession === true ? (
+              <Button
+                subtle
+                disabled={loading || !agentSubject}
+                onClick={handleAddPasskey}
+                data-test='add-passkey'
+              >
+                Add a passkey
+              </Button>
+            ) : portalUrl ? (
+              <Button
+                subtle
+                onClick={() => window.open(`${portalUrl}/dashboard`, '_blank')}
+              >
+                Sign in to add a passkey
+              </Button>
+            ) : null}
+          </Row>
+          {needsCode ? (
+            <Hint>
+              Enter your recovery code to show your secret or add a passkey on
+              this device. Your existing recovery code will keep working.
+            </Hint>
+          ) : null}
+          {passkeyAdded ? (
+            <p>Passkey added. Your recovery code still works.</p>
+          ) : null}
+        </Column>
+      ) : null}
+
       {secret ? (
         <Column gap='0.5rem'>
           <p>
@@ -498,23 +599,11 @@ export function AccountRecoveryCard({
         </Column>
       ) : (
         <Column gap='0.5rem'>
-          {needsCode ? (
-            <InputWrapper hasPrefix>
-              <FaKey />
-              <InputStyled
-                value={codeInput}
-                onChange={e => setCodeInput(e.target.value)}
-                type='password'
-                placeholder='Recovery code'
-                aria-label='Recovery code'
-              />
-            </InputWrapper>
-          ) : null}
           <Row gap='1rem' wrapItems>
             <Button
               subtle
               onClick={handleReveal}
-              disabled={loading}
+              disabled={loading || (needsCode && !codeInput.trim())}
               data-test='reveal-secret'
             >
               {loading ? 'Unlocking…' : 'Show my agent secret'}

--- a/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
@@ -1,0 +1,142 @@
+// @wc-ignore-file
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { managedFetch } from './api';
+import { getManagedAccount } from './session';
+import {
+  addPasskeyWrapper,
+  buildEnvelopeWithPasskeyAndCode,
+  decryptEnvelopeV2,
+  decryptEnvelopeWithPasskey,
+  revealSecretFromBackup,
+  type RecoverySecret,
+} from './recovery';
+
+vi.mock('./session', () => ({ getManagedAccount: vi.fn() }));
+vi.mock('./api', () => ({ managedFetch: vi.fn() }));
+vi.mock('../wasmUrls', () => ({
+  wasmJsUrl: () => './test-fixtures/recovery-wasm.ts',
+  wasmBinaryUrl: () => '',
+}));
+vi.mock('./binding', () => ({ writeManagedAccountBinding: vi.fn() }));
+
+let stored: RecoverySecret;
+let code: string;
+let credentialNumber: number;
+let selectedCredential: number;
+const create = vi.fn();
+const get = vi.fn();
+const subject = 'did:ad:agent:test-account';
+
+function credential(n: number) {
+  return {
+    rawId: new Uint8Array([n]).buffer,
+    response: {},
+    getClientExtensionResults: () => ({
+      prf: {
+        enabled: true,
+        results: { first: new Uint8Array(32).fill(n).buffer },
+      },
+    }),
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.stubGlobal('crypto', webcrypto);
+  vi.stubGlobal('navigator', { credentials: { create, get } });
+  credentialNumber = 0;
+  selectedCredential = 1;
+  create.mockImplementation(async () => credential(++credentialNumber));
+  get.mockImplementation(async () => credential(selectedCredential));
+  vi.mocked(getManagedAccount).mockResolvedValue({
+    email: 'test@example.com',
+  } as never);
+  const built = await buildEnvelopeWithPasskeyAndCode({
+    secret: 'test-agent-secret',
+    agentSubject: subject,
+    userName: 'Test',
+  });
+  code = built.recoveryCode;
+  stored = {
+    ...built.request,
+    owner_email: 'test@example.com',
+    wrappers: built.request.wrappers!.map(w => ({ ...w, created_at: 1 })),
+  } as RecoverySecret;
+  vi.mocked(managedFetch).mockImplementation(async (_path, options) => {
+    if (options?.method === 'PUT') {
+      const input = JSON.parse(options.body as string);
+      stored = {
+        ...stored,
+        ...input,
+        wrappers: input.wrappers.map((w: object) => ({ ...w, created_at: 2 })),
+      };
+    }
+
+    return new Response(JSON.stringify(stored), { status: 200 });
+  });
+}, 60000);
+afterEach(() => vi.unstubAllGlobals());
+
+describe('recovery-code passkey enrollment', () => {
+  it('reveals with a supplied code without requiring WebAuthn', async () => {
+    get.mockRejectedValue(new Error('Web Authentication unavailable'));
+    expect(await revealSecretFromBackup(code, subject)).toBe(
+      'test-agent-secret',
+    );
+    expect(get).not.toHaveBeenCalled();
+  }, 60000);
+
+  it('preserves the code and old passkey, and can unlock using the new passkey', async () => {
+    const original = structuredClone(stored);
+    const saved = await addPasskeyWrapper(code, subject, 'Test');
+    expect(saved.encrypted_secret).toBe(original.encrypted_secret);
+    expect(saved.nonce).toBe(original.nonce);
+    expect(
+      saved.wrappers.map(({ created_at: _, ...w }) => w).slice(0, 2),
+    ).toEqual(original.wrappers.map(({ created_at: _, ...w }) => w));
+    expect(await decryptEnvelopeV2(saved, code)).toBe('test-agent-secret');
+    expect(await decryptEnvelopeWithPasskey(saved)).toBe('test-agent-secret');
+    selectedCredential = 2;
+    expect(await decryptEnvelopeWithPasskey(saved)).toBe('test-agent-secret');
+    const options = get.mock.calls.at(-1)![0];
+    expect(options.publicKey.allowCredentials).toHaveLength(2);
+    expect(
+      Object.keys(options.publicKey.extensions.prf.evalByCredential),
+    ).toEqual(['AQ', 'Ag']);
+  }, 60000);
+
+  it('does not create a credential or write when the recovery code is wrong', async () => {
+    create.mockClear();
+    await expect(
+      addPasskeyWrapper('wrong-code', subject, 'Test'),
+    ).rejects.toThrow('Wrong recovery code');
+    expect(create).not.toHaveBeenCalled();
+    expect(
+      vi
+        .mocked(managedFetch)
+        .mock.calls.some(([, options]) => options?.method === 'PUT'),
+    ).toBe(false);
+  }, 60000);
+
+  it('does not enroll a passkey for a different signed-in account', async () => {
+    create.mockClear();
+    await expect(
+      addPasskeyWrapper(code, 'did:ad:agent:other', 'Test'),
+    ).rejects.toThrow('Sign in to the account');
+    expect(create).not.toHaveBeenCalled();
+  });
+  it('keeps the existing backup when passkey creation is cancelled', async () => {
+    const original = structuredClone(stored);
+    create.mockRejectedValue(new DOMException('Cancelled', 'NotAllowedError'));
+    await expect(addPasskeyWrapper(code, subject, 'Test')).rejects.toThrow(
+      'Cancelled',
+    );
+    expect(stored).toEqual(original);
+    expect(
+      vi
+        .mocked(managedFetch)
+        .mock.calls.some(([, options]) => options?.method === 'PUT'),
+    ).toBe(false);
+  }, 60000);
+});

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -505,14 +505,6 @@ async function evaluatePrf(
   return results;
 }
 
-async function derivePrfKey(
-  credentialId: Uint8Array,
-  salt: Uint8Array,
-  usages: KeyUsage[],
-): Promise<CryptoKey> {
-  return importPrfKey(await evaluatePrf(credentialId, salt), usages);
-}
-
 /**
  * Whether the new credential is a *synced* passkey (iCloud Keychain, Google
  * Password Manager) or bound to this one device.
@@ -861,28 +853,65 @@ async function openWithDekKey(
   return new TextDecoder().decode(plaintext);
 }
 
-/** Unlock a v2 backup with its registered passkey (one biometric prompt). */
-export async function decryptEnvelopeWithPasskey(
-  recovery: RecoverySecret,
-): Promise<string> {
-  const wrapper = recovery.wrappers.find(
+/** Let the authenticator choose any registered passkey, including one added later. */
+async function unlockPasskeyWrapper(recovery: RecoverySecret) {
+  const wrappers = recovery.wrappers.filter(
     w => w.wrapper_type === 'webauthn-prf' && w.credential_id,
   );
 
-  if (!wrapper?.credential_id) {
-    throw new Error('This backup has no passkey.');
-  }
+  if (!wrappers.length) throw new Error('This backup has no passkey.');
 
-  const wrapKey = await derivePrfKey(
-    base64ToBytes(wrapper.credential_id),
-    base64ToBytes(wrapper.salt),
-    ['decrypt'],
-  );
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      challenge: randomBytes(32),
+      rpId: passkeyRpId(),
+      allowCredentials: wrappers.map(w => ({
+        type: 'public-key',
+        id: base64ToBytes(w.credential_id!),
+      })),
+      userVerification: 'required',
+      timeout: WEBAUTHN_TIMEOUT_MS,
+      extensions: {
+        prf: {
+          evalByCredential: Object.fromEntries(
+            wrappers.map(w => [
+              w
+                .credential_id!.replace(/\+/g, '-')
+                .replace(/\//g, '_')
+                .replace(/=+$/, ''),
+              { first: base64ToBytes(w.salt) },
+            ]),
+          ),
+        },
+      },
+    },
+  } as CredentialRequestOptions)) as PublicKeyCredential | null;
+  const wrapper =
+    assertion &&
+    wrappers.find(
+      w => w.credential_id === bytesToBase64(new Uint8Array(assertion.rawId)),
+    );
+  const output =
+    assertion &&
+    (assertion.getClientExtensionResults() as PrfExtensionOutputs).prf?.results
+      ?.first;
+
+  if (!wrapper || !output)
+    throw new PrfUnsupportedError('No usable passkey was provided.');
+
+  return { wrapper, key: await importPrfKey(output, ['decrypt']) };
+}
+
+/** Unlock a v2 backup with any of its registered passkeys. */
+export async function decryptEnvelopeWithPasskey(
+  recovery: RecoverySecret,
+): Promise<string> {
+  const { wrapper, key } = await unlockPasskeyWrapper(recovery);
 
   return openWithDekKey(
     recovery,
     wrapper,
-    wrapKey,
+    key,
     'That passkey could not unlock this backup.',
   );
 }
@@ -980,21 +1009,8 @@ export async function addRecoveryCodeWrapper(agentSubject?: string): Promise<{
     throw new Error('There is no backup to add a recovery code to.');
   }
 
-  const passkeyWrapper = recovery.wrappers.find(
-    w => w.wrapper_type === 'webauthn-prf' && w.credential_id,
-  );
-
-  if (!passkeyWrapper?.credential_id) {
-    throw new Error('Adding a recovery code needs an existing passkey.');
-  }
-
-  // Unwrap the DEK itself (not the secret) so every existing wrapper keeps
-  // opening the same ciphertext.
-  const prfKey = await derivePrfKey(
-    base64ToBytes(passkeyWrapper.credential_id),
-    base64ToBytes(passkeyWrapper.salt),
-    ['decrypt'],
-  );
+  const { wrapper: passkeyWrapper, key: prfKey } =
+    await unlockPasskeyWrapper(recovery);
 
   let dek: ArrayBuffer;
 
@@ -1027,6 +1043,67 @@ export async function addRecoveryCodeWrapper(agentSubject?: string): Promise<{
   });
 
   return { recoveryCode, saved };
+}
+
+/** Add a passkey without replacing the recovery code or existing passkeys. */
+export async function addPasskeyWrapper(
+  recoveryCode: string,
+  agentSubject: string,
+  userName: string,
+): Promise<RecoverySecret> {
+  // This is a write: require the current server copy and an account session,
+  // rather than overwriting a newer envelope with a cached version.
+  const recovery = await getRecoverySecret();
+
+  if (!recovery || recovery.agent_subject !== agentSubject) {
+    throw new Error(
+      'Sign in to the account holding this backup before adding a passkey.',
+    );
+  }
+
+  const codeWrapper = recovery.wrappers.find(
+    w => w.wrapper_type === 'recovery-code',
+  );
+
+  if (recovery.format_version < 2 || !codeWrapper) {
+    throw new Error('Adding a passkey needs a recovery code for this backup.');
+  }
+
+  const key = await deriveKeyFromRecoveryCode(
+    normalizeRecoveryCodeInput(recoveryCode),
+    base64ToBytes(codeWrapper.salt),
+    ['decrypt'],
+    codeWrapper.kdf_params,
+  );
+  let dek: ArrayBuffer;
+
+  try {
+    dek = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(codeWrapper.wrap_nonce) },
+      key,
+      base64ToBytes(codeWrapper.wrapped_dek),
+    );
+  } catch {
+    throw new Error('Wrong recovery code');
+  }
+
+  const { wrapper } = await wrapDekWithPasskey(new Uint8Array(dek), {
+    userName,
+    userDisplayName: userName,
+  });
+
+  return saveRecoverySecret({
+    agent_subject: recovery.agent_subject,
+    drive_subject: recovery.drive_subject,
+    encrypted_secret: recovery.encrypted_secret,
+    encryption_algorithm: recovery.encryption_algorithm,
+    nonce: recovery.nonce,
+    format_version: recovery.format_version,
+    wrappers: [
+      ...recovery.wrappers.map(({ created_at: _created, ...rest }) => rest),
+      wrapper,
+    ],
+  });
 }
 
 /**

--- a/browser/data-browser/src/helpers/managed/test-fixtures/recovery-wasm.ts
+++ b/browser/data-browser/src/helpers/managed/test-fixtures/recovery-wasm.ts
@@ -1,0 +1,14 @@
+// @wc-ignore-file
+// Native test substitute for the WASM boundary, using the same Argon2id algorithm.
+import { argon2id } from '@noble/hashes/argon2.js';
+
+export default async function init() {}
+export function argon2idDeriveKey(
+  code: string,
+  salt: Uint8Array,
+  m: number,
+  t: number,
+  p: number,
+) {
+  return argon2id(code, salt, { m, t, p, dkLen: 32 });
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -5629,6 +5629,7 @@ msgid "Use a recovery code instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
 msgstr ""
@@ -6979,6 +6980,7 @@ msgstr ""
 msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
 msgstr ""
@@ -7587,3 +7589,43 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not add a passkey."
+msgstr "Der Passkey konnte nicht hinzugefügt werden."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+msgstr "Gib deinen Wiederherstellungscode ein, um deinen geheimen Schlüssel anzuzeigen oder diesem Gerät einen Passkey hinzuzufügen. Dein bisheriger Wiederherstellungscode bleibt gültig."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Passkey added. Your recovery code still works."
+msgstr "Passkey hinzugefügt. Dein Wiederherstellungscode bleibt gültig."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Add a passkey"
+msgstr "Passkey hinzufügen"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a passkey"
+msgstr "Zum Hinzufügen eines Passkeys anmelden"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use recovery code"
+msgstr "Wiederherstellungscode verwenden"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "<0>Save this recovery code.</0> It gets you back in on a new device, and you will need your email with it. We cannot show it again, but you can generate a new one here any time, which retires this one."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not unlock with a passkey. Use your recovery code instead."
+msgstr "Entsperren mit einem Passkey fehlgeschlagen. Verwende stattdessen deinen Wiederherstellungscode."

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -5663,6 +5663,7 @@ msgid "Use a recovery code instead"
 msgstr "Use a recovery code instead"
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
 msgstr "Atomic account"
@@ -7013,6 +7014,7 @@ msgstr "Only your passkey opens this account. If it isn't on this device, unlock
 msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
 msgstr "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
 msgstr "Add a recovery code"
@@ -7621,3 +7623,43 @@ msgstr "Use local Ollama"
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr "Connect local Ollama"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not add a passkey."
+msgstr "Could not add a passkey."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+msgstr "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Passkey added. Your recovery code still works."
+msgstr "Passkey added. Your recovery code still works."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
+msgstr "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Add a passkey"
+msgstr "Add a passkey"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a passkey"
+msgstr "Sign in to add a passkey"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use recovery code"
+msgstr "Use recovery code"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a recovery code"
+msgstr "Sign in to add a recovery code"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "<0>Save this recovery code.</0> It gets you back in on a new device, and you will need your email with it. We cannot show it again, but you can generate a new one here any time, which retires this one."
+msgstr "<0>Save this recovery code.</0> It gets you back in on a new device, and you will need your email with it. We cannot show it again, but you can generate a new one here any time, which retires this one."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not unlock with a passkey. Use your recovery code instead."
+msgstr "Could not unlock with a passkey. Use your recovery code instead."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -5629,6 +5629,7 @@ msgid "Use a recovery code instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
 msgstr ""
@@ -6979,6 +6980,7 @@ msgstr ""
 msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
 msgstr ""
@@ -7587,3 +7589,43 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not add a passkey."
+msgstr "No se pudo añadir una clave de acceso."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+msgstr "Introduce tu código de recuperación para mostrar tu secreto o añadir una clave de acceso en este dispositivo. Tu código de recuperación actual seguirá funcionando."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Passkey added. Your recovery code still works."
+msgstr "Clave de acceso añadida. Tu código de recuperación sigue funcionando."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Add a passkey"
+msgstr "Añadir una clave de acceso"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a passkey"
+msgstr "Iniciar sesión para añadir una clave de acceso"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use recovery code"
+msgstr "Usar código de recuperación"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "<0>Save this recovery code.</0> It gets you back in on a new device, and you will need your email with it. We cannot show it again, but you can generate a new one here any time, which retires this one."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not unlock with a passkey. Use your recovery code instead."
+msgstr "No se pudo desbloquear con una clave de acceso. Usa tu código de recuperación."

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -5629,6 +5629,7 @@ msgid "Use a recovery code instead"
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Atomic account"
 msgstr ""
@@ -6979,6 +6980,7 @@ msgstr ""
 msgid "{0}. We hold your key sealed, but only your passkey opens it. A browser your passkey has not synced to cannot get you back in — a recovery code would."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Add a recovery code"
 msgstr ""
@@ -7587,3 +7589,43 @@ msgstr ""
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Connect local Ollama"
 msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not add a passkey."
+msgstr "Impossible d’ajouter une clé d’accès."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+msgstr "Saisissez votre code de récupération pour afficher votre secret ou ajouter une clé d’accès sur cet appareil. Votre code de récupération actuel restera valide."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Passkey added. Your recovery code still works."
+msgstr "Clé d’accès ajoutée. Votre code de récupération reste valide."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Add a passkey"
+msgstr "Ajouter une clé d’accès"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a passkey"
+msgstr "Se connecter pour ajouter une clé d’accès"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use recovery code"
+msgstr "Utiliser le code de récupération"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Sign in to add a recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "<0>Save this recovery code.</0> It gets you back in on a new device, and you will need your email with it. We cannot show it again, but you can generate a new one here any time, which retires this one."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not unlock with a passkey. Use your recovery code instead."
+msgstr "Impossible de déverrouiller avec une clé d’accès. Utilisez votre code de récupération."

--- a/planning/sync-onboarding-ux.md
+++ b/planning/sync-onboarding-ux.md
@@ -190,3 +190,7 @@ version 1 and persists account, agent and server timestamp on the enrollment.
 Existing records retain unknown consent; no consent is inferred from a drive
 being present. Browser switcher rows carry compact service state labels, with
 one Storage and hosting action for details. Unknown cloud status stays explicit.
+
+### Account recovery after code sign-in
+
+The browser/Tauri Account recovery card offers recovery-code unlock independently of passkeys, including after a WebAuthn failure. A portal session plus the existing recovery code can add a passkey without replacing the code or older passkeys. Each passkey uses its own PRF salt. Flutter has no corresponding envelope-management card yet.


### PR DESCRIPTION
After signing in with a recovery code, accounts with an existing passkey could only reveal their agent secret by opening WebAuthn again. A WebAuthn failure left no way to enter the working recovery code.

The Account recovery card now offers an explicit recovery-code path and exposes it after a passkey error. Users with a portal session can use the code to add a passkey here. Registration wraps the existing encryption key, preserving the encrypted secret, recovery code and older passkeys. Unlocking offers all registered passkeys with their own PRF inputs, following the [WebAuthn PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension).

Validation: 11 recovery tests pass, covering code-only reveal, both old and new passkeys, wrapper preservation, wrong codes, account mismatch and cancelled registration. Typecheck and focused lint pass. A mobile-width browser harness verified the recovery-code field and registration controls after a simulated WebAuthn error, with no i18n-404 labels. Catalog diffs reviewed; new UI strings translated into German, French and Spanish. Real phone authenticator enrollment and SaaS persistence have not been tested end to end.
