### PR TITLE
Keep Cloud Server billing links scoped to the current drive

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -392,8 +392,14 @@ Cloud Vault display metadata: `vaultAutoBackup.test.ts` verifies name/emoji enro
   and failed connection without local-drive promotion.
 - `data-browser/src/helpers/managed/reconcile.test.ts`: pending/empty placements
   do not switch the app away from its source.
-- Paired `atomic-saas/portal/e2e/server-setup.spec.ts`: setup opens the selected
-  existing drive, never creates a content-free enrollment in the portal.
+- Paired `atomic-saas/portal/e2e/server-setup.spec.ts`: setup checks the selected
+  drive's subscription before opening hosting in the app; it never creates a
+  content-free enrollment in the portal.
+- Paired `atomic-saas/portal/e2e/drive-billing-ux.spec.ts`: billing has no fake
+  account-wide free plan, named drives survive selection/reload/Back, and a
+  paid drive's price and quota do not leak into an unsubscribed drive.
+- `data-browser/src/helpers/driveBillingUrl.test.ts`: Sync links preserve the
+  exact drive and portal, or open the picker when no drive is selected.
 - Paired `atomic-saas/portal/e2e/server-hosting-live.spec.ts`: opt-in real sign-in,
   grant, signed enrollment, setup UI, source replication and destination HTTP
   read. Requires two isolated nodes and dev magic links (`ATOMIC_HOSTING_LIVE=1`).

--- a/browser/data-browser/src/helpers/driveBillingUrl.test.ts
+++ b/browser/data-browser/src/helpers/driveBillingUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { driveBillingUrl } from './driveBillingUrl';
+
+describe('drive billing links', () => {
+  it('keeps the exact selected drive on the account portal', () => {
+    const url = new URL(
+      driveBillingUrl(
+        'https://staging.atomicserver.eu/',
+        'did:ad:drive+with/slash',
+      ),
+    );
+    expect(url.origin).toBe('https://staging.atomicserver.eu');
+    expect(url.pathname).toBe('/billing');
+    expect(url.searchParams.get('drive')).toBe('did:ad:drive+with/slash');
+  });
+  it('opens the drive picker when there is no current drive', () => {
+    expect(driveBillingUrl('https://staging.atomicserver.eu')).toBe(
+      'https://staging.atomicserver.eu/billing',
+    );
+  });
+});

