### PR TITLE
Harden Vault restore and track recovery coverage

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -619,3 +619,22 @@ setup currently fails opening OPFS before it can create its dev drive.
 Staging triage verified that the two reported hashes still returned HTTP 200
 without resize parameters. Deployment acceptance must recheck their resized
 URLs and confirm the rejected-write rate falls after clients update.
+
+
+### Vault reliability branch (2026-09-09)
+
+| Layer | Scenario | Test |
+| --- | --- | --- |
+| Worker glue | Restore flush failure returns error; next flush retries; import failure never acknowledges success | `browser/lib/src/client-db.worker.vault.test.ts` |
+| HTTP glue | 64/65/130-object restores use batches of at most 64; URLs requested just before each batch; listing order and total progress preserved | `vault.test.ts` |
+| HTTP glue | Failed object download does not import a partial list | `vault.test.ts` |
+| Import glue | Unreadable-object count raises incomplete restore instead of success navigation | `vault.test.ts` |
+| Recovery glue | Restored drive key epoch is passed to import rather than defaulting to epoch one | `vaultAutoBackup.test.ts` |
+
+These are controlled adapter tests, not proof of deployed bucket durability,
+attachment byte recovery, real OPFS exhaustion, or a whole-service disaster
+restore. The active gaps and paired SaaS work are in
+[`planning/vault-reliability.md`](planning/vault-reliability.md). In particular,
+network batching still accumulates all ciphertext before import; bounded-memory
+restore remains unimplemented. Browser historical-version coverage and attachment
+bytes must be validated with Cloud Server unreachable.

--- a/browser/data-browser/src/helpers/managed/vault.test.ts
+++ b/browser/data-browser/src/helpers/managed/vault.test.ts
@@ -742,6 +742,155 @@ describe('restoreDrive', () => {
   });
 });
 
