### PR TITLE
Prepare 0.41.0-beta.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+## [v0.41.0-beta.6] - 2026-09-09
+
 - Desktop restore discovers reachable workspace sources and supports an explicit server address when automatic discovery does not find one.
 
 - **Security audit fixes** (`planning/security-audit-2026-09.md`, #1384).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ By far most changes relate to `atomic-server`, so if not specified, assume the c
 **Changes to JS assets (including the front-end and JS libraries) are not shown here**, but in [`/browser/CHANGELOG`](/browser/CHANGELOG.md).
 See [STATUS.md](server/STATUS.md) to learn more about which features will remain stable.
 
+## UNRELEASED
+
+- Desktop restore discovers reachable workspace sources and supports an explicit server address when automatic discovery does not find one.
+
 - **Security audit fixes** (`planning/security-audit-2026-09.md`, #1384).
   `POST /iroh-sync` requires a signed agent with write on the drive and only
   answers POST; `SYNC_PUSH` entries are checked against the admitted drive;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 dependencies = [
  "assert_cmd",
  "async-recursion",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 dependencies = [
  "actix",
  "actix-cors",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server-tauri"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 dependencies = [
  "actix-rt",
  "android_system_properties",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "atomic_lib"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 dependencies = [
  "anyhow",
  "argon2",

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -373,6 +373,7 @@ Not covered: leftover Yjs-era DocumentV2 bodies end-to-end (needs a stored `{ ty
 | Two stores with the same key mint the same subject | `store.personal-drive.test.ts` |
 | Extra drives are listed on the derived personal drive | `store.personal-drive.test.ts` |
 | Extra drive created offline drains on reconnect (genesis must not set a rewind baseline) | `browser/lib/src/offline-create-drain.test.ts` |
+| Idempotent offline saves clear only after a complete local snapshot matches the synced baseline | `browser/lib/src/offline-create-drain.test.ts`, `browser/e2e/tests/offline-create-then-online.spec.ts` |
 | Lists from a previous random-DID home are unioned onto the derived drive | `store.personal-drive.test.ts` |
 | `Agent.personalDriveSubject` matches the genesis helper | `agent.test.ts` |
 | `Db::setup` / `ensure_personal_drive` use the derived DID and are idempotent | `lib/src/db.rs::personal_drive_tests` |
@@ -534,3 +535,11 @@ This does not yet prove restoration of the user's private staging workspace.
 ## Recovery-code passkey enrollment
 
 `browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts` verifies code-only reveal without WebAuthn, preservation of ciphertext and existing wrappers when adding a passkey, unlocking with either passkey, and no writes on wrong-code, account-mismatch or cancelled registration. Tests use WebCrypto, Argon2id and a simulated authenticator; physical mobile PRF support remains a device acceptance check.
+
+## Plugin UI sandbox and private assets
+
+- `browser/e2e/tests/plugin.spec.ts`: private plugin assets load through signed parent requests; custom rendering and RPC still work.
+- The bootstrap test opens the shell directly and verifies its server-enforced opaque origin, independently of iframe attributes.
+- `signout-signin-data.spec.ts` uses fresh persistent profiles on macOS WebKit because ephemeral contexts reject OPFS; these remain browser tests, not native Tauri acceptance.
+
+- `browser/lib/src/store.test.ts`: receiving an older resource preserves the merged value in both JSON and the persisted Loro snapshot; dashboard configuration reload exercises the real OPFS path.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- An older server response no longer rolls back the local cache after an edit, fixing dashboard configuration reverting on reload.
+
+- Private plugin views load authenticated assets through the parent while retaining their sandbox.
+- Idempotent offline saves no longer leave the sync queue retrying an empty update.
+- Navigating to sign-in no longer fetches the welcome screen as a data resource.
+
 - Account recovery: reveal the agent secret with a recovery code when passkey authentication is unavailable, and enroll an additional passkey.
 - Desktop onboarding explains workspace discovery with a dedicated loading screen, offers discovered sources and a manual server address, and retries while waiting for another device.
 - Sync and Cloud Server status now describe the selected drive; linking a cloud account does not imply that its workspace has been transferred.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Account recovery: reveal the agent secret with a recovery code when passkey authentication is unavailable, and enroll an additional passkey.
+- Desktop onboarding explains workspace discovery with a dedicated loading screen, offers discovered sources and a manual server address, and retries while waiting for another device.
+- Sync and Cloud Server status now describe the selected drive; linking a cloud account does not imply that its workspace has been transferred.
+- Cloud Vault backups preserve drive names and emoji, run incrementally, and retry transient failures.
+- Security fixes bind managed account tokens to their portal and validate links and uploaded content.
+
 - Right-clicking a resource (sidebar link, table cell, kanban card) opens the same searchable action menu as Cmd+M: the filter input is focused, typing narrows the actions, Enter runs one.
 - Fix: `Store.applyIncoming` imports the echo of this client's own commit before deduping it, so the server's `lastCommit` stamp lands locally and a collaborator's next edit applies instead of triggering a catch-up fetch that remounted the editor.
 - Fix: an own commit's echo is recognised by signature (registered at sign time), not only by the `lastCommit` the ack stamps, so an echo that lands before the ack no longer re-renders the page mid-edit (the tag picker in the tables e2e closed under load).

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+## [v0.41.0-beta.6] - 2026-09-09
+
 - An older server response no longer rolls back the local cache after an edit, fixing dashboard configuration reverting on reload.
 
 - Private plugin views load authenticated assets through the parent while retaining their sandbox.

--- a/browser/cli/package.json
+++ b/browser/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/js-cli",
   "repository": {

--- a/browser/create-template/package.json
+++ b/browser/create-template/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/create-template/atomic-template",
   "repository": {

--- a/browser/create-template/templates/nextjs-site/package.json
+++ b/browser/create-template/templates/nextjs-site/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.11.1",
-    "@tomic/lib": "^0.41.0-beta.5",
-    "@tomic/react": "^0.41.0-beta.5",
+    "@tomic/lib": "^0.41.0-beta.6",
+    "@tomic/react": "^0.41.0-beta.6",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "loro-crdt": "^1.12.1",
@@ -25,7 +25,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@tomic/cli": "^0.41.0-beta.5",
+    "@tomic/cli": "^0.41.0-beta.6",
     "@types/node": "^20",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/browser/create-template/templates/sveltekit-site/package.json
+++ b/browser/create-template/templates/sveltekit-site/package.json
@@ -18,7 +18,7 @@
 		"@sveltejs/adapter-node": "^5.2.9",
 		"@sveltejs/kit": "^2.7.3",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
-		"@tomic/cli": "^0.41.0-beta.5",
+		"@tomic/cli": "^0.41.0-beta.6",
 		"@types/eslint": "^9.6.1",
 		"eslint": "^9.13.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -37,8 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@tomic/lib": "^0.41.0-beta.5",
-		"@tomic/svelte": "^0.41.0-beta.5",
+		"@tomic/lib": "^0.41.0-beta.6",
+		"@tomic/svelte": "^0.41.0-beta.6",
 		"loro-crdt": "^1.12.1",
 		"svelte-markdown": "^0.4.1"
 	}

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "author": {
     "email": "joep@ontola.io",
     "name": "Joep Meindertsma"

--- a/browser/data-browser/src/routes/RootRoutes.tsx
+++ b/browser/data-browser/src/routes/RootRoutes.tsx
@@ -183,7 +183,9 @@ const TopRouteComponent: React.FC = () => {
 
   const subject = `${origin}${pathname}${window.location.search}`;
 
-  if (resolvingRoot) return null;
+  // During a route transition this outgoing component can observe the new
+  // location before it unmounts. App routes are screens, not data subjects.
+  if (resolvingRoot || pathname.startsWith('/app/')) return null;
 
   return <ResourcePage subject={subject} key={subject} />;
 };

--- a/browser/data-browser/src/views/PluginView/PluginView.tsx
+++ b/browser/data-browser/src/views/PluginView/PluginView.tsx
@@ -3,7 +3,9 @@ import { useStore } from '@tomic/react';
 import { useSettings } from '@helpers/AppSettings';
 import { usePluginRPC } from '@views/PluginView/pluginRPC';
 import styled from 'styled-components';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { signRequest } from '@tomic/lib';
+import { ErrorBlock } from '@components/ErrorLook';
 
 import resetCss from '../../reset.css?raw';
 import { useCreateThemeVars } from './useCreateThemeVars';
@@ -44,6 +46,62 @@ export const PluginView: React.FC<PluginViewProps> = ({ plugin }) => {
   const pluginUrl = `${store.getServerUrl()}/plugin-ui?drive=${encodeURIComponent(drive)}&plugin=${encodeURIComponent(plugin)}`;
   const src = `${pluginUrl}&format=html`;
 
+  const hasCss = pluginData?.uiManifest.css ?? false;
+  const [loadError, setLoadError] = useState<Error>();
+
+  // A null-origin sandbox cannot send the account cookie. Fetch assets in
+  // the trusted parent with signed requests and send only their contents to
+  // the frame; credentials and signing keys never enter the plugin sandbox.
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchAsset = async (format: string) => {
+      const url = `${pluginUrl}&format=${format}`;
+      const agent = store.getAgent();
+      const headers = agent ? await signRequest(url, agent, {}) : {};
+      const response = await fetch(url, { headers, credentials: 'include' });
+      if (!response.ok)
+        throw new Error(
+          /* @wc-ignore */ `Plugin asset request failed (${response.status})`,
+        );
+
+      return response.text();
+    };
+
+    const onReady = (event: MessageEvent) => {
+      if (
+        event.source !== frameRef.current?.contentWindow ||
+        event.data?.type !== '__atomic_plugin_ready'
+      )
+        return;
+      setLoadError(undefined);
+      void Promise.all([
+        fetchAsset('js'),
+        hasCss ? fetchAsset('css') : Promise.resolve(''),
+      ])
+        .then(([js, css]) => {
+          if (!cancelled)
+            frameRef.current?.contentWindow?.postMessage(
+              { type: '__atomic_plugin_assets', js, css },
+              '*',
+            );
+        })
+        .catch(error => {
+          if (!cancelled)
+            setLoadError(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+        });
+    };
+
+    window.addEventListener('message', onReady);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('message', onReady);
+    };
+  }, [pluginUrl, hasCss, store, frameRef]);
+
   // Hand the reset + theme CSS to the null-origin iframe via postMessage. The
   // iframe applies it to its `<style id="__atomic_theme">`. We (re)send on the
   // iframe's ready signal and whenever the theme changes.
@@ -79,6 +137,7 @@ export const PluginView: React.FC<PluginViewProps> = ({ plugin }) => {
 
   return (
     <>
+      {loadError && <ErrorBlock error={loadError} />}
       <StyledIframe
         title='plugin-view'
         id='custom-view'

--- a/browser/e2e/package.json
+++ b/browser/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/e2e",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "private": true,
   "homepage": "https://atomicdata.dev/",
   "license": "MIT",

--- a/browser/e2e/tests/dashboard.spec.ts
+++ b/browser/e2e/tests/dashboard.spec.ts
@@ -6,6 +6,7 @@ import {
   newResource,
   pickFromMenu,
   waitForRowsMaterialized,
+  waitForSynced,
   smoke,
 } from './test-utils';
 
@@ -451,11 +452,8 @@ test.describe('dashboards', () => {
       timeout: 15_000,
     });
 
-    await page.waitForFunction(
-      () => window.store?.getSyncStatus().pendingDirtyCount === 0,
-      undefined,
-      { timeout: 30_000 },
-    );
+    await waitForSynced(page);
+
     await page.reload({ waitUntil: 'domcontentloaded' });
 
     await expect(block(page, 'Average spend')).toContainText('236.63', {

--- a/browser/e2e/tests/kanban.spec.ts
+++ b/browser/e2e/tests/kanban.spec.ts
@@ -394,6 +394,9 @@ test.describe('kanban', () => {
     const copyTab = page.getByRole('tab', { name: 'Board copy' });
     await expect(copyTab).toBeVisible();
 
+    // Duplication persists the view before navigating to it. Wait for that
+    // navigation so the click opens the active tab's menu.
+    await expect(copyTab).toHaveAttribute('aria-selected', 'true');
     // Delete the copy via its tab menu + confirmation dialog.
     await copyTab.click();
     await page.getByTestId('menu-item-delete').click();

--- a/browser/e2e/tests/onboarding.spec.ts
+++ b/browser/e2e/tests/onboarding.spec.ts
@@ -86,10 +86,6 @@ test.describe('onboarding', () => {
     await page2.goto(`${FRONTEND_URL}/app/agent`);
     await page2.getByRole('button', { name: 'Sign in', exact: true }).click();
     await page2.getByLabel('Agent secret').fill(secret!);
-    // Submit via Enter rather than racing the Continue button, which can briefly
-    // re-mount as the welcome panel settles (managed-info fetch) right after the
-    // step transition.
-    await page2.getByLabel('Agent secret').press('Enter');
 
     // Signing in lands the user on their home drive (sign-in is unified through
     // /app/welcome now; /app/agent no longer hosts its own login form). Wait for

--- a/browser/e2e/tests/plugin.spec.ts
+++ b/browser/e2e/tests/plugin.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect } from './fixtures';
 import {
   before,
+  SERVER_URL,
   currentDriveTitle,
   fillSearchBox,
   inDialog,
@@ -246,4 +247,17 @@ test.describe('Plugins', () => {
     await expect(page.locator('#custom-view')).toHaveCount(0);
     await expect(page.getByTestId('editable-title')).toHaveText('Duck');
   });
+});
+
+// The bootstrap accepts asset contents from its parent, so the server must
+// enforce an opaque origin even when a caller omits the iframe sandbox.
+test('plugin bootstrap enforces its own sandbox', async ({ page }) => {
+  const response = await page.goto(
+    `${SERVER_URL}/plugin-ui?drive=unused&plugin=test.shell&format=html`,
+  );
+  expect(response?.headers()['content-security-policy']).toMatch(
+    /sandbox[^;]*;/,
+  );
+  expect(await page.evaluate(() => window.origin)).toBe('null');
+  expect(await page.locator('script[src]').count()).toBe(0);
 });

--- a/browser/e2e/tests/signout-signin-data.spec.ts
+++ b/browser/e2e/tests/signout-signin-data.spec.ts
@@ -18,17 +18,52 @@
  *     be opened, and the cache silently empties even though the server still
  *     has everything. That is exactly what "the content is gone" looks like.
  */
-import { test, expect, type Page } from './fixtures';
+import { test as base, expect, type Page, webkit } from './fixtures';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   before,
   getCurrentSubject,
   getDevDriveSecret,
   newResource,
-  openAgentPage,
-  openSubject,
   setTitle,
   timestamp,
 } from './test-utils';
+
+// WebKit's ephemeral contexts on macOS reject OPFS even though regular
+// profiles support it. These tests assert persistence, so use an isolated
+// regular profile rather than exercising private-browsing storage policy.
+const test = base.extend({
+  context: async (
+    { browserName, context, headless, viewport, locale, timezoneId },
+    use,
+  ) => {
+    if (browserName !== 'webkit' || process.platform !== 'darwin') {
+      await use(context);
+
+      return;
+    }
+
+    const profile = await mkdtemp(join(tmpdir(), 'atomic-webkit-storage-'));
+    const persistent = await webkit.launchPersistentContext(profile, {
+      headless,
+      viewport,
+      locale,
+      timezoneId,
+    });
+    await persistent.addInitScript(() => {
+      localStorage.setItem('viewTransitionsDisabled', 'true');
+    });
+
+    try {
+      await use(persistent);
+    } finally {
+      await persistent.close();
+      await rm(profile, { recursive: true, force: true });
+    }
+  },
+});
 
 const SESSION_KEY_PREFIX = 'atomic.clientdb.session-key.';
 const WRAPPED_KEY_PREFIX = 'atomic.clientdb.wrapped-key.';
@@ -104,7 +139,7 @@ async function signOut(page: Page) {
     dialog.accept();
   });
 
-  await openAgentPage(page);
+  await page.locator('a[href$="/app/agent"]').click();
   await page.click('[data-test="sign-out"]');
   await expect(
     page.getByRole('button', { name: 'Create account' }),
@@ -128,7 +163,6 @@ async function signInAgain(page: Page, secret: string) {
 
   const field = page.getByLabel('Agent secret');
   await field.fill(secret);
-  await field.blur();
 
   // The whole point of this spec. This device made the workspace moments ago
   // and is still talking to the same server, so "your data is elsewhere" is
@@ -137,6 +171,8 @@ async function signInAgain(page: Page, secret: string) {
   await expect(
     page.getByRole('heading', { name: 'Your data is on another device' }),
   ).toBeHidden({ timeout: 15000 });
+  await expect(page.locator('a[href$="/app/agent"]')).toBeVisible();
+  await expect(page).toHaveURL(/did(?:%3A|:)ad(?:%3A|:)/);
 }
 
 test.describe('sign-out / sign-in round trip', () => {
@@ -155,15 +191,16 @@ test.describe('sign-out / sign-in round trip', () => {
     await newResource('folder', page);
     await setTitle(page, folderTitle);
 
-    // Capture the subject rather than relying on the sidebar after sign-in:
-    // sign-out clears the active drive on purpose, so the sidebar legitimately
-    // starts empty. What must survive is the resource.
+    // Keep the subject so reopening the folder proves it is the same resource.
     const folderSubject = await getCurrentSubject(page);
 
     await signOut(page);
     await signInAgain(page, secret);
 
-    await openSubject(page, folderSubject);
+    await page.locator(`a[about="${folderSubject}"]`).first().click();
+    await expect(
+      page.locator(`main[about="${folderSubject}"]`).first(),
+    ).toBeVisible();
     await expect(page.locator(`text=${folderTitle}`).first()).toBeVisible({
       timeout: 15000,
     });

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -484,16 +484,12 @@ function waitForCommitForSubject(page: Page, subject: string, since: number) {
 /**
  * Types the agent secret and lets the flow sign itself in.
  *
- * `fill()` alone usually suffices — it dispatches the input event React's
- * onChange listens for, which calls `trySecret`. The explicit blur() covers the
- * other half of the component's contract (`onBlur` re-runs `trySecret` with its
- * final flag), so a value that arrives too fast for the change handler still
- * gets validated rather than sitting in a field nobody submitted.
+ * Filling a valid secret starts sign-in immediately. Do not blur or submit
+ * afterward: the input may already have unmounted. Callers await the resulting
+ * signed-in state before continuing.
  */
 async function enterSecret(page: Page, secret: string) {
-  const field = page.getByLabel('Agent secret');
-  await field.fill(secret);
-  await field.blur();
+  await page.getByLabel('Agent secret').fill(secret);
 }
 
 export async function signIn(page: Page, secret: string = SECRET) {
@@ -1291,11 +1287,19 @@ export async function waitForSynced(page: Page, timeoutMs = 30_000) {
                 enqueuedAt: number;
                 signedGenesis?: unknown;
                 lastAttemptError?: unknown;
+                baseVersion?: string;
               }) => ({
                 subject: entry.subject,
                 enqueuedAt: entry.enqueuedAt,
                 hasSignedGenesis: !!entry.signedGenesis,
                 lastAttemptError: entry.lastAttemptError,
+                baseVersion: entry.baseVersion,
+                saveCursor: store?.resources
+                  .get(entry.subject)
+                  ?.getEncodedSaveCursor(),
+                hasUnsavedChanges: store?.resources
+                  .get(entry.subject)
+                  ?.hasUnsavedChanges(),
               }),
             ) ?? [];
 

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -43,7 +43,7 @@ const PORTAL_URL =
  * the page back on the welcome gate, which reads like an onboarding bug and
  * is not one.
  */
-const uniqueEmail = () => `vault-${randomUUID()}@localhost`;
+const uniqueEmail = () => `vault-${randomUUID()}@example.com`;
 
 /**
  * The control plane answers `/api/me` with 401 when nobody is signed in, which

--- a/browser/edit-mode/package.json
+++ b/browser/edit-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/edit-mode",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "description": "Turn any page rendered from Atomic Data into an editable local-first clone: 'Edit this page' for visitors (guest agent + local-only drive, zero server writes) and inline-editing UI chrome.",
   "type": "module",
   "license": "MIT",

--- a/browser/lib/package.json
+++ b/browser/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/lib",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "author": "Joep Meindertsma",
   "homepage": "https://docs.atomicdata.dev/js",
   "repository": {

--- a/browser/lib/src/offline-create-drain.test.ts
+++ b/browser/lib/src/offline-create-drain.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from 'vitest';
+import { describe, it, vi, expect as assert } from 'vitest';
 import { server } from './ontologies/server.js';
 import { testStore } from './test-store.js';
+import type { ClientDb } from './client-db.js';
 
 /**
  * Reproduces the develop full-e2e failure of
@@ -82,4 +83,32 @@ describe('offline create drain', () => {
     expect(store.outbox.getEntry(ontology)).toBeUndefined();
     expect(store.getSyncStatus().pendingDirtyCount).toBe(0);
   });
+  it.each([true, false])(
+    'only clears an unchanged offline baseline with a complete local snapshot (available: %s)',
+    async available => {
+      const { store, agentDID, postCommitSpy } = await testStore();
+      await store.createDrive('Home', { personal: true });
+      const agent = store.resources.get(agentDID)!;
+      agent.setLastCommitValue('did:ad:commit:previous');
+      const snapshot = agent.getLoroDoc()!.export({ mode: 'snapshot' });
+      agent.markLoroSavedAt(agent.getLoroDoc()!.oplogVersion());
+      const baseline = agent.getEncodedSaveCursor()!;
+      store.outbox.markDirty(agentDID);
+      store.outbox.setBaseVersion(agentDID, baseline);
+      const getResourceWithSnapshot = vi
+        .fn()
+        .mockResolvedValue({ snapshot: available ? snapshot : undefined });
+      (store as unknown as { clientDb: ClientDb }).clientDb = {
+        isReady: true,
+        getResourceWithSnapshot,
+      } as unknown as ClientDb;
+      postCommitSpy.mockClear();
+      await store.syncDirtyResources();
+      assert(getResourceWithSnapshot).toHaveBeenCalledWith(agentDID);
+      assert(store.outbox.getEntry(agentDID) === undefined).toBe(available);
+      assert(postCommitSpy).not.toHaveBeenCalled();
+      store.setServerConnected(false);
+      store.outbox.clearDirty(agentDID);
+    },
+  );
 });

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -69,6 +69,42 @@ describe('Store', () => {
     ).toBe(true);
   });
 
+  it('persists merged state when an older resource arrives after an acknowledged edit', async ({
+    expect,
+  }) => {
+    const { store } = await testStore();
+    const resource = await store.newResource({
+      isA: core.classes.resource,
+      propVals: { [core.properties.name]: 'Before' },
+    });
+    await resource.save();
+    const older = new Resource(resource.subject);
+    older.setStore(store);
+    older.importLoroUpdate(
+      resource.getLoroDoc()!.export({ mode: 'snapshot' }),
+      true,
+    );
+    const putResourceWithSnapshot = vi.fn().mockResolvedValue(undefined);
+    store.setClientDb({
+      isReady: true,
+      flush: async () => undefined,
+      putResourceWithSnapshot,
+    } as unknown as Parameters<Store['setClientDb']>[0]);
+    await resource.set(core.properties.name, 'After', false);
+    await resource.save();
+    store.addResource(older, { skipCommitCompare: true });
+    expect(
+      store.resources.get(resource.subject)!.get(core.properties.name),
+    ).toBe('After');
+    expect(putResourceWithSnapshot).toHaveBeenCalled();
+    const [, json, snapshot] = putResourceWithSnapshot.mock.calls.at(-1)!;
+    expect(JSON.parse(json)[core.properties.name]).toBe('After');
+    const persisted = new Resource(resource.subject);
+    persisted.setStore(store);
+    persisted.importLoroUpdate(snapshot, true);
+    expect(persisted.get(core.properties.name)).toBe('After');
+  });
+
   it.each(['snapshot', 'flush'])(
     'an acknowledged edit waits for local %s before save resolves',
     async stage => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1292,6 +1292,8 @@ export class Store {
     // Then rewind the cursor to the synced baseline so the export emits the
     // offline delta. No-op during normal online operation (`baseVersion` is
     // only set on the offline path).
+    let offlineSnapshotLoaded = false;
+
     if (entry.baseVersion) {
       if (this.clientDb && !this.clientDb.isReady) {
         this.emitSyncStatus();
@@ -1313,7 +1315,10 @@ export class Store {
           if (refreshed && snapshot && snapshot.length > 0) {
             // OPFS stores a full snapshot — replace any server-hydrated doc
             // that raced ahead of the offline local state.
-            refreshed.importLoroUpdate(snapshot, true);
+            offlineSnapshotLoaded = refreshed.importLoroUpdate(
+              snapshot,
+              true,
+            ).complete;
           }
 
           if (refreshed) resource = refreshed;
@@ -1343,11 +1348,17 @@ export class Store {
     let exported = resource.exportLoroDeltaForDrain(isFirstCommit, commitToken);
 
     if (!exported) {
-      if (entry.baseVersion && postedGenesis) {
-        // Genesis already captured the doc. An empty follow-up is "caught
-        // up", not "OPFS not ready" — leaving dirty here is what stranded
-        // `offline-create-then-online` (pendingDirtyCount stuck at 1,
-        // hasSignedGenesis false, drain spinning).
+      if (
+        entry.baseVersion &&
+        (postedGenesis ||
+          (offlineSnapshotLoaded &&
+            resource.hasLoroDoc() &&
+            !resource.hasOpsPastSaveCursor()))
+      ) {
+        // A complete local snapshot equal to the last synced baseline has
+        // nothing left to send. Idempotent offline saves (e.g. re-linking an
+        // existing personal drive) still enqueue a baseline. Clear them only
+        // after reading that snapshot, never from a possibly stale server copy.
         this.outbox.clearBaseVersion(subject);
         this.outbox.clearDirty(subject);
         this.emitSyncStatus();
@@ -2034,6 +2045,10 @@ export class Store {
 
     const emitResource = storeResource ?? resource.__internalObject;
 
+    // Persist the canonical merged resource, not the incoming snapshot. An
+    // older response may contribute valid CRDT history without replacing a
+    // newer local edit; writing the incoming object would roll back OPFS while
+    // mounted readers continue to show the merged (correct) state.
     // Atomic put queued BEFORE notify. The worker's serialised
     // queue means a follow-up `queryLocalDb` (e.g. from
     // Collection.refresh in a notify listener) sees the new
@@ -2050,7 +2065,7 @@ export class Store {
       // the `lastCommit` skip above, they are re-added (and so re-written) on
       // every refresh. Building one table from a template wrote a single
       // collection page seven times.
-      !resource.hasClasses(collections.classes.collection) &&
+      !emitResource.hasClasses(collections.classes.collection) &&
       // Skip persisting when the worker has a known init failure (e.g.
       // OPFS leader-election couldn't steal the lock — Firefox doesn't
       // support `navigator.locks.request({ steal: true })`). Without this
@@ -2059,19 +2074,19 @@ export class Store {
       // stack trace per resource. The worker itself has already warned
       // once when init failed — that single line is the actionable signal.
       !this.clientDb.initError &&
-      !resource.loading &&
-      !resource.new &&
-      !resource.hasPendingCommits &&
-      !resource.get(core.properties.incomplete)
+      !emitResource.loading &&
+      !emitResource.new &&
+      !emitResource.hasPendingCommits &&
+      !emitResource.get(core.properties.incomplete)
     ) {
       try {
-        const jsonAd = resourceToJsonAd(resource);
+        const jsonAd = resourceToJsonAd(emitResource);
 
         if (jsonAd) {
-          const doc = resource.getLoroDoc?.();
+          const doc = emitResource.getLoroDoc?.();
           // A snapshot export commits pending ops, untagged; keep a
           // mid-edit persist from stripping the edit's history token.
-          resource.sealPendingEdits();
+          emitResource.sealPendingEdits();
           const snapshot = doc?.export({ mode: 'snapshot' });
 
           // One local-DB write costs ~9ms, three quarters of it rebuilding
@@ -2088,16 +2103,16 @@ export class Store {
           // is a cache, not the record.
           const stamp = hashPersistedState(jsonAd, snapshot);
 
-          if (this.lastPersistedStamp.get(resource.subject) !== stamp) {
-            this.lastPersistedStamp.set(resource.subject, stamp);
+          if (this.lastPersistedStamp.get(emitResource.subject) !== stamp) {
+            this.lastPersistedStamp.set(emitResource.subject, stamp);
             this.clientDb
-              .putResourceWithSnapshot(resource.subject, jsonAd, snapshot)
+              .putResourceWithSnapshot(emitResource.subject, jsonAd, snapshot)
               .catch(e => {
                 // Failed write: drop the stamp so the next attempt is not
                 // skipped as a duplicate of a write that never landed.
-                this.lastPersistedStamp.delete(resource.subject);
+                this.lastPersistedStamp.delete(emitResource.subject);
                 console.error(
-                  `[ClientDb] put failed for ${resource.subject.slice(0, 60)}:`,
+                  `[ClientDb] put failed for ${emitResource.subject.slice(0, 60)}:`,
                   e,
                 );
               });
@@ -2105,7 +2120,7 @@ export class Store {
         }
       } catch (e) {
         console.error(
-          `[ClientDb] put serialization threw for ${resource.subject.slice(0, 60)}:`,
+          `[ClientDb] put serialization threw for ${emitResource.subject.slice(0, 60)}:`,
           e,
         );
       }

--- a/browser/package.json
+++ b/browser/package.json
@@ -14,7 +14,7 @@
     "vitest": "^4.1.7"
   },
   "name": "@tomic/root",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/browser/plugin/package.json
+++ b/browser/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tomic/plugin",
   "type": "module",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "description": "Utils for building UI plugins for AtomicServer",
   "author": "Polle Pas <polle@ontola.io>",
   "license": "MIT",

--- a/browser/react/package.json
+++ b/browser/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/react",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "author": "Joep Meindertsma",
   "description": "Atomic Data React library",
   "homepage": "https://docs.atomicdata.dev/usecases/react",

--- a/browser/svelte/package.json
+++ b/browser/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ontola, Polle Pas",
   "name": "@tomic/svelte",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "license": "MIT",
   "homepage": "https://docs.atomicdata.dev/svelte",
   "repository": {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT"
 name = "atomic-cli"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 
 [dependencies]
 async-recursion = "1.1.1"
-atomic_lib = { version = "0.41.0-beta.5", path = "../lib", features = [
+atomic_lib = { version = "0.41.0-beta.6", path = "../lib", features = [
     "config",
     "rdf",
 ] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ name = "atomic-server-tauri"
 # crates.io forbids — see the note on `publish` in ../wasm/Cargo.toml.
 publish = false
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Atomic Server",
-  "version": "0.41.0-beta.5",
+  "version": "0.41.0-beta.6",
   "identifier": "io.ontola.atomicserver",
   "build": {
     "frontendDist": "../browser/data-browser/dist-tauri",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "atomic_lib"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 
 
 [dependencies]

--- a/planning/beta6-e2e-results.md
+++ b/planning/beta6-e2e-results.md
@@ -1,74 +1,39 @@
-# Beta.6 local E2E results — 2026-09-09
+# Beta.6 local E2E validation — 2026-09-09
 
-Tested commit: c9fe15630. Scope: the full Atomic Server Playwright suite, including configured Firefox locks and opt-in WebKit storage tests, with local SaaS/Vault services. This is not real Tauri device acceptance or a full SaaS portal-suite run.
+Scope: the full Atomic Server Playwright suite, including Firefox locks and opt-in WebKit storage tests, with local SaaS/Vault services. This is not native Tauri acceptance or the full SaaS portal suite.
 
-## Results
+## Current validation
 
-- Full pass: 164 passed, 29 failed, 6 skipped, 1 not run (9.6 minutes).
-- Single-worker failed-case rerun: 8 passed, 21 failed (7.3 minutes).
-- After building CLI/Svelte dependencies, both template cases passed individually, including the previously unrun serial Svelte case.
-- Latest result per case across runs: **174 passed, 20 failed, 6 skipped**. This is not one clean full-suite pass.
+- [x] Original failures reproduced and investigated.
+- [x] Affected scenarios passed on focused reruns, including offline sync, private plugin rendering, Vault, and WebKit storage.
+- [x] Library tests: 64 files, 392 tests passed.
+- [x] Frontend production build and typecheck passed.
+- [x] Final full 201-case run after the cache fix: **195 passed, 6 existing skips, zero failures (9.3 minutes)**. Playwright exited 0 and reported no failed tests.
+- [x] Native server build, targeted formatting/lint checks, and git diff --check passed. The full Rust test suite was not rerun.
 
-Initial setup failures involved the preview proxy, VITE_E2E and the managed API address. These were corrected before the failed-case rerun. Test services used ports 6757/9893/3040 and MinIO 9110, with disposable databases.
+## Changes
 
-## Remaining failures
+- Dashboard reload diagnosis found that an older resource response was merged correctly in memory but persisted unmerged to OPFS. Cache writes now serialize the canonical merged resource; the regression is covered in store.test.ts and the dashboard reload E2E.
 
-- [chromium] › tests/canvas-live-update.spec.ts:71:7 › canvas live update › a stroke drawn in one session appears live in another session viewing the same canvas
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/documents.spec.ts:41:7 › documents › create document, edit, page title, websockets
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/documents.spec.ts:175:7 › documents › shows a collaborator’s ephemeral cursor position
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/kanban.spec.ts:376:7 › kanban › view tab menu: change type, duplicate, and delete
-  - TimeoutError: locator.click: Timeout 10000ms exceeded.
-- [chromium] › tests/meetings.spec.ts:113:5 › start a meeting, join it, follow along, and end it
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/meetings.spec.ts:237:5 › records join and leave in the meeting chat ────────
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/offline-create-then-online.spec.ts:26:7 › offline create → online sync → disable localDB › offline-created drive loads after disabling localDB
-  - Error: waitForSynced timed out. Outbox diagnostics: {"status":{"serverConnected":true,"syncInProgress":true,"pendingDirtyCount":1,"blockedCount":0,"serverUrl":"http://localhost:9893","drive":"did:ad:JsacRosa93F_ZoKH7dRPT1skj854W8E3u9j0e88g2tmZw7yVmq5RkjhoU3U7CdSuGKnMQgHQ2r9lpaSa0q7RBA","clientDbReady":true,"clientDbAttached":true,"lastDriveSync":{"drive":"did:ad:JsacRosa93F_ZoKH7dRPT1skj854W8E3u9j0e88g2tmZw7yVmq5Rkjh
-- [chromium] › tests/onboarding.spec.ts:13:7 › onboarding › create new identity with verifySecret flow - profile name persists
-  - TimeoutError: locator.press: Timeout 10000ms exceeded.
-- [chromium] › tests/plugin.spec.ts:21:7 › Plugins › install a plugin ───────────────────────────
-  - Error: expect(locator).toBeVisible() failed
-- [chromium] › tests/presence-follow.spec.ts:27:5 › presence avatars and follow mode across two sessions
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/second-device-load.spec.ts:18:5 › a fresh-OPFS second device loads an existing drive’s contents @smoke
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/sign-in-without-data.spec.ts:62:7 › signing in on a device that holds none of the account’s data › stops, and says so, instead of opening a workspace
-  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
-- [chromium] › tests/sign-in-without-data.spec.ts:80:7 › signing in on a device that holds none of the account’s data › leaves no other workspace active
-  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
-- [chromium] › tests/sign-in-without-data.spec.ts:99:7 › signing in on a device that holds none of the account’s data › names the account’s own drive as the place to write
-  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
-- [chromium] › tests/signout-signin-data.spec.ts:145:7 › sign-out / sign-in round trip › content made before signing out is still readable after signing back in
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/signout-signin-data.spec.ts:172:7 › sign-out / sign-in round trip › the local database key survives sign-out and is restored on sign-in
-  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
-- [chromium] › tests/vault-backup-restore.spec.ts:236:7 › Cloud Vault backup and restore › a second backup after an edit stores more than the first
-  - Error: signup failed: 400 {"error":"Enter a single valid email address, like name@example.com."}
-- [chromium] › tests/vault-backup-restore.spec.ts:283:7 › Cloud Vault backup and restore › a device with no local data restores the workspace from the vault
-  - Error: signup failed: 400 {"error":"Enter a single valid email address, like name@example.com."}
-- [webkit] › tests/signout-signin-data.spec.ts:145:7 › sign-out / sign-in round trip › content made before signing out is still readable after signing back in
-  - TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
-- [webkit] › tests/signout-signin-data.spec.ts:172:7 › sign-out / sign-in round trip › the local database key survives sign-out and is restored on sign-in
-  - TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+- Sign-in tests stop acting on the input after automatic submission and wait for the signed-in state. Storage tests navigate through the app instead of interrupting background requests with hard navigations.
+- The outgoing data route no longer fetches an incoming `/app/` screen as a resource.
+- Private plugin assets are fetched with signed requests in the parent and passed into the sandbox. The server enforces an opaque origin even without iframe sandbox attributes; the E2E suite checks this directly.
+- Offline saves with no changes beyond the synced baseline clear only after loading a complete local snapshot. Unit tests verify that missing snapshots leave the queue intact.
+- The duplicated-view test waits for selection before opening the active tab menu.
+- Vault signup uses a valid example.com email fixture. macOS WebKit storage tests use fresh regular profiles because ephemeral contexts reject OPFS.
 
-## Interpretation and next work
+## Local setup
 
-- [ ] Investigate the disappearing Agent secret field: shared helper blur/Enter waits block several collaboration, second-device and storage assertions.
-- [ ] Investigate /app/welcome 404 diagnostics in signed-out and no-data flows.
-- [ ] Investigate offline agent outbox drain, kanban deletion menu and plugin iframe rendering.
-- [ ] Update Vault test email fixtures to valid domains accepted by the security validator, then actually exercise backup/restore. Current failures stop at signup.
-- [ ] Diagnose WebKit dev-drive setup timeouts.
-- [ ] Obtain a clean full-suite run after fixes; keep the release draft.
+Frontend preview 6757, Atomic Server 9893, local SaaS 3040, MinIO 9110. Build variables: VITE_E2E=true, VITE_ATOMIC_SERVER_URL=http://localhost:9893, VITE_MANAGED_API_BASE=http://localhost:3040/api, VITE_MANAGED_PORTAL_URL=http://localhost:3040. Preview also receives VITE_ATOMIC_SERVER_URL for its proxy. Wait for `/server` readiness before starting tests.
 
-Skips: four opt-in performance instrumentation cases, one existing drafts fixme, and the existing Cmd+M context-menu fixme. No test was newly disabled.
+MinIO refused uploads with 507 because the host was below its free-disk threshold. The disposable `atomic-beta6-e2e-minio-memory` container instead uses a 1 GiB tmpfs at /data with the atomic-vault-e2e bucket. The original test data remains untouched.
 
-## Local artifacts
+## Previous baseline and artifacts
 
-- Full report: /tmp/beta6-e2e-first/playwright-report/index.html
-- Failed-case rerun report: /tmp/beta6-e2e-rerun/playwright-report/index.html
-- Logs: /tmp/beta6-e2e.log, /tmp/beta6-e2e-rerun.log, /tmp/beta6-next-e2e.log, /tmp/beta6-svelte-e2e.log
+Before these fixes, latest results across the initial full run and reruns were 174 passed, 20 failed, 6 skipped; this was not a clean full pass. Earlier reports remain at /tmp/beta6-e2e-first/playwright-report/index.html and /tmp/beta6-e2e-rerun/playwright-report/index.html.
 
-Reports contain screenshots and traces. These temporary local paths are not CI artifacts and are not committed.
+Previous full-run log: /tmp/beta6-e2e-final.log; report preserved at /tmp/beta6-full-before-cache-fix/playwright-report/index.html. Focused logs: /tmp/beta6-fixes2-e2e.log, /tmp/beta6-final-focused.log, /tmp/beta6-plugin-webkit-final.log, /tmp/beta6-webkit-green.log. Reports and traces are temporary local artifacts, not CI evidence.
+
+Six pre-existing skips: four opt-in profiling cases, drafts fixme, and Cmd+M context-menu fixme. No new skips or diagnostic allowlists were added.
+
+Final log: /tmp/beta6-e2e-verified.log; HTML report: /tmp/beta6-e2e-verified/playwright-report/index.html. Test-owned services and MinIO were stopped after the run.

--- a/planning/beta6-e2e-results.md
+++ b/planning/beta6-e2e-results.md
@@ -1,0 +1,74 @@
+# Beta.6 local E2E results — 2026-09-09
+
+Tested commit: c9fe15630. Scope: the full Atomic Server Playwright suite, including configured Firefox locks and opt-in WebKit storage tests, with local SaaS/Vault services. This is not real Tauri device acceptance or a full SaaS portal-suite run.
+
+## Results
+
+- Full pass: 164 passed, 29 failed, 6 skipped, 1 not run (9.6 minutes).
+- Single-worker failed-case rerun: 8 passed, 21 failed (7.3 minutes).
+- After building CLI/Svelte dependencies, both template cases passed individually, including the previously unrun serial Svelte case.
+- Latest result per case across runs: **174 passed, 20 failed, 6 skipped**. This is not one clean full-suite pass.
+
+Initial setup failures involved the preview proxy, VITE_E2E and the managed API address. These were corrected before the failed-case rerun. Test services used ports 6757/9893/3040 and MinIO 9110, with disposable databases.
+
+## Remaining failures
+
+- [chromium] › tests/canvas-live-update.spec.ts:71:7 › canvas live update › a stroke drawn in one session appears live in another session viewing the same canvas
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/documents.spec.ts:41:7 › documents › create document, edit, page title, websockets
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/documents.spec.ts:175:7 › documents › shows a collaborator’s ephemeral cursor position
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/kanban.spec.ts:376:7 › kanban › view tab menu: change type, duplicate, and delete
+  - TimeoutError: locator.click: Timeout 10000ms exceeded.
+- [chromium] › tests/meetings.spec.ts:113:5 › start a meeting, join it, follow along, and end it
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/meetings.spec.ts:237:5 › records join and leave in the meeting chat ────────
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/offline-create-then-online.spec.ts:26:7 › offline create → online sync → disable localDB › offline-created drive loads after disabling localDB
+  - Error: waitForSynced timed out. Outbox diagnostics: {"status":{"serverConnected":true,"syncInProgress":true,"pendingDirtyCount":1,"blockedCount":0,"serverUrl":"http://localhost:9893","drive":"did:ad:JsacRosa93F_ZoKH7dRPT1skj854W8E3u9j0e88g2tmZw7yVmq5RkjhoU3U7CdSuGKnMQgHQ2r9lpaSa0q7RBA","clientDbReady":true,"clientDbAttached":true,"lastDriveSync":{"drive":"did:ad:JsacRosa93F_ZoKH7dRPT1skj854W8E3u9j0e88g2tmZw7yVmq5Rkjh
+- [chromium] › tests/onboarding.spec.ts:13:7 › onboarding › create new identity with verifySecret flow - profile name persists
+  - TimeoutError: locator.press: Timeout 10000ms exceeded.
+- [chromium] › tests/plugin.spec.ts:21:7 › Plugins › install a plugin ───────────────────────────
+  - Error: expect(locator).toBeVisible() failed
+- [chromium] › tests/presence-follow.spec.ts:27:5 › presence avatars and follow mode across two sessions
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/second-device-load.spec.ts:18:5 › a fresh-OPFS second device loads an existing drive’s contents @smoke
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/sign-in-without-data.spec.ts:62:7 › signing in on a device that holds none of the account’s data › stops, and says so, instead of opening a workspace
+  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
+- [chromium] › tests/sign-in-without-data.spec.ts:80:7 › signing in on a device that holds none of the account’s data › leaves no other workspace active
+  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
+- [chromium] › tests/sign-in-without-data.spec.ts:99:7 › signing in on a device that holds none of the account’s data › names the account’s own drive as the place to write
+  - Error: Unexpected browser warnings/errors (2); first 20 shown, full browser-diagnostics attached
+- [chromium] › tests/signout-signin-data.spec.ts:145:7 › sign-out / sign-in round trip › content made before signing out is still readable after signing back in
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/signout-signin-data.spec.ts:172:7 › sign-out / sign-in round trip › the local database key survives sign-out and is restored on sign-in
+  - TimeoutError: locator.blur: Timeout 10000ms exceeded.
+- [chromium] › tests/vault-backup-restore.spec.ts:236:7 › Cloud Vault backup and restore › a second backup after an edit stores more than the first
+  - Error: signup failed: 400 {"error":"Enter a single valid email address, like name@example.com."}
+- [chromium] › tests/vault-backup-restore.spec.ts:283:7 › Cloud Vault backup and restore › a device with no local data restores the workspace from the vault
+  - Error: signup failed: 400 {"error":"Enter a single valid email address, like name@example.com."}
+- [webkit] › tests/signout-signin-data.spec.ts:145:7 › sign-out / sign-in round trip › content made before signing out is still readable after signing back in
+  - TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+- [webkit] › tests/signout-signin-data.spec.ts:172:7 › sign-out / sign-in round trip › the local database key survives sign-out and is restored on sign-in
+  - TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+
+## Interpretation and next work
+
+- [ ] Investigate the disappearing Agent secret field: shared helper blur/Enter waits block several collaboration, second-device and storage assertions.
+- [ ] Investigate /app/welcome 404 diagnostics in signed-out and no-data flows.
+- [ ] Investigate offline agent outbox drain, kanban deletion menu and plugin iframe rendering.
+- [ ] Update Vault test email fixtures to valid domains accepted by the security validator, then actually exercise backup/restore. Current failures stop at signup.
+- [ ] Diagnose WebKit dev-drive setup timeouts.
+- [ ] Obtain a clean full-suite run after fixes; keep the release draft.
+
+Skips: four opt-in performance instrumentation cases, one existing drafts fixme, and the existing Cmd+M context-menu fixme. No test was newly disabled.
+
+## Local artifacts
+
+- Full report: /tmp/beta6-e2e-first/playwright-report/index.html
+- Failed-case rerun report: /tmp/beta6-e2e-rerun/playwright-report/index.html
+- Logs: /tmp/beta6-e2e.log, /tmp/beta6-e2e-rerun.log, /tmp/beta6-next-e2e.log, /tmp/beta6-svelte-e2e.log
+
+Reports contain screenshots and traces. These temporary local paths are not CI artifacts and are not committed.

--- a/planning/release-beta6.md
+++ b/planning/release-beta6.md
@@ -12,7 +12,7 @@ Status: preparation only; do not tag until the gates below pass.
 
 ## Local E2E evidence
 
-Full suite and isolated reruns completed on 2026-09-09: latest result per case is 174 passed, 20 failed, 6 skipped. See [detailed results](beta6-e2e-results.md). Release remains blocked.
+The full 201-case Playwright run passed: **195 passed, 6 existing skips, zero failures**. Library tests passed (392 tests), as did frontend typecheck, production frontend build and native server build. See [detailed results](beta6-e2e-results.md) for fixes, artifacts and scope. Release remains draft pending the release gates below.
 
 ## Release gates
 

--- a/planning/release-beta6.md
+++ b/planning/release-beta6.md
@@ -1,6 +1,6 @@
 # Prepare 0.41.0-beta.6
 
-Status: preparation only; do not tag until the gates below pass.
+Status: user authorized beta.6 publication after the passing full local E2E run on 2026-09-09. Publish the desktop/server beta using the existing workflow; npm automation in #1355 remains separate unfinished work.
 
 ## Prepared
 
@@ -12,9 +12,9 @@ Status: preparation only; do not tag until the gates below pass.
 
 ## Local E2E evidence
 
-The full 201-case Playwright run passed: **195 passed, 6 existing skips, zero failures**. Library tests passed (392 tests), as did frontend typecheck, production frontend build and native server build. See [detailed results](beta6-e2e-results.md) for fixes, artifacts and scope. Release remains draft pending the release gates below.
+The full 201-case Playwright run passed: **195 passed, 6 existing skips, zero failures**. Library tests passed (392 tests), as did frontend typecheck, production frontend build and native server build. See [detailed results](beta6-e2e-results.md) for fixes, artifacts and scope. The user approved release on this local E2E evidence. CI and device acceptance below remain explicitly unverified.
 
-## Release gates
+## Follow-up validation and publishing work
 
 - [ ] Green full CI on the final release commit, including downstream atomic-saas compatibility. Latest develop pipeline was still running when this PR was prepared.
 - [ ] Finish and merge #1355; plugin and edit-mode still need their first npm publication and Trusted Publisher setup. Do not assume OIDC can publish an unconfigured package.
@@ -24,7 +24,7 @@ The full 201-case Playwright run passed: **195 passed, 6 existing skips, zero fa
 - [ ] Test waiting for an offline source, then turning that source on with the discovery screen open.
 - [ ] Confirm staging runs compatible SaaS #54/#55 and server code; merging is not deployment evidence.
 - [ ] Review security compatibility: signed plugin-list/UI requests, node-bound Iroh auth and loopback binding for desktop/Android.
-- [ ] Move UNRELEASED notes to a dated beta.6 section only when ready to tag.
+- [x] Move UNRELEASED notes to a dated beta.6 section after release approval.
 - [ ] After approval, tag the reviewed commit; verify desktop artifacts, crate and npm beta versions, and updater metadata.
 
 ## Draft release highlights
@@ -33,4 +33,4 @@ Beta.6 focuses on restoring an existing workspace onto another device, clearer p
 
 Known limits: #1357 remains excluded at the user's request. First-publish npm setup is incomplete for plugin and edit-mode. Signed history envelopes do not yet travel through bulk sync or Cloud Vault.
 
-No tag, package publication, or deployment is part of this preparation PR.
+The user subsequently authorized tagging and publishing beta.6. Pre-release tags do not deploy production.

--- a/planning/release-beta6.md
+++ b/planning/release-beta6.md
@@ -10,6 +10,10 @@ Status: preparation only; do not tag until the gates below pass.
 - [x] Add recovery, discovery, per-drive sync and security notes under UNRELEASED.
 - [x] Configure npm Trusted Publishing for lib, react, svelte, cli and create-template: ontola/atomic-server, release.yml, direct publishing.
 
+## Local E2E evidence
+
+Full suite and isolated reruns completed on 2026-09-09: latest result per case is 174 passed, 20 failed, 6 skipped. See [detailed results](beta6-e2e-results.md). Release remains blocked.
+
 ## Release gates
 
 - [ ] Green full CI on the final release commit, including downstream atomic-saas compatibility. Latest develop pipeline was still running when this PR was prepared.

--- a/planning/release-beta6.md
+++ b/planning/release-beta6.md
@@ -1,0 +1,32 @@
+# Prepare 0.41.0-beta.6
+
+Status: preparation only; do not tag until the gates below pass.
+
+## Prepared
+
+- [x] Isolated PR branch from develop; beta.5 is the last prerelease.
+- [x] Bump all 17 version sites with scripts/bump-version.mjs.
+- [x] Regenerate Rust and pnpm lockfiles without dependency upgrades.
+- [x] Add recovery, discovery, per-drive sync and security notes under UNRELEASED.
+- [x] Configure npm Trusted Publishing for lib, react, svelte, cli and create-template: ontola/atomic-server, release.yml, direct publishing.
+
+## Release gates
+
+- [ ] Green full CI on the final release commit, including downstream atomic-saas compatibility. Latest develop pipeline was still running when this PR was prepared.
+- [ ] Finish and merge #1355; plugin and edit-mode still need their first npm publication and Trusted Publisher setup. Do not assume OIDC can publish an unconfigured package.
+- [ ] Verify a clean desktop install and an upgrade from beta.5 against staging: restore with the existing agent, discover or enter the staging server, fetch both private and shared drives, and compare actual content.
+- [ ] Verify live edits in both directions after fetching; account linking and a sync acknowledgement alone are insufficient.
+- [ ] Verify recovery-code secret reveal and additional passkey registration on mobile.
+- [ ] Test waiting for an offline source, then turning that source on with the discovery screen open.
+- [ ] Confirm staging runs compatible SaaS #54/#55 and server code; merging is not deployment evidence.
+- [ ] Review security compatibility: signed plugin-list/UI requests, node-bound Iroh auth and loopback binding for desktop/Android.
+- [ ] Move UNRELEASED notes to a dated beta.6 section only when ready to tag.
+- [ ] After approval, tag the reviewed commit; verify desktop artifacts, crate and npm beta versions, and updater metadata.
+
+## Draft release highlights
+
+Beta.6 focuses on restoring an existing workspace onto another device, clearer per-drive cloud status, recovery-code and passkey options, collaboration consistency, incremental backups, and authentication/sync security fixes.
+
+Known limits: #1357 remains excluded at the user's request. First-publish npm setup is incomplete for plugin and edit-mode. Signed history envelopes do not yet travel through bulk sync or Cloud Vault.
+
+No tag, package publication, or deployment is part of this preparation PR.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "atomic-server"
 readme = "./README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 
 [[bin]]
 name = "atomic-server"
@@ -168,7 +168,7 @@ version = "4.13.0"
 # present, so it adds no runtime cost for fresh installs.
 features = ["config", "db-redb", "db-sled", "rdf", "discovery", "iroh", "ring", "ws"]
 path = "../lib"
-version = "0.41.0-beta.5"
+version = "0.41.0-beta.6"
 
 [dependencies.clap]
 features = ["derive", "env", "cargo"]

--- a/server/src/handlers/plugin_ui.rs
+++ b/server/src/handlers/plugin_ui.rs
@@ -90,28 +90,11 @@ fn plugin_nonce() -> String {
 /// network response (not a client-side `srcdoc`) so it gets its OWN
 /// Content-Security-Policy instead of inheriting the parent SPA's nonce-locked
 /// CSP — otherwise the plugin's `<script>` is blocked on any CSP-enforced
-/// server. The plugin script is locked to a fresh per-response nonce; the host
-/// SPA hands over theme CSS via `postMessage` (see PluginView.tsx).
-fn render_plugin_ui_html(query_string: &str, css_exists: bool, nonce: &str) -> String {
-    // The query string is reflected into attributes of a same-origin page,
-    // so it must be attribute-escaped; a stray `"` would otherwise close the
-    // attribute and inject markup (a `<meta http-equiv=refresh>` is enough
-    // to redirect every visitor, CSP or not).
-    let query_string = super::single_page_app::escape_html(query_string);
-    let js_url = format!(
-        "/plugin-ui?{}",
-        query_string.replace("format=html", "format=js")
-    );
-    let css_link = if css_exists {
-        let css_url = format!(
-            "/plugin-ui?{}",
-            query_string.replace("format=html", "format=css")
-        );
-        format!(r#"<link rel="stylesheet" href="{css_url}" />"#)
-    } else {
-        String::new()
-    };
-
+/// server. The parent fetches private assets with signed requests, then hands
+/// their contents to this shell. Only messages from that parent can install
+/// the module, which is locked to a fresh per-response nonce. No credentials
+/// are exposed to the null-origin plugin (see PluginView.tsx).
+fn render_plugin_ui_html(nonce: &str) -> String {
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -119,14 +102,26 @@ fn render_plugin_ui_html(query_string: &str, css_exists: bool, nonce: &str) -> S
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Plugin</title>
-{css_link}
 <style id="__atomic_theme"></style>
-<script type="module" src="{js_url}" nonce="{nonce}"></script>
 <script nonce="{nonce}">
+var loaded = false;
 window.addEventListener('message', function (e) {{
+  if (e.source !== window.parent) return;
   if (e.data && e.data.type === '__atomic_style') {{
     var s = document.getElementById('__atomic_theme');
     if (s) s.textContent = e.data.css;
+  }}
+  if (!loaded && e.data && e.data.type === '__atomic_plugin_assets' &&
+      typeof e.data.js === 'string' && typeof e.data.css === 'string') {{
+    loaded = true;
+    var style = document.createElement('style');
+    style.textContent = e.data.css;
+    document.head.appendChild(style);
+    var script = document.createElement('script');
+    script.type = 'module';
+    script.nonce = '{nonce}';
+    script.textContent = e.data.js;
+    document.head.appendChild(script);
   }}
 }});
 if (window.parent) window.parent.postMessage({{ type: '__atomic_plugin_ready' }}, '*');
@@ -158,12 +153,11 @@ pub async fn handle_plugin_ui(
     // `html` is generated (not a file on disk): serve the iframe host document
     // with its own CSP so the plugin script isn't blocked by the parent CSP.
     if format == "html" {
-        let css_exists =
-            get_plugin_file_path(&appstate, drive_subject, plugin_name, "css")?.exists();
         let nonce = plugin_nonce();
-        let body = render_plugin_ui_html(req.query_string(), css_exists, &nonce);
+        let body = render_plugin_ui_html(&nonce);
         let csp = format!(
-            "default-src 'none'; script-src 'nonce-{nonce}'; style-src 'unsafe-inline' 'self'; \
+            "sandbox allow-scripts allow-downloads allow-pointer-lock allow-presentation; \
+             default-src 'none'; script-src 'nonce-{nonce}'; style-src 'unsafe-inline' 'self'; \
              img-src * data:; connect-src *; font-src *; base-uri 'none'; object-src 'none';"
         );
 


### PR DESCRIPTION
Prepare 0.41.0-beta.6 with synchronized Rust, desktop, JS package and starter-template versions, regenerated lockfiles, and recovery, discovery, per-drive sync and security release notes.

Fix the regressions exposed by the full release E2E run:

- Persist the canonical merged resource to OPFS so an older response cannot undo an acknowledged edit after reload.
- Fetch private plugin assets with signed parent requests and pass their contents to the plugin frame. Enforce an opaque sandbox origin on the server response; credentials stay outside the frame.
- Clear an unchanged offline outbox entry only after loading its complete local snapshot. Missing snapshots remain queued.
- Stop outgoing resource routes from fetching incoming app screens. Correct sign-in/navigation races, duplicated-tab selection, Vault email fixtures and macOS WebKit storage setup in the tests.

Validation on the final code: **195 Playwright cases passed, 6 existing skips, zero failures (9.3 minutes)**, covering Chromium, Firefox locks, opt-in WebKit storage and local SaaS/Vault integration. No new skips or diagnostic allowlists. **392 library tests passed**; frontend typecheck, production frontend build, native server build, targeted lint/format checks and git diff --check passed. Regression coverage includes cache persistence, missing-snapshot outbox behavior, plugin rendering and server-enforced plugin sandboxing. This is local evidence; the full Rust and SaaS portal suites and native Tauri acceptance were not run.

See planning/beta6-e2e-results.md for reproducible setup and artifacts. The release checklist in planning/release-beta6.md retains CI, real-device acceptance, staging compatibility and npm first-publish gates. #1355 remains a prerequisite; plugin and edit-mode still need their first publication and Trusted Publisher setup. #1357 is deliberately excluded.

After the full local E2E pass, the user authorized beta.6 publication. Release notes are dated 2026-09-09 and this PR is merged for tagging. Desktop/server publication uses the existing release workflow; npm automation in #1355 remains unfinished and is not included. CI and real-device acceptance remain separate unverified evidence.