--- a/browser/data-browser/src/helpers/driveBillingUrl.ts
+++ b/browser/data-browser/src/helpers/driveBillingUrl.ts
@@ -1,0 +1,8 @@
+/** Preserve the billing target when leaving a drive for its account portal. */
+export function driveBillingUrl(portal: string, drive?: string): string {
+  const url = new URL('/billing', portal);
+
+  if (drive) url.searchParams.set('drive', drive);
+
+  return url.toString();
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -1730,9 +1730,8 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Manage account & plan →"
-msgstr ""
+#~ msgid "Manage account & plan →"
+#~ msgstr ""
 
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 #: src/chunks/TablePage/PropertyForm/ExternalPropertyDialog.tsx
@@ -7833,4 +7832,12 @@ msgstr ""
 
 #: src/views/InvitePage.tsx
 msgid "Accepting your invitation…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This status describes data synchronization. View this drive’s subscription and price in billing."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage this drive’s plan →"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -1730,9 +1730,8 @@ msgstr "Error: Expected {0}<node-id>"
 msgid "This device"
 msgstr "This device"
 
-#: src/routes/SyncRoute.tsx
-msgid "Manage account & plan →"
-msgstr "Manage account & plan →"
+#~ msgid "Manage account & plan →"
+#~ msgstr "Manage account & plan →"
 
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 #: src/chunks/TablePage/PropertyForm/ExternalPropertyDialog.tsx
@@ -7868,3 +7867,11 @@ msgstr "Local storage is taking too long to initialize."
 #: src/views/InvitePage.tsx
 msgid "Accepting your invitation…"
 msgstr "Accepting your invitation…"
+
+#: src/routes/SyncRoute.tsx
+msgid "This status describes data synchronization. View this drive’s subscription and price in billing."
+msgstr "This status describes data synchronization. View this drive’s subscription and price in billing."
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage this drive’s plan →"
+msgstr "Manage this drive’s plan →"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -1730,9 +1730,8 @@ msgstr "Error: Se esperaba {0}<node-id>"
 msgid "This device"
 msgstr "Este dispositivo"
 
-#: src/routes/SyncRoute.tsx
-msgid "Manage account & plan →"
-msgstr ""
+#~ msgid "Manage account & plan →"
+#~ msgstr ""
 
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 #: src/chunks/TablePage/PropertyForm/ExternalPropertyDialog.tsx
@@ -7833,4 +7832,12 @@ msgstr ""
 
 #: src/views/InvitePage.tsx
 msgid "Accepting your invitation…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This status describes data synchronization. View this drive’s subscription and price in billing."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage this drive’s plan →"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -1730,9 +1730,8 @@ msgstr "Erreur : {0}<node-id> attendu"
 msgid "This device"
 msgstr "Cet appareil"
 
-#: src/routes/SyncRoute.tsx
-msgid "Manage account & plan →"
-msgstr ""
+#~ msgid "Manage account & plan →"
+#~ msgstr ""
 
 #: src/chunks/TablePage/Kanban/KanbanColumn.tsx
 #: src/chunks/TablePage/PropertyForm/ExternalPropertyDialog.tsx
@@ -7833,4 +7832,12 @@ msgstr ""
 
 #: src/views/InvitePage.tsx
 msgid "Accepting your invitation…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "This status describes data synchronization. View this drive’s subscription and price in billing."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Manage this drive’s plan →"
 msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1,3 +1,4 @@
+import { driveBillingUrl } from '../helpers/driveBillingUrl';
 import {
   deriveNodeStatuses,
   currentDriveSync,
@@ -379,15 +380,11 @@ function ServerCard({
       footer={
         isCloud && managedInfo.portalUrl ? (
           <ManagedLink
-            // The dashboard, not the portal root: signed-in visitors get the
-            // marketing page at `/`, so the link landed on a sales pitch
-            // rather than the account it promises to manage.
-            //
-            // `externalLinkProps` rather than a raw target/rel: in the desktop
-            // app the plain form opens nothing at all.
-            {...externalLinkProps(`${managedInfo.portalUrl}/dashboard`)}
+            {...externalLinkProps(
+              driveBillingUrl(managedInfo.portalUrl, status.drive),
+            )}
           >
-            {'Manage account & plan →'}
+            {'Manage this drive’s plan →'}
           </ManagedLink>
         ) : !isActive ? (
           // Removing the server you're using would strand the app.
@@ -397,6 +394,12 @@ function ServerCard({
         ) : undefined
       }
     >
+      {isCloud && (
+        <ConnMeta>
+          This status describes data synchronization. View this drive’s
+          subscription and price in billing.
+        </ConnMeta>
+      )}
       {/* Status details belong to the server actually in use. */}
       {isActive && !status.serverConnected && status.serverConnectionError && (
         <ConnError role='alert'>


### PR DESCRIPTION
Cloud Server’s In sync status describes synchronization, but the adjacent account link discarded the selected drive and opened the generic dashboard. The card now explains what the status means and links directly to `/billing?drive=...` on the account portal, retaining desktop external-link handling.

Paired with https://github.com/ontola/atomic-saas/pull/61 on `codex/drive-billing-ux` for drive-specific billing, hosting setup guidance and removal of the unusable email reference code. Separate from WebRTC #1402; no subscription or staging mutations.

Validation: seven drive-status/billing-link unit tests pass; app typecheck and production build pass; scoped lint has existing warnings only. All four translation catalog diffs were inspected and settled with Vite; the new labels remain present after build. Billing UI coverage is documented in TESTING_COVERAGE.md. Not deployed.
