### PR TITLE
Reconcile account drive lists across devices

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -623,3 +623,14 @@ URLs and confirm the rejected-write rate falls after clients update.
 Automatic browser discovery: `browser/data-browser/src/helpers/browserPeerSync.test.ts` verifies deterministic per-drive rooms, automatic startup for locally snapshotted drives, duplicate prevention, and skipping unknown snapshots. `ATOMIC_PEER_AUTOMATIC=1` with `verify-peer-mesh.mjs` verifies eight browsers rediscover trusted local drives without saved invitations, then sync creations, presence, attachments, reconnects and deletion. Full app UI acceptance remains separate.
 
 The WebSocket unit suite also covers a socket closing while an asynchronous version-vector probe is computed: no SYNC is sent on the closed connection. General UI tests stub public discovery with an empty room; the separate peer mesh acceptance script still exercises real signaling and authenticated sync.
+
+## Account drive catalog
+
+`helpers/managed/driveCatalog.test.ts` covers union/deduplication, removal precedence,
+offline retry/cache isolation, and stale results after logout or account switching.
+`e2e/tests/drive-catalog.spec.ts` renders an account-only drive without a local
+saved pointer, publishes the local drive, and applies a removal after reconnect
+(real app/node, mocked account API). Existing saved-drive tests remain separate.
+SaaS handler tests cover authenticated additive registration, account isolation,
+service-backed discovery and removal versus stale upload. Catalog entries confer
+no access to resource content. A live cross-app deployment acceptance is separate.

