### PR TITLE
Connect LocalThought platforms without pasting tenant secrets

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -764,7 +764,7 @@ export class AtomicServer {
           'atomic-server',
           '--no-default-features',
           '--features',
-          'light',
+          'light,wasm-plugins',
         ])
         .withExec([
           'cp',
@@ -1137,7 +1137,10 @@ export class AtomicServer {
       // data-browser/src/config.ts.
       buildContainer = buildContainer
         .withEnvVariable('VITE_E2E', 'true')
-        .withEnvVariable('VITE_INTEGRATION_PROXY_URL', 'http://127.0.0.1:19090');
+        .withEnvVariable(
+          'VITE_INTEGRATION_PROXY_URL',
+          'http://127.0.0.1:19090',
+        );
     }
 
     return buildContainer.withExec(['pnpm', 'run', 'build']);
@@ -1268,11 +1271,9 @@ export class AtomicServer {
     // `rustBuildSlim`'s glibc path (different symptom there — ABI mismatch,
     // not a missing binary — same root cause).
     //
-    // E2E exception: `plugin.spec.ts` needs `wasm-plugins` so the test
-    // plugin's `after_commit` can rename folders. `light` is https-only and
-    // silently makes that assertion hang until timeout. Defaults minus
-    // `vector-search` (the ort/musl gap above) is enough — wasmtime builds
-    // fine on this musl-cross image.
+    // All server builds include `wasm-plugins`: plugin handlers are compiled
+    // unconditionally, and the E2E suite also executes server-side plugins.
+    // `vector-search` remains excluded because of the ort/musl gap above.
     let wasmPluginsEnabled = false;
     if (target.includes('musl')) {
       if (e2e) {
@@ -1283,7 +1284,12 @@ export class AtomicServer {
         );
         wasmPluginsEnabled = true;
       } else {
-        buildArgs.push('--no-default-features', '--features', 'light');
+        buildArgs.push(
+          '--no-default-features',
+          '--features',
+          'light,wasm-plugins',
+        );
+        wasmPluginsEnabled = true;
       }
     }
     // A named profile lands in `target/<triple>/<profile>/`, not `release/`.

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1492,12 +1492,11 @@ export class AtomicServer {
     // system OpenSSL we don't ship. Default features are what the release
     // binary already builds with.
     //
-    // `--no-default-features --features light`: same ort/musl/cuda gap as
-    // `rustTest` above — `vector-search`'s `ort` dep has no prebuilt binary
-    // for this target, so even a lint-only pass can't compile it. Means
-    // vector-search-gated code isn't clippy-checked on this path; the
-    // tradeoff was a deliberate call, not an oversight — see rustTest's
-    // comment for the full reasoning.
+    // `--no-default-features --features light,wasm-plugins`: same
+    // ort/musl/cuda gap as `rustTest` above — `vector-search`'s `ort` dep has
+    // no prebuilt binary for this target, so even a lint-only pass can't
+    // compile it. Vector-search-gated code isn't clippy-checked on this path;
+    // plugin code is included because rustTest uses the same feature set.
     return this.rustChecksContainer()
       .withExec([
         'cargo',
@@ -1509,7 +1508,7 @@ export class AtomicServer {
         '--all-targets',
         '--no-default-features',
         '--features',
-        'light',
+        'light,wasm-plugins',
       ])
       .stdout();
   }

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -1170,8 +1170,10 @@ installation deletion must use the same selected identity as create/update.
 LocalThought: the browser and fixture tests cover selected-platform consent,
 PKCE redemption, one-time handoff consumption, rotating proxy credentials,
 duplicate-page rejection, typed paginated previews, and Calendar UTC date-range
-validation. The new redirect flow uses a synthetic fixture identity; live
-LocalThought login, consent, redemption and provider writes remain pending.
+validation. The new redirect flow uses a synthetic fixture identity. These
+automated checks do not certify live LocalThought login, consent, redemption or
+provider writes; matching deployment evidence is tracked separately in PR and
+release verification.
 
 Google Calendar one-way projection: `integrations/localthought/calendar.test.ts`
 covers all-day/timed start dates, offset boundaries, exclusive end preservation,
@@ -1183,8 +1185,9 @@ platform consent and PKCE redemption. It covers browser WASM fetching, local
 schema/proposal/apply, Calendar display, provider updates, OPFS reload and
 stable identities while AtomicServer HTTP/WebSockets are unavailable. Missing
 rows in a bounded snapshot are retained, not interpreted as deletions.
-Live-provider browser OAuth verification remains pending and separate from this
-fixture test.
+Live-provider browser OAuth and write verification are tracked separately in PR
+and release verification; this fixture intentionally uses no live provider
+account.
 
 ## Google Calendar recurrence
 

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -9,20 +9,22 @@ installation, and an unavailable database. This is a unit reproduction of the
 local/server lookup mismatch; the patched live Calendar flow remains unverified.
 
 LocalThought browser migration: `integrations/localthought/browser.test.ts`
-covers tenant HMAC, actor/drive ownership, rotation before dispatch, pagination,
-uncertain-response refusal and cross-origin pagination refusal. The real generated
+covers secret-free selected-platform redirects, S256 PKCE, one-time redemption,
+actor/drive/platform ownership, cancellation, expiry, rotation before dispatch,
+pagination, uncertain-response refusal and cross-origin pagination refusal. The real generated
 WASM bundle is exercised by `wasm-smoke.mjs` for pagination, typed ontology,
 timestamps and provider failures. `browser-smoke.mjs` exercises the complete
 mock consent/import/review/OPFS/reload journey with AtomicServer unavailable
 (verified locally). Local installation/schema lookup tests reject missing or
 incomplete local databases rather than inferring permission to create duplicates.
 The companion Syncables branch has 142 passing native tests and a wasm32 build;
-the companion proxy branch has 39 passing tests including CORS preflight and
-exposed headers. Live OAuth on the browser path still requires deployment of
-the companion proxy CORS change and is not yet verified.
+the proxy redirect work has 60 passing Rust tests including PostgreSQL-backed
+consent/replay, optional credential grants, callback binding and redemption expiry.
+CORS was verified with the earlier live browser flow; the new secret-free flow
+still requires matching proxy/frontend deployments and live verification.
 
-`browser/e2e/tests/devonian-issue-sync.spec.mts` exercises tenant-secret entry,
-proxy consent, direct HTTP writes and local OPFS storage for two-way issue
+`browser/e2e/tests/devonian-issue-sync.spec.mts` exercises the no-paste redirect,
+selected-platform consent and PKCE redemption, direct HTTP writes and local OPFS storage for two-way issue
 creation, comments, close/reopen and reload without duplicate resources. Its
 stateful HTTP mock isolates repositories and consumes/rotates connection codes;
 it does not substitute the in-page sample transport.
@@ -99,17 +101,19 @@ It edits JavaScript, saves and reviews a real proposed effect, enables execution
 returns to review mode and checks history. The trigger HTTP response regression
 `response_filters_round_trip_into_updates` ensures GET filter values can be sent
 back to POST; tagged database values previously broke the enable button.
-The Pets flow now uses a real mock integration-proxy service: signed consent,
+The Pets flow uses a real mock integration-proxy service: selected-platform consent,
+PKCE handoff redemption,
 return to the same drive, rotating connection codes, two-page Syncables fetch,
 review/apply, and five displayed records with integer/boolean/float/timestamp
 properties. Dagger starts the mock for E2E; local runs opt in with
 `ATOMIC_MOCK_INTEGRATION_PROXY=1` and the README configuration.
-`browser.test.ts` and the real WASM smoke cover actor/drive binding, tenant HMAC,
+`browser.test.ts` and the real WASM smoke cover actor/drive binding, PKCE redemption,
 Syncables pagination/ontology and duplicate-page refusal. The mock's Node test
-covers invalid tenant proofs and replayed/rotated codes. The mapping tests cover
+covers invalid PKCE verifiers, replayed handoffs and rotated proxy codes. The mapping tests cover
 typed proposals, missing identities, repeat imports, local edits and duplicates.
 The historical server path was live-verified for GitHub and Google Calendar.
-The new browser path awaits deployment of the companion proxy CORS change.
+The new secret-free browser path awaits matching proxy/frontend deployment and
+live verification.
 Run it against a production build to catch missing translation catalog entries:
 Vite dev extracts them automatically and can hide blank production labels.
 The GitHub setup flow also covers opting into assistant-led automation creation:
@@ -1163,19 +1167,24 @@ cancelled on teardown. Old plugin-name grants are deliberately not migrated.
 `store_host::destroy_identity_tests` checks the signer of the persisted destroy
 commit. It failed with the server signer before `Resource::destroy_as` was used;
 installation deletion must use the same selected identity as create/update.
-LocalThought: Rust handler tests cover connection binding, request signing, duplicate-page rejection, typed paginated previews, and Calendar UTC date-range validation. Live Calendar OAuth, bounded fetch, review/apply and event table display were verified against proxy v39 (54 records).
+LocalThought: the browser and fixture tests cover selected-platform consent,
+PKCE redemption, one-time handoff consumption, rotating proxy credentials,
+duplicate-page rejection, typed paginated previews, and Calendar UTC date-range
+validation. The new redirect flow uses a synthetic fixture identity; live
+LocalThought login, consent, redemption and provider writes remain pending.
 
 Google Calendar one-way projection: `integrations/localthought/calendar.test.ts`
 covers all-day/timed start dates, offset boundaries, exclusive end preservation,
 feature notes (including WASM-normalized field names), cancellations without
 start data, invalid active events, namespace isolation and repeat import/local
 field preservation. `browser/e2e/tests/google-calendar-import.spec.mts` uses the
-shared HTTP mock integration-proxy with a paginated Google Calendar, tenant
-secret entry and OAuth consent. It covers browser WASM fetching, local
+shared HTTP mock integration-proxy with a paginated Google Calendar, selected
+platform consent and PKCE redemption. It covers browser WASM fetching, local
 schema/proposal/apply, Calendar display, provider updates, OPFS reload and
 stable identities while AtomicServer HTTP/WebSockets are unavailable. Missing
 rows in a bounded snapshot are retained, not interpreted as deletions.
-Live-provider browser OAuth verification remains separate from this fixture test.
+Live-provider browser OAuth verification remains pending and separate from this
+fixture test.
 
 ## Google Calendar recurrence
 

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -86,8 +86,9 @@ unimplemented.
 Integration maintenance: `node integrations/tooling/certify.mjs` automatically
 discovers provider packages, verifies reproducible shipped bundles and types,
 runs fixture suites and exact Rust sandbox tests, and exports JSON evidence.
-`integrations/tooling/certify.test.mjs` covers zero-test refusal and missing
-metadata. Dagger's JS gate discovers provider packages, while Rust includes all provider
+`integrations/tooling/certify.test.mjs` covers zero-test refusal, missing
+metadata, and concise diagnostics for failed commands or bundle validation.
+The browser workspace explicitly declares esbuild for clean-install certification. Dagger's JS gate discovers provider packages, while Rust includes all provider
 fixtures. Reports explicitly distinguish selected offline layers and unrun live
 checks. GitHub's compatible code-only upgrade preserves bindings and prevents
 replacement of pending effects across upgrade/rollback. Mapping migrations and

--- a/browser/data-browser/scripts/integration-mcp.mjs
+++ b/browser/data-browser/scripts/integration-mcp.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Small stdio host: no listener, provider credentials, approval tool or new worker.
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -8,7 +9,12 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { Agent, integrationMcpAdapter } from '@tomic/lib';
+// This CLI runs directly in Node. The ESM build externalizes rrule,
+// whose package does not declare its ESM entry as type=module, so use the
+// package's CommonJS condition for Node's resolver.
+const { Agent, integrationMcpAdapter } = createRequire(import.meta.url)(
+  '@tomic/lib',
+);
 
 export function createIntegrationMcpServer(store, target) {
   const adapter = integrationMcpAdapter(store, target);

--- a/browser/data-browser/scripts/integration-mcp.test.mjs
+++ b/browser/data-browser/scripts/integration-mcp.test.mjs
@@ -1,13 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { Agent } from '@tomic/lib';
 import { main } from './integration-mcp.mjs';
+
+const { Agent } = createRequire(import.meta.url)('@tomic/lib');
 
 test('real stdio handshake, discovery and signed calls; no approval tool', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'atomic-mcp-'));

--- a/browser/data-browser/src/chunks/DevonianDemo/demo.d.mts
+++ b/browser/data-browser/src/chunks/DevonianDemo/demo.d.mts
@@ -43,6 +43,5 @@ export function editFixture(
 export function connectDemo(
   store: Store,
   options: { repository: string; proxy: string },
-  secret: string,
 ): Promise<void>;
 export function resumeDemo(store: Store): Promise<Demo | undefined>;

--- a/browser/data-browser/src/chunks/DevonianDemo/demo.mjs
+++ b/browser/data-browser/src/chunks/DevonianDemo/demo.mjs
@@ -289,6 +289,7 @@ export async function resumeDemo(store) {
       (callbackCode && callbackError)
     )
       throw new Error('Invalid connection callback state');
+
     if (callbackError) {
       client(handoff.proxy).cancel(handoff.drive, handoff.actor, handoff.state);
       sessionStorage.removeItem(handoffKey);
@@ -296,6 +297,7 @@ export async function resumeDemo(store) {
         'The connection was not authorized. Start connecting again when you are ready.',
       );
     }
+
     handoff.code = callbackCode;
     sessionStorage.setItem(handoffKey, JSON.stringify(handoff));
   }

--- a/browser/data-browser/src/chunks/DevonianDemo/demo.mjs
+++ b/browser/data-browser/src/chunks/DevonianDemo/demo.mjs
@@ -247,18 +247,24 @@ const client = origin =>
     origin,
   );
 
-export async function connectDemo(store, options, secret) {
+export async function connectDemo(store, options) {
   const demo = await openDemo(store, { ...options, sample: false });
   const result = await client(options.proxy).start(
     demo.state.config.connection.drive,
     store.getAgent().subject,
     'github-issues',
     `${location.origin}/app/devonian-demo`,
-    secret,
   );
   sessionStorage.setItem(
     handoffKey,
-    JSON.stringify({ key: demo.key, state: result.state }),
+    JSON.stringify({
+      key: demo.key,
+      state: result.state,
+      platform: 'github-issues',
+      drive: demo.state.config.connection.drive,
+      actor: store.getAgent().subject,
+      proxy: options.proxy,
+    }),
   );
   location.assign(result.url);
 }
@@ -266,14 +272,30 @@ export async function resumeDemo(store) {
   const url = new URL(location.href);
   const callbackCode = url.searchParams.get('connection_code');
   const callbackState = url.searchParams.get('integration_state');
+  const callbackPlatform = url.searchParams.get('platform');
+  const callbackError = url.searchParams.get('error');
   const handoff = JSON.parse(sessionStorage.getItem(handoffKey) ?? 'null');
 
   // Save the validated handoff before removing credentials from the URL, so a
   // reload while OPFS opens cannot abandon the completed proxy consent.
   if (callbackCode || callbackState) {
     history.replaceState(null, '', url.pathname);
-    if (!handoff || callbackState !== handoff.state || !callbackCode)
+    if (
+      !handoff ||
+      callbackState !== handoff.state ||
+      callbackPlatform !== handoff.platform ||
+      handoff.actor !== store.getAgent()?.subject ||
+      (!callbackCode && callbackError !== 'access_denied') ||
+      (callbackCode && callbackError)
+    )
       throw new Error('Invalid connection callback state');
+    if (callbackError) {
+      client(handoff.proxy).cancel(handoff.drive, handoff.actor, handoff.state);
+      sessionStorage.removeItem(handoffKey);
+      throw new Error(
+        'The connection was not authorized. Start connecting again when you are ready.',
+      );
+    }
     handoff.code = callbackCode;
     sessionStorage.setItem(handoffKey, JSON.stringify(handoff));
   }
@@ -296,7 +318,7 @@ export async function resumeDemo(store) {
 
   if (code) {
     if (!handoff.finished) {
-      client(saved.options.proxy).finish(
+      await client(saved.options.proxy).finish(
         saved.config.connection.drive,
         store.getAgent().subject,
         stateId,

--- a/browser/data-browser/src/chunks/PluginRuns/CalendarSync.tsx
+++ b/browser/data-browser/src/chunks/PluginRuns/CalendarSync.tsx
@@ -40,11 +40,13 @@ export function CalendarSync({
       path,
       init,
     );
+
   const preview = async () => {
     setBusy(true);
     setError('');
     setDone(false);
     setEdits(undefined);
+
     try {
       setEdits(
         await previewCalendarEdits(
@@ -59,10 +61,12 @@ export function CalendarSync({
       setBusy(false);
     }
   };
+
   const apply = async () => {
     if (!edits || busy) return;
     setBusy(true);
     setError('');
+
     try {
       for (const edit of edits) {
         const resource = await store.getResource(edit.subject);
@@ -77,6 +81,7 @@ export function CalendarSync({
           },
         );
       }
+
       setDone(true);
     } catch (reason) {
       setError(String(reason));
@@ -85,6 +90,7 @@ export function CalendarSync({
       setEdits(undefined);
     }
   };
+
   return (
     <Column gap='0.75rem'>
       <p>

--- a/browser/data-browser/src/chunks/PluginRuns/ConnectLocalThought.tsx
+++ b/browser/data-browser/src/chunks/PluginRuns/ConnectLocalThought.tsx
@@ -66,7 +66,6 @@ export function ConnectLocalThought({
     start: new Date().toISOString().slice(0, 10),
     end: new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10),
   }));
-  const [tenantSecret, setTenantSecret] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [preview, setPreview] = useState<{
@@ -117,7 +116,6 @@ export function ConnectLocalThought({
         {
           drive,
           platform,
-          tenantSecret,
           returnUrl: `${location.origin}/app/integrations`,
         },
       );
@@ -290,21 +288,11 @@ export function ConnectLocalThought({
         Connect your personal account through LocalThought, then return here to
         preview an import.
       </p>
-      <Field fieldId='tenant-secret' label='LocalThought tenant secret'>
-        <Input
-          id='tenant-secret'
-          type='password'
-          autoComplete='off'
-          value={tenantSecret}
-          onChange={e => setTenantSecret(e.target.value)}
-          disabled={busy}
-        />
-      </Field>
       <p>
-        The tenant secret is used in this tab. Connection credentials stay in
-        this browser.
+        LocalThought will ask you to sign in and authorize this connection.
+        Connection credentials stay in this browser.
       </p>
-      <Button disabled={busy || !tenantSecret} onClick={connect}>
+      <Button disabled={busy} onClick={connect}>
         {connection ? 'Reconnect account' : 'Install and connect'}
       </Button>
       {connection && (

--- a/browser/data-browser/src/chunks/PluginRuns/LocalThoughtCatalog.tsx
+++ b/browser/data-browser/src/chunks/PluginRuns/LocalThoughtCatalog.tsx
@@ -45,6 +45,8 @@ export function LocalThoughtCatalog({
     const url = new URL(location.href);
     const state = url.searchParams.get('integration_state');
     const code = url.searchParams.get('connection_code');
+    const callbackPlatform = url.searchParams.get('platform');
+    const callbackError = url.searchParams.get('error');
     if (!state) return;
     completing.current = true;
     // Remove the single-use credential before fetching anything else or following links.
@@ -59,15 +61,27 @@ export function LocalThoughtCatalog({
         pending.state !== state ||
         pending.drive !== drive ||
         pending.actor !== actor ||
-        !code
+        pending.platform !== callbackPlatform ||
+        (!code && callbackError !== 'access_denied') ||
+        (code && callbackError)
       )
         throw new Error(
           'Connection return is missing, expired or belongs to another account. Start connecting again.',
         );
+      // A redeem response can be lost after the one-time code is consumed.
+      sessionStorage.removeItem('localthought-pending');
+
+      if (callbackError) {
+        browserIntegrations().cancel(drive, actor!, state);
+        throw new Error(
+          'The connection was not authorized. Start connecting again when you are ready.',
+        );
+      }
+
       const result = await proxyRequest<{
         connection: string;
         platform: string;
-      }>(store, 'finish', { drive, state, connectionCode: code });
+      }>(store, 'finish', { drive, state, connectionCode: code! });
       if (result.platform !== pending.platform)
         throw new Error(
           'Returned platform did not match the requested platform',
@@ -81,7 +95,6 @@ export function LocalThoughtCatalog({
           installationConnection: pending.installationConnection,
         }),
       );
-      sessionStorage.removeItem('localthought-pending');
       setReturned(result.platform);
     };
 

--- a/browser/data-browser/src/chunks/PluginRuns/localImportVerdict.ts
+++ b/browser/data-browser/src/chunks/PluginRuns/localImportVerdict.ts
@@ -34,6 +34,7 @@ export async function localImportRows(
         throw new Error('Local import snapshot is incomplete');
     }
   }
+
   return rows;
 }
 
@@ -43,6 +44,7 @@ export async function localImportVerdict(
   config: Config,
 ) {
   const rows = await localImportRows(store, drive, config);
+
   return JSON.stringify(
     run({
       config,

--- a/browser/data-browser/src/chunks/PluginRuns/localThought.ts
+++ b/browser/data-browser/src/chunks/PluginRuns/localThought.ts
@@ -42,7 +42,6 @@ export async function proxyRequest<T>(
     drive: string;
     platform?: string;
     returnUrl?: string;
-    tenantSecret?: string;
     state?: string;
     connectionCode?: string;
     connection?: string;
@@ -59,15 +58,14 @@ export async function proxyRequest<T>(
       actor,
       body.platform!,
       body.returnUrl!,
-      body.tenantSecret!,
     )) as T;
   if (action === 'finish')
-    return client.finish(
+    return (await client.finish(
       body.drive,
       actor,
       body.state!,
       body.connectionCode!,
-    ) as T;
+    )) as T;
   if (action === 'fetch')
     return client.fetchRecords(
       body.drive,

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4318,7 +4318,6 @@ msgid "as a classtype."
 msgstr ""
 
 #: src/components/Share/ShareDialog.tsx
-#: src/components/Share/ShareDialog.tsx
 #: src/components/Share/ShareDialog.tsx src/routes/Share/ShareRoute.tsx
 #: src/routes/Share/ShareRoute.tsx
 msgid "Create Invite"
@@ -4696,6 +4695,7 @@ msgstr ""
 msgid "{0}% used"
 msgstr ""
 
+#: src/chunks/PluginRuns/CalendarSync.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -7535,6 +7535,7 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Entsperren mit einem Passkey fehlgeschlagen. Verwende stattdessen deinen Wiederherstellungscode."
+
 #~ msgid "Last Modified"
 #~ msgstr ""
 
@@ -9853,9 +9854,8 @@ msgstr ""
 msgid "Open imported records"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
-msgstr ""
+#~ msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
+#~ msgstr ""
 
 #: src/chunks/PluginRuns/ConnectLocalThought.tsx
 msgid "Events from (UTC)"
@@ -9865,14 +9865,12 @@ msgstr ""
 msgid "Events before (UTC)"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
 #: src/routes/DevonianDemoRoute.tsx
 msgid "LocalThought tenant secret"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
-msgstr ""
+#~ msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
+#~ msgstr ""
 
 #. 0: count
 #: src/routes/DevonianDemoRoute.tsx
@@ -9998,6 +9996,7 @@ msgstr ""
 
 #: src/routes/DevonianDemoRoute.tsx
 msgid "Connect another tracker"
+msgstr ""
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "All day"
@@ -10006,4 +10005,41 @@ msgstr ""
 #. 0: title || subject
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "{0} · Recurring meeting (opens its series or exception)"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "LocalThought will ask you to sign in and authorize this connection. Connection credentials stay in this browser."
+msgstr ""
+
+#. 0: calendar ? ' After importing, preview edits to send changes back to Google Calendar.' \\: ' No provider writes.'
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync. {0}"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Preview edits for Google"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "No supported local edits to send."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Edits synced. Fetch and preview to receive the latest Google changes."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Send edits to imported events back to Google: Name or Summary, Description, Location, Start and End. Edit Start and End together to change duration or all-day dates. Calendar day and all-day display columns are derived on import. New events, deletion, recurrence rules, guests and RSVP stay in Google. Reconnect with Calendar write access before your first sync."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Applying these edits updates Google Calendar and notifies event guests."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Apply edits to Google"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4329,7 +4329,6 @@ msgid "as a classtype."
 msgstr "as a classtype."
 
 #: src/components/Share/ShareDialog.tsx
-#: src/components/Share/ShareDialog.tsx
 #: src/components/Share/ShareDialog.tsx src/routes/Share/ShareRoute.tsx
 #: src/routes/Share/ShareRoute.tsx
 msgid "Create Invite"
@@ -4707,6 +4706,7 @@ msgstr "{0}% of storage used"
 msgid "{0}% used"
 msgstr "{0}% used"
 
+#: src/chunks/PluginRuns/CalendarSync.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -7546,6 +7546,7 @@ msgstr "<0>Save this recovery code.</0> It gets you back in on a new device, and
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Could not unlock with a passkey. Use your recovery code instead."
+
 #~ msgid "Last Modified"
 #~ msgstr "Last Modified"
 
@@ -9892,9 +9893,8 @@ msgstr "Connect your personal account through LocalThought, then return here to 
 msgid "Open imported records"
 msgstr "Open imported records"
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
-msgstr "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
+#~ msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
+#~ msgstr "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
 
 #: src/chunks/PluginRuns/ConnectLocalThought.tsx
 msgid "Events from (UTC)"
@@ -9904,14 +9904,12 @@ msgstr "Events from (UTC)"
 msgid "Events before (UTC)"
 msgstr "Events before (UTC)"
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
 #: src/routes/DevonianDemoRoute.tsx
 msgid "LocalThought tenant secret"
 msgstr "LocalThought tenant secret"
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
-msgstr "The tenant secret is used in this tab. Connection credentials stay in this browser."
+#~ msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
+#~ msgstr "The tenant secret is used in this tab. Connection credentials stay in this browser."
 
 #. 0: count
 #: src/routes/DevonianDemoRoute.tsx
@@ -10047,3 +10045,40 @@ msgstr "All day"
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "{0} · Recurring meeting (opens its series or exception)"
 msgstr "{0} · Recurring meeting (opens its series or exception)"
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr "Error: Sign in before syncing with another device"
+
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "LocalThought will ask you to sign in and authorize this connection. Connection credentials stay in this browser."
+msgstr "LocalThought will ask you to sign in and authorize this connection. Connection credentials stay in this browser."
+
+#. 0: calendar ? ' After importing, preview edits to send changes back to Google Calendar.' \\: ' No provider writes.'
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync. {0}"
+msgstr "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync. {0}"
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Preview edits for Google"
+msgstr "Preview edits for Google"
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "No supported local edits to send."
+msgstr "No supported local edits to send."
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Edits synced. Fetch and preview to receive the latest Google changes."
+msgstr "Edits synced. Fetch and preview to receive the latest Google changes."
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Send edits to imported events back to Google: Name or Summary, Description, Location, Start and End. Edit Start and End together to change duration or all-day dates. Calendar day and all-day display columns are derived on import. New events, deletion, recurrence rules, guests and RSVP stay in Google. Reconnect with Calendar write access before your first sync."
+msgstr "Send edits to imported events back to Google: Name or Summary, Description, Location, Start and End. Edit Start and End together to change duration or all-day dates. Calendar day and all-day display columns are derived on import. New events, deletion, recurrence rules, guests and RSVP stay in Google. Reconnect with Calendar write access before your first sync."
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Applying these edits updates Google Calendar and notifies event guests."
+msgstr "Applying these edits updates Google Calendar and notifies event guests."
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Apply edits to Google"
+msgstr "Apply edits to Google"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4318,7 +4318,6 @@ msgid "as a classtype."
 msgstr ""
 
 #: src/components/Share/ShareDialog.tsx
-#: src/components/Share/ShareDialog.tsx
 #: src/components/Share/ShareDialog.tsx src/routes/Share/ShareRoute.tsx
 #: src/routes/Share/ShareRoute.tsx
 msgid "Create Invite"
@@ -4696,6 +4695,7 @@ msgstr ""
 msgid "{0}% used"
 msgstr ""
 
+#: src/chunks/PluginRuns/CalendarSync.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -7535,6 +7535,7 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "No se pudo desbloquear con una clave de acceso. Usa tu código de recuperación."
+
 #~ msgid "Last Modified"
 #~ msgstr "Última modificación"
 
@@ -9853,9 +9854,8 @@ msgstr ""
 msgid "Open imported records"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
-msgstr ""
+#~ msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
+#~ msgstr ""
 
 #: src/chunks/PluginRuns/ConnectLocalThought.tsx
 msgid "Events from (UTC)"
@@ -9865,14 +9865,12 @@ msgstr ""
 msgid "Events before (UTC)"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
 #: src/routes/DevonianDemoRoute.tsx
 msgid "LocalThought tenant secret"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
-msgstr ""
+#~ msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
+#~ msgstr ""
 
 #. 0: count
 #: src/routes/DevonianDemoRoute.tsx
@@ -9998,6 +9996,7 @@ msgstr ""
 
 #: src/routes/DevonianDemoRoute.tsx
 msgid "Connect another tracker"
+msgstr ""
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "All day"
@@ -10006,4 +10005,41 @@ msgstr ""
 #. 0: title || subject
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "{0} · Recurring meeting (opens its series or exception)"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "LocalThought will ask you to sign in and authorize this connection. Connection credentials stay in this browser."
+msgstr ""
+
+#. 0: calendar ? ' After importing, preview edits to send changes back to Google Calendar.' \\: ' No provider writes.'
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync. {0}"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Preview edits for Google"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "No supported local edits to send."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Edits synced. Fetch and preview to receive the latest Google changes."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Send edits to imported events back to Google: Name or Summary, Description, Location, Start and End. Edit Start and End together to change duration or all-day dates. Calendar day and all-day display columns are derived on import. New events, deletion, recurrence rules, guests and RSVP stay in Google. Reconnect with Calendar write access before your first sync."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Applying these edits updates Google Calendar and notifies event guests."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Apply edits to Google"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4318,7 +4318,6 @@ msgid "as a classtype."
 msgstr ""
 
 #: src/components/Share/ShareDialog.tsx
-#: src/components/Share/ShareDialog.tsx
 #: src/components/Share/ShareDialog.tsx src/routes/Share/ShareRoute.tsx
 #: src/routes/Share/ShareRoute.tsx
 msgid "Create Invite"
@@ -4696,6 +4695,7 @@ msgstr ""
 msgid "{0}% used"
 msgstr ""
 
+#: src/chunks/PluginRuns/CalendarSync.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -7535,6 +7535,7 @@ msgstr ""
 #: src/components/AccountRecoveryCard.tsx
 msgid "Could not unlock with a passkey. Use your recovery code instead."
 msgstr "Impossible de déverrouiller avec une clé d’accès. Utilisez votre code de récupération."
+
 #~ msgid "Last Modified"
 #~ msgstr "Dernière modification"
 
@@ -9853,9 +9854,8 @@ msgstr ""
 msgid "Open imported records"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
-msgstr ""
+#~ msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync or provider writes."
+#~ msgstr ""
 
 #: src/chunks/PluginRuns/ConnectLocalThought.tsx
 msgid "Events from (UTC)"
@@ -9865,14 +9865,12 @@ msgstr ""
 msgid "Events before (UTC)"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
 #: src/routes/DevonianDemoRoute.tsx
 msgid "LocalThought tenant secret"
 msgstr ""
 
-#: src/chunks/PluginRuns/ConnectLocalThought.tsx
-msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
-msgstr ""
+#~ msgid "The tenant secret is used in this tab. Connection credentials stay in this browser."
+#~ msgstr ""
 
 #. 0: count
 #: src/routes/DevonianDemoRoute.tsx
@@ -9998,6 +9996,7 @@ msgstr ""
 
 #: src/routes/DevonianDemoRoute.tsx
 msgid "Connect another tracker"
+msgstr ""
 
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "All day"
@@ -10006,4 +10005,41 @@ msgstr ""
 #. 0: title || subject
 #: src/chunks/TablePage/Calendar/CalendarDay.tsx
 msgid "{0} · Recurring meeting (opens its series or exception)"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Error: Sign in before syncing with another device"
+msgstr ""
+
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "LocalThought will ask you to sign in and authorize this connection. Connection credentials stay in this browser."
+msgstr ""
+
+#. 0: calendar ? ' After importing, preview edits to send changes back to Google Calendar.' \\: ' No provider writes.'
+#: src/chunks/PluginRuns/ConnectLocalThought.tsx
+msgid "Imports the collections described by the platform, following pagination. Review changes before applying them. No background sync. {0}"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Preview edits for Google"
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "No supported local edits to send."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Edits synced. Fetch and preview to receive the latest Google changes."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Send edits to imported events back to Google: Name or Summary, Description, Location, Start and End. Edit Start and End together to change duration or all-day dates. Calendar day and all-day display columns are derived on import. New events, deletion, recurrence rules, guests and RSVP stay in Google. Reconnect with Calendar write access before your first sync."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Applying these edits updates Google Calendar and notifies event guests."
+msgstr ""
+
+#: src/chunks/PluginRuns/CalendarSync.tsx
+msgid "Apply edits to Google"
 msgstr ""

--- a/browser/data-browser/src/routes/DevonianDemoRoute.tsx
+++ b/browser/data-browser/src/routes/DevonianDemoRoute.tsx
@@ -27,7 +27,6 @@ function DevonianDemo() {
   const [rows, setRows] = useState<Row[]>([]);
   const [proxy, setProxy] = useState('https://localthought.io');
   const [repository, setRepository] = useState('');
-  const [secret, setSecret] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [status, setStatus] = useState('');
@@ -60,9 +59,7 @@ function DevonianDemo() {
   const start = (sample: boolean) =>
     run(async () => {
       if (!sample) {
-        const credential = secret;
-        setSecret('');
-        await connectDemo(store, { repository, proxy }, credential);
+        await connectDemo(store, { repository, proxy });
 
         return;
       }
@@ -113,8 +110,8 @@ function DevonianDemo() {
                 <summary>Connect a real GitHub repository</summary>
                 <Column gap='0.75rem'>
                   <p>
-                    Connect through LocalThought. The tenant secret is used in
-                    this tab to start the connection and is never saved.
+                    LocalThought will ask you to sign in and authorize the
+                    GitHub connection.
                   </p>
                   <Field fieldId='devonian-proxy' label='Integration proxy URL'>
                     <Input
@@ -133,20 +130,8 @@ function DevonianDemo() {
                       onChange={e => setRepository(e.target.value)}
                     />
                   </Field>
-                  <Field
-                    fieldId='devonian-secret'
-                    label='LocalThought tenant secret'
-                  >
-                    <Input
-                      id='devonian-secret'
-                      type='password'
-                      autoComplete='off'
-                      value={secret}
-                      onChange={e => setSecret(e.target.value)}
-                    />
-                  </Field>
                   <Button
-                    disabled={busy || !repository || !secret}
+                    disabled={busy || !repository}
                     onClick={() => start(false)}
                   >
                     Connect GitHub tracker

--- a/browser/e2e/tests/devonian-issue-sync.spec.mts
+++ b/browser/e2e/tests/devonian-issue-sync.spec.mts
@@ -1,15 +1,11 @@
 import { test, expect } from '@playwright/test';
-import {
-  mockProxy,
-  tenantSecret,
-} from '../../../integrations/localthought/mock-proxy.mjs';
+import { mockProxy } from '../../../integrations/localthought/mock-proxy.mjs';
 const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:6747';
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:9883';
 
 test.use({ serviceWorkers: 'block' });
 
-// This is a public fixture secret, never an environment/live credential.
-// Exercise the real form, tenant challenge, consent, rotating HTTP transport and OPFS.
+// Exercise the real redirect consent, PKCE redemption, rotating HTTP transport and OPFS.
 test('Devonian syncs issue creation, state and comments both ways through the browser proxy', async ({
   page,
 }) => {
@@ -62,12 +58,14 @@ test('Devonian syncs issue creation, state and comments both ways through the br
       .click();
     await page.getByLabel('Integration proxy URL').fill(proxyOrigin);
     await page.getByLabel('GitHub repository (owner/repo)').fill(repository);
-    await page.getByLabel('LocalThought tenant secret').fill(tenantSecret);
     await page
       .getByRole('button', { name: 'Connect GitHub tracker', exact: true })
       .click();
     await page
-      .getByRole('button', { name: 'Connect test account', exact: true })
+      .getByRole('button', {
+        name: 'Use LocalThought to sync GitHub Issues with your Atomic Data Hub',
+        exact: true,
+      })
       .click();
 
     const sync = async () => {
@@ -84,11 +82,6 @@ test('Devonian syncs issue creation, state and comments both ways through the br
       page.getByRole('button', { name: 'Sync now', exact: true }),
     ).toBeVisible();
     expect(page.url()).not.toContain('connection_code');
-    expect(
-      await page.evaluate(() =>
-        JSON.stringify({ ...localStorage, ...sessionStorage }),
-      ),
-    ).not.toContain(tenantSecret);
     await sync();
     const issue = (title: string) =>
       page

--- a/browser/e2e/tests/google-calendar-import.spec.mts
+++ b/browser/e2e/tests/google-calendar-import.spec.mts
@@ -1,14 +1,11 @@
 import { test, expect } from '@playwright/test';
-import {
-  mockProxy,
-  tenantSecret,
-} from '../../../integrations/localthought/mock-proxy.mjs';
+import { mockProxy } from '../../../integrations/localthought/mock-proxy.mjs';
 const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:6747';
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:9883';
 test.use({ serviceWorkers: 'block' });
 
 // Reuse the browser transport and HTTP mock from the Devonian integration.
-// The tenant secret is a public fixture. No real provider credentials are used.
+// No real provider credentials are used.
 for (const keepSeries of [false, true]) {
   test(`Calendar ${keepSeries ? 'series' : 'instances'} import, refresh and persist without AtomicServer`, async ({
     page,
@@ -58,8 +55,8 @@ for (const keepSeries of [false, true]) {
     await page.routeWebSocket('**/*', socket => socket.close());
     const forbidden: string[] = [];
     const providerMethods: string[] = [];
-    // Forward the configured proxy to this test's isolated HTTP fixture. All
-    // tenant proof, consent, code rotation, pagination and WASM code remain real.
+    // Forward the configured proxy to this test's isolated HTTP fixture. Consent,
+    // PKCE redemption, code rotation, pagination and WASM code remain real.
     await page.route('**/*', async route => {
       const request = route.request();
       const url = new URL(request.url());
@@ -105,22 +102,19 @@ for (const keepSeries of [false, true]) {
       };
 
       await setup();
-      await page.getByLabel('LocalThought tenant secret').fill(tenantSecret);
       await page
         .getByRole('button', { name: 'Install and connect', exact: true })
         .click();
       await page
-        .getByRole('button', { name: 'Connect test account', exact: true })
+        .getByRole('button', {
+          name: 'Use LocalThought to sync Google Calendar with your Atomic Data Hub',
+          exact: true,
+        })
         .click();
       await expect(
         page.getByRole('button', { name: 'Fetch and preview', exact: true }),
       ).toBeVisible();
       expect(page.url()).not.toContain('connection_code');
-      expect(
-        await page.evaluate(() =>
-          JSON.stringify({ ...localStorage, ...sessionStorage }),
-        ),
-      ).not.toContain(tenantSecret);
 
       const apply = async (count: number) => {
         await page

--- a/browser/e2e/tests/plugins.spec.ts
+++ b/browser/e2e/tests/plugins.spec.ts
@@ -53,16 +53,18 @@ test.describe('plugins', () => {
       setup.getByRole('button', { name: 'Install and connect', exact: true }),
     ).toBeVisible();
     await setup
-      .getByLabel('LocalThought tenant secret')
-      .fill('bW9jay10ZW5hbnQ.mock-signature');
-    await setup
       .getByRole('button', { name: 'Install and connect', exact: true })
       .click();
 
     await expect(
       page.getByRole('heading', { name: 'Mock integration proxy' }),
     ).toBeVisible();
-    await page.getByRole('button', { name: 'Connect test account' }).click();
+    await page
+      .getByRole('button', {
+        name: 'Use LocalThought to sync Pets with your Atomic Data Hub',
+        exact: true,
+      })
+      .click();
     await expect(page).not.toHaveURL(/connection_code=/);
     await page.getByRole('button', { name: 'Fetch and preview' }).click();
 

--- a/browser/lib/src/calendar-recurrence.ts
+++ b/browser/lib/src/calendar-recurrence.ts
@@ -181,7 +181,8 @@ function parseRule(line: string, allDay = false) {
   )
     throw new Error('Invalid recurrence interval');
   if (
-    options.count !== undefined && options.count !== null &&
+    options.count !== undefined &&
+    options.count !== null &&
     (!Number.isSafeInteger(options.count) ||
       options.count < 1 ||
       options.count > MAX_STEPS)
@@ -296,7 +297,13 @@ export function expandCalendar(
     overrides = new Set<string>();
 
   for (const record of records) {
-    if (typeof record.calendarId !== 'string' || !record.calendarId || typeof record.subject !== 'string' || !record.subject) throw new Error('Calendar record needs source identity and subject');
+    if (
+      typeof record.calendarId !== 'string' ||
+      !record.calendarId ||
+      typeof record.subject !== 'string' ||
+      !record.subject
+    )
+      throw new Error('Calendar record needs source identity and subject');
     validateCalendarEvent(record.event);
     const key = identity(record.calendarId, record.event.id);
     if (masters.has(key)) throw new Error('Duplicate calendar event identity');
@@ -308,7 +315,8 @@ export function expandCalendar(
         record.event.recurringEventId,
         instant(record.event.originalStartTime),
       ]);
-      if (overrides.has(instanceKey)) throw new Error('Duplicate recurring instance');
+      if (overrides.has(instanceKey))
+        throw new Error('Duplicate recurring instance');
       overrides.add(instanceKey);
     }
   }

--- a/browser/package.json
+++ b/browser/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^4.4.1",
     "@types/node": "^25.9.1",
+    "esbuild": "0.28.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "netlify-cli": "26.0.2",

--- a/browser/package.json
+++ b/browser/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^4.4.1",
     "@types/node": "^25.9.1",
-    "esbuild": "0.28.1",
+    "esbuild": ">=0.28.1 <0.29.0",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "netlify-cli": "26.0.2",

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         specifier: ^25.9.1
         version: 25.9.1
       esbuild:
-        specifier: 0.28.1
+        specifier: '>=0.28.1 <0.29.0'
         version: 0.28.1
       globals:
         specifier: ^17.6.0

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
       globals:
         specifier: ^17.6.0
         version: 17.6.0

--- a/integrations/localthought/README.md
+++ b/integrations/localthought/README.md
@@ -1,14 +1,17 @@
 # LocalThought browser integrations
 
-The LocalThought flow runs entirely in the browser: catalog discovery, tenant
-challenge signing, OAuth return handling, paginated Syncables reads, ontology
+The LocalThought flow runs entirely in the browser: catalog discovery, OAuth
+consent, PKCE-protected return handling, paginated Syncables reads, ontology
 creation, proposal review and local Store/OPFS writes. No AtomicServer HTTP
 instance is needed. LocalThought remains the remote OAuth and API proxy.
 
-Open Integrations, select a platform and paste your `TENANT_SECRET`. It is used
-in tab memory to sign the handoff and is not persisted. OAuth returns to the
-same frontend `/app/integrations` page. The short-lived return is bound to the
-agent, drive and proxy; its code is removed from the address bar immediately.
+Open Integrations, select a platform and choose **Install and connect**. The
+browser creates a PKCE verifier and opens LocalThought's consent page, where
+the selected platform is shown before you approve access. OAuth returns to the
+same frontend `/app/integrations` page, and the browser redeems the one-time
+handoff with the verifier. No tenant secret is entered in the browser. The
+short-lived return is bound to the agent, drive and proxy; its code is removed
+from the address bar immediately.
 Connection codes are stored in this browser's localStorage, outside the synced
 graph, and may be read by code running on this frontend origin. Clearing site
 data requires reconnecting. Existing server-held connections require reconnecting.
@@ -31,7 +34,10 @@ Local edits and repeated imports retain the existing reconciliation behavior.
 - Deploy the companion integration-proxy CORS change. It handles preflights for
   explicit Authorization headers and exposes `X-Connection-Code`, `Link`,
   pagination/count headers, `ETag` and `Retry-After`. Cookie credentials are not
-  enabled; login and consent use top-level navigation.
+  enabled; login and consent use top-level navigation. The browser sends
+  `platform`, `redirect_uri`, `user_id`, `code_challenge`,
+  `code_challenge_method=S256` and `credentials=connection` to `/connect`, then
+  redeems the callback code at `/connect/redeem` with its PKCE verifier.
 - Native AtomicServer's `TENANT_SECRET`, `ATOMIC_INTEGRATION_PROXY_URL` and
   `ATOMIC_INTEGRATION_FRONTEND_ORIGIN` no longer configure this flow. Its
   `/integration-proxy/*` handlers and Syncables dependency have been removed.
@@ -59,9 +65,16 @@ VITE_INTEGRATION_PROXY_URL=http://127.0.0.1:19091 VITE_ATOMIC_SERVER_URL=http://
 node integrations/localthought/browser-smoke.mjs
 ```
 
-The mock is test-only. It uses synthetic credentials and data; never deploy it.
+The mock is test-only. It uses a synthetic signed-in identity and data; never
+deploy it.
 
 ## Historical server-flow verification
+
+The server-owned tenant-secret flow described by the historical notes below is
+superseded by the browser redirect and PKCE flow. Live verification of the new
+LocalThought login, selected-platform consent and one-time redemption is checked
+separately after matching deployments and recorded in PR/release verification.
+The fixture tests below do not claim live-provider verification.
 
 Live verification on 2026-09-09 succeeded against proxy Heroku release v38
 (`5960ae43`): OAuth returned to AtomicServer, Syncables fetched 29 issue/PR
@@ -145,8 +158,8 @@ identity and repeated imports with private local fields.
 ## Browser-only Calendar regression
 
 `browser/e2e/tests/google-calendar-import.spec.mts` starts the shared mock
-integration-proxy from #1399 with a synthetic Google Calendar. The test enters
-the public fixture tenant secret, completes consent, and exercises real browser
+integration-proxy with a synthetic Google Calendar. The test selects Calendar,
+completes the mock PKCE consent and redemption, and exercises real browser
 credential rotation, WASM pagination, local schema installation, proposal review,
 OPFS application, and Calendar rendering. It refreshes changed provider data
 and checks that native identities and Atomic-only notes survive reload.
@@ -168,4 +181,6 @@ test process. The test forwards that origin to its own fixture. Live Google
 OAuth on the browser path still depends on the proxy CORS deployment described
 above; this fixture test does not claim live-provider verification.
 
-Verification: 28 LocalThought Vitest tests, frontend TypeScript check, and all 41 companion proxy tests passed. Browser UI and live Google write verification remain unperformed.
+Verification: the focused LocalThought fixture and frontend checks cover the
+redirect, PKCE, rotation and import paths. Live LocalThought login, consent,
+redemption and Google write verification remain pending.

--- a/integrations/localthought/browser-smoke.mjs
+++ b/integrations/localthought/browser-smoke.mjs
@@ -16,12 +16,14 @@ try {
   const pets = page.locator('[data-integration=pets]');
   await pets.getByRole('button', { name: 'Set up connection' }).click();
   await page
-    .getByLabel('LocalThought tenant secret')
-    .fill('bW9jay10ZW5hbnQ.mock-signature');
-  await page
     .getByRole('button', { name: 'Install and connect', exact: true })
     .click();
-  await page.getByRole('button', { name: 'Connect test account' }).click();
+  await page
+    .getByRole('button', {
+      name: 'Use LocalThought to sync Pets with your Atomic Data Hub',
+      exact: true,
+    })
+    .click();
   console.log('Fetching preview');
   await page.getByRole('button', { name: 'Fetch and preview' }).click();
   console.log('Applying preview');

--- a/integrations/localthought/browser.test.ts
+++ b/integrations/localthought/browser.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, expect, it, vi } from 'vitest';
-import { BrowserIntegrations, proxyOrigin, sign, type Engine } from './browser';
-const secret = 'bW9jay10ZW5hbnQ.mock-signature';
+import { BrowserIntegrations, proxyOrigin, type Engine } from './browser';
 const origin = 'https://proxy.example';
 function setup() {
   const values = new Map<string, string>();
@@ -8,6 +7,9 @@ function setup() {
     getItem: (k: string) => values.get(k) ?? null,
     setItem: (k: string, v: string) => {
       values.set(k, v);
+    },
+    removeItem: (k: string) => {
+      values.delete(k);
     },
   } as Storage;
   vi.stubGlobal('location', { origin: 'https://atomic.example' });
@@ -18,8 +20,8 @@ function setup() {
     expect(init?.credentials).toBe('omit');
     expect(init?.redirect).toBe('error');
     if (url.endsWith('/catalog')) return new Response('["pets"]');
-    if (url.endsWith('/session'))
-      return Response.json({ ts: 1, nonce: 'nonce', challenge: 'challenge' });
+    if (url.endsWith('/connect/redeem'))
+      return Response.json({ connection_code: 'first', platform: 'pets' });
     return new Response('{}');
   });
   const engine: Engine = {
@@ -44,37 +46,141 @@ function setup() {
       'actor',
       'pets',
       'https://atomic.example/app/integrations',
-      secret,
     );
   return { values, storage, http, engine, client, start };
 }
 afterEach(() => vi.unstubAllGlobals());
-it('matches the tenant HMAC protocol and rejects non-origin proxy URLs', async () => {
-  expect(await sign('key', 'The quick brown fox jumps over the lazy dog')).toBe(
-    '97yD9DBThCSxMpjmqm-xQ-9NWaFJRhdZl0edvC0aPNg',
-  );
+it('rejects non-origin proxy URLs', () => {
   expect(() => proxyOrigin('https://proxy.example/path')).toThrow();
   expect(() => proxyOrigin('http://proxy.example')).toThrow();
 });
-it('binds returns to actor, drive and expiry without saving tenant secrets', async () => {
-  const { client, start, values } = setup();
+it('starts a platform-bound PKCE redirect without a tenant session', async () => {
+  const { start, values, http } = setup();
   const { state, url } = await start();
-  expect(url).not.toContain(secret);
-  expect([...values.values()].join()).not.toContain(secret);
-  expect(() => client.finish('other', 'actor', state, 'code')).toThrow();
-  expect(() => client.finish('drive', 'other', state, 'code')).toThrow();
-  expect(client.finish('drive', 'actor', state, 'code').platform).toBe('pets');
-  expect(() => client.finish('drive', 'actor', state, 'code')).toThrow();
+  const redirect = new URL(url);
+  const callback = new URL(redirect.searchParams.get('redirect_uri')!);
+  const pending = JSON.parse([...values.values()][0]);
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(pending.codeVerifier),
+  );
+  const expectedChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+
+  expect(redirect.pathname).toBe('/connect');
+  expect(Object.fromEntries(redirect.searchParams)).toEqual({
+    platform: 'pets',
+    redirect_uri: callback.href,
+    user_id: 'actor',
+    code_challenge: expectedChallenge,
+    code_challenge_method: 'S256',
+    credentials: 'connection',
+  });
+  expect(callback.searchParams.get('integration_state')).toBe(state);
+  expect(callback.searchParams.get('platform')).toBe('pets');
+  expect(pending.codeVerifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  expect(
+    http.mock.calls.some(([request]) => String(request).endsWith('/session')),
+  ).toBe(false);
+});
+it('binds redemption to actor, drive, platform and expiry', async () => {
+  const { client, start, values, http } = setup();
+  const { state } = await start();
+  await expect(
+    client.finish('other', 'actor', state, 'code'),
+  ).rejects.toThrow();
+  await expect(
+    client.finish('drive', 'other', state, 'code'),
+  ).rejects.toThrow();
+  http.mockImplementationOnce(async (_url, init) => {
+    const pending = JSON.parse([...values.values()][0]);
+    expect(pending.codeVerifier).toBeUndefined();
+    expect(init).toMatchObject({
+      method: 'POST',
+      body: expect.any(String),
+      credentials: 'omit',
+      redirect: 'error',
+    });
+    expect(JSON.parse(init!.body as string)).toEqual({
+      code: 'code',
+      code_verifier: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+    });
+    return Response.json({ connection_code: 'first', platform: 'pets' });
+  });
+  await expect(client.finish('drive', 'actor', state, 'code')).resolves.toEqual(
+    {
+      connection: state,
+      platform: 'pets',
+    },
+  );
+  expect(JSON.parse([...values.values()][0])).toMatchObject({
+    platform: 'pets',
+    ready: true,
+    code: 'first',
+  });
+  expect(JSON.parse([...values.values()][0]).codeVerifier).toBeUndefined();
+  await expect(
+    client.finish('drive', 'actor', state, 'code'),
+  ).rejects.toThrow();
+});
+it('does not save a credential when redemption returns another platform', async () => {
+  const { client, start, values, http } = setup();
+  const { state } = await start();
+  http.mockImplementationOnce(async () =>
+    Response.json({ connection_code: 'first', platform: 'github-issues' }),
+  );
+  await expect(client.finish('drive', 'actor', state, 'code')).rejects.toThrow(
+    'platform',
+  );
+  expect(JSON.parse([...values.values()][0])).toMatchObject({ ready: false });
+  expect(JSON.parse([...values.values()][0]).code).toBeUndefined();
+});
+it('clears expired and denied pending verifiers', async () => {
+  const { client, start, values, http } = setup();
+  const expired = await start();
+  const [expiredKey, expiredValue] = [...values.entries()][0];
+  values.set(
+    expiredKey,
+    JSON.stringify({ ...JSON.parse(expiredValue), expires: Date.now() - 1 }),
+  );
+  await expect(
+    client.finish('drive', 'actor', expired.state, 'code'),
+  ).rejects.toThrow('Reconnect');
+  expect(values.has(expiredKey)).toBe(false);
+
+  const denied = await start();
+  client.cancel('drive', 'actor', denied.state);
+  expect([...values.values()]).toHaveLength(0);
+  expect(
+    http.mock.calls.some(([request]) => String(request).endsWith('/redeem')),
+  ).toBe(false);
+});
+it('never retries an uncertain redemption after consuming its verifier', async () => {
+  const { client, start, http } = setup();
+  const { state } = await start();
+  http.mockImplementationOnce(async () => {
+    throw new Error('connection lost');
+  });
+  await expect(client.finish('drive', 'actor', state, 'code')).rejects.toThrow(
+    'lost',
+  );
+  const calls = http.mock.calls.length;
+  await expect(client.finish('drive', 'actor', state, 'code')).rejects.toThrow(
+    'Reconnect',
+  );
+  expect(http.mock.calls).toHaveLength(calls);
 });
 it('consumes before dispatch and preserves rotation and pagination', async () => {
   const { client, start, http, values } = setup();
   const { state } = await start();
-  client.finish('drive', 'actor', state, 'first');
+  await client.finish('drive', 'actor', state, 'handoff');
   const codes: string[] = [];
   http.mockImplementation(async (url, init) => {
     if (url.includes('/catalog/')) return new Response('{}');
     expect(JSON.parse([...values.values()][0]).code).toBeUndefined();
-    codes.push((init?.headers as Record<string, string>).Authorization);
+    codes.push((init!.headers as Record<string, string>).Authorization);
     return new Response('[]', {
       headers: {
         'x-connection-code': 'second',
@@ -89,7 +195,7 @@ it('consumes before dispatch and preserves rotation and pagination', async () =>
 it('never retries an uncertain consumed credential', async () => {
   const { client, start, http } = setup();
   const { state } = await start();
-  client.finish('drive', 'actor', state, 'first');
+  await client.finish('drive', 'actor', state, 'handoff');
   http.mockImplementation(async url => {
     if (url.includes('/catalog/')) return new Response('{}');
     throw new Error('connection lost');
@@ -106,7 +212,7 @@ it('never retries an uncertain consumed credential', async () => {
 it('rejects pagination to a different provider before spending a credential', async () => {
   const { client, start, engine, values } = setup();
   const { state } = await start();
-  client.finish('drive', 'actor', state, 'first');
+  await client.finish('drive', 'actor', state, 'handoff');
   engine.fetchIntegration = async (_t, _p, _c, _r, fetch) =>
     fetch('https://evil.example/pets');
   await expect(
@@ -132,9 +238,8 @@ it('supports the demo callback and write credentials without using the import en
     'actor',
     'pets',
     'https://atomic.example/app/devonian-demo',
-    secret,
   );
-  client.finish('drive', 'actor', state, 'first');
+  await client.finish('drive', 'actor', state, 'handoff');
   http.mockImplementation(async (_url, init) => {
     expect(JSON.parse([...values.values()][0]).code).toBeUndefined();
     expect(init?.method).toBe('POST');
@@ -161,7 +266,7 @@ it('supports the demo callback and write credentials without using the import en
 it('forwards the conditional event version while keeping authorization host-owned', async () => {
   const { client, start, http } = setup();
   const { state } = await start();
-  client.finish('drive', 'actor', state, 'first');
+  await client.finish('drive', 'actor', state, 'handoff');
   http.mockImplementation(async (_url, init) => {
     expect(init?.headers).toEqual({
       Authorization: 'Bearer first',

--- a/integrations/localthought/browser.ts
+++ b/integrations/localthought/browser.ts
@@ -8,6 +8,7 @@ export interface Connection {
   origin: string;
   expires: number;
   code?: string;
+  codeVerifier?: string;
   ready: boolean;
 }
 export interface Engine {
@@ -38,19 +39,6 @@ const base64url = (bytes: Uint8Array) =>
     .replaceAll('+', '-')
     .replaceAll('/', '_')
     .replaceAll('=', '');
-export async function sign(secret: string, text: string) {
-  const encoder = new TextEncoder();
-  const k = await crypto.subtle.importKey(
-    'raw',
-    encoder.encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  return base64url(
-    new Uint8Array(await crypto.subtle.sign('HMAC', k, encoder.encode(text))),
-  );
-}
 async function limitedText(response: Response): Promise<string> {
   if (!response.body) throw new Error('Empty proxy response');
   const reader = response.body.getReader();
@@ -121,24 +109,9 @@ export class BrowserIntegrations {
     actor: string,
     platform: string,
     returnUrl: string,
-    secret: string,
   ) {
     if (!(await this.catalog()).includes(platform))
       throw new Error('Unknown platform');
-    const encoded = secret.split('.')[0];
-    let tenant: string;
-    try {
-      tenant = new TextDecoder('utf-8', { fatal: true }).decode(
-        Uint8Array.from(
-          atob(encoded.replaceAll('-', '+').replaceAll('_', '/')),
-          c => c.charCodeAt(0),
-        ),
-      );
-    } catch {
-      throw new Error('Invalid tenant secret');
-    }
-    if (!tenant || !secret.includes('.'))
-      throw new Error('Invalid tenant secret');
     const callback = new URL(returnUrl);
     if (
       callback.origin !== location.origin ||
@@ -150,23 +123,28 @@ export class BrowserIntegrations {
     )
       throw new Error('Invalid integration return URL');
     const state = base64url(crypto.getRandomValues(new Uint8Array(32)));
+    const codeVerifier = base64url(crypto.getRandomValues(new Uint8Array(32)));
+    const codeChallenge = base64url(
+      new Uint8Array(
+        await crypto.subtle.digest(
+          'SHA-256',
+          new TextEncoder().encode(codeVerifier),
+        ),
+      ),
+    );
     callback.searchParams.set('integration_state', state);
     callback.searchParams.set('platform', platform);
-    const challenge = JSON.parse(await this.get('/session'));
     const url = new URL(`${this.origin}/connect`);
     for (const [k, v] of Object.entries({
-      redirect_uri: callback.href,
       platform,
-      ts: String(challenge.ts),
-      nonce: challenge.nonce,
-      challenge: challenge.challenge,
-      tenant_id: tenant,
+      redirect_uri: callback.href,
       user_id: actor,
-      user_id_sig: await sign(secret, actor),
-      response: await sign(secret, challenge.challenge),
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      credentials: 'connection',
     }))
       url.searchParams.set(k, v as string);
-    // Only the short-lived handoff survives navigation, never the tenant secret.
+    // Only the short-lived PKCE handoff survives navigation.
     this.storage.setItem(
       key + state,
       JSON.stringify({
@@ -175,6 +153,7 @@ export class BrowserIntegrations {
         platform,
         origin: this.origin,
         expires: Date.now() + 600000,
+        codeVerifier,
         ready: false,
       } satisfies Connection),
     );
@@ -188,13 +167,47 @@ export class BrowserIntegrations {
       throw new Error('Connection belongs to another drive, agent or proxy');
     return c;
   }
-  finish(drive: string, actor: string, state: string, code: string) {
+  cancel(drive: string, actor: string, state: string) {
+    this.connection(state, drive, actor);
+    this.storage.removeItem(key + state);
+  }
+  async finish(drive: string, actor: string, state: string, code: string) {
     const c = this.connection(state, drive, actor);
-    if (c.ready || c.expires < Date.now() || !code || code.length > 4096)
-      throw new Error('Invalid, expired or completed connection');
+    if (c.expires < Date.now()) {
+      this.storage.removeItem(key + state);
+      throw new Error('Reconnect your account');
+    }
+    if (c.ready || !c.codeVerifier || !code || code.length > 4096)
+      throw new Error('Reconnect your account');
+    const verifier = c.codeVerifier;
+    delete c.codeVerifier;
+    // Consume before dispatch: a lost response may have spent the handoff code.
+    this.storage.setItem(key + state, JSON.stringify(c));
+    const response = await this.http(`${this.origin}/connect/redeem`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code, code_verifier: verifier }),
+      credentials: 'omit',
+      redirect: 'error',
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!response.ok)
+      throw new Error(`LocalThought returned HTTP ${response.status}`);
+    const result = JSON.parse(await limitedText(response)) as {
+      connection_code?: unknown;
+      platform?: unknown;
+    };
+    if (result.platform !== c.platform)
+      throw new Error('Returned platform did not match the requested platform');
+    if (
+      typeof result.connection_code !== 'string' ||
+      !result.connection_code ||
+      result.connection_code.length > 4096
+    )
+      throw new Error('LocalThought returned an invalid connection code');
     this.storage.setItem(
       key + state,
-      JSON.stringify({ ...c, ready: true, code }),
+      JSON.stringify({ ...c, ready: true, code: result.connection_code }),
     );
     return { connection: state, platform: c.platform };
   }

--- a/integrations/localthought/mock-proxy.d.mts
+++ b/integrations/localthought/mock-proxy.d.mts
@@ -46,7 +46,6 @@ interface CalendarFixture {
     query: Record<string, string>;
   }>;
 }
-export const tenantSecret: string;
 export function mockProxy(options?: {
   frontendOrigin?: string;
 }): Server & { github: GitHubTracker; calendar: CalendarFixture };

--- a/integrations/localthought/mock-proxy.mjs
+++ b/integrations/localthought/mock-proxy.mjs
@@ -3,15 +3,20 @@ import { calendarDocument, calendarFixture } from './mock-calendar.mjs';
 import { githubTracker } from './mock-github.mjs';
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
-export const tenantSecret = 'bW9jay10ZW5hbnQ.mock-signature';
-const sign = value =>
-  createHmac('sha256', tenantSecret).update(value).digest('base64url');
 const equal = (a, b) =>
   typeof a === 'string' &&
+  typeof b === 'string' &&
   a.length === b.length &&
   timingSafeEqual(Buffer.from(a), Buffer.from(b));
+const pkceChallenge = verifier =>
+  createHash('sha256').update(verifier).digest('base64url');
+const platforms = {
+  'github-issues': 'GitHub Issues',
+  'google-calendar': 'Google Calendar',
+  pets: 'Pets',
+};
 const pets = ['Rex', 'Whiskers', 'Tweety', 'Nibbles', 'Bubbles'].map(
   (name, i) => ({
     id: i + 1,
@@ -29,7 +34,7 @@ export function mockProxy({
   const github = githubTracker();
   const calendar = calendarFixture();
   const codes = new Map();
-  const challenges = new Set();
+  const handoffs = new Map();
   const issueCode = platform => {
     const code = randomBytes(32).toString('base64url');
     codes.set(code, platform);
@@ -66,45 +71,73 @@ export function mockProxy({
     }
     if (url.pathname === '/catalog/google-calendar.yaml')
       return json(200, calendarDocument);
-    if (url.pathname === '/session') {
-      const challenge = randomBytes(32).toString('base64url');
-      challenges.add(challenge);
-      return json(200, {
-        ts: Math.floor(Date.now() / 1000),
-        nonce: randomBytes(16).toString('hex'),
-        challenge,
-      });
-    }
     if (url.pathname === '/connect') {
       const p = url.searchParams;
-      const challenge = p.get('challenge');
+      const platform = p.get('platform');
+      const verifierChallenge = p.get('code_challenge');
       if (
-        !challenges.has(challenge) ||
-        !equal(p.get('response'), sign(challenge)) ||
-        !equal(p.get('user_id_sig'), sign(p.get('user_id') ?? '')) ||
-        p.get('tenant_id') !== 'mock-tenant'
+        !Object.hasOwn(platforms, platform) ||
+        !verifierChallenge ||
+        p.get('code_challenge_method') !== 'S256' ||
+        p.get('credentials') !== 'connection' ||
+        !p.get('user_id')
       )
-        return json(401, { error: 'Invalid tenant proof' });
-      const redirect = new URL(p.get('redirect_uri'));
+        return json(400, { error: 'Invalid connection request' });
+      let redirect;
+      try {
+        redirect = new URL(p.get('redirect_uri'));
+      } catch {
+        return json(400, { error: 'Invalid callback' });
+      }
       if (
         redirect.origin !== frontendOrigin ||
-        !['/app/integrations', '/app/devonian-demo'].includes(redirect.pathname)
+        !['/app/integrations', '/app/devonian-demo'].includes(redirect.pathname) ||
+        !redirect.searchParams.get('integration_state') ||
+        redirect.searchParams.get('platform') !== platform
       )
         return json(400, { error: 'Invalid callback' });
-      const platform = p.get('platform');
-      if (!['github-issues', 'google-calendar', 'pets'].includes(platform))
-        return json(400, { error: 'Invalid platform' });
       if (req.method === 'GET') {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         return res.end(
-          '<h1>Mock integration proxy</h1><p>Connect your test account.</p><form method="post"><button>Connect test account</button></form>',
+          `<h1>Mock integration proxy</h1><p>Signed in as mock-user.</p><p>Use the selected ${platforms[platform]} account to sync with your Atomic Data Hub.</p><form method="post"><button>Use LocalThought to sync ${platforms[platform]} with your Atomic Data Hub</button></form>`,
         );
       }
       if (req.method !== 'POST') return json(405, {});
-      challenges.delete(challenge);
-      redirect.searchParams.set('connection_code', issueCode(platform));
+      const handoff = randomBytes(32).toString('base64url');
+      handoffs.set(handoff, {
+        platform,
+        userId: p.get('user_id'),
+        codeChallenge: verifierChallenge,
+      });
+      redirect.searchParams.set('connection_code', handoff);
       res.writeHead(303, { Location: redirect.href });
       return res.end();
+    }
+    if (url.pathname === '/connect/redeem') {
+      if (req.method !== 'POST') return json(405, {});
+      let body;
+      try {
+        let text = '';
+        for await (const chunk of req) {
+          text += chunk;
+          if (text.length > 16 * 1024) return json(413, {});
+        }
+        body = JSON.parse(text);
+      } catch {
+        return json(400, { error: 'Invalid redemption body' });
+      }
+      const handoff = handoffs.get(body?.code);
+      if (
+        !handoff ||
+        typeof body?.code_verifier !== 'string' ||
+        !equal(pkceChallenge(body.code_verifier), handoff.codeChallenge)
+      )
+        return json(400, { error: 'Invalid or consumed connection code' });
+      handoffs.delete(body.code);
+      return json(200, {
+        connection_code: issueCode(handoff.platform),
+        platform: handoff.platform,
+      });
     }
     if (url.pathname.startsWith('/proxy/')) {
       const code = req.headers.authorization?.replace(/^Bearer /, '');

--- a/integrations/localthought/mock-proxy.test.mjs
+++ b/integrations/localthought/mock-proxy.test.mjs
@@ -1,29 +1,86 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createHmac } from 'node:crypto';
-import { mockProxy, tenantSecret } from './mock-proxy.mjs';
-test('catalog, signed handoff, provider read and single-use rotation', async () => {
+import { createHash } from 'node:crypto';
+import { mockProxy } from './mock-proxy.mjs';
+
+const verifier = 'a'.repeat(64);
+const challenge = createHash('sha256').update(verifier).digest('base64url');
+
+test('catalog, selected-platform PKCE consent, redemption and single-use rotation', async () => {
   const server = mockProxy();
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   const base = `http://127.0.0.1:${server.address().port}`;
   try {
-    assert.deepEqual(await (await fetch(`${base}/catalog`)).json(), ['github-issues', 'google-calendar', 'pets']);
-    const challenge = await (await fetch(`${base}/session`)).json();
-    const sign = value => createHmac('sha256', tenantSecret).update(value).digest('base64url');
+    assert.deepEqual(
+      await (await fetch(`${base}/catalog`)).json(),
+      ['github-issues', 'google-calendar', 'pets'],
+    );
+    const callback =
+      'http://localhost:6747/app/integrations?integration_state=abc&platform=pets';
     const url = new URL(`${base}/connect`);
-    url.search = new URLSearchParams({ ...challenge, redirect_uri: 'http://localhost:6747/app/integrations?integration_state=abc', platform: 'pets', tenant_id: 'mock-tenant', user_id: 'agent', user_id_sig: sign('agent'), response: sign(challenge.challenge) });
-    const bad = new URL(url); bad.searchParams.set('response', 'invalid');
-    assert.equal((await fetch(bad)).status, 401);
+    url.search = new URLSearchParams({
+      redirect_uri: callback,
+      platform: 'pets',
+      user_id: 'synthetic-agent',
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      credentials: 'connection',
+    });
+    const login = await fetch(url);
+    assert.equal(login.status, 200);
+    const loginHtml = await login.text();
+    assert.match(
+      loginHtml,
+      /Use LocalThought to sync Pets with your Atomic Data Hub/,
+    );
+    assert.doesNotMatch(loginHtml, /tenant secret/i);
+    assert.doesNotMatch(loginHtml, /GitHub|Google Calendar/);
+
+    const badPlatform = new URL(url);
+    badPlatform.searchParams.set('platform', 'github-issues');
+    assert.equal((await fetch(badPlatform)).status, 400);
+
     const consent = await fetch(url, { method: 'POST', redirect: 'manual' });
     assert.equal(consent.status, 303);
-    const code = new URL(consent.headers.get('location')).searchParams.get('connection_code');
-    const read = (token, query = '') => fetch(`${base}/proxy/pets/pets${query}`, { headers: { Authorization: `Bearer ${token}` } });
-    const first = await read(code);
+    const location = new URL(consent.headers.get('location'));
+    const handoff = location.searchParams.get('connection_code');
+    assert.equal(location.searchParams.get('platform'), 'pets');
+    assert.ok(handoff);
+
+    const redeem = codeVerifier =>
+      fetch(`${base}/connect/redeem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: handoff, code_verifier: codeVerifier }),
+      });
+    assert.equal((await redeem('wrong-verifier')).status, 400);
+    const redeemed = await redeem(verifier);
+    assert.equal(redeemed.status, 200);
+    const result = await redeemed.json();
+    assert.equal(result.platform, 'pets');
+    assert.equal(typeof result.connection_code, 'string');
+    assert.ok(result.connection_code);
+    assert.equal((await redeem(verifier)).status, 400);
+
+    const read = (token, query = '') =>
+      fetch(`${base}/proxy/pets/pets${query}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    const first = await read(result.connection_code);
     assert.equal((await first.json()).length, 2);
     assert.match(first.headers.get('link'), /page=2/);
-    assert.equal((await read(code)).status, 401);
+    assert.equal((await read(result.connection_code)).status, 401);
     const second = await read(first.headers.get('x-connection-code'), '?page=2');
     assert.equal((await second.json()).length, 3);
-    assert.equal((await fetch(url, { method: 'POST' })).status, 401);
+    assert.equal(
+      (
+        await fetch(`${base}/proxy/google-calendar/events`, {
+          headers: {
+            Authorization: `Bearer ${second.headers.get('x-connection-code')}`,
+          },
+        })
+      ).status,
+      403,
+    );
   } finally { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); }
 });

--- a/integrations/tooling/certify.mjs
+++ b/integrations/tooling/certify.mjs
@@ -79,6 +79,22 @@ export function evaluateJs(report) {
 export function evaluateRust(output) {
   return /test result: ok\. 1 passed; 0 failed; 0 ignored;/.test(output);
 }
+export function summarizeFailure({ error, stderr, stdout }) {
+  const line = [error, stderr, stdout]
+    .flatMap(value => String(value ?? '').split(/\r?\n/))
+    .map(value => value.trim())
+    .find(Boolean);
+  if (!line) return 'command failed without output';
+  return line.length > 240 ? `${line.slice(0, 237)}...` : line;
+}
+export function formatFailureSummary(checks) {
+  return checks
+    .filter(check => check.status === 'failed')
+    .map(check =>
+      check.detail ? `${check.name}: ${check.detail}` : check.name,
+    )
+    .join('; ');
+}
 export function certify({
   layer = 'all',
   output = resolve(root, 'artifacts/integration-certification'),
@@ -132,7 +148,13 @@ export function certify({
     });
     const text = `${r.stdout ?? ''}${r.stderr ?? ''}${r.error ? '\n' + r.error.message : ''}\nexit=${r.status} signal=${r.signal ?? 'none'}`;
     writeFileSync(resolve(output, log), text);
-    return { ok: r.status === 0, text, stdout: r.stdout };
+    return {
+      ok: r.status === 0,
+      text,
+      stdout: r.stdout,
+      stderr: r.stderr,
+      error: r.error?.message,
+    };
   };
   for (const p of packages.filter(p => !only || p.id === only)) {
     const shipped = readFileSync(resolve(root, p.path, 'plugin.js'));
@@ -148,8 +170,20 @@ export function certify({
       status: 'pending',
     };
     report.integrations.push(item);
-    const check = (name, r, extra = true) =>
-      item.checks.push({ name, status: r.ok && extra ? 'passed' : 'failed' });
+    const check = (name, r, extra = true, failedValidation) => {
+      const passed = r.ok && extra;
+      item.checks.push({
+        name,
+        status: passed ? 'passed' : 'failed',
+        ...(passed
+          ? {}
+          : {
+              detail: r.ok
+                ? failedValidation || 'validation failed'
+                : summarizeFailure(r),
+            }),
+      });
+    };
     if (layer !== 'sandbox') {
       const bundle = run(
         resolve(root, 'browser/node_modules/.bin/esbuild'),
@@ -166,6 +200,7 @@ export function certify({
         'reproducible-bundle',
         bundle,
         bundle.stdout === shipped.toString(),
+        'generated bundle differs from committed plugin.js',
       );
       check(
         'typecheck',
@@ -192,7 +227,12 @@ export function certify({
       try {
         counts = JSON.parse(readFileSync(resultPath, 'utf8'));
       } catch {}
-      check('fixtures', tests, evaluateJs(counts));
+      check(
+        'fixtures',
+        tests,
+        evaluateJs(counts),
+        'test report did not contain a successful executed test',
+      );
       item.fixtureCounts = {
         passed: counts.numPassedTests ?? 0,
         skipped: counts.numPendingTests ?? 0,
@@ -217,7 +257,12 @@ export function certify({
           ],
           `${p.id}-${test.split('::').at(-1)}.log`,
         );
-        check(test, r, evaluateRust(r.text));
+        check(
+          test,
+          r,
+          evaluateRust(r.text),
+          'sandbox output did not report exactly one passing test',
+        );
       }
     item.status = item.checks.every(c => c.status === 'passed')
       ? 'passed'
@@ -226,7 +271,10 @@ export function certify({
       resolve(output, 'report.json'),
       JSON.stringify({ ...report, status: 'running' }, null, 2) + '\n',
     );
-    console.log(`${p.id}: ${item.status} (${layer}; live not run)`);
+    const failures = formatFailureSummary(item.checks);
+    console.log(
+      `${p.id}: ${item.status} (${layer}; live not run)${failures ? ` — ${failures}` : ''}`,
+    );
   }
   report.status =
     report.integrations.length &&

--- a/integrations/tooling/certify.test.mjs
+++ b/integrations/tooling/certify.test.mjs
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { discover, evaluateJs, evaluateRust } from './certify.mjs';
+import {
+  discover,
+  evaluateJs,
+  evaluateRust,
+  formatFailureSummary,
+  summarizeFailure,
+} from './certify.mjs';
 test('zero executed tests cannot certify an integration', () => {
   assert.equal(
     evaluateJs({ success: true, numPassedTests: 0, numFailedTests: 0 }),
@@ -39,6 +45,28 @@ test('new packages cannot silently escape certification', () => {
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+test('failed certification checks surface a concise useful diagnostic', () => {
+  assert.equal(
+    summarizeFailure({
+      error: 'spawnSync /browser/node_modules/.bin/esbuild ENOENT',
+      stderr: 'ignored stderr',
+      stdout: 'ignored stdout',
+    }),
+    'spawnSync /browser/node_modules/.bin/esbuild ENOENT',
+  );
+  assert.equal(
+    formatFailureSummary([
+      { name: 'typecheck', status: 'passed' },
+      {
+        name: 'reproducible-bundle',
+        status: 'failed',
+        detail: 'generated bundle differs from committed plugin.js',
+      },
+      { name: 'fixtures', status: 'failed' },
+    ]),
+    'reproducible-bundle: generated bundle differs from committed plugin.js; fixtures',
+  );
 });
 test('both current providers are discovered with exact sandbox tests', () => {
   const ids = discover().map(p => p.id);

--- a/server/src/handlers/plugin_ui.rs
+++ b/server/src/handlers/plugin_ui.rs
@@ -1,11 +1,15 @@
 use std::path::PathBuf;
 
 use actix_web::{http::header, web, HttpResponse};
-use atomic_lib::{db::plugin_meta::PluginMetaKey, hierarchy::check_read, urls, Storelike, Subject, Value};
+use atomic_lib::{
+    db::plugin_meta::PluginMetaKey, hierarchy::check_read, urls, Storelike, Subject, Value,
+};
 use base64::{engine::general_purpose, Engine as _};
 
 use crate::{
-    appstate::AppState, context::RequestContext, errors::{AtomicServerError, AtomicServerResult},
+    appstate::AppState,
+    context::RequestContext,
+    errors::{AtomicServerError, AtomicServerResult},
     helpers::get_client_agent,
 };
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1126,5 +1126,5 @@ impl ClientDb {
     }
 }
 
-mod integrations;
 mod calendar_import;
+mod integrations;


### PR DESCRIPTION
GitHub Issues and the other LocalThought integrations previously required pasting a tenant secret before authorization. The hub now redirects with the selected platform and a PKCE challenge, then redeems a one-time handoff after Google/provider authorization. No tenant secret is entered, received or saved by the browser flow.

Preserve actor, drive, platform and callback-state validation; consume pending verifiers before redemption; clear expired/denied attempts and require reconnecting after an uncertain exchange. Both the integration catalog and Devonian issue tracker use the same new handshake, while existing rotating proxy credentials remain unchanged. Update the HTTP fixture, browser journeys, generated locale catalogs, README and coverage map. Apply the existing Calendar and demo spacing fixes and two Rust formatting fixes required by CI.

Companion proxy: https://github.com/localthought/integration-proxy/pull/39, with follow-ups #40 (concurrent schema initialization), #41 (Chrome consent Origin), and #42 (GitHub pagination). All merged after green CI and deployed in Heroku v54 (3f674ebe).

Validation: 39 LocalThought unit tests and the Node HTTP fixture contract test pass; workspace package builds, data-browser typecheck and production Vite build pass. Full data-browser lint and formatting pass. A matching WASM build and the complete no-paste browser mock journey passed: consent, PKCE redemption, paginated fetch, review, OPFS apply and reload. Live verification follows the authorized merge into localthought/atomic-server feat/heroku and deployment of both revisions.

Live preflight (2026-09-10): this frontend at localhost:6747 connected through deployed localthought.io and real GitHub OAuth without secret entry, redeemed the handoff, cleared the callback URL, fetched both pages plus comments from public localthought/integration-proxy, reviewed/applied 46 records, and showed 43 issue rows after reload. Proxy v54 (3f674ebe) contains the consent-origin correction PR41 and canonical-pagination correction PR42, both merged after green CI. Final localthought.ai verification follows this PR merge and deployment. Full browser workspace lint and 647 library unit tests also pass.

CI feature correction: run clippy with `light,wasm-plugins`, matching Rust tests and the deployed server. The old `light`-only invocation failed on this branch’s plugin-dependent handlers. Native all-target clippy passes with the corrected feature set, reusing separately built frontend assets and skipping embedded-runtime generation for this static preflight. Hosted CI still builds and tests the actual runtime.

The Node MCP host uses the library’s CommonJS entry so Node can resolve its rrule dependency correctly. The full data-browser test command passes: 854 Vitest tests and 2 real stdio MCP integration tests. CI server builds also enable wasm-plugins, required by the branch’s plugin handlers.

Clean-install certification: esbuild is now a direct workspace development dependency rather than an assumed transitive executable. A fresh pnpm 10.15.1 frozen install passes certification for Clockify, GitHub Issues, MT940, Notion and Pets. Failed certification summaries include the check and command/validation error.

Merged with explicit approval to proceed without green CI on 2026-09-10. The remaining hosted failure is the integration certification harness under its Linux filesystem layout (bundle comparisons and fixture tests), despite all five passing locally. Upstream squash add0ea40 is included in localthought/atomic-server feat/heroku merge1cc561f1. The feat/heroku push triggers its configured automatic deployment. At the user’s request, live deployment verification and the production test were handed back to the user; the new AtomicServer release was not verified by this task.
