### PR TITLE
Fix drive selection, sync refresh, and cloud account status

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -543,3 +543,5 @@ This does not yet prove restoration of the user's private staging workspace.
 - `signout-signin-data.spec.ts` uses fresh persistent profiles on macOS WebKit because ephemeral contexts reject OPFS; these remain browser tests, not native Tauri acceptance.
 
 - `browser/lib/src/store.test.ts`: receiving an older resource preserves the merged value in both JSON and the persisted Loro snapshot; dashboard configuration reload exercises the real OPFS path.
+
+Drive changes and reauthentication on an already-open WebSocket: `browser/lib/src/websockets.test.ts` verifies a fresh SYNC is sent without reconnecting, including local-only drive exclusion. This covers the Sync page remaining at Connecting after sign-in or drive switching; live staging acceptance remains separate.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -511,10 +511,13 @@ the reader's active drive to receive live updates.
 
 `driveSyncStatus.test.ts` rejects another drive's sync timestamp and scopes
 asynchronous hosting/usage results to the selected drive and server. It covers
-unenrolled/local drives and shared drives confirmed directly by their node.
-`sync-devices.spec.ts` renders a managed connection with zero data for the selected
-drive, injects another drive's completed sync, and verifies that Cloud Server
-stays off with its setup action visible.
+unenrolled/local drives, unknown enrollment, and the requirement for both enrollment and remote data before claiming hosted service. Node synchronization remains a separate status.
+`sync-devices.spec.ts` renders a managed connection with data but no enrollment,
+injects another drive's completed sync, and verifies that Cloud Server does not
+claim hosting. It checks unknown recovery wording, account refresh on window focus,
+and missing translation markers. `saved-drives.spec.ts` checks that a portal Open
+link selects the requested drive, consumes the drive parameter, and preserves
+current-drive behavior for ordinary resource links.
 
 - Managed Vault display metadata: `vaultAutoBackup.test.ts` now covers a drive
   present only in local storage, as well as rename/emoji refresh. Manual enable

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Reconcile the selected cloud drive after switching drives or signing in on an open connection, so Sync no longer waits for a page refresh to confirm its status.
+
 ## [v0.41.0-beta.6] - 2026-09-09
 
 - An older server response no longer rolls back the local cache after an edit, fixing dashboard configuration reverting on reload.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Portal Open links select their workspace; ordinary resource links keep the current drive.
+- Sync distinguishes remote node data from Cloud Server enrollment, explains drive-specific plans, and refreshes account/recovery status after portal sign-in.
+- Account linking explains its purpose without implying another purchase or workspace transfer.
+
 - Reconcile the selected cloud drive after switching drives or signing in on an open connection, so Sync no longer waits for a page refresh to confirm its status.
 
 ## [v0.41.0-beta.6] - 2026-09-09

--- a/browser/data-browser/src/components/Vault/LinkProviderPanel.tsx
+++ b/browser/data-browser/src/components/Vault/LinkProviderPanel.tsx
@@ -97,6 +97,7 @@ export function LinkProviderPanel({
     }
   }
 
