### PR TITLE
Automatically discover browser peers and simplify sync UI

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -619,3 +619,5 @@ setup currently fails opening OPFS before it can create its dev drive.
 Staging triage verified that the two reported hashes still returned HTTP 200
 without resize parameters. Deployment acceptance must recheck their resized
 URLs and confirm the rejected-write rate falls after clients update.
+
+Automatic browser discovery: `browser/data-browser/src/helpers/browserPeerSync.test.ts` verifies deterministic per-drive rooms, automatic startup for locally snapshotted drives, duplicate prevention, and skipping unknown snapshots. `ATOMIC_PEER_AUTOMATIC=1` with `verify-peer-mesh.mjs` verifies eight browsers rediscover trusted local drives without saved invitations, then sync creations, presence, attachments, reconnects and deletion. Full app UI acceptance remains separate.

--- a/browser/data-browser/src/components/BrowserPeerPanel.tsx
+++ b/browser/data-browser/src/components/BrowserPeerPanel.tsx
@@ -1,123 +1,16 @@
-import { isClientDbEnabled, setClientDbEnabled } from '../helpers/clientDbMode';
 import { useEffect, useState } from 'react';
-import { useStore } from '@tomic/react';
-import { Card } from './Card';
-import { Column, Row } from './Row';
-import { Button } from './Button';
-import { TextAreaStyled } from './forms/InputStyles';
-import {
-  createPeerLink,
-  parsePeerLink,
-  savePeerLink,
-  removePeerLink,
-  savedPeerLinks,
-  peerLinkStatus,
-  PEER_LINK_CHANGED,
-} from '../helpers/browserPeerSync';
+import { peerLinkStatus, PEER_LINK_CHANGED } from '../helpers/browserPeerSync';
 
 export function BrowserPeerPanel({ drive }: { drive?: string }) {
-  const store = useStore();
-  const [invitation, setInvitation] = useState(() =>
-    window.location.hash.startsWith('#peer=') ? window.location.href : '',
-  );
   const [status, setStatus] = useState('');
-  const [error, setError] = useState('');
-  const [enabled, setEnabled] = useState(false);
   useEffect(() => {
-    const update = () => {
-      setStatus(drive ? peerLinkStatus(drive) : '');
-      setEnabled(savedPeerLinks(store).some(link => link.drive === drive));
-    };
-
+    const update = () => setStatus(drive ? peerLinkStatus(drive) : '');
     update();
     window.addEventListener(PEER_LINK_CHANGED, update);
 
     return () => window.removeEventListener(PEER_LINK_CHANGED, update);
-  }, [drive, store]);
+  }, [drive]);
+  if (!status.startsWith(/* @wc-ignore */ 'Connected to')) return null;
 
-  const create = () => {
-    if (!drive) return;
-    const result = createPeerLink(store, drive);
-    savePeerLink(store, result.link);
-
-    if (!isClientDbEnabled()) {
-      setClientDbEnabled(true);
-      window.history.replaceState(null, '', result.invitation);
-      window.location.reload();
-
-      return;
-    }
-
-    setInvitation(result.invitation);
-    setError('');
-  };
-
-  const connect = () => {
-    try {
-      const link = parsePeerLink(invitation);
-      if (drive && drive !== link.drive)
-        throw new Error('Open the peer link to select its workspace first');
-      const existing = store.resources.get(link.drive);
-      if (!existing?.isReady() || existing.error)
-        store.registerLocalOnlyDrive(link.drive);
-      savePeerLink(store, link);
-
-      if (!isClientDbEnabled()) {
-        setClientDbEnabled(true);
-        window.location.reload();
-      }
-
-      setError('');
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  };
-
-  return (
-    <Card data-testid='peer-sync-panel'>
-      <Card.Content>
-        <Column>
-          <h2>Peer sync</h2>
-          <p>
-            Sync and collaborate between open browsers. No Cloud subscription
-            required. Changes catch up when both devices are online.
-          </p>
-          <p>
-            Pair another device signed in as you, or someone who already has
-            workspace access. Use Share to manage their permissions.
-          </p>
-          <Row>
-            <Button onClick={create} disabled={!drive || !store.getAgent()}>
-              Create peer link
-            </Button>
-            {enabled && drive && (
-              <Button onClick={() => removePeerLink(store, drive)}>
-                Disconnect
-              </Button>
-            )}
-          </Row>
-          <label htmlFor='browser-peer-link'>Peer link</label>
-          <TextAreaStyled
-            id='browser-peer-link'
-            rows={3}
-            value={invitation}
-            onChange={event => setInvitation(event.target.value)}
-          />
-          <Row>
-            <Button onClick={connect} disabled={!invitation}>
-              Connect
-            </Button>
-            <Button
-              onClick={() => navigator.clipboard.writeText(invitation)}
-              disabled={!invitation}
-            >
-              Copy link
-            </Button>
-          </Row>
-          <p role='status'>{status}</p>
-          {error && <p role='alert'>{error}</p>}
-        </Column>
-      </Card.Content>
-    </Card>
-  );
+  return <small role='status'>{status}</small>;
 }