--- a/browser/data-browser/src/components/Drives/DriveRow.tsx
+++ b/browser/data-browser/src/components/Drives/DriveRow.tsx
@@ -8,6 +8,7 @@ import { PrivateDriveBadge } from './PrivateDriveBadge';
 
 export interface DriveRowProps {
   subject: string;
+  label?: string;
   /** This is the drive the app is currently on. */
   selected?: boolean;
   /** The private drive can't be starred or unstarred — it's always yours. */
@@ -39,6 +40,7 @@ export interface DriveRowProps {
  */
 export function DriveRow({
   subject,
+  label,
   selected,
   hideFavorite,
   isPrivate,
@@ -55,9 +57,7 @@ export function DriveRow({
         onClick={() => onClick(subject)}
       >
         {selected ? <FaSquareCheck /> : <FaRegCircle />}
-        <Name>
-          <ResourceInline subject={subject} />
-        </Name>
+        <Name>{label || <ResourceInline subject={subject} />}</Name>
         {isPrivate && <PrivateDriveBadge />}
       </Choice>
       <Actions>

--- a/browser/data-browser/src/components/Drives/DrivesCard.tsx
+++ b/browser/data-browser/src/components/Drives/DrivesCard.tsx
@@ -9,6 +9,7 @@ import type { JSX } from 'react';
 
 export interface DriveCardProps {
   drives: string[];
+  labels?: Record<string, string>;
   /** Lets a test name this list, since two of them render on the same page. */
   testId?: string;
   /** Which of these, if any, is the user's private drive. */
@@ -29,6 +30,7 @@ export interface DriveCardProps {
  */
 export function DrivesCard({
   drives,
+  labels,
   testId,
   privateDrive,
   showNewOption,
@@ -49,6 +51,7 @@ export function DrivesCard({
           <DriveRow
             key={subject}
             subject={subject}
+            label={labels?.[subject]}
             selected={subject === drive}
             isPrivate={subject === privateDrive}
             // Never unstarrable: it is not in the list by choice, and a star

--- a/browser/data-browser/src/components/SideBar/DriveSwitcher.tsx
+++ b/browser/data-browser/src/components/SideBar/DriveSwitcher.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useAccountDriveCatalog } from '../../hooks/useAccountDriveCatalog';
 import { useDriveHostingStates } from '../../hooks/useDriveHostingStates';
 import { Resource, core, server, useResources } from '@tomic/react';
 import {
@@ -48,10 +49,18 @@ export function DriveSwitcher({
   const [history, addToHistory] = useDriveHistory(savedDrives, 5);
 
   // The private drive leads the menu; keep it out of the lists below.
-  const myDrives = savedDrives.filter(subject => subject !== privateDrive);
-  const recentDrives = history.filter(subject => subject !== privateDrive);
+  const catalog = useAccountDriveCatalog(
+    privateDrive ? [privateDrive, ...savedDrives] : savedDrives,
+  );
+  const myDrives = catalog.subjects.filter(subject => subject !== privateDrive);
+  const recentDrives = history.filter(
+    subject =>
+      subject !== privateDrive &&
+      !catalog.removed.includes(subject) &&
+      !myDrives.includes(subject),
+  );
 
-  const myDrivesMap = useResources(myDrives);
+  const myDrivesMap = useResources(savedDrives);
   const recentDrivesMap = useResources(recentDrives);
 
   const switchTo = (subject: string) => {
@@ -63,7 +72,7 @@ export function DriveSwitcher({
   const createNewResource = useNewResourceUI();
 
   const items: DropdownItem[] = [
-    ...(privateDrive
+    ...(privateDrive && !catalog.removed.includes(privateDrive)
       ? [
           {
             id: privateDrive,
@@ -76,17 +85,24 @@ export function DriveSwitcher({
           },
         ]
       : []),
-    ...Array.from(myDrivesMap.entries())
-      .filter(([_, resource]) => !resource.error)
-      .map(([subject, resource]) => ({
+    ...myDrives.map(subject => {
+      const resource = myDrivesMap.get(subject);
+      const label =
+        resource && !resource.error
+          ? getTitle(resource)
+          : catalog.entries.find(e => e.drive_subject === subject)
+              ?.drive_name || subject;
+
+      return {
         id: subject,
         suffix: badge(subject),
-        label: getTitle(resource),
-        helper: `Switch to ${getTitle(resource)}`,
+        label,
+        helper: `Switch to ${label}`,
         disabled: false,
         onClick: (): void => switchTo(subject),
         icon: subject === drive ? <FaSquareCheck /> : <FaRegCircle />,
-      })),
+      };
+    }),
     {
       id: 'new-drive',
       label: 'New Drive',

--- a/browser/data-browser/src/helpers/managed/driveCatalog.test.ts
+++ b/browser/data-browser/src/helpers/managed/driveCatalog.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  catalogSubjects,
+  DriveCatalogSync,
+  catalogCacheKey,
+  readCatalogCache,
+} from './driveCatalog';
+const identity = { email: 'one@example.com', agent: 'did:ad:agent:one' };
+const remote = {
+  drives: [{ drive_subject: 'did:ad:remote' }],
+  removed: ['did:ad:removed'],
+};
+
+describe('account drive catalog', () => {
+  it('shows both indexes, deduplicates, and never resurrects removed entries', () => {
+    expect(
+      catalogSubjects(
+        ['did:ad:local', 'did:ad:remote', 'did:ad:removed'],
+        remote,
+      ),
+    ).toEqual(['did:ad:local', 'did:ad:remote']);
+  });
+  it('keeps last successful data through an offline failure and retries', async () => {
+    const send = vi.fn().mockResolvedValue(remote);
+    const sync = new DriveCatalogSync({
+      identity: async () => identity,
+      send,
+      changed: vi.fn(),
+    });
+    await sync.refresh([]);
+    send.mockRejectedValueOnce(new Error('offline'));
+    await expect(sync.refresh([])).rejects.toThrow('offline');
+    expect(sync.snapshot?.drives).toEqual(remote.drives);
+    await sync.refresh([{ drive_subject: 'did:ad:new' }]);
+    expect(send).toHaveBeenLastCalledWith([{ drive_subject: 'did:ad:new' }]);
+  });
+  it('discards a response after logout', async () => {
+    let resolve!: (value: unknown) => void;
+    const send = vi.fn(
+      () =>
+        new Promise(r => {
+          resolve = r;
+        }),
+    );
+    const sync = new DriveCatalogSync({
+      identity: async () => identity,
+      send,
+      changed: vi.fn(),
+    });
+    const pending = sync.refresh([]);
+    await vi.waitFor(() => expect(send).toHaveBeenCalled());
+    sync.reset();
+    resolve(remote);
+    await pending;
+    expect(sync.snapshot).toBeNull();
+  });
+  it('does not mix identities when accounts change during an upload', async () => {
+    const who = vi
+      .fn()
+      .mockResolvedValueOnce(identity)
+      .mockResolvedValueOnce({ ...identity, email: 'two@example.com' });
+    const sync = new DriveCatalogSync({
+      identity: who,
+      send: async () => remote,
+      changed: vi.fn(),
+    });
+    await sync.refresh([]);
+    expect(sync.snapshot).toBeNull();
+  });
+});
+
+it('restores an offline cache only for its bound account and agent', () => {
+  const storage = {
+    getItem: (key: string) =>
+      key === catalogCacheKey(identity) ? JSON.stringify(remote) : null,
+  };
+  expect(readCatalogCache(identity, storage)?.drives).toEqual(remote.drives);
+  expect(
+    readCatalogCache({ ...identity, email: 'other@example.com' }, storage),
+  ).toBeNull();
+  expect(readCatalogCache({ ...identity, agent: 'other' }, storage)).toBeNull();
+});

--- a/browser/data-browser/src/helpers/managed/driveCatalog.ts
+++ b/browser/data-browser/src/helpers/managed/driveCatalog.ts
@@ -1,0 +1,115 @@
+// @wc-ignore-file
+/** Account pointers are discovery hints, never resource access grants. */
+export type CatalogEntry = {
+  drive_subject: string;
+  drive_name?: string | null;
+  drive_emoji?: string | null;
+};
+export type DriveCatalog = { drives: CatalogEntry[]; removed: string[] };
+export type CatalogIdentity = { email: string; agent: string };
+export type CatalogSnapshot = DriveCatalog & CatalogIdentity;
+
+export function catalogSubjects(
+  local: string[],
+  catalog: DriveCatalog | null,
+): string[] {
+  const removed = new Set(catalog?.removed ?? []);
+
+  return [
+    ...new Set([
+      ...local,
+      ...(catalog?.drives.map(d => d.drive_subject) ?? []),
+    ]),
+  ].filter(s => !removed.has(s));
+}
+
+export function parseCatalog(value: unknown): DriveCatalog {
+  const c = value as DriveCatalog;
+
+  if (
+    !c ||
+    !Array.isArray(c.drives) ||
+    !Array.isArray(c.removed) ||
+    c.drives.some(d => typeof d?.drive_subject !== 'string') ||
+    c.removed.some(d => typeof d !== 'string')
+  ) {
+    throw new Error('Invalid drive catalog');
+  }
+
+  return c;
+}
+
+export class DriveCatalogSync {
+  private generation = 0;
+  snapshot: CatalogSnapshot | null = null;
+  constructor(
+    private deps: {
+      identity: () => Promise<CatalogIdentity | null>;
+      send: (entries: CatalogEntry[]) => Promise<unknown>;
+      changed: (snapshot: CatalogSnapshot | null) => void;
+    },
+  ) {}
+
+  reset() {
+    this.generation++;
+    this.snapshot = null;
+    this.deps.changed(null);
+  }
+
+  async refresh(entries: CatalogEntry[]) {
+    const request = ++this.generation;
+    const identity = await this.deps.identity();
+    if (request !== this.generation) return;
+
+    if (!identity) {
+      this.reset();
+
+      return;
+    }
+
+    if (
+      this.snapshot &&
+      (this.snapshot.email !== identity.email ||
+        this.snapshot.agent !== identity.agent)
+    ) {
+      this.snapshot = null;
+      this.deps.changed(null);
+    }
+
+    const result = parseCatalog(await this.deps.send(entries));
+    if (request !== this.generation) return;
+    const after = await this.deps.identity();
+    if (request !== this.generation) return;
+
+    if (
+      !after ||
+      after.email !== identity.email ||
+      after.agent !== identity.agent
+    ) {
+      this.reset();
+
+      return;
+    }
+
+    this.snapshot = { ...result, ...identity };
+    this.deps.changed(this.snapshot);
+  }
+}
+
+export function catalogCacheKey(identity: CatalogIdentity): string {
+  return `atomic-drive-catalog:${JSON.stringify([identity.email, identity.agent])}`;
+}
+
+export function readCatalogCache(
+  identity: CatalogIdentity,
+  storage: Pick<Storage, 'getItem'>,
+): CatalogSnapshot | null {
+  try {
+    const raw = storage.getItem(catalogCacheKey(identity));
+    if (!raw) return null;
+
+    return { ...parseCatalog(JSON.parse(raw)), ...identity };
+  } catch {
+    return null;
+  }
+}

--- a/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
+++ b/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { core, server, useStore } from '@tomic/react';
+import { hasManagedApi, managedFetch } from '../helpers/managed/api';
+import { evaluateIdentityReconciliation } from '../helpers/managed/reconcile';
+import { readManagedAccountBinding } from '../helpers/managed/binding';
+import { onManagedLogout } from '../helpers/managed/session';
+import {
+  DriveCatalogSync,
+  catalogCacheKey,
+  readCatalogCache,
+  catalogSubjects,
+  type CatalogSnapshot,
+} from '../helpers/managed/driveCatalog';
+
+/** Reconcile account membership separately from the user's favorite pointers. */
+export function useAccountDriveCatalog(local: string[]) {
+  const store = useStore();
+  const agent = store.getAgent()?.subject;
+  const [snapshot, setSnapshot] = useState<CatalogSnapshot | null>(null);
+  const key = JSON.stringify([...new Set(local)].sort());
+  useEffect(() => {
+    if (!agent || !hasManagedApi()) return;
+    let stopped = false;
+    let running = false;
+    const sync = new DriveCatalogSync({
+      identity: async () => {
+        const result = await evaluateIdentityReconciliation(agent);
+
+        return !stopped &&
+          store.getAgent()?.subject === agent &&
+          result.ok &&
+          result.managedAccount
+          ? { agent, email: result.managedAccount.email }
+          : null;
+      },
+      send: async entries => {
+        const response = await managedFetch('/drives/catalog', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(entries),
+        });
+        if (!response.ok) throw new Error('Could not refresh account drives');
+
+        return response.json();
+      },
+      changed: next => {
+        if (!stopped) {
+          setSnapshot(next);
+
+          if (next) {
+            try {
+              localStorage.setItem(catalogCacheKey(next), JSON.stringify(next));
+            } catch {
+              /* Memory still retains the list. */
+            }
+          }
+        }
+      },
+    });
+
+    const binding = readManagedAccountBinding();
+
+    if (binding?.expected_agent_subject === agent) {
+      const cached = readCatalogCache(
+        { agent, email: binding.owner_email },
+        localStorage,
+      );
+
+      if (cached) {
+        sync.snapshot = cached;
+        setSnapshot(cached);
+      }
+    }
+
+    const refresh = async () => {
+      if (running) return;
+      running = true;
+
+      try {
+        const subjects: string[] = JSON.parse(key);
+
+        // Include newly created owned drives even before they are bookmarked.
+        for (const resource of store.resources.values()) {
+          if (
+            resource.get(core.properties.parent) === agent &&
+            resource.hasClasses(server.classes.drive)
+          )
+            subjects.push(resource.subject);
+        }
+
+        const entries = [...new Set(subjects)].map(subject => {
+          const resource = store.resources.get(subject);
+
+          return {
+            drive_subject: subject,
+            drive_name: resource?.get(core.properties.name) as
+              | string
+              | undefined,
+          };
+        });
+        await sync.refresh(entries);
+      } catch {
+        /* Keep the last successful list; reconnect/focus retries. */
+      } finally {
+        running = false;
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(refresh, 30000);
+    window.addEventListener('focus', refresh);
+    window.addEventListener('online', refresh);
+    const logout = onManagedLogout(() => {
+      if (sync.snapshot) {
+        try {
+          localStorage.removeItem(catalogCacheKey(sync.snapshot));
+        } catch {
+          /* The visible list is cleared regardless. */
+        }
+      }
+
+      sync.reset();
+    });
+
+    return () => {
+      stopped = true;
+      sync.reset();
+      logout();
+      window.clearInterval(interval);
+      window.removeEventListener('focus', refresh);
+      window.removeEventListener('online', refresh);
+    };
+  }, [store, agent, key]);
+  const current = snapshot?.agent === agent ? snapshot : null;
+
+  return {
+    subjects: catalogSubjects(local, current),
+    entries: current?.drives ?? [],
+    removed: current?.removed ?? [],
+  };
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -2418,7 +2418,7 @@ msgstr ""
 #~ msgid "Could not update your list: no personal drive is set up for this account yet."
 #~ msgstr ""
 
-#. 0: getTitle(resource)
+#. 0: label
 #. 0: getTitle(resource)
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/components/SideBar/DriveSwitcher.tsx

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -2418,7 +2418,7 @@ msgstr "Add tag"
 #~ msgid "Could not update your list: no personal drive is set up for this account yet."
 #~ msgstr "Could not update your list: no personal drive is set up for this account yet."
 
-#. 0: getTitle(resource)
+#. 0: label
 #. 0: getTitle(resource)
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/components/SideBar/DriveSwitcher.tsx

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -2418,7 +2418,7 @@ msgstr "Añadir etiqueta"
 #~ msgid "Could not update your list: no personal drive is set up for this account yet."
 #~ msgstr ""
 
-#. 0: getTitle(resource)
+#. 0: label
 #. 0: getTitle(resource)
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/components/SideBar/DriveSwitcher.tsx

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -2418,7 +2418,7 @@ msgstr "Ajouter une étiquette"
 #~ msgid "Could not update your list: no personal drive is set up for this account yet."
 #~ msgstr ""
 
-#. 0: getTitle(resource)
+#. 0: label
 #. 0: getTitle(resource)
 #: src/components/SideBar/DriveSwitcher.tsx
 #: src/components/SideBar/DriveSwitcher.tsx

--- a/browser/data-browser/src/routes/SettingsAgent.tsx
+++ b/browser/data-browser/src/routes/SettingsAgent.tsx
@@ -1,3 +1,4 @@
+import { useAccountDriveCatalog } from '../hooks/useAccountDriveCatalog';
 import * as React from 'react';
 import { useEffect, useId, useState } from 'react';
 import { core, server, urls, useCurrentAgent, useStore } from '@tomic/react';
@@ -65,11 +66,17 @@ const SettingsAgent: React.FunctionComponent = () => {
   // thing" when the honest statement is "these are your drives, and one of
   // them is special". A reader with a single other drive met two headings and
   // two cards to hold two rows.
-  const myDrives = privateDrive
-    ? [privateDrive, ...savedDrives.filter(subject => subject !== privateDrive)]
-    : savedDrives;
+  const catalog = useAccountDriveCatalog(
+    privateDrive ? [privateDrive, ...savedDrives] : savedDrives,
+  );
+  const myDrives = catalog.subjects;
   // Still kept out of Recently visited: it is not somewhere you happened to go.
-  const recentDrives = history.filter(subject => subject !== privateDrive);
+  const recentDrives = history.filter(
+    subject =>
+      subject !== privateDrive &&
+      !catalog.removed.includes(subject) &&
+      !myDrives.includes(subject),
+  );
 
   const driveUrlId = useId();
   const [driveInput, setDriveInput] = useState('');
@@ -258,6 +265,15 @@ const SettingsAgent: React.FunctionComponent = () => {
 
               <DrivesCard
                 drives={myDrives}
+                labels={Object.fromEntries(
+                  catalog.entries
+                    .filter(
+                      e =>
+                        e.drive_name &&
+                        !store.resources.get(e.drive_subject)?.isReady(),
+                    )
+                    .map(e => [e.drive_subject, e.drive_name!]),
+                )}
                 testId='my-drives'
                 privateDrive={privateDrive}
                 onDriveSelect={handleSetDrive}

--- a/browser/e2e/tests/drive-catalog.spec.ts
+++ b/browser/e2e/tests/drive-catalog.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from './fixtures';
+import { before, FRONTEND_URL } from './test-utils';
+
+test('account drives appear without local pointers and removals reconcile after reconnect', async ({
+  page,
+  context,
+}) => {
+  await before({ page });
+  const agent = await page.evaluate(() => window.store.getAgent()!.subject);
+  const local = await page.evaluate(() => window.store.getDrive()!);
+  const remote = 'did:ad:catalog-remote';
+  let removed = false;
+  let published: { drive_subject: string }[] = [];
+  await context.route('http://localhost:3037/api/**', async route => {
+    const path = new URL(route.request().url()).pathname;
+    let json: unknown = [];
+    if (path === '/api/me') json = { email: 'catalog@example.com' };
+    if (path === '/api/recovery-secret')
+      json = { agent_subject: agent, drive_subject: local, wrappers: [] };
+
+    if (path === '/api/drives/catalog') {
+      published = route.request().postDataJSON();
+      json = {
+        drives: removed
+          ? []
+          : [{ drive_subject: remote, drive_name: 'Account-only project' }],
+        removed: removed ? [remote] : [],
+      };
+    }
+
+    await route.fulfill({
+      json,
+      headers: {
+        'Access-Control-Allow-Origin': FRONTEND_URL,
+        'Access-Control-Allow-Credentials': 'true',
+      },
+    });
+  });
+  await context.addInitScript(() => {
+    (
+      window as unknown as { __ATOMIC_MANAGED__: { portalUrl: string } }
+    ).__ATOMIC_MANAGED__ = { portalUrl: 'http://localhost:3037' };
+  });
+  await page.goto(`${FRONTEND_URL}/app/agent`);
+  const list = page.getByTestId('my-drives');
+  await expect(
+    list.getByRole('radio', { name: 'Account-only project' }),
+  ).toBeVisible();
+  await expect
+    .poll(() => published.some(e => e.drive_subject === local))
+    .toBe(true);
+  removed = true;
+  await page.evaluate(() => window.dispatchEvent(new Event('online')));
+  await expect(
+    list.getByRole('radio', { name: 'Account-only project' }),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
Include account catalog entries in the drive switcher and My drives without rewriting favorites. Publish saved and locally owned drive references to SaaS, reconcile on reconnect/focus, preserve the last known list through outages, and honor explicit removal markers. Account-only drives remain visible even when their resource is not locally available. References do not grant resource access or upload content.

Validation: five app E2E cases pass, including account-only discovery/removal and the existing saved-drive suite. Five catalog unit cases cover union, offline retries/cache isolation, logout, and account changes. The full data-browser unit suite passed before the final cache addition (817 tests); the five focused cases passed afterwards. App and E2E type checks and lint pass. Translation diffs were reviewed.

Paired SaaS branch: codex/drive-catalog. Live cross-app staging acceptance remains separate.