### PR TITLE
Fix staging sync, onboarding, recovery, and Sentry regressions

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -284,9 +284,10 @@ export class AtomicServer {
   ): Container {
     return container
       .withMountedCache(`${cargoHome}/registry`, dag.cacheVolume('cargo'), {
-        // Shared: Locked serialized every parallel CI lane behind whichever
-        // job held the volume. Cargo's own flock handles concurrent writers.
-        sharing: CacheSharingMode.Shared,
+        // Cargo locks live outside this registry mount, so separate containers
+        // cannot coordinate extraction. Lock the mount to prevent concurrent
+        // unpack failures (including bzip2-sys .cargo-ok collisions).
+        sharing: CacheSharingMode.Locked,
       })
       .withMountedCache(`${cargoHome}/git`, dag.cacheVolume('cargo-git'), {
         sharing: CacheSharingMode.Shared,

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -568,3 +568,20 @@ and loading candidates even if a query page lists them. `forks.spec.ts` checks
 ordinary resources after reload and real proposals on their original resource.
 The reported Safari query contamination is not reproduced locally: WebKit test
 setup currently fails opening OPFS before it can create its dev drive.
+
+### Managed admission retries and content-addressed image downloads
+
+- `local-outbox.test.ts`: enrollment/quota refusals stop after bounded retries,
+  retain dirty edits, and can be re-armed by a new edit; legacy messages and
+  structured `SYNC_REJECTED` classification are covered.
+- `store-commit-fallback.test.ts`: a WebSocket enrollment refusal is not
+  duplicated over HTTP; a transport failure still falls back.
+- Server `errors::admission_error_tests`: enrollment/quota refusals carry a
+  blocking code and HTTP 403 rather than an internal-error response.
+- Server `tests::content_addressed_image_download`: raw, WebP and AVIF downloads
+  work for a blob with no File resource at its hash URL; missing hashes return
+  404, and attachment/nosniff headers are retained for renditions.
+
+Staging triage verified that the two reported hashes still returned HTTP 200
+without resize parameters. Deployment acceptance must recheck their resized
+URLs and confirm the rejected-write rate falls after clients update.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -543,3 +543,5 @@ This does not yet prove restoration of the user's private staging workspace.
 - `signout-signin-data.spec.ts` uses fresh persistent profiles on macOS WebKit because ephemeral contexts reject OPFS; these remain browser tests, not native Tauri acceptance.
 
 - `browser/lib/src/store.test.ts`: receiving an older resource preserves the merged value in both JSON and the persisted Loro snapshot; dashboard configuration reload exercises the real OPFS path.
+
+Drive changes and reauthentication on an already-open WebSocket: `browser/lib/src/websockets.test.ts` verifies a fresh SYNC is sent without reconnecting, including local-only drive exclusion. This covers the Sync page remaining at Connecting after sign-in or drive switching; live staging acceptance remains separate.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -490,6 +490,13 @@ personal drive. Browser warnings/errors fail these tests, including localization
 render warnings. The authorization journey also covers cropped avatar upload, metadata and image
 download from the recipient account, and existing-agent acceptance. SaaS
 email-to-drive acceptance still needs dedicated flow coverage.
+The invite journey also rejects transient duplicate acceptance buttons, opens the
+avatar file picker from the person button, and checks Feedback in the secret
+backup dialog. `onboarding-storage.spec.ts` injects a failed ClientDb initialization
+and verifies that signup controls stay hidden while recovery advice and Feedback
+remain available. `onboardingStorage.test.ts` covers initialization readiness,
+failure, missing attachment, and timeout. Actual private-window storage policies
+across browsers remain outside the injected-failure test.
 `ollama-feedback.spec.ts` checks sidebar feedback hover, local Ollama discovery
 only after expanding AI settings, one-click URL acceptance and persistence after
 reload. Its default run stubs the model-list endpoint; `TEST_REAL_OLLAMA=1` ran

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -560,3 +560,11 @@ This does not yet prove restoration of the user's private staging workspace.
 - `browser/lib/src/store.test.ts`: receiving an older resource preserves the merged value in both JSON and the persisted Loro snapshot; dashboard configuration reload exercises the real OPFS path.
 
 Drive changes and reauthentication on an already-open WebSocket: `browser/lib/src/websockets.test.ts` verifies a fresh SYNC is sent without reconnecting, including local-only drive exclusion. This covers the Sync page remaining at Connecting after sign-in or drive switching; live staging acceptance remains separate.
+
+### Pending fork banner
+
+`PendingForks.test.tsx` rejects ordinary resources, proposals for another subject,
+and loading candidates even if a query page lists them. `forks.spec.ts` checks
+ordinary resources after reload and real proposals on their original resource.
+The reported Safari query contamination is not reproduced locally: WebKit test
+setup currently fails opening OPFS before it can create its dev drive.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -489,7 +489,12 @@ verify subsequent shared access. The chatroom journey also checks the named
 personal drive. Browser warnings/errors fail these tests, including localization
 render warnings. The authorization journey also covers cropped avatar upload, metadata and image
 download from the recipient account, and existing-agent acceptance. SaaS
-email-to-drive acceptance still needs dedicated flow coverage.
+`portal/e2e/invite-signup.spec.ts` covers a real invitation through email signup,
+recovery-code backup, automatic acceptance, and workspace reload. It also restores
+the existing identity in a second browser before accepting the invitation again.
+The test injects the standalone node's managed/portal metadata and declines
+automatic workspace-vault enrollment (no S3 service). Invitation, email login,
+encrypted identity recovery, and workspace operations use real local services.
 The invite journey also rejects transient duplicate acceptance buttons, opens the
 avatar file picker from the person button, and checks Feedback in the secret
 backup dialog. `onboarding-storage.spec.ts` injects a failed ClientDb initialization

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -511,10 +511,13 @@ the reader's active drive to receive live updates.
 
 `driveSyncStatus.test.ts` rejects another drive's sync timestamp and scopes
 asynchronous hosting/usage results to the selected drive and server. It covers
-unenrolled/local drives and shared drives confirmed directly by their node.
-`sync-devices.spec.ts` renders a managed connection with zero data for the selected
-drive, injects another drive's completed sync, and verifies that Cloud Server
-stays off with its setup action visible.
+unenrolled/local drives, unknown enrollment, and the requirement for both enrollment and remote data before claiming hosted service. Node synchronization remains a separate status.
+`sync-devices.spec.ts` renders a managed connection with data but no enrollment,
+injects another drive's completed sync, and verifies that Cloud Server does not
+claim hosting. It checks unknown recovery wording, account refresh on window focus,
+and missing translation markers. `saved-drives.spec.ts` checks that a portal Open
+link selects the requested drive, consumes the drive parameter, and preserves
+current-drive behavior for ordinary resource links.
 
 - Managed Vault display metadata: `vaultAutoBackup.test.ts` now covers a drive
   present only in local storage, as well as rename/emoji refresh. Manual enable

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Reconcile the selected cloud drive after switching drives or signing in on an open connection, so Sync no longer waits for a page refresh to confirm its status.
+
 ## [v0.41.0-beta.6] - 2026-09-09
 
 - An older server response no longer rolls back the local cache after an edit, fixing dashboard configuration reverting on reload.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Portal Open links select their workspace; ordinary resource links keep the current drive.
+- Sync distinguishes remote node data from Cloud Server enrollment, explains drive-specific plans, and refreshes account/recovery status after portal sign-in.
+- Account linking explains its purpose without implying another purchase or workspace transfer.
+
 - Reconcile the selected cloud drive after switching drives or signing in on an open connection, so Sync no longer waits for a page refresh to confirm its status.
 
 ## [v0.41.0-beta.6] - 2026-09-09

--- a/browser/data-browser/src/components/Dialog/index.tsx
+++ b/browser/data-browser/src/components/Dialog/index.tsx
@@ -1,3 +1,5 @@
+import { FeedbackMenuItem } from '../SideBar/FeedbackMenuItem';
+import { useRootWelcomeLayout } from '../../context/RootWelcomeLayoutContext';
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -21,6 +23,8 @@ import { timeoutEffect } from '@helpers/timeoutEffect';
 
 export interface InternalDialogProps {
   show: boolean;
+  /** Avoid offering another feedback dialog inside feedback itself. */
+  hideOnboardingFeedback?: boolean;
   onClose: (success: boolean) => void;
   onClosed: () => void;
   /** Skip the exit animation (e.g. after a successful form save). */
@@ -85,12 +89,14 @@ export function Dialog(props: React.PropsWithChildren<InternalDialogProps>) {
 const InnerDialog: React.FC<React.PropsWithChildren<InternalDialogProps>> = ({
   children,
   show,
+  hideOnboardingFeedback = false,
   width,
   instantClose = false,
   disableLightDismiss = false,
   onClose,
   onClosed,
 }) => {
+  const { rootWelcomeChromeHidden } = useRootWelcomeLayout();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const innerDialogRef = useRef<HTMLDivElement>(null);
   const { hasOpenInnerPopup } = useDialogTreeContext();
@@ -230,6 +236,11 @@ const InnerDialog: React.FC<React.PropsWithChildren<InternalDialogProps>> = ({
               </CloseButtonSlot>
             )}
             {children}
+            {show && rootWelcomeChromeHidden && !hideOnboardingFeedback && (
+              <FeedbackCorner>
+                <FeedbackMenuItem floating />
+              </FeedbackCorner>
+            )}
           </DropdownContainer>
         </PopoverContainer>
       </StyledInnerDialog>
@@ -410,4 +421,10 @@ const TitleSlot = styled(Slot)`
     margin: 0;
     line-height: 1.25;
   }
+`;
+
+const FeedbackCorner = styled.div`
+  position: fixed;
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  left: max(1rem, env(safe-area-inset-left));
 `;

--- a/browser/data-browser/src/components/Navigation.tsx
+++ b/browser/data-browser/src/components/Navigation.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { type JSX, useMemo } from 'react';
 import { styled } from 'styled-components';
 
+import { FeedbackMenuItem } from './SideBar/FeedbackMenuItem';
 import { SideBar } from './SideBar';
 import { OverlayContainer } from './OverlayContainer';
 import { CalculatedPageHeight } from '../globalCssVars';
@@ -20,7 +21,7 @@ import NavBarContent from './NavBar';
 import { useLocation } from '@tanstack/react-router';
 import { useSettings } from '../helpers/AppSettings';
 import { ChromeTheme } from '../styling';
-import { paths } from '../routes/paths';
+import { paths, pathNames } from '../routes/paths';
 import { useRootWelcomeLayout } from '../context/RootWelcomeLayoutContext';
 import { isHostedDistribution } from '../helpers/managedServer';
 
@@ -60,6 +61,7 @@ export function NavWrapper({ children }: NavWrapperProps): JSX.Element {
     onboardingOrChild ||
     welcomeOrChild ||
     demoSplash ||
+    pathname === `${pathNames.app}${pathNames.invite}` ||
     signedOutHosted;
 
   const search = useMemo(() => new URLSearchParams(searchStr), [searchStr]);
@@ -96,6 +98,11 @@ export function NavWrapper({ children }: NavWrapperProps): JSX.Element {
             </HideInPrint>
           )}
         </SideBarWrapper>
+        {hideGlobalChrome && (
+          <OnboardingFeedback>
+            <FeedbackMenuItem floating />
+          </OnboardingFeedback>
+        )}
         <OverlayContainer />
       </AISidebarContextProvider>
     </RightPanelProvider>
@@ -188,4 +195,11 @@ const SideBarWrapper = styled.div<{
     position: static;
     display: block;
   }
+`;
+
+const OnboardingFeedback = styled.div`
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: ${p => p.theme.zIndex.sidebar};
 `;

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -35,6 +35,8 @@ type Step =
 interface NewIdentitySectionProps {
   /** Called after the drive is created (or skipped). */
   onDone: () => void;
+  /** Invite onboarding resumes acceptance instead of opening the personal drive. */
+  navigateToDrive?: boolean;
   /** Called after the agent and drive are created. Use this for any extra server-side steps (e.g. /setup). */
   onAfterCreate?: (driveSubject: string) => Promise<void>;
   /** If true, start creation immediately on mount without showing the button. */
@@ -85,6 +87,7 @@ interface IdentityData {
  */
 export function NewIdentitySection({
   onDone,
+  navigateToDrive = true,
   onAfterCreate,
   autoStart = false,
   verifySecret = false,
@@ -289,7 +292,7 @@ export function NewIdentitySection({
       // An earlier lookup can have cached "not found" before creation.
       // Read the now-persisted drive and profile before opening the workspace.
       await reopenRestoredDrive(store, identity.driveSubject);
-      navigate(constructOpenURL(identity.driveSubject));
+      if (navigateToDrive) navigate(constructOpenURL(identity.driveSubject));
     }
 
     onDone();
@@ -385,7 +388,7 @@ export function NewIdentitySection({
 
       if (home) {
         setDrive(home);
-        navigate(constructOpenURL(home));
+        if (navigateToDrive) navigate(constructOpenURL(home));
       }
 
       onDone();

--- a/browser/data-browser/src/components/PendingForks.test.tsx
+++ b/browser/data-browser/src/components/PendingForks.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Resource } from '@tomic/react';
+import { PendingForks } from './PendingForks';
+
+const state = vi.hoisted(() => ({ candidates: new Map<string, Resource>() }));
+vi.mock('@tomic/react', async importOriginal => ({
+  ...(await importOriginal<typeof import('@tomic/react')>()),
+  useDrive: () => ['did:ad:drive'],
+  useCollection: () => ({ collection: {}, ready: true }),
+  useCollectionPage: () => [...state.candidates.keys()],
+  useResources: () => state.candidates,
+}));
+vi.mock('../views/ResourceInline/ResourceInline', () => ({
+  ResourceInline: 'a',
+}));
+
+const original = { subject: 'did:ad:original', isFork: false } as Resource;
+
+function candidate(
+  subject: string,
+  isFork: boolean,
+  target?: string,
+  loading = false,
+): Resource {
+  return { subject, isFork, loading, get: () => target } as unknown as Resource;
+}
+
+describe('pending fork banner validates query candidates', () => {
+  it('does not label ordinary drive contents as proposals', () => {
+    state.candidates = new Map([
+      ['did:ad:document', candidate('did:ad:document', false)],
+      ['did:ad:folder', candidate('did:ad:folder', false)],
+    ]);
+    expect(PendingForks({ resource: original })).toBeNull();
+  });
+
+  it('does not carry proposals from a previous resource or an unresolved candidate', () => {
+    state.candidates = new Map([
+      [
+        'did:ad:other-fork',
+        candidate('did:ad:other-fork', true, 'did:ad:other'),
+      ],
+      [
+        'did:ad:loading',
+        candidate('did:ad:loading', true, original.subject, true),
+      ],
+    ]);
+    expect(PendingForks({ resource: original })).toBeNull();
+  });
+
+  it('shows a verified fork of this resource', () => {
+    state.candidates = new Map([
+      ['did:ad:fork', candidate('did:ad:fork', true, original.subject)],
+    ]);
+    expect(PendingForks({ resource: original })).not.toBeNull();
+  });
+});

--- a/browser/data-browser/src/components/PendingForks.tsx
+++ b/browser/data-browser/src/components/PendingForks.tsx
@@ -4,6 +4,7 @@ import {
   useCollection,
   useCollectionPage,
   useDrive,
+  useResources,
   type Resource,
 } from '@tomic/react';
 import { FaCodeBranch } from 'react-icons/fa6';
@@ -27,13 +28,28 @@ export function PendingForks({
 }: PendingForksProps): React.JSX.Element | null {
   const [drive] = useDrive();
 
-  const { collection } = useCollection({
+  const { collection, ready } = useCollection({
     property: forks.properties.originalSubject,
     value: resource.subject,
     drive,
   });
 
-  const forkSubjects = useCollectionPage(collection, 0);
+  const candidates = useCollectionPage(collection, 0);
+  const resources = useResources(candidates);
+  // A cached query page is only a list of candidates. Confirm the relationship
+  // before calling anything a proposal, including while changing resources.
+  const forkSubjects = candidates.filter(subject => {
+    const fork = resources.get(subject);
+
+    return (
+      ready &&
+      !fork?.loading &&
+      !fork?.error &&
+      fork?.isFork &&
+      subject !== resource.subject &&
+      fork.get(forks.properties.originalSubject) === resource.subject
+    );
+  });
 
   // Don't show it on a fork itself, or when there is nothing pending.
   if (resource.isFork || forkSubjects.length === 0) {

--- a/browser/data-browser/src/components/SideBar/FeedbackMenuItem.tsx
+++ b/browser/data-browser/src/components/SideBar/FeedbackMenuItem.tsx
@@ -22,7 +22,8 @@ import {
 } from './SideBarMenuItem';
 import { submitFeedback } from '../../helpers/feedback';
 
-export function FeedbackMenuItem() {
+export function FeedbackMenuItem({ floating = false }: { floating?: boolean }) {
+  const feedbackTitle = 'Send feedback';
   const messageId = useId();
   const emailId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -53,28 +54,40 @@ export function FeedbackMenuItem() {
 
   return (
     <>
-      <SideBarMenuRow
-        as='button'
-        ref={triggerRef}
-        type='button'
-        onClick={() => {
-          setSent(false);
-          showDialog();
-        }}
-        style={{
-          border: 0,
-          font: 'inherit',
-          cursor: 'pointer',
-        }}
-      >
-        <SideBarMenuRowIcon>
-          <FaComment />
-        </SideBarMenuRowIcon>
-        <SideBarMenuRowLabel>Feedback</SideBarMenuRowLabel>
-      </SideBarMenuRow>
-      <Dialog {...dialogProps}>
+      {floating ? (
+        <Button
+          ref={triggerRef}
+          onClick={() => {
+            setSent(false);
+            showDialog();
+          }}
+        >
+          Feedback
+        </Button>
+      ) : (
+        <SideBarMenuRow
+          as='button'
+          ref={triggerRef}
+          type='button'
+          onClick={() => {
+            setSent(false);
+            showDialog();
+          }}
+          style={{
+            border: 0,
+            font: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          <SideBarMenuRowIcon>
+            <FaComment />
+          </SideBarMenuRowIcon>
+          <SideBarMenuRowLabel>Feedback</SideBarMenuRowLabel>
+        </SideBarMenuRow>
+      )}
+      <Dialog {...dialogProps} hideOnboardingFeedback>
         <DialogTitle>
-          <h1>Send feedback</h1>
+          <h1>{feedbackTitle}</h1>
         </DialogTitle>
         <DialogContent>
           {sent ? (

--- a/browser/data-browser/src/components/TeamProfileStep.tsx
+++ b/browser/data-browser/src/components/TeamProfileStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import {
   core,
   dataBrowser,
@@ -11,6 +11,7 @@ import { Column, Row } from './Row';
 import Field from './forms/Field';
 import { Input } from './forms/InputStyles';
 import { AvatarCropper } from './AvatarCropper';
+import { FaUser } from 'react-icons/fa6';
 import { ResourceGlyph } from './ResourceGlyph';
 import { ErrorLook } from './ErrorLook';
 import { styled } from 'styled-components';
@@ -39,6 +40,7 @@ export function TeamProfileStep({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<Error>();
   const id = useId();
+  const fileInput = useRef<HTMLInputElement>(null);
   const handleCropVisibility = useCallback((open: boolean) => {
     if (!open) setSource(undefined);
   }, []);
@@ -86,16 +88,24 @@ export function TeamProfileStep({
         />
       </Field>
       <Row>
-        <Avatar>
+        <Avatar
+          type='button'
+          aria-label='Choose profile picture'
+          disabled={busy}
+          onClick={() => fileInput.current?.click()}
+        >
           {preview ? (
             <img src={preview} alt='Your selected avatar' />
-          ) : (
+          ) : resource.get(dataBrowser.properties.icon) ? (
             <ResourceGlyph resource={resource} />
+          ) : (
+            <FaUser aria-hidden />
           )}
         </Avatar>
         <Column>
           <label htmlFor={`${id}-picture`}>Profile picture (optional)</label>
           <input
+            ref={fileInput}
             id={`${id}-picture`}
             type='file'
             accept='image/*'
@@ -135,7 +145,15 @@ export function TeamProfileStep({
   );
 }
 
-const Avatar = styled.div`
+const Avatar = styled.button`
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
   width: 4rem;
   height: 4rem;
   flex-shrink: 0;

--- a/browser/data-browser/src/components/Vault/LinkProviderPanel.tsx
+++ b/browser/data-browser/src/components/Vault/LinkProviderPanel.tsx
@@ -97,6 +97,7 @@ export function LinkProviderPanel({
     }
   }
 
+  const explanation = `Connect this app to your existing ${providerName(portalUrl)} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace.`;
   const body = request ? (
     <>
       <Sub>
@@ -115,14 +116,7 @@ export function LinkProviderPanel({
     </>
   ) : (
     <>
-      {!compact && (
-        <Sub>
-          This app cannot sign in on its own, so approve it from somewhere you
-          already are. Then it can keep an encrypted copy of your workspaces —
-          sealed here, so {providerName(portalUrl)} stores it without being able
-          to read it.
-        </Sub>
-      )}
+      {!compact && <Sub>{explanation}</Sub>}
       {error && <ErrorText data-testid='link-error'>{error}</ErrorText>}
       <Actions $compact={compact}>
         <Button
@@ -134,7 +128,7 @@ export function LinkProviderPanel({
             ? 'Getting a code…'
             : compact
               ? `Connect to ${providerName(portalUrl)}`
-              : 'Connect this device'}
+              : 'Connect existing account'}
         </Button>
       </Actions>
     </>

--- a/browser/data-browser/src/helpers/driveSyncStatus.test.ts
+++ b/browser/data-browser/src/helpers/driveSyncStatus.test.ts
@@ -26,10 +26,12 @@ describe('Cloud Server requires evidence for the selected drive', () => {
     expect(hasHostedDriveConnection(false, true, true, 28)).toBe(false);
   });
 
-  it('recognizes an enrolled drive and a colleague with node-confirmed data', () => {
-    expect(hasHostedDriveConnection(true, true, true, undefined)).toBe(true);
-    expect(hasHostedDriveConnection(true, true, false, 28)).toBe(true);
+  it('requires enrollment and a populated remote copy to claim hosting', () => {
+    expect(hasHostedDriveConnection(true, true, true, undefined)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, false, 28)).toBe(false);
     expect(hasHostedDriveConnection(true, false, true, 28)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, null, 28)).toBe(false);
+    expect(hasHostedDriveConnection(true, true, true, 28)).toBe(true);
   });
 
   it('discards usage or enrollment from another drive or server immediately', () => {

--- a/browser/data-browser/src/helpers/driveSyncStatus.ts
+++ b/browser/data-browser/src/helpers/driveSyncStatus.ts
@@ -63,11 +63,9 @@ export function hasHostedDriveConnection(
   enrolled: boolean | null,
   resourceCount: number | undefined,
 ): boolean {
-  // A colleague can verify the shared drive directly on its node without
-  // access to the owner's billing account. A global connection is not proof.
+  // Node synchronization is shown independently in Devices. Data on a managed
+  // node alone does not prove this account has hosting enabled for this drive.
   return (
-    liveSyncedDrive &&
-    managed &&
-    (enrolled === true || (resourceCount ?? 0) > 0)
+    liveSyncedDrive && managed && enrolled === true && (resourceCount ?? 0) > 0
   );
 }

--- a/browser/data-browser/src/helpers/inviteSignup.test.ts
+++ b/browser/data-browser/src/helpers/inviteSignup.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest';
+import { inviteSignupUrl, resumeInviteUrl } from './inviteSignup';
+import type { ManagedInfo } from './managedServer';
+
+it('sends managed invitees to email signup and preserves the opaque token', () => {
+  const url = new URL(
+    inviteSignupUrl(
+      {
+        managed: true,
+        portalUrl: 'https://staging.atomicserver.eu',
+      } as ManagedInfo,
+      'a+b/=',
+    )!,
+  );
+  expect(url.origin + url.pathname).toBe(
+    'https://staging.atomicserver.eu/signin',
+  );
+  expect(url.searchParams.get('invite')).toBe('a+b/=');
+});
+it('keeps self-hosted invitations local', () => {
+  expect(
+    inviteSignupUrl(
+      { managed: false, acceptsNewDrives: false } as ManagedInfo,
+      'token',
+    ),
+  ).toBeUndefined();
+});
+it('resumes at the local invite route, never an arbitrary destination', () => {
+  expect(resumeInviteUrl('https://evil.example')).toBe(
+    '/app/invite?token=https%3A%2F%2Fevil.example&accept=true',
+  );
+});

--- a/browser/data-browser/src/helpers/inviteSignup.ts
+++ b/browser/data-browser/src/helpers/inviteSignup.ts
@@ -1,0 +1,18 @@
+import { accountCreationTarget, type ManagedInfo } from './managedServer';
+
+/** Carry only an invitation, never a caller-controlled redirect destination. */
+export function inviteSignupUrl(
+  info: ManagedInfo,
+  token: string,
+): string | undefined {
+  const target = accountCreationTarget(info);
+  if (target.kind !== 'portal') return;
+  const url = new URL(target.url);
+  url.searchParams.set('invite', token);
+
+  return url.href;
+}
+
+export function resumeInviteUrl(token: string): string {
+  return `/app/invite?${new URLSearchParams({ token, accept: 'true' })}`;
+}

--- a/browser/data-browser/src/helpers/managedServer.ts
+++ b/browser/data-browser/src/helpers/managedServer.ts
@@ -135,7 +135,9 @@ export async function fetchManagedInfo(
     // this device holds a token for a different one.
     const portalUrl =
       safePortalUrl(
-        rawPortalUrl && onLocalhost ? 'http://localhost:49237' : rawPortalUrl,
+        rawPortalUrl && onLocalhost
+          ? (managedPortalOverride() ?? 'http://localhost:49237')
+          : rawPortalUrl,
       ) ?? null;
 
     // The desktop app learns where the control plane lives ONLY from here —

--- a/browser/data-browser/src/helpers/onboardingStorage.test.ts
+++ b/browser/data-browser/src/helpers/onboardingStorage.test.ts
@@ -1,0 +1,59 @@
+import { expect, it, vi } from 'vitest';
+import { checkOnboardingStorage } from './onboardingStorage';
+
+it('waits for the actual database before allowing onboarding', async () => {
+  let ready!: (value: boolean) => void;
+  const db = {
+    waitForInit: () =>
+      new Promise<boolean>(resolve => {
+        ready = resolve;
+      }),
+  };
+  const store = { waitForClientDb: async () => true, getClientDb: () => db };
+  const done = vi.fn();
+  const result = checkOnboardingStorage(store).then(done);
+  await Promise.resolve();
+  expect(done).not.toHaveBeenCalled();
+  ready(true);
+  await result;
+  expect(done).toHaveBeenCalledWith(undefined);
+});
+
+it('reports initialization failure before account creation', async () => {
+  const store = {
+    waitForClientDb: async () => true,
+    getClientDb: () => ({
+      waitForInit: async () => false,
+      initError: new Error('Storage denied'),
+    }),
+  };
+  await expect(checkOnboardingStorage(store)).rejects.toThrow('Storage denied');
+});
+
+it('does not hang indefinitely if no database attaches', async () => {
+  const store = {
+    waitForClientDb: async () => false,
+    getClientDb: () => undefined,
+  };
+  await expect(checkOnboardingStorage(store)).rejects.toThrow();
+});
+
+it('times out a stalled worker rather than leaving an endless loading screen', async () => {
+  vi.useFakeTimers();
+
+  try {
+    const store = {
+      waitForClientDb: async () => true,
+      getClientDb: () => ({
+        waitForInit: () => new Promise<boolean>(() => {}),
+      }),
+    };
+    const assertion = expect(checkOnboardingStorage(store)).rejects.toThrow(
+      'taking too long',
+    );
+    await vi.advanceTimersByTimeAsync(20_000);
+    await assertion;
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/browser/data-browser/src/helpers/onboardingStorage.ts
+++ b/browser/data-browser/src/helpers/onboardingStorage.ts
@@ -1,0 +1,40 @@
+interface OnboardingStore {
+  waitForClientDb(timeoutMs: number): Promise<boolean>;
+  getClientDb():
+    | { waitForInit(): Promise<boolean>; initError?: Error | null }
+    | undefined;
+}
+
+/** Check the actual storage engine, including worker OPFS access, before signup. */
+export async function checkOnboardingStorage(
+  store: OnboardingStore,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      (async () => {
+        await store.waitForClientDb(20_000);
+        const db = store.getClientDb();
+
+        if (!db || !(await db.waitForInit())) {
+          throw (
+            db?.initError ??
+            new Error('Local storage could not be initialized.')
+          );
+        }
+      })(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error('Local storage is taking too long to initialize.'),
+            ),
+          20_000,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Entsperren mit einem Passkey fehlgeschlagen. Verwende stattdessen deinen Wiederherstellungscode."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7830,3 +7830,7 @@ msgstr ""
 #: src/helpers/onboardingStorage.ts
 msgid "Local storage is taking too long to initialize."
 msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Accepting your invitation…"
+msgstr ""

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7351,6 +7351,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
+#: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
 msgstr ""
 
@@ -7796,4 +7797,36 @@ msgstr ""
 #. 0: providerName(portalUrl)
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Creating your account…"
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Invite accepted. Finishing setup…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Checking local storage…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "This browser could not open local storage"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Open this link in a non-private browser window and allow this site to store data. If you are already in a regular window, close other tabs for this site and try again."
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Reload and try again"
+msgstr ""
+
+#: src/components/TeamProfileStep.tsx
+msgid "Choose profile picture"
+msgstr ""
+
+#: src/helpers/onboardingStorage.ts
+msgid "Local storage is taking too long to initialize."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7385,6 +7385,7 @@ msgstr "Local stays on your devices. Vault is encrypted backup. Server hosts a r
 #~ msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
+#: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
 msgstr "Feedback"
 
@@ -7831,3 +7832,35 @@ msgstr "Existing content stays in this drive. Hosting uses the Server plan or in
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
 msgstr "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+
+#: src/views/InvitePage.tsx
+msgid "Creating your account…"
+msgstr "Creating your account…"
+
+#: src/views/InvitePage.tsx
+msgid "Invite accepted. Finishing setup…"
+msgstr "Invite accepted. Finishing setup…"
+
+#: src/views/getting-started/chrome.tsx
+msgid "Checking local storage…"
+msgstr "Checking local storage…"
+
+#: src/views/getting-started/chrome.tsx
+msgid "This browser could not open local storage"
+msgstr "This browser could not open local storage"
+
+#: src/views/getting-started/chrome.tsx
+msgid "Open this link in a non-private browser window and allow this site to store data. If you are already in a regular window, close other tabs for this site and try again."
+msgstr "Open this link in a non-private browser window and allow this site to store data. If you are already in a regular window, close other tabs for this site and try again."
+
+#: src/views/getting-started/chrome.tsx
+msgid "Reload and try again"
+msgstr "Reload and try again"
+
+#: src/components/TeamProfileStep.tsx
+msgid "Choose profile picture"
+msgstr "Choose profile picture"
+
+#: src/helpers/onboardingStorage.ts
+msgid "Local storage is taking too long to initialize."
+msgstr "Local storage is taking too long to initialize."

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7864,3 +7864,7 @@ msgstr "Choose profile picture"
 #: src/helpers/onboardingStorage.ts
 msgid "Local storage is taking too long to initialize."
 msgstr "Local storage is taking too long to initialize."
+
+#: src/views/InvitePage.tsx
+msgid "Accepting your invitation…"
+msgstr "Accepting your invitation…"

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -6562,9 +6562,8 @@ msgstr "Waiting for you to approve it…"
 msgid "Getting a code…"
 msgstr "Getting a code…"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr "Connect this device"
+#~ msgid "Connect this device"
+#~ msgstr "Connect this device"
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6813,10 +6812,8 @@ msgstr "{0} failed: {1}"
 msgid "Sign in →"
 msgstr "Sign in →"
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6828,7 +6825,6 @@ msgstr "{0}. We hold your key sealed, so this email gets you back in on a new de
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr "{0}. No recovery backup stored, so losing every device loses this workspace."
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr "Set up email recovery"
@@ -7216,13 +7212,11 @@ msgstr "Couldn’t reach {0}. Check your connection and try again."
 msgid "Connect to {0}"
 msgstr "Connect to {0}"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr "stores it without being able to read it."
+#~ msgid "stores it without being able to read it."
+#~ msgstr "stores it without being able to read it."
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7387,9 +7381,8 @@ msgstr "Local stays on your devices. Vault is encrypted backup. Server hosts a r
 #~ msgid "Choose Server plan"
 #~ msgstr "Choose Server plan"
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7804,3 +7797,37 @@ msgstr "<0>Save this recovery code.</0> It gets you back in on a new device, and
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Could not unlock with a passkey. Use your recovery code instead."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr "Connect existing account"
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr "Error: Sign in before syncing with another device"
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr "Sign in to check recovery"
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "No se pudo desbloquear con una clave de acceso. Usa tu código de recuperación."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7830,3 +7830,7 @@ msgstr ""
 #: src/helpers/onboardingStorage.ts
 msgid "Local storage is taking too long to initialize."
 msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Accepting your invitation…"
+msgstr ""

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7351,6 +7351,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
+#: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
 msgstr ""
 
@@ -7796,4 +7797,36 @@ msgstr ""
 #. 0: providerName(portalUrl)
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Creating your account…"
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Invite accepted. Finishing setup…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Checking local storage…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "This browser could not open local storage"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Open this link in a non-private browser window and allow this site to store data. If you are already in a regular window, close other tabs for this site and try again."
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Reload and try again"
+msgstr ""
+
+#: src/components/TeamProfileStep.tsx
+msgid "Choose profile picture"
+msgstr ""
+
+#: src/helpers/onboardingStorage.ts
+msgid "Local storage is taking too long to initialize."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -6528,9 +6528,8 @@ msgstr ""
 msgid "Getting a code…"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "Connect this device"
-msgstr ""
+#~ msgid "Connect this device"
+#~ msgstr ""
 
 #: src/helpers/managed/deviceLink.ts
 msgid "Android"
@@ -6779,10 +6778,8 @@ msgstr ""
 msgid "Sign in →"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
-msgstr ""
+#~ msgid "Not set up. With an account on {0} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
@@ -6794,7 +6791,6 @@ msgstr ""
 msgid "{0}. No recovery backup stored, so losing every device loses this workspace."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Set up email recovery"
 msgstr ""
@@ -7182,13 +7178,11 @@ msgstr ""
 msgid "Connect to {0}"
 msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
-msgstr ""
+#~ msgid "This app cannot sign in on its own, so approve it from somewhere you already are. Then it can keep an encrypted copy of your workspaces — sealed here, so"
+#~ msgstr ""
 
-#: src/components/Vault/LinkProviderPanel.tsx
-msgid "stores it without being able to read it."
-msgstr ""
+#~ msgid "stores it without being able to read it."
+#~ msgstr ""
 
 #: src/routes/History/VersionTitle.tsx
 msgid "Verified"
@@ -7353,9 +7347,8 @@ msgstr ""
 #~ msgid "Choose Server plan"
 #~ msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
-msgstr ""
+#~ msgid "Existing content stays in this drive. Hosting requires a Server plan or an invitation for this drive."
+#~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
@@ -7770,3 +7763,37 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Impossible de déverrouiller avec une clé d’accès. Utilisez votre code de récupération."
+
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect existing account"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#. 0: PRODUCT_NAME
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to your {0} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Sign in to check recovery"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
+msgstr ""
+
+#. 0: providerName(portalUrl)
+#: src/components/Vault/LinkProviderPanel.tsx
+msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7830,3 +7830,7 @@ msgstr ""
 #: src/helpers/onboardingStorage.ts
 msgid "Local storage is taking too long to initialize."
 msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Accepting your invitation…"
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7351,6 +7351,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/SideBar/FeedbackMenuItem.tsx
+#: src/components/SideBar/FeedbackMenuItem.tsx
 msgid "Feedback"
 msgstr ""
 
@@ -7796,4 +7797,36 @@ msgstr ""
 #. 0: providerName(portalUrl)
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect this app to your existing {0} account to use your cloud services. Approve a code in the portal to sign this app in. This is free and does not purchase hosting or fetch a workspace."
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Creating your account…"
+msgstr ""
+
+#: src/views/InvitePage.tsx
+msgid "Invite accepted. Finishing setup…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Checking local storage…"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "This browser could not open local storage"
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Open this link in a non-private browser window and allow this site to store data. If you are already in a regular window, close other tabs for this site and try again."
+msgstr ""
+
+#: src/views/getting-started/chrome.tsx
+msgid "Reload and try again"
+msgstr ""
+
+#: src/components/TeamProfileStep.tsx
+msgid "Choose profile picture"
+msgstr ""
+
+#: src/helpers/onboardingStorage.ts
+msgid "Local storage is taking too long to initialize."
 msgstr ""

--- a/browser/data-browser/src/routes/ShowRoute.tsx
+++ b/browser/data-browser/src/routes/ShowRoute.tsx
@@ -11,6 +11,8 @@ import { isOriginWithoutNode } from '../helpers/originNode';
 
 export type ShowRouteSearch = {
   subject: string;
+  /** Explicit workspace selection, as used by the portal Open action. */
+  drive?: string;
   /**
    * The active View of a Table, so switching tabs is linkable and lands in
    * browser history. Absent = the table's default view.
@@ -24,6 +26,10 @@ export const ShowRoute = createRoute({
   getParentRoute: () => appRoute,
   validateSearch: (search): ShowRouteSearch => ({
     subject: (search.subject as string) ?? '',
+    drive:
+      typeof search.drive === 'string' && Client.isValidSubject(search.drive)
+        ? search.drive
+        : undefined,
     view: (search.view as string) || undefined,
   }),
 });
@@ -32,7 +38,9 @@ export const ShowRoute = createRoute({
 export const ShowComponent: React.FunctionComponent = () => {
   // Value shown in navbar, after Submitting
   const subject = ShowRoute.useSearch({ select: state => state.subject });
-  const { agent } = useSettings();
+  const requestedDrive = ShowRoute.useSearch({ select: state => state.drive });
+  const view = ShowRoute.useSearch({ select: state => state.view });
+  const { agent, drive, setDrive } = useSettings();
   const store = useStore();
   const navigate = useNavigate();
 
@@ -46,6 +54,13 @@ export const ShowComponent: React.FunctionComponent = () => {
     !agent &&
     Client.isValidSubject(subject) &&
     isOriginWithoutNode(store.getServerUrl());
+
+  React.useEffect(() => {
+    if (signInFirst || !requestedDrive || requestedDrive !== subject) return;
+    if (drive !== requestedDrive) setDrive(requestedDrive);
+    // Consume the instruction so a later manual drive switch is not undone.
+    navigate({ to: paths.show, search: { subject, view }, replace: true });
+  }, [signInFirst, requestedDrive, subject, view, drive, setDrive, navigate]);
 
   React.useEffect(() => {
     if (!signInFirst) return;

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -703,12 +703,21 @@ function SyncPage() {
    * none", and telling someone their recovery is missing when the control
    * plane was merely unreachable is the one wrong answer this row can give.
    */
-  const [recoveryBackup, setRecoveryBackup] = useState<
-    'stored' | 'passkey-only' | 'device-only' | 'none' | null
-  >(null);
+  const [recoveryState, setRecoveryState] = useState<{
+    account: ManagedAccount;
+    value: 'stored' | 'passkey-only' | 'device-only' | 'none' | null;
+  } | null>(null);
+  const recoveryBackup =
+    recoveryState?.account === managedAccount
+      ? (recoveryState?.value ?? null)
+      : null;
 
   useEffect(() => {
     if (!managedAccount) return;
+
+    const setRecoveryBackup = (
+      value: NonNullable<typeof recoveryState>['value'],
+    ) => setRecoveryState({ account: managedAccount, value });
 
     let cancelled = false;
 
@@ -750,7 +759,10 @@ function SyncPage() {
   useEffect(() => {
     let cancelled = false;
 
-    void (async () => {
+    let generation = 0;
+
+    const refreshAccount = async () => {
+      const requestGeneration = ++generation;
       // Asked even when this device is already linked. The link only settles
       // *how* this client authenticates; it says nothing about who, and the
       // portal link needs the account itself.
@@ -759,7 +771,7 @@ function SyncPage() {
       try {
         const account = await getManagedAccount();
 
-        if (cancelled) return;
+        if (cancelled || requestGeneration !== generation) return;
 
         setManagedAccount(account);
         setNeedsProviderLink(!linked && account === null);
@@ -767,14 +779,25 @@ function SyncPage() {
         // Unreachable control plane. Offering to link is the useful answer —
         // the alternative is a Sync page that silently omits backup with no
         // way to ask for it.
-        if (!cancelled) setNeedsProviderLink(!linked);
+        if (!cancelled && requestGeneration === generation) {
+          setManagedAccount(null);
+          setNeedsProviderLink(!linked);
+        }
       }
-    })();
+    };
+
+    const onFocus = () => void refreshAccount();
+
+    void refreshAccount();
+    window.addEventListener('focus', onFocus);
+    const unsubscribe = store.on(StoreEvents.AgentChanged, onFocus);
 
     return () => {
       cancelled = true;
+      unsubscribe();
+      window.removeEventListener('focus', onFocus);
     };
-  }, []);
+  }, [status.drive, store]);
 
   useEffect(() => {
     const serverUrl = status.serverUrl;
@@ -873,7 +896,7 @@ function SyncPage() {
     return () => {
       cancelled = true;
     };
-  }, [status.drive, status.serverUrl, store]);
+  }, [status.drive, status.serverUrl, status.lastDriveSync?.timestamp, store]);
 
   // Plan quota — managed nodes only, from the control plane. Billing stays a
   // managed concern; the usage numbers above are generic to every node.
@@ -939,14 +962,13 @@ function SyncPage() {
           setCloudEnrollment({ drive, server: status.serverUrl, value: has });
       })
       .catch(() => {
-        if (!cancelled)
-          setCloudEnrollment({ drive, server: status.serverUrl, value: false });
+        if (!cancelled) setCloudEnrollment(null);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [status.drive, status.serverUrl, managedInfo]);
+  }, [status.drive, status.serverUrl, managedInfo, managedAccount]);
 
   useEffect(() => {
     const refresh = () => setStatus(store.getSyncStatus());
@@ -1516,7 +1538,7 @@ function SyncPage() {
                 <ConnTitle>Email recovery</ConnTitle>
                 <ConnSub>
                   {!managedAccount
-                    ? `Not set up. With an account on ${PRODUCT_NAME} we hold your key sealed, so an email gets you back in on a new device. Without one, losing every device loses this workspace.`
+                    ? `Sign in to your ${PRODUCT_NAME} account to check email recovery. Signing in to this workspace with a passkey or secret does not by itself connect your cloud account.`
                     : recoveryBackup === null
                       ? `Signed in as ${managedAccount.email}.`
                       : recoveryBackup === 'stored'
@@ -1546,7 +1568,7 @@ function SyncPage() {
                     <LearnMore
                       {...externalLinkProps(`${accountPortalUrl}/signin`)}
                     >
-                      Set up email recovery
+                      Sign in to check recovery
                     </LearnMore>
                   </ConnActions>
                 ) : recoveryBackup === 'none' ||
@@ -1622,6 +1644,12 @@ function SyncPage() {
                     another device to be awake. Unlike Cloud Vault, our servers
                     process what you put here.
                   </ConnSub>
+                  <ConnMeta>
+                    {subscriptionStatus === 'active' ||
+                    subscriptionStatus === 'trialing'
+                      ? 'This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again.'
+                      : 'Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free.'}
+                  </ConnMeta>
                   {hostedCopyOrigin && (
                     <ConnMeta>
                       This workspace has been copied to Cloud Server. You’re
@@ -1699,8 +1727,9 @@ function SyncPage() {
             sharing permissions still control other users’ access.
           </p>
           <p>
-            Existing content stays in this drive. Hosting requires a Server plan
-            or an invitation for this drive.
+            Existing content stays in this drive. Hosting uses the Server plan
+            or invitation for this drive. If a purchase is needed, you will see
+            the price at checkout before paying.
           </p>
         </ConfirmationDialog>
 

--- a/browser/data-browser/src/views/CrashPage.tsx
+++ b/browser/data-browser/src/views/CrashPage.tsx
@@ -1,3 +1,5 @@
+import { FeedbackMenuItem } from '../components/SideBar/FeedbackMenuItem';
+import { DialogGlobalContextProvider } from '../components/Dialog/DialogGlobalContextProvider';
 import * as React from 'react';
 import { Resource } from '@tomic/react';
 
@@ -41,6 +43,9 @@ function CrashPage({
             >
               Try Again
             </Button>
+            <DialogGlobalContextProvider>
+              <FeedbackMenuItem floating />
+            </DialogGlobalContextProvider>
           </Row>
         </Column>
       </ContainerWide>

--- a/browser/data-browser/src/views/InvitePage.tsx
+++ b/browser/data-browser/src/views/InvitePage.tsx
@@ -267,7 +267,13 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
   });
 
   // When the Invite is accepted, a new Agent might be created client-side.
+  const [creating, setCreating] = useState(false);
+  const [accepted, setAccepted] = useState(false);
+
   async function handleNew() {
+    if (creating) return;
+    setCreating(true);
+
     try {
       const keypair = await generateKeyPair();
 
@@ -309,6 +315,8 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
       setReviewProfile(true);
     } catch (error) {
       store.notifyError(error);
+    } finally {
+      setCreating(false);
     }
   }
 
@@ -320,9 +328,7 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
     const redirect = await store.postToServer<Server.Redirect>(inviteURL.href);
 
     if (redirect.error) {
-      store.notifyError(redirect.error);
-
-      return;
+      throw redirect.error;
     }
 
     const destination = await getRedirectDestination(redirect);
@@ -371,6 +377,7 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
       setAgent(newAgent);
       setIsNewAgent(true);
     } else {
+      setAccepted(true);
       setIsNewAgent(false);
       setRedirectURL(destination);
 
@@ -386,6 +393,7 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
       return;
     }
 
+    setAccepted(true);
     // New agent: back up the secret, then persist and redirect.
     setRedirectURL(destination);
     show();
@@ -410,12 +418,15 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
             You've been invited to {write ? 'edit' : 'view'}
             {resourceName ? ` "${resourceName}"` : ''}
           </CardTitle>
-          {reviewProfile && agentSubject ? (
+          {creating ? (
+            <p role='status'>Creating your account…</p>
+          ) : accepted ? (
+            <p role='status'>Invite accepted. Finishing setup…</p>
+          ) : reviewProfile && agentSubject ? (
             <TeamProfileStep
               subject={agentSubject}
               onContinue={async () => {
                 await handleAccept(pendingKeys);
-                setReviewProfile(false);
               }}
             />
           ) : usagesLeft === 0 ? (
@@ -430,7 +441,9 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
                   disabled={!agentResource.isReady()}
                   onClick={() => {
                     if (agentResource.get(dataBrowser.properties.icon)) {
-                      void handleAccept();
+                      void handleAccept().catch(error =>
+                        store.notifyError(error),
+                      );
                     } else {
                       setReviewProfile(true);
                     }

--- a/browser/data-browser/src/views/InvitePage.tsx
+++ b/browser/data-browser/src/views/InvitePage.tsx
@@ -1,3 +1,5 @@
+import { fetchManagedInfo } from '../helpers/managedServer';
+import { inviteSignupUrl } from '../helpers/inviteSignup';
 import { TeamProfileStep } from '../components/TeamProfileStep';
 import {
   useBoolean,
@@ -28,7 +30,7 @@ import { useWelcomeLayoutEffect } from '../hooks/useWelcomeLayoutEffect';
 import { Shell, Card, CardTitle, CtaButton } from './getting-started/chrome';
 import { Logo } from '../components/Logo';
 
-import { useState, type JSX } from 'react';
+import { useEffect, useEffectEvent, useRef, useState, type JSX } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { fetchPrivateDriveSubject } from '@helpers/privateDrive';
 import { saveAgentToIDB } from '@helpers/agentStorage';
@@ -40,6 +42,19 @@ import Field from '@components/forms/Field';
 /** A View that opens an invite */
 function InvitePage({ resource }: ResourcePageProps): JSX.Element {
   const store = useStore();
+  const [signupTarget, setSignupTarget] = useState<string | null>();
+  useEffect(() => {
+    let active = true;
+    void fetchManagedInfo(store.getServerUrl()).then(info => {
+      const token = new URL(resource.subject).searchParams.get('token');
+      if (active)
+        setSignupTarget(token ? (inviteSignupUrl(info, token) ?? null) : null);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [store, resource.subject]);
   const [usagesLeft] = useNumber(resource, server.properties.usagesLeft);
   const [write] = useBoolean(resource, server.properties.write);
   const [description] = useString(resource, core.properties.description);
@@ -271,7 +286,14 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
   const [accepted, setAccepted] = useState(false);
 
   async function handleNew() {
-    if (creating) return;
+    if (creating || signupTarget === undefined) return;
+
+    if (signupTarget) {
+      window.location.assign(signupTarget);
+
+      return;
+    }
+
     setCreating(true);
 
     try {
@@ -401,6 +423,24 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
 
   const agentSubject = agent?.subject;
 
+  const resumeAcceptance =
+    new URLSearchParams(window.location.search).get('accept') === 'true';
+  const resumed = useRef(false);
+  const [resumeError, setResumeError] = useState(false);
+  const agentReady = agentResource.isReady();
+  const acceptAfterSignup = useEffectEvent(() => {
+    void handleAccept().catch(error => {
+      setResumeError(true);
+      store.notifyError(error);
+    });
+  });
+  useEffect(() => {
+    if (!resumeAcceptance || !agentSubject || !agentReady || resumed.current)
+      return;
+    resumed.current = true;
+    acceptAfterSignup();
+  }, [resumeAcceptance, agentSubject, agentReady]);
+
   useWelcomeLayoutEffect();
 
   // Extract the resource name from the server-generated description
@@ -422,6 +462,8 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
             <p role='status'>Creating your account…</p>
           ) : accepted ? (
             <p role='status'>Invite accepted. Finishing setup…</p>
+          ) : resumeAcceptance && agentSubject && !resumeError ? (
+            <p role='status'>Accepting your invitation…</p>
           ) : reviewProfile && agentSubject ? (
             <TeamProfileStep
               subject={agentSubject}
@@ -453,12 +495,20 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
                 </CtaButton>
               ) : (
                 <>
-                  <CtaButton data-test='accept-new' onClick={handleNew}>
+                  <CtaButton
+                    data-test='accept-new'
+                    disabled={signupTarget === undefined}
+                    onClick={handleNew}
+                  >
                     Create account and accept
                   </CtaButton>
                   <CtaButton
                     data-test='accept-sign-in'
-                    onClick={() => navigate(paths.agentSettings)}
+                    disabled={signupTarget === undefined}
+                    onClick={() => {
+                      if (signupTarget) window.location.assign(signupTarget);
+                      else navigate(paths.agentSettings);
+                    }}
                     subtle
                   >
                     I already have an account

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -1,3 +1,4 @@
+import { resumeInviteUrl } from '../../helpers/inviteSignup';
 import { WorkspaceLoading } from './WorkspaceLoading';
 import {
   PRODUCT_NAME,
@@ -182,10 +183,17 @@ export function GettingStartedFlow({
   // A sign-in guard (clicking a drive you're not signed in for) sends the user
   // here with `next` carrying that drive's subject, so we open straight to the
   // sign-in step and return them to that drive afterwards (not their home).
+  const inviteToken = new URLSearchParams(window.location.search).get('invite');
   const nextDrive =
     new URLSearchParams(window.location.search).get('next') || undefined;
   const [step, setStep] = useState<Step>(
-    fromManaged ? 'create' : nextDrive ? 'signin' : initialStep,
+    fromManaged
+      ? 'create'
+      : inviteToken
+        ? 'restore'
+        : nextDrive
+          ? 'signin'
+          : initialStep,
   );
   const [loading, setLoading] = useState(false);
   const [workspaceStage, setWorkspaceStage] = useState<
@@ -584,6 +592,12 @@ export function GettingStartedFlow({
           SIGN_IN_LOOKUP_TIMEOUT_MS,
           undefined,
         );
+      }
+
+      if (inviteToken) {
+        navigate(resumeInviteUrl(inviteToken));
+
+        return;
       }
 
       // Where this sign-in wants to end up: the drive it came from, or the
@@ -1335,6 +1349,7 @@ export function GettingStartedFlow({
                 ) : (
                   <NewIdentitySection
                     autoStart
+                    navigateToDrive={!inviteToken}
                     verifySecret
                     stepIndicatorPortal={stepDotsSlotRef.current}
                     defaultProfileName={managedUsername}
@@ -1347,7 +1362,7 @@ export function GettingStartedFlow({
                       fromManaged ? enableEncryptedBackup : undefined
                     }
                     onDone={() => {
-                      // After verify, NewIdentitySection navigates to privateDrive / home
+                      if (inviteToken) navigate(resumeInviteUrl(inviteToken));
                     }}
                   />
                 )}

--- a/browser/data-browser/src/views/getting-started/chrome.tsx
+++ b/browser/data-browser/src/views/getting-started/chrome.tsx
@@ -3,11 +3,62 @@
 // "connect a device" screen. Lives apart from GettingStartedFlow so a step it
 // renders can use the chrome without importing its parent.
 
+import { useEffect, useState, type ComponentProps } from 'react';
+import { useStore } from '@tomic/react';
+import { checkOnboardingStorage } from '../../helpers/onboardingStorage';
 import { styled, css } from 'styled-components';
 import { Button } from '../../components/Button';
 import { welcomeBackgroundCss } from './welcomeBackground';
 
-export const Shell = styled.div`
+export function Shell({ children, ...props }: ComponentProps<'div'>) {
+  const store = useStore();
+  const [state, setState] = useState<'checking' | 'ready' | 'failed'>(
+    'checking',
+  );
+  useEffect(() => {
+    let active = true;
+    void checkOnboardingStorage(store).then(
+      () => {
+        if (active) setState('ready');
+      },
+      () => {
+        if (active) setState('failed');
+      },
+    );
+
+    return () => {
+      active = false;
+    };
+  }, [store]);
+
+  return (
+    <ShellSurface {...props}>
+      {state === 'ready' ? (
+        children
+      ) : (
+        <Card>
+          {state === 'checking' ? (
+            <p role='status'>Checking local storage…</p>
+          ) : (
+            <>
+              <CardTitle>This browser could not open local storage</CardTitle>
+              <p>
+                Open this link in a non-private browser window and allow this
+                site to store data. If you are already in a regular window,
+                close other tabs for this site and try again.
+              </p>
+              <Button onClick={() => window.location.reload()}>
+                Reload and try again
+              </Button>
+            </>
+          )}
+        </Card>
+      )}
+    </ShellSurface>
+  );
+}
+
+const ShellSurface = styled.div`
   /* A concrete viewport height (not 100%): nothing in the html/body/#root
      chain sets a height, so 100% would collapse to content height and,
      because body is overflow:hidden, tall content (the welcome pitch on a

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -129,19 +129,21 @@ test.describe('data-browser', async () => {
       await page.click('button:has-text("Create Invite")');
       await page.getByLabel('Full name', { exact: true }).fill('Drive Owner');
       const pickerOpened = page.waitForEvent('filechooser');
-      await page.getByRole('button', { name: 'Choose profile picture' }).click();
+      await page
+        .getByRole('button', { name: 'Choose profile picture' })
+        .click();
       const picker = await pickerOpened;
       await picker.setFiles({
-          name: 'profile.svg',
-          mimeType: 'image/svg+xml',
-          buffer: Buffer.from(
-            `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#${Math.floor(
-              Math.random() * 0xffffff,
-            )
-              .toString(16)
-              .padStart(6, '0')}"/></svg>`,
-          ),
-        });
+        name: 'profile.svg',
+        mimeType: 'image/svg+xml',
+        buffer: Buffer.from(
+          `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#${Math.floor(
+            Math.random() * 0xffffff,
+          )
+            .toString(16)
+            .padStart(6, '0')}"/></svg>`,
+        ),
+      });
       await page
         .getByRole('dialog')
         .filter({ has: page.getByRole('heading', { name: 'Adjust image' }) })

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -128,9 +128,10 @@ test.describe('data-browser', async () => {
       // Create invite
       await page.click('button:has-text("Create Invite")');
       await page.getByLabel('Full name', { exact: true }).fill('Drive Owner');
-      await page
-        .getByLabel('Profile picture (optional)', { exact: true })
-        .setInputFiles({
+      const pickerOpened = page.waitForEvent('filechooser');
+      await page.getByRole('button', { name: 'Choose profile picture' }).click();
+      const picker = await pickerOpened;
+      await picker.setFiles({
           name: 'profile.svg',
           mimeType: 'image/svg+xml',
           buffer: Buffer.from(

--- a/browser/e2e/tests/forks.spec.ts
+++ b/browser/e2e/tests/forks.spec.ts
@@ -27,16 +27,17 @@ test.describe('forks', () => {
     await newResource('folder', page);
     await editTitle('Ordinary folder', page);
     const subject = await getCurrentSubject(page);
-    const remoteMembers = await page.evaluate(async subject => {
+    const remoteMembers = await page.evaluate(async targetSubject => {
       const store = window.store!;
       const query = new URL('/query', store.getServerUrl());
       query.searchParams.set(
         'property',
         'https://atomicdata.dev/properties/originalSubject',
       );
-      query.searchParams.set('value', subject);
+      query.searchParams.set('value', targetSubject);
       query.searchParams.set('drive', store.getDrive()!);
       const result = await store.fetchResourceFromServer(query.toString());
+
       return result.get('https://atomicdata.dev/properties/collection/members');
     }, subject);
     expect(remoteMembers).toEqual([]);

--- a/browser/e2e/tests/forks.spec.ts
+++ b/browser/e2e/tests/forks.spec.ts
@@ -21,6 +21,37 @@ import {
 test.describe('forks', () => {
   test.beforeEach(before);
 
+  test('ordinary resources do not become proposals after refresh', async ({
+    page,
+  }) => {
+    await newResource('folder', page);
+    await editTitle('Ordinary folder', page);
+    const subject = await getCurrentSubject(page);
+    const remoteMembers = await page.evaluate(async subject => {
+      const store = window.store!;
+      const query = new URL('/query', store.getServerUrl());
+      query.searchParams.set(
+        'property',
+        'https://atomicdata.dev/properties/originalSubject',
+      );
+      query.searchParams.set('value', subject);
+      query.searchParams.set('drive', store.getDrive()!);
+      const result = await store.fetchResourceFromServer(query.toString());
+      return result.get('https://atomicdata.dev/properties/collection/members');
+    }, subject);
+    expect(remoteMembers).toEqual([]);
+    await page.reload();
+    await expect(editableTitle(page)).toHaveText('Ordinary folder');
+    await expect(
+      page.getByText(/forks? propose(s)? (a change|changes) to this/),
+    ).toBeHidden();
+    await openSubject(page, subject);
+    await expect(editableTitle(page)).toHaveText('Ordinary folder');
+    await expect(
+      page.getByText(/forks? propose(s)? (a change|changes) to this/),
+    ).toBeHidden();
+  });
+
   test('edit as fork, then merge, applies the change to the original', async ({
     page,
   }) => {

--- a/browser/e2e/tests/onboarding-storage.spec.ts
+++ b/browser/e2e/tests/onboarding-storage.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures';
+import { before, FRONTEND_URL } from './test-utils';
+
+test.beforeEach(before);
+
+test('onboarding checks storage before showing account controls and keeps feedback available', async ({ page }) => {
+  await page.evaluate(() => {
+    // Simulate the real ClientDb reporting a denied initialization, without
+    // breaking the test account's database or depending on private-mode policy.
+    window.store!.getClientDb = () => ({
+      waitForInit: async () => false,
+      initError: new Error('Storage denied'),
+    }) as ReturnType<NonNullable<typeof window.store>['getClientDb']>;
+    window.history.pushState({}, '', '/app/welcome');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await expect(page.getByRole('heading', { name: 'This browser could not open local storage' })).toBeVisible();
+  await expect(page.getByText('Open this link in a non-private browser window', { exact: false })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Feedback', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Send feedback' })).toBeVisible();
+  await page.getByRole('button', { name: 'Close', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Reload and try again' })).toBeVisible();
+});
+
+
+test('malformed invites still offer feedback', async ({ page }) => {
+  await page.goto(`${FRONTEND_URL}/app/invite`);
+  await expect(page.getByText('No invite token provided.')).toBeVisible();
+  await page.getByRole('button', { name: 'Feedback', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Send feedback' })).toBeVisible();
+});

--- a/browser/e2e/tests/onboarding-storage.spec.ts
+++ b/browser/e2e/tests/onboarding-storage.spec.ts
@@ -3,30 +3,48 @@ import { before, FRONTEND_URL } from './test-utils';
 
 test.beforeEach(before);
 
-test('onboarding checks storage before showing account controls and keeps feedback available', async ({ page }) => {
+test('onboarding checks storage before showing account controls and keeps feedback available', async ({
+  page,
+}) => {
   await page.evaluate(() => {
     // Simulate the real ClientDb reporting a denied initialization, without
     // breaking the test account's database or depending on private-mode policy.
-    window.store!.getClientDb = () => ({
-      waitForInit: async () => false,
-      initError: new Error('Storage denied'),
-    }) as ReturnType<NonNullable<typeof window.store>['getClientDb']>;
+    window.store!.getClientDb = () =>
+      ({
+        waitForInit: async () => false,
+        initError: new Error('Storage denied'),
+      }) as ReturnType<NonNullable<typeof window.store>['getClientDb']>;
     window.history.pushState({}, '', '/app/welcome');
     window.dispatchEvent(new PopStateEvent('popstate'));
   });
-  await expect(page.getByRole('heading', { name: 'This browser could not open local storage' })).toBeVisible();
-  await expect(page.getByText('Open this link in a non-private browser window', { exact: false })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toHaveCount(0);
+  await expect(
+    page.getByRole('heading', {
+      name: 'This browser could not open local storage',
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText('Open this link in a non-private browser window', {
+      exact: false,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Create account', exact: true }),
+  ).toHaveCount(0);
   await page.getByRole('button', { name: 'Feedback', exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Send feedback' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Send feedback' }),
+  ).toBeVisible();
   await page.getByRole('button', { name: 'Close', exact: true }).click();
-  await expect(page.getByRole('button', { name: 'Reload and try again' })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Reload and try again' }),
+  ).toBeVisible();
 });
-
 
 test('malformed invites still offer feedback', async ({ page }) => {
   await page.goto(`${FRONTEND_URL}/app/invite`);
   await expect(page.getByText('No invite token provided.')).toBeVisible();
   await page.getByRole('button', { name: 'Feedback', exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Send feedback' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Send feedback' }),
+  ).toBeVisible();
 });

--- a/browser/e2e/tests/saved-drives.spec.ts
+++ b/browser/e2e/tests/saved-drives.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from './fixtures';
-import { before, newDrive, openConfigureDrive, FRONTEND_URL, currentDriveTitle } from './test-utils';
+import {
+  before,
+  newDrive,
+  openConfigureDrive,
+  FRONTEND_URL,
+  currentDriveTitle,
+} from './test-utils';
 
 /**
  * A drive you make is one of your drives.
@@ -14,18 +20,31 @@ import { before, newDrive, openConfigureDrive, FRONTEND_URL, currentDriveTitle }
 test.describe('saved drives', () => {
   test.beforeEach(before);
 
-  test('a portal Open link selects its drive and consumes the instruction', async ({ page }) => {
+  test('a portal Open link selects its drive and consumes the instruction', async ({
+    page,
+  }) => {
     const original = await page.evaluate(() => window.store.getDrive());
     const originalTitle = await currentDriveTitle(page).textContent();
     const { driveURL } = await newDrive(page);
-    const search = new URLSearchParams({ subject: original!, drive: original! });
+    const search = new URLSearchParams({
+      subject: original!,
+      drive: original!,
+    });
     await page.goto(`${FRONTEND_URL}/app/show?${search}`);
-    await expect.poll(() => page.evaluate(() => window.store.getDrive())).toBe(original);
+    await expect
+      .poll(() => page.evaluate(() => window.store.getDrive()))
+      .toBe(original);
     await expect(currentDriveTitle(page)).toHaveText(originalTitle!);
-    await expect.poll(() => new URL(page.url()).searchParams.has('drive')).toBe(false);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has('drive'))
+      .toBe(false);
     // Ordinary resource links do not silently replace the selected workspace.
-    await page.goto(`${FRONTEND_URL}/app/show?${new URLSearchParams({ subject: driveURL })}`);
-    await expect(page.getByRole('button', { name: 'Set as current drive', exact: true })).toBeVisible();
+    await page.goto(
+      `${FRONTEND_URL}/app/show?${new URLSearchParams({ subject: driveURL })}`,
+    );
+    await expect(
+      page.getByRole('button', { name: 'Set as current drive', exact: true }),
+    ).toBeVisible();
     expect(await page.evaluate(() => window.store.getDrive())).toBe(original);
   });
 

--- a/browser/e2e/tests/saved-drives.spec.ts
+++ b/browser/e2e/tests/saved-drives.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { before, newDrive, openConfigureDrive } from './test-utils';
+import { before, newDrive, openConfigureDrive, FRONTEND_URL, currentDriveTitle } from './test-utils';
 
 /**
  * A drive you make is one of your drives.
@@ -13,6 +13,21 @@ import { before, newDrive, openConfigureDrive } from './test-utils';
  */
 test.describe('saved drives', () => {
   test.beforeEach(before);
+
+  test('a portal Open link selects its drive and consumes the instruction', async ({ page }) => {
+    const original = await page.evaluate(() => window.store.getDrive());
+    const originalTitle = await currentDriveTitle(page).textContent();
+    const { driveURL } = await newDrive(page);
+    const search = new URLSearchParams({ subject: original!, drive: original! });
+    await page.goto(`${FRONTEND_URL}/app/show?${search}`);
+    await expect.poll(() => page.evaluate(() => window.store.getDrive())).toBe(original);
+    await expect(currentDriveTitle(page)).toHaveText(originalTitle!);
+    await expect.poll(() => new URL(page.url()).searchParams.has('drive')).toBe(false);
+    // Ordinary resource links do not silently replace the selected workspace.
+    await page.goto(`${FRONTEND_URL}/app/show?${new URLSearchParams({ subject: driveURL })}`);
+    await expect(page.getByRole('button', { name: 'Set as current drive', exact: true })).toBeVisible();
+    expect(await page.evaluate(() => window.store.getDrive())).toBe(original);
+  });
 
   test('a drive you create is listed among your drives', async ({ page }) => {
     const { driveTitle } = await newDrive(page);

--- a/browser/e2e/tests/sync-devices.spec.ts
+++ b/browser/e2e/tests/sync-devices.spec.ts
@@ -31,6 +31,7 @@ test.describe('sync page devices', () => {
     page,
   }) => {
     let managedInfoRequests = 0;
+    let accountConnected = false;
     await page.route('**/server', async route => {
       const response = await route.fetch();
       const body = await response.json();
@@ -45,13 +46,15 @@ test.describe('sync page devices', () => {
       });
     });
     await page.route('**/drive-usage?**', route =>
-      route.fulfill({ json: { resourceCount: 0, blobBytes: 0, loroBytes: 0 } }),
+      route.fulfill({ json: { resourceCount: 3, blobBytes: 0, loroBytes: 7800 } }),
     );
     await page.route('**/api/**', route => {
       const path = new URL(route.request().url()).pathname;
 
       return path === '/api/me'
-        ? route.fulfill({ status: 204 })
+        ? accountConnected
+          ? route.fulfill({ json: { email: 'sync-account@example.com' } })
+          : route.fulfill({ status: 204 })
         : route.fulfill({ json: [] });
     });
     await gotoSync(page);
@@ -64,9 +67,17 @@ test.describe('sync page devices', () => {
     await expect(cloud).not.toContainText('In sync');
     await expect(cloud).not.toContainText('Synced');
     await expect(cloud).not.toContainText('Cloud Server is on');
+    const recovery = page.getByTestId('recovery-row');
+    await expect(recovery).toContainText('Sign in to your');
+    await expect(recovery).not.toContainText('Not set up');
+    await expect(page.locator('body')).not.toContainText('[i18n-404:');
     await expect(
       cloud.getByRole('button', { name: 'Set up Cloud Server', exact: true }),
     ).toBeVisible();
+    accountConnected = true;
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect(recovery).toContainText('sync-account@example.com');
+    await expect(page.getByTestId('link-provider-panel')).not.toBeVisible();
   });
 
   test('the pairing code on screen is a routable envelope', async ({

--- a/browser/e2e/tests/sync-devices.spec.ts
+++ b/browser/e2e/tests/sync-devices.spec.ts
@@ -46,7 +46,9 @@ test.describe('sync page devices', () => {
       });
     });
     await page.route('**/drive-usage?**', route =>
-      route.fulfill({ json: { resourceCount: 3, blobBytes: 0, loroBytes: 7800 } }),
+      route.fulfill({
+        json: { resourceCount: 3, blobBytes: 0, loroBytes: 7800 },
+      }),
     );
     await page.route('**/api/**', route => {
       const path = new URL(route.request().url()).pathname;

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -2037,6 +2037,15 @@ export async function acceptInvite(page: Page) {
     name: 'Create account and accept',
   });
   await expect(acceptBtn).toBeVisible({ timeout: 15000 });
+  // Record even a transient duplicate acceptance CTA during agent creation.
+  await page.evaluate(() => {
+    const observer = new MutationObserver(() => {
+      if (document.querySelector('[data-test="accept-existing"]')) {
+        document.documentElement.dataset.duplicateInviteAcceptance = 'true';
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
   await acceptBtn.click();
 
   await page
@@ -2059,6 +2068,20 @@ export async function acceptInvite(page: Page) {
         dialog.getByRole('heading', { name: 'Agent created!' }),
       ).toBeVisible();
       await expect(dialog.getByLabel('Agent Name')).toHaveCount(0);
+      await dialog
+        .getByRole('button', { name: 'Feedback', exact: true })
+        .click();
+      await expect(
+        page.getByRole('heading', { name: 'Send feedback' }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Close', exact: true }).click();
+      await expect(
+        dialog.getByRole('heading', { name: 'Agent created!' }),
+      ).toBeVisible();
+      await expect(page.locator('html')).not.toHaveAttribute(
+        'data-duplicate-invite-acceptance',
+        'true',
+      );
       await dialog.getByRole('button', { name: 'Copy to clipboard' }).click();
       await closeDialog('Continue');
     },

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -300,7 +300,11 @@ test.describe('Cloud Vault backup and restore', () => {
     // makes "it came back" mean "it came back from the vault".
     await page.evaluate(() => {
       const store = window.store;
-      store.registerLocalOnlyDrive(store.getDrive());
+      const drive = store.getDrive();
+
+      if (!drive) throw new Error('Vault test needs a selected drive');
+
+      store.registerLocalOnlyDrive(drive);
       store.getDefaultWebSocket()?.close();
     });
 

--- a/browser/lib/src/local-outbox.test.ts
+++ b/browser/lib/src/local-outbox.test.ts
@@ -1,5 +1,5 @@
 import { RequestCancelledError } from './error.js';
-import { describe, it, beforeEach, vi } from 'vitest';
+import { describe, it, beforeEach, vi, expect as assert } from 'vitest';
 import {
   LocalOutbox,
   isTerminalCommitErrorMessage,
@@ -587,6 +587,44 @@ describe('LocalOutbox blocking', () => {
       vi.setSystemTime(now);
     }
   }
+
+  it.each([
+    'Drive did:ad:private is not enrolled for sync on this node.',
+    'Drive did:ad:private has reached its storage quota on this node.',
+  ])(
+    'parks managed-node refusals without dropping edits: %s',
+    async message => {
+      vi.useFakeTimers();
+
+      try {
+        const outbox = new LocalOutbox();
+        outbox.markDirty(SUBJECT);
+        const drainSubject = vi.fn(async () => {
+          throw new Error(message);
+        });
+        const ctx = blockingCtx(drainSubject);
+        await drainUntilBlocked(outbox, ctx);
+        assert(outbox.getEntry(SUBJECT)?.blocked).toBe(true);
+        assert(outbox.size).toBe(1);
+        assert(outbox.nextDueAt()).toBeUndefined();
+        assert(isTerminalCommitError(message)).toBe(false);
+        assert(
+          isUnrecoverableCommitError(
+            'localized refusal',
+            ErrorCode.SYNC_REJECTED,
+          ),
+        ).toBe(true);
+        vi.setSystemTime(1_000_000);
+        await outbox.drain(ctx);
+        assert(drainSubject).toHaveBeenCalledTimes(BLOCK_AFTER_FAILURES);
+        // A new edit after enrollment re-arms the preserved write.
+        outbox.markDirty(SUBJECT);
+        assert(outbox.getEntry(SUBJECT)?.blocked).toBeFalsy();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it('retries a blocking error first, then parks after sustained failures', async ({
     expect,

--- a/browser/lib/src/local-outbox.ts
+++ b/browser/lib/src/local-outbox.ts
@@ -196,6 +196,15 @@ export function isTerminalCommitErrorMessage(message: string): boolean {
  * rights change or the user abandoning the edit — neither helped by hammering.
  */
 export function isUnrecoverableCommitErrorMessage(message: string): boolean {
+  // Managed nodes refuse writes until enrollment/quota changes. Keep the edit,
+  // but park it after bounded retries rather than flooding the node forever.
+  if (
+    message.includes('is not enrolled for sync on this node') ||
+    message.includes('has reached its storage quota on this node')
+  ) {
+    return true;
+  }
+
   // Server emits: "No https://atomicdata.dev/properties/write right has been found..."
   if (message.includes('/properties/write right has been found')) {
     return true;
@@ -234,6 +243,7 @@ const KNOWN_ERROR_CODES: ReadonlySet<number> = new Set([
   ErrorCode.MISSING_REQUIRED_PROPERTY,
   ErrorCode.UNAUTHORIZED_WRITE,
   ErrorCode.MISSING_CLASS,
+  ErrorCode.SYNC_REJECTED,
 ]);
 
 /**
@@ -263,7 +273,9 @@ export function isUnrecoverableCommitError(
 ): boolean {
   if (code !== undefined && KNOWN_ERROR_CODES.has(code)) {
     return (
-      code === ErrorCode.UNAUTHORIZED_WRITE || code === ErrorCode.MISSING_CLASS
+      code === ErrorCode.UNAUTHORIZED_WRITE ||
+      code === ErrorCode.MISSING_CLASS ||
+      code === ErrorCode.SYNC_REJECTED
     );
   }
 

--- a/browser/lib/src/offline-create-drain.test.ts
+++ b/browser/lib/src/offline-create-drain.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, vi, expect as assert } from 'vitest';
 import { server } from './ontologies/server.js';
 import { testStore } from './test-store.js';
-import type { ClientDb } from './client-db.js';
+import type { ClientDbWorker } from './client-db.js';
 
 /**
  * Reproduces the develop full-e2e failure of
@@ -98,10 +98,10 @@ describe('offline create drain', () => {
       const getResourceWithSnapshot = vi
         .fn()
         .mockResolvedValue({ snapshot: available ? snapshot : undefined });
-      (store as unknown as { clientDb: ClientDb }).clientDb = {
+      (store as unknown as { clientDb: ClientDbWorker }).clientDb = {
         isReady: true,
         getResourceWithSnapshot,
-      } as unknown as ClientDb;
+      } as unknown as ClientDbWorker;
       postCommitSpy.mockClear();
       await store.syncDirtyResources();
       assert(getResourceWithSnapshot).toHaveBeenCalledWith(agentDID);

--- a/browser/lib/src/store-commit-fallback.test.ts
+++ b/browser/lib/src/store-commit-fallback.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Store } from './store.js';
+import { AtomicError, ErrorType } from './error.js';
+import type { Commit } from './commit.js';
+import { ErrorCode } from './ws-v2.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('commit transport fallback', () => {
+  it.each([undefined, ErrorCode.SYNC_REJECTED])(
+    'does not retry an enrollment refusal over HTTP (code %s)',
+    async code => {
+      const store = new Store({ serverUrl: 'https://example.com' });
+      vi.stubGlobal('WebSocket', { OPEN: 1 });
+      const rejected = new AtomicError(
+        'Drive did:ad:private is not enrolled for sync on this node.',
+        ErrorType.Server,
+        code,
+      );
+      const internals = store as unknown as {
+        getWebSocketForEndpoint: () => unknown;
+        client: { postCommit: () => Promise<Commit> };
+      };
+      vi.spyOn(internals, 'getWebSocketForEndpoint').mockReturnValue({
+        readyState: 1,
+        postCommit: vi.fn().mockRejectedValue(rejected),
+      });
+      const http = vi
+        .spyOn(internals.client, 'postCommit')
+        .mockRejectedValue(rejected);
+      await expect(
+        store.postCommit(
+          { subject: 'did:ad:edit' } as Commit,
+          'https://example.com/commit',
+        ),
+      ).rejects.toBe(rejected);
+      expect(http).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still uses HTTP when the socket transport fails', async () => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const commit = { subject: 'did:ad:edit' } as Commit;
+    const internals = store as unknown as {
+      getWebSocketForEndpoint: () => unknown;
+      client: { postCommit: () => Promise<Commit> };
+    };
+    vi.spyOn(internals, 'getWebSocketForEndpoint').mockReturnValue({
+      readyState: 1,
+      postCommit: vi.fn().mockRejectedValue(new Error('socket closed')),
+    });
+    const http = vi
+      .spyOn(internals.client, 'postCommit')
+      .mockResolvedValue(commit);
+    await expect(
+      store.postCommit(commit, 'https://example.com/commit'),
+    ).resolves.toBe(commit);
+    expect(http).toHaveBeenCalledTimes(1);
+  });
+});

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -74,7 +74,6 @@ describe('Store', () => {
   }) => {
     const { store } = await testStore();
     const resource = await store.newResource({
-      isA: core.classes.resource,
       propVals: { [core.properties.name]: 'Before' },
     });
     await resource.save();

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -5544,6 +5544,18 @@ export class Store {
         return await ws.postCommit(commit);
       } catch (e) {
         if (e instanceof RequestCancelledError) throw e;
+        // A server refusal is an answer, not a broken transport. Retrying the
+        // same rejected commit over HTTP only duplicates the failed write.
+        const message = e instanceof Error ? e.message : String(e);
+        const code = e instanceof AtomicError ? e.code : undefined;
+
+        if (
+          isUnrecoverableCommitError(message, code) ||
+          isTerminalCommitError(message, code)
+        ) {
+          throw e;
+        }
+
         // Fall through to HTTP — a broken WS shouldn't block saves while
         // the reconnect timer is still backing off. The WS error already
         // surfaced in console; the HTTP path will produce its own.

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -468,6 +468,77 @@ describe('WSClient drive subscription', () => {
     client.close();
   });
 
+  it('reconciles drives selected after authentication without reopening the socket', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('late-drive'));
+    const auth = client.authenticate();
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await auth;
+    await new Promise(resolve => setTimeout(resolve, 10));
+    vi.mocked(store.getDrive).mockRestore();
+    vi.spyOn(store, 'isLiveSyncedDrive').mockImplementation(
+      drive => drive !== 'did:ad:local',
+    );
+    vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
+      drive: 'did:ad:a',
+      driveHash: 'hash',
+      resources: {},
+      peers: [],
+    });
+
+    for (const drive of ['did:ad:a', 'did:ad:b']) {
+      const before = framesWithTag(socket, Tag.SYNC).length;
+      store.setDrive(drive);
+      await vi.waitFor(() =>
+        expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(before + 1),
+      );
+    }
+
+    const before = framesWithTag(socket, Tag.SYNC).length;
+    store.setDrive('did:ad:local');
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(before);
+    client.close();
+  });
+
+  it('reconciles the selected drive after reauthentication on an open socket', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('signin-drive'));
+    const initial = client.authenticate();
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await initial;
+    await new Promise(resolve => setTimeout(resolve, 10));
+    socket.sent.length = 0;
+    vi.mocked(store.getDrive).mockReturnValue('did:ad:a');
+    vi.spyOn(store, 'isLiveSyncedDrive').mockReturnValue(true);
+    vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
+      drive: 'did:ad:a',
+      driveHash: 'hash',
+      resources: {},
+      peers: [],
+    });
+    const auth = client.authenticate(true);
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+    );
+    socket.receive(encodeAuthOk([]));
+    await auth;
+    await vi.waitFor(() =>
+      expect(framesWithTag(socket, Tag.SYNC).length).toBeGreaterThan(0),
+    );
+    client.close();
+  });
+
   it('UNSUBs the previous drive when the store switches drives', async ({
     expect,
   }) => {

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -341,6 +341,7 @@ export class WSClient {
     this._driveUnsub = store.on(StoreEvents.DriveChanged, () => {
       this._pendingSyncState.clear();
       this.subscribeToDrive();
+      void this.reconcileSubscribedDrive();
     });
 
     const wsURL = new URL(url);
@@ -589,6 +590,8 @@ export class WSClient {
 
         // Refetch resources that had 401 errors
         if (fetchAll) {
+          await this.reconcileSubscribedDrive();
+
           for (const resource of this.store.resources.values()) {
             if (resource.isUnauthorized()) {
               this.fetch(resource.subject).catch(() => {});
@@ -1338,6 +1341,26 @@ export class WSClient {
       this.sendBinary(encodeSub(drive));
       this._subscribedDrive = drive;
     }
+  }
+
+  /** A SUB only enables future updates; it does not reconcile existing data.
+   * Drive selection and sign-in can happen on an already-open socket, without
+   * running handleOpen's initial sync. Reconcile only a drive we could subscribe
+   * under the current identity; never upload local-only or inaccessible drives. */
+  private async reconcileSubscribedDrive(): Promise<void> {
+    const drive = this.store.getDrive();
+    if (
+      this._closed ||
+      this.readyState !== WebSocket.OPEN ||
+      !drive ||
+      this._subscribedDrive !== drive ||
+      !this.store.isLiveSyncedDrive(drive) ||
+      (this.store.getAgent()?.subject &&
+        this.authenticatedWith !== this.store.getAgent()?.subject)
+    )
+      return;
+
+    await this.startVVSync(drive);
   }
 
   /** Agent profiles are public resources outside the reader's active drive. */

--- a/browser/lib/src/ws-v2.ts
+++ b/browser/lib/src/ws-v2.ts
@@ -97,7 +97,8 @@ export const ErrorCode = {
    *  LORO_SYNC_SUBSCRIBE, ...) arrived before AUTH. Connection-level (`requestId`
    *  0); the socket stays open and the frame is simply not processed. */
   AUTH_REQUIRED: 5,
-  /** The server refused a SYNC_PUSH as a whole (no write right on the
+  /** Node policy refused a commit (enrollment/quota), or the server refused
+   *  a SYNC_PUSH as a whole (no write right on the
    *  drive, quota, not enrolled). Nothing from the push landed, and no
    *  SYNC_OK follows for it. The message names the drive. */
   SYNC_REJECTED: 6,

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -418,7 +418,7 @@ Everything else is open to an anonymous socket and gated per subject by
 | `3` | `UNAUTHORIZED_WRITE` | The signer has no write right on the target or its parents. Blocking, not terminal. |
 | `4` | `MISSING_CLASS` | The commit names a class this node does not hold, so validation cannot run. Blocking, not terminal: the class may still arrive. |
 | `5` | `AUTH_REQUIRED` | The frame needs an authenticated session. `request_id = 0`. |
-| `6` | `SYNC_REJECTED` | A `SYNC_PUSH` was refused as a whole and nothing from it landed. `request_id = 0`. Message: `SYNC_PUSH rejected for drive <drive>: <reason>`. |
+| `6` | `SYNC_REJECTED` | A commit was refused by node enrollment/quota policy, or a `SYNC_PUSH` was refused as a whole. Keep local edits; stop unbounded retries. Commits carry their request ID; `SYNC_PUSH` uses `request_id = 0` and message `SYNC_PUSH rejected for drive <drive>: <reason>`. |
 | `7` | `UNAUTHORIZED_READ` | A subscription or a read-side reconcile frame was refused. `request_id = 0`. Message: `<FRAME> refused for <subject>: <reason>`. |
 | `8` | `AUTH_FAILED` | An `AUTH` frame was refused. `request_id = 0`. |
 | `9` | `INVALID_SIGNATURE` | A `COMMIT` whose signature does not verify against its signer's key, or that has none. Terminal for that envelope: sign again. |

--- a/lib/src/sync/protocol.rs
+++ b/lib/src/sync/protocol.rs
@@ -223,8 +223,9 @@ pub mod error_code {
     /// authenticate first — retrying the same frame without an `AUTH`
     /// changes nothing.
     pub const AUTH_REQUIRED: u16 = 5;
-    /// A `SYNC_PUSH` was refused as a whole — the agent may not write the
-    /// drive, or this node's sync policy does not admit it — and **nothing**
+    /// A commit was refused by node admission policy, or a `SYNC_PUSH` was
+    /// refused as a whole — the agent may not write the drive, or this node's
+    /// sync policy does not admit it — and **nothing**
     /// from it landed. Replaces the old behaviour of silently dropping the
     /// import and still answering `SYNC_OK`, which made the ack meaningless.
     /// The message names the drive. Blocking, not terminal: keep the local
@@ -279,6 +280,14 @@ pub struct DecodedError {
 /// `isTerminalCommitErrorMessage` / `isUnrecoverableCommitErrorMessage`
 /// patterns — update both sides together if you add a case.
 pub fn classify_commit_error(message: &str) -> u16 {
+    // Admission refusals are not transport failures. They can recover after
+    // enrollment/quota changes, so keep the write but stop unlimited retries.
+    if message.contains("is not enrolled for sync on this node")
+        || message.contains("has reached its storage quota on this node")
+    {
+        return error_code::SYNC_REJECTED;
+    }
+
     if message.contains("is_genesis: true, but the resource already exists") {
         return error_code::GENESIS_COLLISION;
     }
@@ -1507,6 +1516,16 @@ mod tests {
         let code = u16::from_be_bytes([encoded[3], encoded[4]]);
         assert_eq!(code, error_code::UNAUTHORIZED_WRITE);
         assert_eq!(&encoded[5..], b"Not found");
+    }
+
+    #[test]
+    fn managed_commit_refusals_are_blocking() {
+        for message in [
+            "Drive did:ad:private is not enrolled for sync on this node.",
+            "Drive did:ad:private has reached its storage quota on this node.",
+        ] {
+            assert_eq!(classify_commit_error(message), error_code::SYNC_REJECTED);
+        }
     }
 
     #[test]

--- a/planning/consolidated-staging-fixes.md
+++ b/planning/consolidated-staging-fixes.md
@@ -1,0 +1,8 @@
+# Consolidated staging fixes
+
+- [x] Verify all five PR commits are included in the two repository heads.
+- [x] Fix fork regression lint errors and Cargo registry extraction race.
+- [ ] Fix portable OpenSSL builds and pnpm cache setup in SaaS.
+- [ ] Run local lint and relevant checks; push paired branches.
+- [ ] Update combined PRs and close superseded PRs.
+- [ ] Verify CI and address remaining failures.

--- a/planning/consolidated-staging-fixes.md
+++ b/planning/consolidated-staging-fixes.md
@@ -2,7 +2,13 @@
 
 - [x] Verify all five PR commits are included in the two repository heads.
 - [x] Fix fork regression lint errors and Cargo registry extraction race.
-- [ ] Fix portable OpenSSL builds and pnpm cache setup in SaaS.
-- [ ] Run local lint and relevant checks; push paired branches.
-- [ ] Update combined PRs and close superseded PRs.
+- [x] Fix portable OpenSSL builds and pnpm cache setup in SaaS.
+- [x] Run local lint and relevant checks; push paired branches.
+- [x] Update combined PRs and close superseded PRs.
 - [ ] Verify CI and address remaining failures.
+
+Combined PRs: atomic-server #1397 and atomic-saas #60. Superseded #1395, #1400 and SaaS #59 are closed.
+
+Local validation: 399 client tests, 800 app tests, 71 server tests, full browser lint, app typecheck, portal lint/build pass.
+
+CI runs 34353039272 (server) and 34353048110 (SaaS): SaaS control-plane, managed-node, coverage and real protocol E2E passed; portal E2E and server pipeline still running. No local Dagger execution.

--- a/planning/fork-banner-refresh.md
+++ b/planning/fork-banner-refresh.md
@@ -1,0 +1,9 @@
+# Fork banner after refresh
+
+- [x] Trace originalSubject through local, HTTP, and WebSocket collection paths.
+- [x] Reproduce the incorrect banner with query candidates containing normal drive resources (two failing component tests before the fix).
+- [x] Verify Fork type and originalSubject before counting or rendering proposals.
+- [x] Validate: three component tests, five Chromium fork E2E tests, typecheck and frontend build pass; catalogs unchanged.
+- [ ] Reproduce why Safari's query returned unrelated resources. Local HTTP, WS and OPFS queries return the correct empty set. Playwright WebKit fails OPFS initialization before dev-drive setup. No query-engine cause has been confirmed.
+
+The UI safeguard is in PR #1397. Do not describe this as a verified fix to the underlying query engine or as Safari acceptance testing.

--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -34,6 +34,13 @@ impl Error for AtomicServerError {}
 
 impl ResponseError for AtomicServerError {
     fn status_code(&self) -> StatusCode {
+        // A managed node refusing enrollment/quota is an expected admission
+        // decision, not an internal failure or a request to sign in again.
+        if atomic_lib::sync::protocol::classify_commit_error(&self.message)
+            == atomic_lib::sync::protocol::error_code::SYNC_REJECTED
+        {
+            return StatusCode::FORBIDDEN;
+        }
         match self.error_type {
             AppErrorType::NotFound => StatusCode::NOT_FOUND,
             AppErrorType::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
@@ -172,6 +179,26 @@ impl From<actix_web::Error> for AtomicServerError {
             message: error.to_string(),
             error_type: AppErrorType::Other,
             error_resource: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod admission_error_tests {
+    use super::*;
+
+    #[test]
+    fn managed_commit_errors_carry_a_blocking_code() {
+        for message in [
+            "Drive did:ad:private is not enrolled for sync on this node.",
+            "Drive did:ad:private has reached its storage quota on this node.",
+        ] {
+            let error: AtomicServerError = message.into();
+            assert_eq!(error.status_code(), StatusCode::FORBIDDEN);
+            assert_eq!(
+                atomic_lib::sync::protocol::classify_commit_error(&error.message),
+                atomic_lib::sync::protocol::error_code::SYNC_REJECTED
+            );
         }
     }
 }

--- a/server/src/handlers/download.rs
+++ b/server/src/handlers/download.rs
@@ -38,21 +38,23 @@ pub async fn handle_download(
         return Err("Put `/download` in front of an File URL to download it.".into());
     };
 
-    // Content-addressed shortcut: `/download/files/<64-hex>` serves the blob
-    // directly from Tree::Blobs without requiring a resource to live at
-    // `<origin>/files/<hash>`. Only fires for raw fetches — image-processing
-    // params still go through the File-resource path so we can read mimetype.
-    if params.q.is_none() && params.w.is_none() && params.f.is_none() {
-        if let Some(hash_hex) = subject_path.strip_prefix("/files/") {
-            if let Some(bytes) = blob_by_hash_hex(hash_hex, &appstate)? {
+    // Content-addressed URLs identify blob bytes, not a File resource at
+    // `/files/<hash>`. This remains true when requesting an image rendition:
+    // uploads have DID resources, and peers can hold the blob without metadata.
+    if let Some(hash_hex) = subject_path.strip_prefix("/files/") {
+        if hash_hex.len() == 64 && hex::decode(hash_hex).is_ok() {
+            let bytes = match blob_by_hash_hex(hash_hex, &appstate)? {
+                Some(bytes) => Some(bytes),
+                None => chunked_file_by_internal_id(hash_hex, &appstate).await?,
+            };
+            let bytes = bytes.ok_or_else(|| {
+                atomic_lib::errors::AtomicError::not_found(format!("Blob not found: {hash_hex}"))
+            })?;
+            if params.q.is_none() && params.w.is_none() && params.f.is_none() {
                 return Ok(user_blob_response("application/octet-stream", bytes));
             }
-
-            // No whole-file blob under this hash: it may be a chunked file whose
-            // `internalId` is this hash. Find it and reconstruct from its chunks.
-            if let Some(bytes) = chunked_file_by_internal_id(hash_hex, &appstate).await? {
-                return Ok(user_blob_response("application/octet-stream", bytes));
-            }
+            let hash_bytes = hex::decode(hash_hex).expect("validated hash");
+            return serve_processed_image(&bytes, &hash_bytes, &params, &appstate);
         }
     }
 
@@ -118,9 +120,7 @@ fn blob_by_hash_hex(hash_hex: &str, appstate: &AppState) -> AtomicServerResult<O
     Ok(appstate
         .store
         .kv
-        .get(atomic_lib::db::trees::Tree::Blobs, &hash_bytes)
-        .ok()
-        .flatten())
+        .get(atomic_lib::db::trees::Tree::Blobs, &hash_bytes)?)
 }
 
 /// The bytes of a File: concatenated chunk blobs when it is chunked (its `chunks`

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -539,6 +539,100 @@ fn get_body(resp: ServiceResponse) -> String {
     String::from_utf8(bytes.as_ref().into()).unwrap()
 }
 
+/// Content-addressed image URLs need no resource at `/files/<hash>`.
+#[cfg(feature = "img")]
+#[actix_rt::test]
+async fn content_addressed_image_download() {
+    use clap::Parser;
+    let dir = std::path::PathBuf::from(format!("./.temp/{}", atomic_lib::utils::random_string(10)));
+    let opts = Opts::parse_from([
+        "atomic-server",
+        "--initialize",
+        "--data-dir",
+        dir.join("db").to_str().unwrap(),
+        "--config-dir",
+        dir.join("config").to_str().unwrap(),
+    ]);
+    let mut config = config::build_config(opts).unwrap();
+    config.search_index_path = dir.join("search");
+    config.vector_search_index_path = dir.join("vectors");
+    let appstate = AppState::init(config).await.unwrap();
+    let mut png = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+        2,
+        2,
+        image::Rgba([40, 80, 120, 255]),
+    ))
+    .write_to(&mut png, image::ImageFormat::Png)
+    .unwrap();
+    let bytes = png.into_inner();
+    let hash = blake3::hash(&bytes);
+    appstate
+        .store
+        .kv
+        .insert(atomic_lib::db::trees::Tree::Blobs, hash.as_bytes(), &bytes)
+        .unwrap();
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(appstate))
+            .configure(crate::routes::config_routes),
+    )
+    .await;
+    let path = format!("/download/files/{}", hash.to_hex());
+    let raw = test::call_service(&app, TestRequest::get().uri(&path).to_request()).await;
+    assert_eq!(raw.status(), 200);
+    assert_eq!(test::read_body(raw).await.as_ref(), bytes.as_slice());
+    for (format, expected_format) in [
+        ("webp", image::ImageFormat::WebP),
+        ("avif", image::ImageFormat::Avif),
+    ] {
+        let resized = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri(&format!("{path}?f={format}&w=64&q=60"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            resized.status(),
+            200,
+            "resizing must use the existing blob, not a nonexistent File URL"
+        );
+        assert_eq!(
+            resized.headers().get("content-type").unwrap(),
+            format!("image/{format}").as_str()
+        );
+        assert_eq!(
+            resized.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert!(resized
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("attachment"));
+        let rendered = test::read_body(resized).await;
+        assert_eq!(image::guess_format(&rendered).unwrap(), expected_format);
+    }
+    let missing = "0".repeat(64);
+    for suffix in ["", "?f=webp&w=64&q=60"] {
+        let response = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri(&format!("/download/files/{missing}{suffix}"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            404,
+            "missing blobs must not become HTTP 500"
+        );
+    }
+}
+
 #[actix_rt::test]
 async fn upload_download_test() {
     let unique_string = atomic_lib::utils::random_string(10);


### PR DESCRIPTION
Opening a drive or signing back in could leave cloud sync stuck, managed invitations used the old secret-only signup flow, and refreshed resources could show unrelated fork proposals. This PR consolidates the staging fixes from #1395, #1397 and #1400.

- Select portal-opened drives and reconnect after drive/authentication changes; refresh account and enrollment status.
- Route managed invitations through email signup/recovery and accept once; show storage failures early, keep feedback accessible, and use a clickable person avatar.
- Validate fork relationships before showing proposals.
- Park rejected managed writes while preserving edits, avoid duplicate HTTP retries, and serve raw and resized content-addressed images from stored blobs.
- Fix E2E lint/formatting and serialize Cargo registry extraction across CI containers.

Paired with ontola/atomic-saas#60 on the same branch. Merge this repository first.

Validation: full browser workspace lint passes (existing warnings); 399 client tests, 800 app tests, 71 server tests and the app typecheck pass. Earlier browser validation includes five Chromium fork E2E tests and onboarding tests. Safari query contamination was not reproduced; the banner guard is covered. CI is being rerun on the consolidated head; no local Dagger run. Private drives still require server enrollment.