+  const explanation = `Connect this app to your existing ${providerName(portalUrl)} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace.`;
   const body = request ? (
     <>
       <Sub>
@@ -115,14 +116,7 @@ export function LinkProviderPanel({
     </>
   ) : (
     <>
-      {!compact && (
-        <Sub>
-          This app cannot sign in on its own, so approve it from somewhere you
-          already are. Then it can keep an encrypted copy of your workspaces —
-          sealed here, so {providerName(portalUrl)} stores it without being able
-          to read it.
-        </Sub>
-      )}
+      {!compact && <Sub>{explanation}</Sub>}
       {error && <ErrorText data-testid='link-error'>{error}</ErrorText>}
       <Actions $compact={compact}>
         <Button
@@ -134,7 +128,7 @@ export function LinkProviderPanel({
             ? 'Getting a code…'
             : compact
               ? `Connect to ${providerName(portalUrl)}`
-              : 'Connect this device'}
+              : 'Connect existing account'}
         </Button>
       </Actions>
     </>

--- a/browser/data-browser/src/helpers/driveSyncStatus.test.ts
+++ b/browser/data-browser/src/helpers/driveSyncStatus.test.ts
@@ -26,10 +26,12 @@ describe('Cloud Server requires evidence for the selected drive', () => {
     expect(hasHostedDriveConnection(false, true, true, 28)).toBe(false);
   });
 
-  it('recognizes an enrolled drive and a colleague with node-confirmed data', () => {
-    expect(hasHostedDriveConnection(true, true, true, undefined)).toBe(true);
-    expect(hasHostedDriveConnection(true, true, false, 28)).toBe(true);
+  it('requires enrollment and a populated remote copy to claim hosting', () => {
+    expect(hasHostedDriveConnection(true, true, true, undefined)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, false, 28)).toBe(false);
     expect(hasHostedDriveConnection(true, false, true, 28)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, null, 28)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, true, 28)).toBe(true);
   });
 
   it('discards usage or enrollment from another drive or server immediately', () => {

--- a/browser/data-browser/src/helpers/driveSyncStatus.ts
+++ b/browser/data-browser/src/helpers/driveSyncStatus.ts
@@ -63,11 +63,9 @@ export function hasHostedDriveConnection(
   enrolled: boolean | null,
   resourceCount: number | undefined,
 ): boolean {
-  // A colleague can verify the shared drive directly on its node without
-  // access to the owner's billing account. A global connection is not proof.
+  // Node synchronization is shown independently in Devices. Data on a managed
+  // node alone does not prove this account has hosting enabled for this drive.
   return (
-    liveSyncedDrive &&
-    managed &&
-    (enrolled === true || (resourceCount ?? 0) > 0)
+    liveSyncedDrive && managed && enrolled === true && (resourceCount ?? 0) > 0
   );
 }

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Entsperren mit einem Passkey fehlgeschlagen. Verwende stattdessen deinen Wiederherstellungscode."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -6562,9 +6562,8 @@ msgstr "Waiting for you to approve it…"
 msgid "Getting a code…"
 msgstr "Getting a code…"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr "Connect this device"
+#~ msgid "Connect this device"
+#~ msgstr "Connect this device"
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6813,10 +6812,8 @@ msgstr "{0} failed: {1}"
 msgid "Sign in →"
 msgstr "Sign in →"
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6828,7 +6825,6 @@ msgstr "{0}. We hold your key sealed, so this email gets you back in on a new de
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr "{0}. No recovery backup stored, so losing every device loses this workspace."
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr "Set up email recovery"
@@ -7216,13 +7212,11 @@ msgstr "Couldn’t reach {0}. Check your connection and try again."
 msgid "Connect to {0}"
 msgstr "Connect to {0}"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr "stores it without being able to read it."
+#~ msgid "stores it without being able to read it."
+#~ msgstr "stores it without being able to read it."
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7387,9 +7381,8 @@ msgstr "Local stays on your devices. Vault is encrypted backup. Server hosts a r
 #~ msgid "Choose Server plan"
 #~ msgstr "Choose Server plan"
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7804,3 +7797,37 @@ msgstr "<0>Save this recovery code.</0> It gets you back in on a new device, and
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Could not unlock with a passkey. Use your recovery code instead."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr "Connect existing account"
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr "Error: Sign in before syncing with another device"
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr "Sign in to check recovery"
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "No se pudo desbloquear con una clave de acceso. Usa tu código de recuperación."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Impossible de déverrouiller avec une clé d’accès. Utilisez votre code de récupération."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/routes/ShowRoute.tsx
+++ b/browser/data-browser/src/routes/ShowRoute.tsx
@@ -11,6 +11,8 @@ import { isOriginWithoutNode } from '../helpers/originNode';
 
 export type ShowRouteSearch = {
   subject: string;
+  /** Explicit workspace selection, as used by the portal Open action. */
+  drive?: string;
   /**
    * The active View of a Table, so switching tabs is linkable and lands in
    * browser history. Absent = the table's default view.
@@ -24,6 +26,10 @@ export const ShowRoute = createRoute({
   getParentRoute: () => appRoute,
   validateSearch: (search): ShowRouteSearch => ({
     subject: (search.subject as string) ?? '',
+    drive:
+      typeof search.drive === 'string' && Client.isValidSubject(search.drive)
+        ? search.drive
+        : undefined,
     view: (search.view as string) || undefined,
   }),
 });
@@ -32,7 +38,9 @@ export const ShowRoute = createRoute({
 export const ShowComponent: React.FunctionComponent = () => {
   // Value shown in navbar, after Submitting
   const subject = ShowRoute.useSearch({ select: state => state.subject });
-  const { agent } = useSettings();
+  const requestedDrive = ShowRoute.useSearch({ select: state => state.drive });
+  const view = ShowRoute.useSearch({ select: state => state.view });
+  const { agent, drive, setDrive } = useSettings();
   const store = useStore();
   const navigate = useNavigate();
 
@@ -46,6 +54,13 @@ export const ShowComponent: React.FunctionComponent = () => {
     !agent &&
     Client.isValidSubject(subject) &&
     isOriginWithoutNode(store.getServerUrl());
+
+  React.useEffect(() => {
+    if (signInFirst || !requestedDrive || requestedDrive !== subject) return;
+    if (drive !== requestedDrive) setDrive(requestedDrive);
+    // Consume the instruction so a later manual drive switch is not undone.
+    navigate({ to: paths.show, search: { subject, view }, replace: true });
+  }, [signInFirst, requestedDrive, subject, view, drive, setDrive, navigate]);
 
   React.useEffect(() => {
     if (!signInFirst) return;

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -703,12 +703,21 @@ function SyncPage() {
    * none", and telling someone their recovery is missing when the control
    * plane was merely unreachable is the one wrong answer this row can give.
    */
-  const [recoveryBackup, setRecoveryBackup] = useState<
-    'stored' | 'passkey-only' | 'device-only' | 'none' | null
-  >(null);
+  const [recoveryState, setRecoveryState] = useState<{
+    account: ManagedAccount;
+    value: 'stored' | 'passkey-only' | 'device-only' | 'none' | null;
+  } | null>(null);
+  const recoveryBackup =
+    recoveryState?.account === managedAccount
+      ? (recoveryState?.value ?? null)
+      : null;
 
   useEffect(() => {
     if (!managedAccount) return;
+
+    const setRecoveryBackup = (
+      value: NonNullable<typeof recoveryState>['value'],
+    ) => setRecoveryState({ account: managedAccount, value });
 
     let cancelled = false;
 
@@ -750,7 +759,10 @@ function SyncPage() {
   useEffect(() => {
     let cancelled = false;
 
-    void (async () => {
+    let generation = 0;
+
+    const refreshAccount = async () => {
+      const requestGeneration = ++generation;
       // Asked even when this device is already linked. The link only settles
       // *how* this client authenticates; it says nothing about who, and the
       // portal link needs the account itself.
@@ -759,7 +771,7 @@ function SyncPage() {
       try {
         const account = await getManagedAccount();
 
-        if (cancelled) return;
+        if (cancelled || requestGeneration !== generation) return;
 
         setManagedAccount(account);
         setNeedsProviderLink(!linked && account === null);
@@ -767,14 +779,25 @@ function SyncPage() {
         // Unreachable control plane. Offering to link is the useful answer —
         // the alternative is a Sync page that silently omits backup with no
         // way to ask for it.
-        if (!cancelled) setNeedsProviderLink(!linked);
+        if (!cancelled && requestGeneration === generation) {
+          setManagedAccount(null);
+          setNeedsProviderLink(!linked);
+        }
       }
-    })();
+    };
+
+    const onFocus = () => void refreshAccount();
+
+    void refreshAccount();
+    window.addEventListener('focus', onFocus);
+    const unsubscribe = store.on(StoreEvents.AgentChanged, onFocus);
 
     return () => {
       cancelled = true;
+      unsubscribe();
+      window.removeEventListener('focus', onFocus);
     };
-  }, []);
+  }, [status.drive, store]);
 
   useEffect(() => {
     const serverUrl = status.serverUrl;
@@ -873,7 +896,7 @@ function SyncPage() {
     return () => {
       cancelled = true;
     };
-  }, [status.drive, status.serverUrl, store]);
+  }, [status.drive, status.serverUrl, status.lastDriveSync?.timestamp, store]);
 
   // Plan quota — managed nodes only, from the control plane. Billing stays a
   // managed concern; the usage numbers above are generic to every node.
@@ -939,14 +962,13 @@ function SyncPage() {
           setCloudEnrollment({ drive, server: status.serverUrl, value: has });
       })
       .catch(() => {
-        if (!cancelled)
-          setCloudEnrollment({ drive, server: status.serverUrl, value: false });
+        if (!cancelled) setCloudEnrollment(null);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [status.drive, status.serverUrl, managedInfo]);
+  }, [status.drive, status.serverUrl, managedInfo, managedAccount]);
 
   useEffect(() => {
     const refresh = () => setStatus(store.getSyncStatus());
@@ -1516,7 +1538,7 @@ function SyncPage() {
                 <ConnTitle>Email recovery</ConnTitle>
                 <ConnSub>
                   {!managedAccount
-                    ? `Not set up. With an account on ${PRODUCT_NAME} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace.`
+                    ? `Sign in to your ${PRODUCT_NAME} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account.`
                     : recoveryBackup === null
                       ? `Signed in as ${managedAccount.email}.`
                       : recoveryBackup === 'stored'
@@ -1546,7 +1568,7 @@ function SyncPage() {
                     <LearnMore
                       {...externalLinkProps(`${accountPortalUrl}/signin`)}
                     >
-                      Set up email recovery
+                      Sign in to check recovery
                     </LearnMore>
                   </ConnActions>
                 ) : recoveryBackup === 'none' ||
@@ -1622,6 +1644,12 @@ function SyncPage() {
                     another device to be awake. Unlike Cloud Vault, our servers
                     process what you put here.
                   </ConnSub>
+                  <ConnMeta>
+                    {subscriptionStatus === 'active' ||
+                    subscriptionStatus === 'trialing'
+                      ? 'This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again.'
+                      : 'Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free.'}
+                  </ConnMeta>
                   {hostedCopyOrigin && (
                     <ConnMeta>
                       This workspace has been copied to Cloud Server. You’re
@@ -1699,8 +1727,9 @@ function SyncPage() {
             sharing permissions still control other users’ access.
           </p>
           <p>
-            Existing content stays in this drive. Hosting requires a Server plan
-            or an invitation for this drive.
+            Existing content stays in this drive. Hosting uses the Server plan
+            or invitation for this drive. If a purchase is needed, you will see
+            the price at checkout before paying.
           </p>
         </ConfirmationDialog>
 

--- a/browser/e2e/tests/saved-drives.spec.ts
+++ b/browser/e2e/tests/saved-drives.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { before, newDrive, openConfigureDrive } from './test-utils';
+import { before, newDrive, openConfigureDrive, FRONTEND_URL, currentDriveTitle } from './test-utils';
 
 /**
  * A drive you make is one of your drives.
@@ -13,6 +13,21 @@ import { before, newDrive, openConfigureDrive } from './test-utils';
  */
 test.describe('saved drives', () => {
   test.beforeEach(before);
+
+  test('a portal Open link selects its drive and consumes the instruction', async ({ page }) => {
+    const original = await page.evaluate(() => window.store.getDrive());
+    const originalTitle = await currentDriveTitle(page).textContent();
+    const { driveURL } = await newDrive(page);
+    const search = new URLSearchParams({ subject: original!, drive: original! });
+    await page.goto(`${FRONTEND_URL}/app/show?${search}`);
+    await expect.poll(() => page.evaluate(() => window.store.getDrive())).toBe(original);
+    await expect(currentDriveTitle(page)).toHaveText(originalTitle!);
+    await expect.poll(() => new URL(page.url()).searchParams.has('drive')).toBe(false);
+    // Ordinary resource links do not silently replace the selected workspace.
+    await page.goto(`${FRONTEND_URL}/app/show?${new URLSearchParams({ subject: driveURL })}`);
+    await expect(page.getByRole('button', { name: 'Set as current drive', exact: true })).toBeVisible();
+    expect(await page.evaluate(() => window.store.getDrive())).toBe(original);
+  });
 
   test('a drive you create is listed among your drives', async ({ page }) => {
     const { driveTitle } = await newDrive(page);

--- a/browser/e2e/tests/sync-devices.spec.ts
+++ b/browser/e2e/tests/sync-devices.spec.ts
@@ -31,6 +31,7 @@ test.describe('sync page devices', () => {
     page,
   }) => {
     let managedInfoRequests = 0;
+    let accountConnected = false;
     await page.route('**/server', async route => {
       const response = await route.fetch();
       const body = await response.json();
@@ -45,13 +46,15 @@ test.describe('sync page devices', () => {
       });
     });
     await page.route('**/drive-usage?**', route =>
-      route.fulfill({ json: { resourceCount: 0, blobBytes: 0, loroBytes: 0 } }),
+      route.fulfill({ json: { resourceCount: 3, blobBytes: 0, loroBytes: 7800 } }),
     );
     await page.route('**/api/**', route => {
       const path = new URL(route.request().url()).pathname;
 
       return path === '/api/me'
-        ? route.fulfill({ status: 204 })
+        ? accountConnected
+          ? route.fulfill({ json: { email: 'sync-account@example.com' } })
+          : route.fulfill({ status: 204 })
         : route.fulfill({ json: [] });
     });
     await gotoSync(page);
@@ -64,9 +67,17 @@ test.describe('sync page devices', () => {
     await expect(cloud).not.toContainText('In sync');
     await expect(cloud).not.toContainText('Synced');
     await expect(cloud).not.toContainText('Cloud Server is on');
+    const recovery = page.getByTestId('recovery-row');
+    await expect(recovery).toContainText('Sign in to your');
+    await expect(recovery).not.toContainText('Not set up');
+    await expect(page.locator('body')).not.toContainText('[i18n-404:');
     await expect(
       cloud.getByRole('button', { name: 'Set up Cloud Server', exact: true }),
     ).toBeVisible();
+    accountConnected = true;
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect(recovery).toContainText('sync-account@example.com');
+    await expect(page.getByTestId('link-provider-panel')).not.toBeVisible();
   });
 
   test('the pairing code on screen is a routable envelope', async ({

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -300,7 +300,11 @@ test.describe('Cloud Vault backup and restore', () => {
     // makes "it came back" mean "it came back from the vault".
     await page.evaluate(() => {
       const store = window.store;
-      store.registerLocalOnlyDrive(store.getDrive());
+      const drive = store.getDrive();
+
+      if (!drive) throw new Error('Vault test needs a selected drive');
+
+      store.registerLocalOnlyDrive(drive);
       store.getDefaultWebSocket()?.close();
     });
 

--- a/browser/lib/src/offline-create-drain.test.ts
+++ b/browser/lib/src/offline-create-drain.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, vi, expect as assert } from 'vitest';
 import { server } from './ontologies/server.js';
 import { testStore } from './test-store.js';
-import type { ClientDb } from './client-db.js';
+import type { ClientDbWorker } from './client-db.js';
 
 /**
  * Reproduces the develop full-e2e failure of
@@ -98,10 +98,10 @@ describe('offline create drain', () => {
       const getResourceWithSnapshot = vi
         .fn()
         .mockResolvedValue({ snapshot: available ? snapshot : undefined });
-      (store as unknown as { clientDb: ClientDb }).clientDb = {
+      (store as unknown as { clientDb: ClientDbWorker }).clientDb = {
         isReady: true,
         getResourceWithSnapshot,
-      } as unknown as ClientDb;
+      } as unknown as ClientDbWorker;
       postCommitSpy.mockClear();
       await store.syncDirtyResources();
       assert(getResourceWithSnapshot).toHaveBeenCalledWith(agentDID);

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -74,7 +74,6 @@ describe('Store', () => {
   }) => {
     const { store } = await testStore();
     const resource = await store.newResource({
-      isA: core.classes.resource,
       propVals: { [core.properties.name]: 'Before' },
     });
     await resource.save();

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -468,6 +468,77 @@ describe('WSClient drive subscription', () => {
     client.close();
   });
 
+  it('reconciles drives selected after authentication without reopening the socket', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('late-drive'));
+    const auth = client.authenticate();
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await auth;
+    await new Promise(resolve => setTimeout(resolve, 10));
+    vi.mocked(store.getDrive).mockRestore();
+    vi.spyOn(store, 'isLiveSyncedDrive').mockImplementation(
+      drive => drive !== 'did:ad:local',
+    );
+    vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
+      drive: 'did:ad:a',
+      driveHash: 'hash',
+      resources: {},
+      peers: [],
+    });
+
+    for (const drive of ['did:ad:a', 'did:ad:b']) {
+      const before = framesWithTag(socket, Tag.SYNC).length;
+      store.setDrive(drive);
+      await vi.waitFor(() =>
+        expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(before + 1),
+      );
+    }
+
+    const before = framesWithTag(socket, Tag.SYNC).length;
+    store.setDrive('did:ad:local');
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(before);
+    client.close();
+  });
+
+  it('reconciles the selected drive after reauthentication on an open socket', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('signin-drive'));
+    const initial = client.authenticate();
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await initial;
+    await new Promise(resolve => setTimeout(resolve, 10));
+    socket.sent.length = 0;
+    vi.mocked(store.getDrive).mockReturnValue('did:ad:a');
+    vi.spyOn(store, 'isLiveSyncedDrive').mockReturnValue(true);
+    vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
+      drive: 'did:ad:a',
+      driveHash: 'hash',
+      resources: {},
+      peers: [],
+    });
+    const auth = client.authenticate(true);
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await auth;
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.SYNC).length).toBeGreaterThan(0),
+    );
+    client.close();
+  });
+
   it('UNSUBs the previous drive when the store switches drives', async ({
     expect,
   }) => {

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -341,6 +341,7 @@ export class WSClient {
     this._driveUnsub = store.on(StoreEvents.DriveChanged, () => {
       this._pendingSyncState.clear();
       this.subscribeToDrive();
+      void this.reconcileSubscribedDrive();
     });
 
     const wsURL = new URL(url);
@@ -589,6 +590,8 @@ export class WSClient {
 
         // Refetch resources that had 401 errors
         if (fetchAll) {
+          await this.reconcileSubscribedDrive();
+
           for (const resource of this.store.resources.values()) {
             if (resource.isUnauthorized()) {
               this.fetch(resource.subject).catch(() => {});
@@ -1338,6 +1341,26 @@ export class WSClient {
       this.sendBinary(encodeSub(drive));
       this._subscribedDrive = drive;
     }
+  }
+
+  /** A SUB only enables future updates; it does not reconcile existing data.
+   * Drive selection and sign-in can happen on an already-open socket, without
+   * running handleOpen's initial sync. Reconcile only a drive we could subscribe
+   * under the current identity; never upload local-only or inaccessible drives. */
+  private async reconcileSubscribedDrive(): Promise<void> {
+    const drive = this.store.getDrive();
+    if (
+      this._closed ||
+      this.readyState !== WebSocket.OPEN ||
+      !drive ||
+      this._subscribedDrive !== drive ||
+      !this.store.isLiveSyncedDrive(drive) ||
+      (this.store.getAgent()?.subject &&
+        this.authenticatedWith !== this.store.getAgent()?.subject)
+    )
+      return;
+
+    await this.startVVSync(drive);
   }
 
   /** Agent profiles are public resources outside the reader's active drive. */


### PR DESCRIPTION
Drive changes and sign-in on an existing socket now start reconciliation, so Sync can confirm the selected drive without a refresh. Portal Open links explicitly select their drive and consume that instruction, preserving ordinary resource-link behavior.

The Sync page distinguishes node synchronization from paid hosting enrollment. A managed node containing data alone no longer claims Cloud Server is enabled. Hosting requires enrollment and a populated remote copy; ordinary node sync remains visible under Devices. Remote usage refreshes after reconciliation.

Missing portal sessions are shown as unknown recovery status, rather than “Not set up.” Account status refreshes on focus, identity changes and drive changes. Recovery results are scoped to the account. Linking copy explains that it connects an existing account without purchasing hosting or fetching a workspace; hosting copy explains drive-scoped plans and checkout before payment.

Paired portal PR: https://github.com/ontola/atomic-saas/pull/59 (explicit drive links and verified portal passkey login).

Validation:
- JS library suite: 394 tests passed, including new sign-in/drive-switch SYNC frame regressions.
- Drive status unit tests: 5 passed; the stronger hosting assertion failed before the fix.
- Two Chromium browser tests passed against the built app and an isolated real local node: explicit portal drive selection; unenrolled remote data, unknown recovery, focus refresh and no i18n error markers.
- Frontend and E2E TypeScript checks passed; frontend build passed. Fixed a pre-existing missing-drive guard that prevented E2E type checking.
- Changed-file lint has no errors (existing React-effect warnings remain).
- Reviewed catalog diffs; fresh dev extraction left all four catalogs unchanged.

No staging or production deployment has been performed for these changes. Earlier CI stopped while unpacking a wasm-pack dependency; the new push starts fresh checks.