--- a/browser/data-browser/src/components/BrowserPeerWatcher.tsx
+++ b/browser/data-browser/src/components/BrowserPeerWatcher.tsx
@@ -1,15 +1,24 @@
 import { useEffect } from 'react';
 import { useStore } from '@tomic/react';
 import { useSettings } from '../helpers/AppSettings';
-import { resumePeerLinks, stopPeerLinks } from '../helpers/browserPeerSync';
+import {
+  discoverPeerDrives,
+  resumePeerLinks,
+  stopPeerLinks,
+} from '../helpers/browserPeerSync';
 
 /** Keep enabled peer links alive across route changes, scoped to this identity. */
 export function BrowserPeerWatcher() {
   const store = useStore();
   const { agent } = useSettings();
   useEffect(() => {
-    const timer = setInterval(() => resumePeerLinks(store), 2000);
-    resumePeerLinks(store);
+    const resume = () => {
+      resumePeerLinks(store);
+      void discoverPeerDrives(store);
+    };
+
+    const timer = setInterval(resume, 2000);
+    resume();
 
     return () => {
       clearInterval(timer);

--- a/browser/data-browser/src/helpers/browserPeerSync.test.ts
+++ b/browser/data-browser/src/helpers/browserPeerSync.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, expect, it, vi } from 'vitest';
-import type { Store } from '@tomic/lib';
+import { BrowserPeerSync, server, type Store } from '@tomic/lib';
+vi.mock('@tomic/lib', async importOriginal => ({
+  ...(await importOriginal<typeof import('@tomic/lib')>()),
+  BrowserPeerSync: vi.fn(
+    class {
+      close() {}
+    },
+  ),
+}));
 import {
   createPeerLink,
   parsePeerLink,
@@ -76,4 +84,57 @@ it('creates a local-drive invitation without asking a node for discovery', () =>
   expect(parsePeerLink(invitation).signalingUrl).toBe(
     'wss://staging.atomicserver.eu/webrtc-signal',
   );
+});
+
+it('derives the same discovery room independently, and separates drives', async () => {
+  const { automaticPeerRoom } = await import('./browserPeerSync');
+  expect(await automaticPeerRoom('did:ad:one')).toMatch(/^[a-f0-9]{64}$/);
+  expect(await automaticPeerRoom('did:ad:one')).toBe(
+    await automaticPeerRoom('did:ad:one'),
+  );
+  expect(await automaticPeerRoom('did:ad:one')).not.toBe(
+    await automaticPeerRoom('did:ad:two'),
+  );
+});
+
+it('automatically connects stored drives once, without bootstrapping unknown drives', async () => {
+  const { discoverPeerDrives, stopPeerLinks } =
+    await import('./browserPeerSync');
+  vi.stubGlobal('window', {
+    location: { hostname: 'localhost' },
+    dispatchEvent: vi.fn(),
+  });
+  const agent = { subject: 'did:ad:agent:test' };
+  const db = {
+    getResourceWithSnapshot: vi.fn(async (drive: string) => ({
+      snapshot: drive === 'did:ad:stored' ? 'snapshot' : undefined,
+    })),
+  };
+  const resources = new Map(
+    ['did:ad:stored', 'did:ad:unknown'].map(subject => [
+      subject,
+      {
+        subject,
+        isReady: () => true,
+        hasClasses: (cls: string) => cls === server.classes.drive,
+      },
+    ]),
+  );
+  const store = {
+    getAgent: () => agent,
+    getClientDb: () => db,
+    resources,
+  } as unknown as Store;
+  vi.mocked(BrowserPeerSync).mockImplementation(function () {
+    return { close: vi.fn() } as unknown as BrowserPeerSync;
+  });
+  vi.mocked(BrowserPeerSync).mockClear();
+  await discoverPeerDrives(store);
+  await discoverPeerDrives(store);
+  expect(BrowserPeerSync).toHaveBeenCalledOnce();
+  expect(BrowserPeerSync).toHaveBeenCalledWith(
+    store,
+    expect.objectContaining({ drive: 'did:ad:stored' }),
+  );
+  stopPeerLinks(store);
 });

--- a/browser/data-browser/src/helpers/browserPeerSync.ts
+++ b/browser/data-browser/src/helpers/browserPeerSync.ts
@@ -1,4 +1,9 @@
-import { BrowserPeerSync, randomPeerToken, type Store } from '@tomic/lib';
+import {
+  BrowserPeerSync,
+  randomPeerToken,
+  server,
+  type Store,
+} from '@tomic/lib';
 
 export interface SavedPeerLink {
   drive: string;
@@ -161,4 +166,78 @@ export function parsePeerLink(invitation: string): SavedPeerLink {
     signalingUrl: link.signalingUrl,
     expectedPeer: link.expectedPeer,
   };
+}
+
+/** Discovery is not authorization: signed sessions still enforce drive ACLs. */
+export async function automaticPeerRoom(drive: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`atomic-browser-drive-v1:${drive}`),
+  );
+
+  return Array.from(new Uint8Array(digest), byte =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+}
+
+const discovering = new WeakSet<Store>();
+
+export async function discoverPeerDrives(store: Store): Promise<void> {
+  const agent = store.getAgent();
+  const db = store.getClientDb();
+  if (!agent || !db || discovering.has(store)) return;
+  discovering.add(store);
+  let links = active.get(store);
+
+  if (!links) {
+    links = new Map();
+    active.set(store, links);
+  }
+
+  const current = () =>
+    store.getAgent() === agent &&
+    store.getClientDb() === db &&
+    active.get(store) === links;
+
+  try {
+    for (const resource of store.resources.values()) {
+      const drive = resource.subject;
+      const id = `automatic:${drive}`;
+      if (
+        !drive.startsWith('did:ad:') ||
+        !resource.isReady() ||
+        resource.error ||
+        !resource.hasClasses(server.classes.drive) ||
+        links.has(id)
+      )
+        continue;
+
+      try {
+        // Never bootstrap trust from a discovered stranger's snapshot.
+        if (!(await db.getResourceWithSnapshot(drive)).snapshot) continue;
+        const room = await automaticPeerRoom(drive);
+        if (!current()) return;
+        links.set(
+          id,
+          new BrowserPeerSync(store, {
+            drive,
+            room,
+            signalingUrl: defaultPeerSignalingUrl(),
+            iceServers: import.meta.env.VITE_ATOMIC_ICE_SERVERS
+              ? JSON.parse(import.meta.env.VITE_ATOMIC_ICE_SERVERS)
+              : undefined,
+            onStatus: status => {
+              if (!current()) return;
+              statuses.set(drive, status);
+              window.dispatchEvent(new Event(PEER_LINK_CHANGED));
+            },
+          }),
+        );
+      } catch {
+        /* Retry after local storage becomes ready. */
+      }
+    }
+  } finally {
+    discovering.delete(store);
+  }
 }

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4730,7 +4730,6 @@ msgstr ""
 msgid "Could not copy — select and copy the code manually."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -6657,7 +6656,6 @@ msgstr ""
 msgid "Cloud Vault is not available here: {0}."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Disconnect"
 msgstr ""
@@ -7394,7 +7392,6 @@ msgstr ""
 msgid "Private"
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/Share/ShareDialog.tsx
 msgid "Copy link"
 msgstr ""
@@ -7768,25 +7765,20 @@ msgstr ""
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Entsperren mit einem Passkey fehlgeschlagen. Verwende stattdessen deinen Wiederherstellungscode."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer sync"
-msgstr ""
+#~ msgid "Peer sync"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
-msgstr ""
+#~ msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
-msgstr ""
+#~ msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Create peer link"
-msgstr ""
+#~ msgid "Create peer link"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer link"
-msgstr ""
+#~ msgid "Peer link"
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect existing account"

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4764,7 +4764,6 @@ msgstr "Pairing code copied."
 msgid "Could not copy — select and copy the code manually."
 msgstr "Could not copy — select and copy the code manually."
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -6691,7 +6690,6 @@ msgstr "A hosted workspace on {0}: shareable links, search across everything, AP
 msgid "Cloud Vault is not available here: {0}."
 msgstr "Cloud Vault is not available here: {0}."
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Disconnect"
 msgstr "Disconnect"
@@ -7428,7 +7426,6 @@ msgstr "Feedback reporting is unavailable on this installation. Email"
 msgid "Private"
 msgstr "Private"
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/Share/ShareDialog.tsx
 msgid "Copy link"
 msgstr "Copy link"
@@ -7802,25 +7799,20 @@ msgstr "<0>Save this recovery code.</0> It gets you back in on a new device, and
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Could not unlock with a passkey. Use your recovery code instead."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer sync"
-msgstr "Peer sync"
+#~ msgid "Peer sync"
+#~ msgstr "Peer sync"
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
-msgstr "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
+#~ msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
+#~ msgstr "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
-msgstr "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
+#~ msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
+#~ msgstr "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Create peer link"
-msgstr "Create peer link"
+#~ msgid "Create peer link"
+#~ msgstr "Create peer link"
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer link"
-msgstr "Peer link"
+#~ msgid "Peer link"
+#~ msgstr "Peer link"
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect existing account"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4730,7 +4730,6 @@ msgstr ""
 msgid "Could not copy — select and copy the code manually."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -6657,7 +6656,6 @@ msgstr ""
 msgid "Cloud Vault is not available here: {0}."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Disconnect"
 msgstr ""
@@ -7394,7 +7392,6 @@ msgstr ""
 msgid "Private"
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/Share/ShareDialog.tsx
 msgid "Copy link"
 msgstr "Copiar enlace"
@@ -7768,25 +7765,20 @@ msgstr ""
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "No se pudo desbloquear con una clave de acceso. Usa tu código de recuperación."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer sync"
-msgstr ""
+#~ msgid "Peer sync"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
-msgstr ""
+#~ msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
-msgstr ""
+#~ msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Create peer link"
-msgstr ""
+#~ msgid "Create peer link"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer link"
-msgstr ""
+#~ msgid "Peer link"
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect existing account"

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4730,7 +4730,6 @@ msgstr ""
 msgid "Could not copy — select and copy the code manually."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/ConnectServerDialog.tsx
 #: src/components/ConnectToDeviceForm.tsx
 #: src/views/getting-started/ConnectDeviceStep.tsx
@@ -6657,7 +6656,6 @@ msgstr ""
 msgid "Cloud Vault is not available here: {0}."
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/routes/SyncRoute.tsx
 msgid "Disconnect"
 msgstr ""
@@ -7394,7 +7392,6 @@ msgstr ""
 msgid "Private"
 msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
 #: src/components/Share/ShareDialog.tsx
 msgid "Copy link"
 msgstr "Copier le lien"
@@ -7768,25 +7765,20 @@ msgstr ""
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Impossible de déverrouiller avec une clé d’accès. Utilisez votre code de récupération."
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer sync"
-msgstr ""
+#~ msgid "Peer sync"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
-msgstr ""
+#~ msgid "Sync and collaborate between open browsers. No Cloud subscription required. Changes catch up when both devices are online."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
-msgstr ""
+#~ msgid "Pair another device signed in as you, or someone who already has workspace access. Use Share to manage their permissions."
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Create peer link"
-msgstr ""
+#~ msgid "Create peer link"
+#~ msgstr ""
 
-#: src/components/BrowserPeerPanel.tsx
-msgid "Peer link"
-msgstr ""
+#~ msgid "Peer link"
+#~ msgstr ""
 
 #: src/components/Vault/LinkProviderPanel.tsx
 msgid "Connect existing account"

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1460,7 +1460,6 @@ function SyncPage() {
       <ContainerNarrow>
         <h1>Sync</h1>
         <Lead>{summaryLine()}</Lead>
-        <BrowserPeerPanel drive={status.drive ?? undefined} />
 
         {/* Everything our paid services own, in one card.
 
@@ -1829,6 +1828,7 @@ function SyncPage() {
             spacious
             icon={<FaLaptop />}
             title='This device'
+            footer={<BrowserPeerPanel drive={status.drive ?? undefined} />}
             subtitle={
               isNode
                 ? status.lastDriveSync

--- a/browser/e2e/scripts/verify-peer-mesh.mjs
+++ b/browser/e2e/scripts/verify-peer-mesh.mjs
@@ -10,12 +10,14 @@ import { randomBytes } from 'node:crypto';
 
 const root = fileURLToPath(new URL('../../../', import.meta.url));
 const signalingUrl = process.env.ATOMIC_PEER_SIGNALING_URL;
+const automatic = process.env.ATOMIC_PEER_AUTOMATIC === '1';
 if (!signalingUrl)
   throw new Error(
     'Set ATOMIC_PEER_SIGNALING_URL to the running SaaS signaling endpoint',
   );
 const vite = await createServer({
   configFile: false,
+  define: { 'import.meta.env.VITE_ATOMIC_SIGNALING_URL': JSON.stringify(signalingUrl) },
   root,
   cacheDir: join(root, 'browser/node_modules/.vite/peer-acceptance'),
   optimizeDeps: { entries: ['browser/e2e/scripts/peer-sync-harness.ts'] },
@@ -79,8 +81,8 @@ try {
     },
     { drive, identities },
   );
-  const room = randomBytes(32).toString('hex');
-  const connect = page =>
+  let room = randomBytes(32).toString('hex');
+  let connect = page =>
     page.evaluate(
       ({ drive, room, expectedPeer, signalingUrl }) => {
         window.state.store.registerLocalOnlyDrive(drive);
@@ -110,6 +112,26 @@ try {
       drive,
       { timeout: 30000 },
     );
+  }
+
+  if (automatic) {
+    // The devices now have trusted local snapshots, as after normal drive access.
+    // Discard the explicit transport and discover with no saved invitation.
+    for (const page of pages) await page.evaluate(async drive => {
+      window.automaticDrive = drive;
+      window.link.close();
+      await window.state.db.flush();
+      window.discovery = await import('/browser/data-browser/src/helpers/browserPeerSync.ts');
+      window.addEventListener('atomic-peer-link-changed', () => {
+        window.peerStatus = window.discovery.peerLinkStatus(window.automaticDrive);
+      });
+    }, drive);
+    room = await pages[0].evaluate(drive => window.discovery.automaticPeerRoom(drive), drive);
+    connect = page => page.evaluate(async () => {
+      await window.discovery.discoverPeerDrives(window.state.store);
+      window.link = { close: () => window.discovery.stopPeerLinks(window.state.store) };
+    });
+    for (const page of pages) await connect(page);
   }
 
   for (const page of pages)


### PR DESCRIPTION
Browsers with the same locally stored drive now discover each other through the shared SaaS signaling endpoint automatically. Signed peer sessions still enforce the local drive ACL; discovery does not bootstrap trust from unknown peers.

Remove the large peer-link card and show connected status under the existing This device entry. Retain background reconnection and legacy saved links.

Validation: six helper tests, typecheck, focused lint, catalog review, and eight real browser contexts using automatic discovery against staging signaling. The mesh checks concurrent edits, presence, attachments, offline reconciliation and deletion. No Cloud Server data endpoint is used. Full app UI acceptance is separate.