+describe('restore download batches', () => {
+  for (const count of [64, 65, 130]) {
+    it(`restores ${count} objects within the control-plane limit`, async () => {
+      const objects = Array.from({ length: count }, (_, i) => ({
+        object_id: String(i),
+        object_key: `pack-${i}`,
+      }));
+      const order: string[] = [];
+      const batches: string[][] = [];
+      const db: VaultCapableDb = {
+        vaultExport: vi.fn(),
+        vaultCommitSegment: vi.fn(),
+        vaultImport: vi.fn(async () => ({
+          packsRead: count,
+          resourcesRestored: count,
+          tombstonesApplied: 0,
+          objectsSkipped: 0,
+          objectsUnreadable: 0,
+        })),
+      };
+      mockFetch((url, init) => {
+        if (url.endsWith('/objects'))
+          return new Response(JSON.stringify(objects));
+
+        if (url.endsWith('/download-urls')) {
+          const ids = JSON.parse(String(init?.body)).object_ids as string[];
+          batches.push(ids);
+          order.push('sign');
+          if (ids.length > 64)
+            return new Response(
+              JSON.stringify({
+                error: 'at most 64 objects per download-urls request',
+              }),
+              { status: 400 },
+            );
+
+          return new Response(
+            JSON.stringify({
+              downloads: ids
+                .toReversed()
+                .map(id => ({
+                  object_id: id,
+                  object_key: `pack-${id}`,
+                  url: `https://s3.test/${id}`,
+                })),
+            }),
+          );
+        }
+
+        order.push('download');
+
+        return new Response(new Uint8Array([1]));
+      });
+      const progress = vi.fn();
+      await restoreDrive({
+        db,
+        drivePseudonym: PSEUDONYM,
+        devicePubkey: DEVICE,
+        driveKey: KEY,
+        onProgress: progress,
+      });
+      expect(batches.flat()).toEqual(objects.map(o => o.object_id));
+      expect(batches.every(batch => batch.length <= 64)).toBe(true);
+      if (count > 64) expect(order[65]).toBe('sign'); // Finish the first batch before obtaining more expiring URLs.
+      expect(db.vaultImport).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(db.vaultImport).mock.calls[0][4].map(o => o.objectKey),
+      ).toEqual(objects.map(o => o.object_key));
+      expect(progress).toHaveBeenLastCalledWith(count, count);
+    });
+  }
+
+  it('does not import a partial download after storage fails', async () => {
+    const db: VaultCapableDb = {
+      vaultExport: vi.fn(),
+      vaultCommitSegment: vi.fn(),
+      vaultImport: vi.fn(),
+    };
+    mockFetch(url => {
+      if (url.endsWith('/objects'))
+        return new Response(
+          JSON.stringify([
+            { object_id: '1', object_key: 'k1' },
+            { object_id: '2', object_key: 'k2' },
+          ]),
+        );
+      if (url.endsWith('/download-urls'))
+        return new Response(
+          JSON.stringify({
+            downloads: [
+              { object_key: 'k1', url: 'https://s3.test/1' },
+              { object_key: 'k2', url: 'https://s3.test/2' },
+            ],
+          }),
+        );
+
+      return url.endsWith('/1')
+        ? new Response(new Uint8Array([1]))
+        : new Response(null, { status: 503 });
+    });
+    await expect(
+      restoreDrive({
+        db,
+        drivePseudonym: PSEUDONYM,
+        devicePubkey: DEVICE,
+        driveKey: KEY,
+      }),
+    ).rejects.toThrow('503');
+    expect(db.vaultImport).not.toHaveBeenCalled();
+  });
+});
+
+it('reports partial recovery as incomplete instead of a clean restore', async () => {
+  const db: VaultCapableDb = {
+    vaultExport: vi.fn(),
+    vaultCommitSegment: vi.fn(),
+    vaultImport: vi.fn(async () => ({
+      packsRead: 1,
+      resourcesRestored: 3,
+      tombstonesApplied: 0,
+      objectsSkipped: 0,
+      objectsUnreadable: 1,
+    })),
+  };
+  mockFetch(url => {
+    if (url.endsWith('/objects'))
+      return new Response(
+        JSON.stringify([{ object_id: '1', object_key: 'k1' }]),
+      );
+    if (url.endsWith('/download-urls'))
+      return new Response(
+        JSON.stringify({
+          downloads: [{ object_key: 'k1', url: 'https://s3.test/1' }],
+        }),
+      );
+
+    return new Response(new Uint8Array([1]));
+  });
+  await expect(
+    restoreDrive({
+      db,
+      drivePseudonym: PSEUDONYM,
+      devicePubkey: DEVICE,
+      driveKey: KEY,
+    }),
+  ).rejects.toThrow(/incomplete/);
+  expect(db.vaultImport).toHaveBeenCalledTimes(1);
+});
+
 describe('key management', () => {
   /** A stand-in for the WASM key ops: wrapping is reversible and keyed. */
   function fakeKeys(): VaultKeyOps {

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -748,39 +748,45 @@ export async function restoreDrive({
     };
   }
 
-  const { downloads } = await api<{ downloads: DownloadUrl[] }>(
-    `/cloud-vault/${drivePseudonym}/download-urls`,
-    {
-      method: 'POST',
-      body: JSON.stringify({ object_ids: objects.map(o => o.object_id) }),
-    },
-  );
-
-  // Preserve the server's ordering: `download-urls` answers per request and is
-  // not required to echo the order back.
-  const urlByKey = new Map(downloads.map(d => [d.object_key, d.url]));
+  // atomic-saas limits upload/download URL requests to 64 objects. Request
+  // each batch immediately before its downloads so later presigned URLs do
+  // not expire while an earlier batch is still transferring.
+  const batchSize = 64;
   const fetched: { objectKey: string; sealed: Uint8Array }[] = [];
 
-  for (const [index, object] of objects.entries()) {
-    const url = urlByKey.get(object.object_key);
+  for (let offset = 0; offset < objects.length; offset += batchSize) {
+    const batch = objects.slice(offset, offset + batchSize);
+    const { downloads } = await api<{ downloads: DownloadUrl[] }>(
+      `/cloud-vault/${drivePseudonym}/download-urls`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ object_ids: batch.map(o => o.object_id) }),
+      },
+    );
+    // Restore order is global listing order, not the broker's response order.
+    const urlByKey = new Map(downloads.map(d => [d.object_key, d.url]));
 
-    if (!url) {
-      throw new Error(`No download URL issued for ${object.object_key}`);
+    for (const [index, object] of batch.entries()) {
+      const url = urlByKey.get(object.object_key);
+
+      if (!url) {
+        throw new Error(`No download URL issued for ${object.object_key}`);
+      }
+
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(
+          `Vault download failed for ${object.object_key} (${response.status})`,
+        );
+      }
+
+      fetched.push({
+        objectKey: object.object_key,
+        sealed: new Uint8Array(await response.arrayBuffer()),
+      });
+      onProgress?.(offset + index + 1, objects.length);
     }
-
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Vault download failed for ${object.object_key} (${response.status})`,
-      );
-    }
-
-    fetched.push({
-      objectKey: object.object_key,
-      sealed: new Uint8Array(await response.arrayBuffer()),
-    });
-    onProgress?.(index + 1, objects.length);
   }
 
   // Every lane, not just this device's: each device appends only to its own,
@@ -791,13 +797,23 @@ export async function restoreDrive({
   // observed maps to decide what to replay and when — see `plan_restore` in
   // `lib/src/vault/sync.rs`. Passing everything and letting it choose is what
   // keeps that decision in one place rather than duplicated here in JS.
-  return db.vaultImport(
+  const outcome = await db.vaultImport(
     driveKey,
     keyEpoch,
     drivePseudonym,
     devicePubkey,
     fetched,
   );
+
+  if (outcome.objectsUnreadable > 0) {
+    // The importer salvages readable objects. Keep them, but do not trigger
+    // success navigation or automatic re-enrollment for an incomplete copy.
+    throw new Error(
+      `Cloud Vault restore is incomplete: ${outcome.objectsUnreadable} backup objects could not be read. Recovered data is kept on this device.`,
+    );
+  }
+
+  return outcome;
 }
 
 /**

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.test.ts
@@ -405,6 +405,19 @@ describe('restoreFromVault', () => {
     );
   });
 
+  it('restores with the recovered key epoch rather than assuming epoch one', async () => {
+    const store = await signedInStore();
+    const deps = fakeDeps({
+      recoverDriveKey: vi.fn(async () => ({ driveKey: KEY, keyEpoch: 7 })),
+    });
+    expect((await restoreFromVault(store, DRIVE, deps)).status).toBe(
+      'restored',
+    );
+    expect(deps.restoreDrive).toHaveBeenCalledWith(
+      expect.objectContaining({ keyEpoch: 7 }),
+    );
+  });
+
   /** The device now holds the key: later edits back up without re-enrolling. */
   it('remembers the key so the next backup skips enrollment', async () => {
     const store = await signedInStore();

--- a/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
+++ b/browser/data-browser/src/helpers/managed/vaultAutoBackup.ts
@@ -492,6 +492,7 @@ export async function restoreFromVault(
       drivePseudonym: enrollment.drive_pseudonym,
       devicePubkey: lane,
       driveKey,
+      keyEpoch,
     });
 
     // The device now holds the drive and the key; later edits here should go

--- a/browser/lib/src/client-db.worker.ts
+++ b/browser/lib/src/client-db.worker.ts
@@ -417,9 +417,10 @@ async function handleMessage(msg: WorkerRequest): Promise<unknown> {
       try {
         db!.flush();
       } catch (e) {
-        // Fall back to the tick rather than failing a restore that did land.
+        // Retry in the background, but do not acknowledge durability: the
+        // caller may reload immediately after a successful response.
         dirty = true;
-        console.error('[ClientDb] flush after vault import failed:', e);
+        throw e;
       }
 
       return summary;

--- a/browser/lib/src/client-db.worker.vault.test.ts
+++ b/browser/lib/src/client-db.worker.vault.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { WorkerRequest, WorkerResponse } from './client-db.worker.js';
+
+const mocks = vi.hoisted(() => ({ flush: vi.fn(), vaultImport: vi.fn() }));
+vi.mock('./client-db-open.js', () => ({
+  openClientDb: async () => ({ db: mocks }),
+  isStorageBlockedDbError: () => false,
+}));
+vi.mock('./wasm-url.js', () => ({
+  default: async () => {},
+  wasmBinaryUrl: () => 'unused.wasm',
+}));
+
+let worker: {
+  onmessage: (event: { data: WorkerRequest }) => void;
+  postMessage: (response: WorkerResponse) => void;
+};
+let nextId = 0;
+type Request = Extract<WorkerRequest, { type: 'init' | 'vaultImport' }>;
+type WithoutId<T> = T extends unknown ? Omit<T, 'id'> : never;
+
+function send(message: WithoutId<Request>): Promise<WorkerResponse> {
+  const id = ++nextId;
+
+  return new Promise(resolve => {
+    worker.postMessage = response => {
+      if (response.id === id) resolve(response);
+    };
+
+    worker.onmessage({ data: { ...message, id } as WorkerRequest });
+  });
+}
+
+const request = {
+  type: 'vaultImport' as const,
+  key: new Uint8Array(32),
+  keyEpoch: 1,
+  drivePseudonym: 'vault',
+  devicePubkey: 'device',
+  objects: [],
+};
+const summary = { resourcesRestored: 2, packsRead: 1, objectsUnreadable: 0 };
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+  worker = { onmessage: () => {}, postMessage: () => {} };
+  vi.stubGlobal('self', worker);
+  mocks.vaultImport.mockResolvedValue(summary);
+  await import('./client-db.worker.js');
+  expect(await send({ type: 'init', wasmUrl: './wasm-url.js' })).toMatchObject({
+    type: 'ok',
+  });
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+it('returns an error if restored data could not be made durable, then retries the flush', async () => {
+  mocks.flush.mockImplementationOnce(() => {
+    throw new Error('disk full');
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  expect(await send(request)).toMatchObject({
+    type: 'error',
+    message: 'disk full',
+  });
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(mocks.flush).toHaveBeenCalledTimes(2);
+});
+
+it('acknowledges restore only after import and flush complete', async () => {
+  const order: string[] = [];
+  mocks.vaultImport.mockImplementation(async () => {
+    order.push('import');
+
+    return summary;
+  });
+  mocks.flush.mockImplementation(() => {
+    order.push('flush');
+  });
+  expect(await send(request)).toMatchObject({ type: 'ok', data: summary });
+  expect(order).toEqual(['import', 'flush']);
+});
+
+it('does not acknowledge or flush a rejected import', async () => {
+  mocks.vaultImport.mockRejectedValue(new Error('invalid backup'));
+  expect(await send(request)).toMatchObject({
+    type: 'error',
+    message: 'invalid backup',
+  });
+  expect(mocks.flush).not.toHaveBeenCalled();
+});

--- a/planning/README.md
+++ b/planning/README.md
@@ -35,6 +35,7 @@ Remaining work, not "this file exists."
 
 | Document | Status |
 | --- | --- |
+| [`vault-reliability.md`](./vault-reliability.md) | **Active.** Restore batching, durability and key-epoch regressions; fresh-device attachment/history, bounded memory, retention and operational acceptance remain. |
 | [`sentry-feedback-readiness.md`](./sentry-feedback-readiness.md) | **Active.** Sidebar feedback and React error capture implemented and locally verified against Sentry. Staging rollout, email receipt and private source-map upload remain release gates. |
 | [`unified-sync.md`](./unified-sync.md) | **Active.** One sync API over WS or Iroh. Carries the single **Remaining work (2026-09-03)** checklist for every open sync item across these plans. The 2026-07 audit history is in [`completed/unified-sync-audit-2026-07.md`](./completed/unified-sync-audit-2026-07.md). |
 | [`serverless-p2p.md`](./serverless-p2p.md) | **Planned.** Device sync without a hub (written same-agent-first; admission is rights-based since 2026-07-17). AUTH-before-SYNC and the `AUTH.requestedSubject`↔drive binding landed 2026-09-01 (Iroh). Live-link destroys travel as signed `COMMIT` frames since 2026-09-03. P0 remaining: require envelopes on every `remove[]` once `Tree::Envelopes` exists. `AtomicTransport` / `SyncSession::serve` first slice landed 2026-09-05; outbox port and the remaining `sync_drive_with_peer*` collapse are open. |

--- a/planning/vault-reliability.md
+++ b/planning/vault-reliability.md
@@ -1,0 +1,34 @@
+# Vault reliability and recovery coverage
+
+Branch: `codex/vault-reliability` in atomic-server and atomic-saas.
+
+## First regression slice
+
+- [x] Restore more than 64 objects without exceeding SaaS URL-batch limits.
+- [x] Request URLs just before downloading each batch; preserve replay order.
+- [x] Reject a failed durable flush rather than report successful restoration.
+- [x] Cover interrupted downloads and import failure.
+- [ ] Audit checkpoint coverage when an export cannot read a resource.
+
+- [x] Preserve the recovered key epoch during automatic restore.
+- [x] Report unreadable-object recovery as incomplete, retaining salvaged data.
+
+Local validation: 416 client-library tests and 96 focused managed Vault tests
+pass. Library build and browser typecheck pass; changed files pass lint. A
+fresh deployed/MinIO browser restore is still pending. The former implementation
+failed the new 65/130-object, flush-error, key-epoch and incomplete-outcome tests.
+
+## Recovery acceptance backlog
+
+- [ ] Browser restore: assert historical versions and diagnose intermittent empty history.
+- [ ] Restore attachment bytes on a fresh device with Cloud Server unreachable.
+- [ ] Bound restore memory and skip superseded packs using authenticated coverage.
+- [ ] Surface stale/skipped backups, with account/key/network recovery tests.
+- [ ] Exercise undelete through the user flow and retained/pruned boundaries.
+- [ ] Whole-service restore with matching metadata, keys and Vault objects.
+- [ ] Independent retention, recurring capture, key escrow and missing-run alerts.
+
+Use unit/worker regressions first, then browser/MinIO drills. Local tests, CI,
+deployed restore and operational guarantees are distinct. No live retention or
+production restore changes are included in the initial slice. SaaS
+`planning/BETA_AND_BACKUP_READINESS.md` owns infrastructure readiness gates.


### PR DESCRIPTION
## First reliability fixes
Restoring a Vault with more than 64 objects exceeded the SaaS download-URL limit, while a failed worker flush could still acknowledge success. Restores now request URLs in batches just before use, preserve replay order, and propagate flush failures while retaining the background retry.

Automatic restore now passes the recovered key epoch. An unreadable-object result is surfaced as an incomplete restore; salvaged data remains local, but the UI does not receive a clean success result.

## Validation
- Nine new regression cases; the old implementation failed the new oversized-batch, flush-error, key-epoch and incomplete-outcome assertions.
- 416 client-library tests and 96 focused managed Vault tests pass.
- Client-library build, library/browser typechecks and changed-file lint pass.
- Translation diff inspected after serving the changed helper: no catalog changes.

## Draft scope
The coverage map and planning/vault-reliability.md track the remaining fresh-device attachment/history drills, bounded-memory restore, checkpoint/retention audit, freshness warnings and operational backup guarantees. No live backup configuration, restore, deployment or fresh browser/MinIO acceptance has been performed in this slice.

Paired atomic-saas branch: codex/vault-reliability (acceptance plan and documentation corrections).
