### PR TITLE
Handle delayed WebRTC pulls after a mesh deletion

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -31,7 +31,7 @@ departure, membership checks and the per-browser connection bound.
 `verify-peer-mesh.mjs` uses eight distinct Chromium agents: full mesh, ninth-member
 rejection, concurrent creations, group presence, attachment replication, creator
 departure, offline reconciliation and signed deletion. Rust regressions cover
-late snapshots after deletion and concurrent blob replies across independent edges.
+late snapshots and delayed pulls after deletion (unknown pulls still fail), and concurrent blob replies across independent edges.
 `browserPeerSync.test.ts` checks that another member can mint an invitation for
 the existing room without restarting its connection.
 `verify-peer-ui.mjs` checks invitation creation and disconnect in the Sync page.

--- a/lib/src/sync/browser_peer.rs
+++ b/lib/src/sync/browser_peer.rs
@@ -235,6 +235,12 @@ impl BrowserPeerSession {
                 }
                 let mut entries = Vec::new();
                 for subject in &diff.pull {
+                    // Another mesh edge can delete a resource after its version
+                    // vector was advertised. The next reconcile sends the
+                    // signed tombstone; a stale pull must not close this edge.
+                    if super::tombstones::is_tombstoned(db, subject) {
+                        continue;
+                    }
                     let resource = db.get_resource(&subject.as_str().into()).await?;
                     if !self.in_drive(&resource) {
                         return Err("Peer requested another drive".into());
@@ -556,6 +562,37 @@ mod tests {
             .unwrap()
             .is_none());
         assert!(session.can_send(&db, &drive).await);
+    }
+
+    #[tokio::test]
+    async fn delayed_mesh_pull_skips_deleted_resources_but_rejects_unknown_ones() {
+        let (db, agent, drive, mut session) = fixture().await;
+        authenticate(&db, &agent, &mut session).await;
+        let deleted = "did:ad:deleted-before-pull".to_string();
+        super::super::tombstones::record_tombstone(&db, &deleted);
+        let frame = protocol::encode_sync_diff(
+            &drive,
+            &[deleted, drive.clone()],
+            &[],
+            &[],
+            &Default::default(),
+            &Default::default(),
+        );
+        let output = session.handle(&db, &frame).await.unwrap();
+        let push = protocol::decode_sync_push(&output.frames[0][1..]).unwrap();
+        assert_eq!(push.entries.len(), 1);
+        assert_eq!(push.entries[0].subject, drive);
+        assert!(session.can_send(&db, &drive).await);
+
+        let unknown = protocol::encode_sync_diff(
+            &drive,
+            &["did:ad:never-existed".into()],
+            &[],
+            &[],
+            &Default::default(),
+            &Default::default(),
+        );
+        assert!(session.handle(&db, &unknown).await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
A mesh neighbor can request a resource advertised just before another connection deletes it. The browser peer session tried to load that missing resource and closed the connection, interrupting signed-deletion propagation.

Ignore delayed pulls for locally recorded tombstones; the next reconcile carries the signed deletion. Unknown resources still fail, and other requested resources are still returned.

Validation: the new Rust test reproduced the missing-resource error before the fix; all 11 browser-peer tests now pass. Rebuilt WASM and ran the real eight-browser mesh three times successfully, including reconnect, offline edits, and signed deletion. Staging deployment was stopped before shipping; this follows #1402. Local e2e results were explicitly authorized as the merge gate while CI is queued.
