### PR TITLE
Fix server crate publication with compatible PRECIS dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "ort",
  "percent-encoding",
  "portpicker",
+ "precis-profiles",
  "rand 0.8.6",
  "rcgen 0.14.8",
  "regex",

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -162,7 +162,7 @@ Not covered: table `contains`; Playwright search overlay on the KV path; Flutter
 | Add-a-device form validation | `sync-devices.spec.ts` |
 | Sync page status renders | `browser/e2e/tests/sync.spec.ts` |
 | Offline edits persist and sync on reconnect | `sync.spec.ts` |
-| Second device cold-loads a drive from the server | `second-device-load.spec.ts` |
+| Second device cold-loads a drive from the server after explicit secret sign-in and completed navigation | `second-device-load.spec.ts` |
 
 ---
 

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -47,6 +47,13 @@ templates, and offline variants stay in the full suite. Policy:
 
 ## Where the suites live
 
+Release dependency regression (#1404): `cargo update -p precis-profiles` followed
+by `cargo check --locked -p stun-rs` checks the server's compatibility constraint
+against fresh registry resolution. Reproduced locally with `stun-rs 0.1.11` and
+`precis-profiles 0.1.14` (12 E0599 errors); the server pins `0.1.13`, which passes.
+This targeted check is manual; the release workflow still lacks a complete
+pre-publication verification of all crates before its first upload.
+
 | Suite | Command | CI job |
 |---|---|---|
 | `atomic_lib` unit + integration | `cargo nextest run -p atomic_lib --features db-redb,iroh,ws` | `rustTest` |

--- a/browser/e2e/tests/second-device-load.spec.ts
+++ b/browser/e2e/tests/second-device-load.spec.ts
@@ -1,11 +1,5 @@
 import { test, expect } from './fixtures';
-import {
-  before,
-  getDevDriveSecret,
-  signIn,
-  FRONTEND_URL,
-  smoke,
-} from './test-utils';
+import { before, getDevDriveSecret, FRONTEND_URL, smoke } from './test-utils';
 
 /**
  * A second device (or a fresh/cleared OPFS) must load an existing drive's
@@ -61,10 +55,17 @@ test(
 
     const ctx2 = await browser.newContext(); // brand-new context ⇒ empty OPFS
     const p2 = await ctx2.newPage();
-    await p2.goto(FRONTEND_URL);
-    await signIn(p2, secret);
+    // Enter the drive's sign-in screen directly. The bare root redirects
+    // asynchronously, so its transient sidebar is not a sign-in readiness
+    // signal. Let sign-in finish navigating before inspecting the drive; a
+    // forced page.goto here can interrupt identity/ClientDb initialization.
     await p2.goto(
+      `${FRONTEND_URL}/app/welcome?next=${encodeURIComponent(drive)}`,
+    );
+    await p2.getByLabel('Agent secret').fill(secret);
+    await expect(p2).toHaveURL(
       `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(drive)}`,
+      { timeout: 30_000 },
     );
 
     await expect(p2.getByText('SecondDeviceChild').first()).toBeVisible({

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,6 +47,12 @@ directories = "6"
 dotenv = "0.15"
 futures = "0.3.32"
 percent-encoding = "2.3.2"
+# Iroh's stun-rs 0.1.11 imports precis-core 0.1's Profile trait. The
+# precis-profiles 0.1.14 release switched to precis-core 0.2 and breaks that
+# build after cargo update (including during crate publication, #1404).
+# Keep this in the published manifest so fresh installs are protected too;
+# remove when the Iroh dependency graph uses a compatible stun-rs release.
+precis-profiles = "=0.1.13"
 regex = "1.12.3"
 rio_api = "0.8.6"
 rio_turtle = "0.8.6"


### PR DESCRIPTION
The beta.6 publisher ran `cargo update` after uploading `atomic_lib`, selecting `precis-profiles 0.1.14`. That release uses `precis-core 0.2`, while Iroh's `stun-rs 0.1.11` imports the incompatible 0.1 trait, so server package verification failed with 12 E0599 errors.

Pin `precis-profiles = "=0.1.13"` in the server's published manifest and record the dependency in Cargo.lock. This protects release-time resolution and fresh server installs, including those using the already-published beta.6 library. The comment identifies when the constraint can be removed.

Validation:
- Minimal dependency reproduction: 12 compiler errors with 0.1.14; passes with 0.1.13.
- `cargo update -p precis-profiles` retains 0.1.13; `cargo check --locked -p stun-rs` passes in the workspace.
- `cargo package --locked --allow-dirty --no-verify -p atomic-server` succeeds; inspected the archive's normalized manifest for the exact constraint.
- Extracted that package, updated precis-profiles, and compiled stun-rs successfully against the registry dependency graph (published atomic_lib).
- `git diff --check` passes.

Full server package compilation/publication was not run. This PR does not change the beta.6 tag or republish crates. The broader pre-upload verification gap is recorded in TESTING_COVERAGE.md.

Fixes #1404.
