### PR TITLE
Fix offline sync race and browser test authentication

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -621,3 +621,5 @@ without resize parameters. Deployment acceptance must recheck their resized
 URLs and confirm the rejected-write rate falls after clients update.
 
 Automatic browser discovery: `browser/data-browser/src/helpers/browserPeerSync.test.ts` verifies deterministic per-drive rooms, automatic startup for locally snapshotted drives, duplicate prevention, and skipping unknown snapshots. `ATOMIC_PEER_AUTOMATIC=1` with `verify-peer-mesh.mjs` verifies eight browsers rediscover trusted local drives without saved invitations, then sync creations, presence, attachments, reconnects and deletion. Full app UI acceptance remains separate.
+
+The WebSocket unit suite also covers a socket closing while an asynchronous version-vector probe is computed: no SYNC is sent on the closed connection. General UI tests stub public discovery with an empty room; the separate peer mesh acceptance script still exercises real signaling and authenticated sync.

--- a/browser/e2e/tests/fixtures.ts
+++ b/browser/e2e/tests/fixtures.ts
@@ -49,9 +49,28 @@ export const test = base.extend<{
         entries.push({ ...entry, expected: !!match });
       };
 
-      const watch = (context: BrowserContext) => {
+      const watch = async (context: BrowserContext) => {
         if (watched.has(context)) return;
         watched.add(context);
+
+        // General UI tests use an empty discovery room, independent of public
+        // service availability. verify-peer-mesh.mjs separately exercises real
+        // signaling, authenticated WebRTC, persistence and reconciliation.
+        await context.routeWebSocket(
+          /^wss:\/\/(?:staging\.)?atomicserver\.eu\/webrtc-signal$/,
+          socket => {
+            socket.onMessage(message => {
+              if (
+                typeof message === 'string' &&
+                JSON.parse(message).type === 'join'
+              ) {
+                socket.send(
+                  JSON.stringify({ type: 'joined', peers: [], iceServers: [] }),
+                );
+              }
+            });
+          },
+        );
 
         const onConsole = (msg: import('@playwright/test').ConsoleMessage) => {
           const kind = msg.type();
@@ -85,13 +104,13 @@ export const test = base.extend<{
       browser.newContext = async options => {
         const context = await newContext.call(browser, options);
         ownedContexts.add(context);
-        watch(context);
+        await watch(context);
 
         return context;
       };
 
-      watch(defaultContext);
-      browser.contexts().forEach(watch);
+      await watch(defaultContext);
+      await Promise.all(browser.contexts().map(watch));
 
       try {
         await use({

--- a/browser/e2e/tests/saved-drives.spec.ts
+++ b/browser/e2e/tests/saved-drives.spec.ts
@@ -32,7 +32,7 @@ test.describe('saved drives', () => {
     });
     await page.goto(`${FRONTEND_URL}/app/show?${search}`);
     await expect
-      .poll(() => page.evaluate(() => window.store.getDrive()))
+      .poll(() => page.evaluate(() => window.store?.getDrive()))
       .toBe(original);
     await expect(currentDriveTitle(page)).toHaveText(originalTitle!);
     await expect

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -493,59 +493,30 @@ async function enterSecret(page: Page, secret: string) {
 }
 
 export async function signIn(page: Page, secret: string = SECRET) {
-  // Wait for one of the three states to actually render. Without this, a
-  // freshly-navigated page may not yet have the welcome gate or sidebar
-  // mounted — visibility checks then time out and we wrongly assume
-  // already-signed-in (state 1) when really we just hit the page too early.
-  await page
-    .locator(
-      'button:has-text("Sign in"), a:has-text("Login / New User"), a:has-text("User Settings")',
-    )
-    .first()
-    .waitFor({ state: 'visible', timeout: 10_000 })
-    .catch(() => undefined);
-
-  // State 2: welcome gate. The "Sign in" button (exact match, not "Sign in with Google" etc.)
-  // is the fast check — if it's there, we're on the gate and need to sign in.
+  const input = page.getByLabel('Agent secret');
   const signInButton = page.getByRole('button', {
     name: 'Sign in',
     exact: true,
   });
+  const settings = page
+    .locator('a[href$="/app/agent"]')
+    .filter({ hasNotText: 'Login / New User' });
+  const login = page.getByRole('link', { name: 'Login / New User' });
+  await expect(
+    input.or(signInButton).or(settings).or(login).first(),
+  ).toBeVisible();
+  if (await settings.isVisible()) return;
 
-  if (await signInButton.isVisible({ timeout: 1500 }).catch(() => false)) {
+  if (!(await input.isVisible())) {
+    // Navigate directly: the sidebar login link opens a new tab and may
+    // unmount while onboarding takes over the initial route.
+    if (!(await signInButton.isVisible()))
+      await page.goto(`${FRONTEND_URL}/app/welcome`);
     await signInButton.click();
-    await enterSecret(page, secret);
-    // Wait for the signed-in sidebar to appear. Without this, callers
-    // (e.g. `openSubject`) may navigate before the auth cookie + localStorage
-    // are written, leaving the next page anonymous (the sidebar then renders
-    // a "Login / New User" link instead of "User Settings").
-    await page
-      .getByRole('link', { name: 'User Settings' })
-      .waitFor({ state: 'visible', timeout: 10_000 })
-      .catch(() => undefined);
-
-    return;
   }
 
-  // State 3: sidebar login link (rare — shown when on a drive but not signed in).
-  const loginLink = page.getByRole('link', { name: 'Login / New User' });
-
-  if (await loginLink.isVisible({ timeout: 1500 }).catch(() => false)) {
-    await loginLink.click();
-    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-    await enterSecret(page, secret);
-    // Sign-in has to have landed before navigating away: goBack() during the
-    // in-flight sign-in leaves the previous page anonymous.
-    await page
-      .getByRole('link', { name: 'User Settings' })
-      .waitFor({ state: 'visible', timeout: 10_000 })
-      .catch(() => undefined);
-    await page.goBack();
-
-    return;
-  }
-
-  // State 1: already signed in. Nothing to do.
+  await enterSecret(page, secret);
+  await expect(settings).toBeVisible({ timeout: 20000 });
 }
 
 /**
@@ -1650,7 +1621,8 @@ export async function openNewSubjectWindow(
 ) {
   const context2 = await browser.newContext();
   const page = await context2.newPage();
-  await page.goto(FRONTEND_URL);
+
+  await page.goto(secret ? `${FRONTEND_URL}/app/welcome` : FRONTEND_URL);
 
   if (secret) {
     if (secret.length < 1) throw new Error('Secret must be provided');

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -267,6 +267,27 @@ describe('WSClient drive sync probe', () => {
     client.close();
   });
 
+  it('does not send a sync probe after the socket closes during computation', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    vi.spyOn(store, 'computeDriveSyncState').mockImplementation(async () => {
+      socket.readyState = 3;
+
+      return {
+        drive: 'did:ad:drive',
+        driveHash: 'hash',
+        peers: [],
+        resources: {},
+      } as never;
+    });
+    await (
+      client as unknown as { startVVSync: (drive: string) => Promise<void> }
+    ).startVVSync('did:ad:drive');
+    expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(0);
+    client.close();
+  });
+
   it('stops range reconciliation when the identity changes between replies', async ({
     expect,
   }) => {

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -1565,6 +1565,7 @@ export class WSClient {
     const selectedDrive = this.store.getDrive();
     const authenticatedWith = this.authenticatedWith;
     const current = () =>
+      this.readyState === WebSocket.OPEN &&
       this.store.getAgent()?.subject === agent &&
       this.store.getDrive() === selectedDrive &&
       this.authenticatedWith === authenticatedWith;


### PR DESCRIPTION
A version-vector calculation could finish after its socket closed and try sending SYNC on that connection. Ignore that stale calculation, with a regression test.

Update browser sign-in helpers to wait for the actual signed-in agent link, and isolate general UI tests from public signaling availability. The separate mesh acceptance script continues testing real signaling and peer synchronization.

Validation: workspace lint, E2E typecheck, and 1,230 browser workspace unit tests pass. The full Chromium run had 184 passes, six skips and 12 failures; all 12 failures subsequently passed in focused reruns after these fixes, including real Cloud Vault backup/restore. A single clean full-suite rerun has not been completed.