### PR TITLE
Use one account passkey for sign-in and encrypted recovery

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -634,3 +634,9 @@ saved pointer, publishes the local drive, and applies a removal after reconnect
 SaaS handler tests cover authenticated additive registration, account isolation,
 service-backed discovery and removal versus stale upload. Catalog entries confer
 no access to resource content. A live cross-app deployment acceptance is separate.
+
+## Unified account passkey
+
+`helpers/managed/accountPasskey.test.ts` checks account-credential reuse, server-challenge registration, PRF-output exclusion from API payloads, cancellation and standalone fallback. `recovery-enrollment.test.ts` covers additive migration, old recovery-code preservation, failed upgrades, unsupported login credentials and duplicate-credential PRF-salt selection. These use simulated authenticators and real WebCrypto/Argon2id.
+
+Paired SaaS `portal/e2e/recovery-passkey.spec.ts` uses Chromium virtual PRF authenticators with the real control plane to verify app enrollment followed by portal login using one credential, reuse of a portal-created credential, and account-settings migration without replacing ciphertext or old wrappers. Physical Safari/iCloud, Android/password-manager and native-shell behavior remain device acceptance checks.

--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -19,6 +19,8 @@ import {
 import {
   addRecoveryCodeWrapper,
   addPasskeyWrapper,
+  unifyAccountPasskey,
+  AccountPasskeyUnsupportedError,
   buildEnvelopeV2,
   buildEnvelopeWithPasskeyAndCode,
   envelopeWrapperKinds,
@@ -70,6 +72,7 @@ export function AccountRecoveryCard({
   const [codeInput, setCodeInput] = useState('');
   const [needsCode, setNeedsCode] = useState(false);
   const [passkeyAdded, setPasskeyAdded] = useState(false);
+  const [needsCompatiblePasskey, setNeedsCompatiblePasskey] = useState(false);
   /**
    * The secret being enrolled, typed by the user.
    *
@@ -399,6 +402,40 @@ export function AccountRecoveryCard({
     }
   }
 
+  async function handleUnifyPasskey() {
+    if (!agentSubject || backup.phase !== 'ready') return;
+
+    if (!envelopeWrapperKinds(backup.secret).hasPasskey && !codeInput.trim()) {
+      setNeedsCode(true);
+
+      return;
+    }
+
+    setLoading(true);
+    setError(undefined);
+
+    try {
+      const saved = await unifyAccountPasskey(
+        agentSubject,
+        codeInput.trim() || undefined,
+        needsCompatiblePasskey,
+      );
+      setBackup({ phase: 'ready', secret: saved, onServer: true });
+      setCodeInput('');
+      setNeedsCode(false);
+      setNeedsCompatiblePasskey(false);
+      setPasskeyAdded(true);
+    } catch (e) {
+      if (e instanceof AccountPasskeyUnsupportedError)
+        setNeedsCompatiblePasskey(true);
+      setError(
+        e instanceof Error ? e.message : 'Could not update your passkey.',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function handleAddPasskey() {
     if (!needsCode || !codeInput.trim()) {
       setNeedsCode(true);
@@ -532,6 +569,25 @@ export function AccountRecoveryCard({
         </Column>
       ) : null}
 
+      {hasSession &&
+      backup.secret.format_version === 2 &&
+      !backup.secret.wrappers.some(w => w.kdf_params.account_passkey) ? (
+        <Column gap='0.5rem'>
+          <Button
+            disabled={loading || !agentSubject}
+            onClick={handleUnifyPasskey}
+            data-test='unify-passkey'
+          >
+            {needsCompatiblePasskey
+              ? 'Create a compatible account passkey'
+              : 'Use one passkey for sign-in and recovery'}
+          </Button>
+          <Hint>
+            Unlock your backup, then choose your account passkey. Your existing
+            recovery methods keep working.
+          </Hint>
+        </Column>
+      ) : null}
       {needsCode ? (
         <InputWrapper hasPrefix>
           <FaKey />

--- a/browser/data-browser/src/helpers/managed/accountPasskey.test.ts
+++ b/browser/data-browser/src/helpers/managed/accountPasskey.test.ts
@@ -1,0 +1,105 @@
+// @wc-ignore-file
+import { beforeEach, expect, it, vi } from 'vitest';
+import { accountPasskey } from './accountPasskey';
+import { hasManagedApi, managedFetch } from './api';
+import { getManagedAccount } from './session';
+vi.mock('./api', () => ({ hasManagedApi: vi.fn(), managedFetch: vi.fn() }));
+vi.mock('./session', () => ({ getManagedAccount: vi.fn() }));
+const create = vi.fn();
+const get = vi.fn();
+const salt = new Uint8Array(16).fill(9);
+const prf = new Uint8Array(32).fill(123).buffer;
+const credential = {
+  rawId: new Uint8Array([1]).buffer,
+  response: {
+    clientDataJSON: new Uint8Array([2]).buffer,
+    authenticatorData: new Uint8Array([3]).buffer,
+    signature: new Uint8Array([4]).buffer,
+    userHandle: new Uint8Array([5]).buffer,
+    attestationObject: new Uint8Array([6]).buffer,
+  },
+  getClientExtensionResults: () => ({ prf: { results: { first: prf } } }),
+};
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal('navigator', { credentials: { create, get } });
+  vi.mocked(hasManagedApi).mockReturnValue(true);
+  vi.mocked(getManagedAccount).mockResolvedValue({
+    email: 'owner@example.com',
+  });
+  create.mockResolvedValue(credential);
+  get.mockResolvedValue(credential);
+});
+
+function api(existing: boolean, finishStatus = 204) {
+  vi.mocked(managedFetch).mockImplementation(async path => {
+    if (path === '/passkeys')
+      return Response.json({ credential_ids: existing ? ['AQ'] : [] });
+    if (path.endsWith('/start'))
+      return Response.json({
+        publicKey: {
+          challenge: 'Ag',
+          rpId: 'localhost',
+          allowCredentials: [{ type: 'public-key', id: 'AQ' }],
+          rp: { id: 'localhost', name: 'Atomic account' },
+          user: { id: 'BQ', name: 'owner@example.com', displayName: 'Owner' },
+        },
+      });
+
+    return new Response(null, { status: finishStatus });
+  });
+}
+
+it('reuses a login credential and never transmits PRF results', async () => {
+  api(true);
+  expect(await accountPasskey(salt)).toMatchObject({
+    credential,
+    rpId: 'localhost',
+    existing: true,
+  });
+  expect(create).not.toHaveBeenCalled();
+  expect(get.mock.calls[0][0].publicKey.extensions.prf.eval.first).toEqual(
+    salt,
+  );
+  const body = JSON.parse(
+    vi.mocked(managedFetch).mock.calls.at(-1)![1]!.body as string,
+  );
+  expect(body.clientExtensionResults).toEqual({});
+  expect(body.response).toEqual({
+    clientDataJSON: 'Ag',
+    authenticatorData: 'Aw',
+    signature: 'BA',
+    userHandle: 'BQ',
+  });
+});
+it('registers one discoverable credential with the server challenge and only attestation data', async () => {
+  api(false);
+  await accountPasskey(salt);
+  expect(get).not.toHaveBeenCalled();
+  expect(create.mock.calls[0][0].publicKey.challenge).toEqual(
+    new Uint8Array([2]),
+  );
+  expect(
+    create.mock.calls[0][0].publicKey.authenticatorSelection.residentKey,
+  ).toBe('required');
+  const body = JSON.parse(
+    vi.mocked(managedFetch).mock.calls.at(-1)![1]!.body as string,
+  );
+  expect(body.clientExtensionResults).toEqual({});
+  expect(body.response.attestationObject).toBe('Bg');
+});
+it('does not accept an unverified account credential', async () => {
+  api(true, 401);
+  await expect(accountPasskey(salt)).rejects.toThrow('Could not set up');
+});
+it('does not create a second credential on cancellation', async () => {
+  api(true);
+  get.mockResolvedValue(null);
+  await expect(accountPasskey(salt)).rejects.toThrow('cancelled');
+  expect(create).not.toHaveBeenCalled();
+});
+it('keeps standalone recovery independent of the portal', async () => {
+  vi.mocked(hasManagedApi).mockReturnValue(false);
+  expect(await accountPasskey(salt)).toBeNull();
+  expect(managedFetch).not.toHaveBeenCalled();
+});

--- a/browser/data-browser/src/helpers/managed/accountPasskey.ts
+++ b/browser/data-browser/src/helpers/managed/accountPasskey.ts
@@ -1,0 +1,126 @@
+// @wc-ignore-file
+import { hasManagedApi, managedFetch } from './api';
+import { getManagedAccount } from './session';
+
+function decode(value: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(atob(value.replace(/-/g, '+').replace(/_/g, '/')), c =>
+    c.charCodeAt(0),
+  );
+}
+
+function encode(value: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(value)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+async function request(path: string, body?: unknown) {
+  const response = await managedFetch(
+    `/passkeys${path}`,
+    body === undefined
+      ? {}
+      : {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+  );
+  if (!response.ok)
+    throw new Error(
+      'Could not set up your account passkey. Sign in to your account and try again.',
+    );
+
+  return response.status === 204 ? undefined : response.json();
+}
+
+/** Serialize only authentication data. PRF outputs must never leave this browser. */
+export function authenticationResponse(credential: PublicKeyCredential) {
+  const response = credential.response as AuthenticatorAssertionResponse;
+
+  return {
+    id: encode(credential.rawId),
+    rawId: encode(credential.rawId),
+    type: 'public-key',
+    response: {
+      clientDataJSON: encode(response.clientDataJSON),
+      authenticatorData: encode(response.authenticatorData),
+      signature: encode(response.signature),
+      userHandle: response.userHandle ? encode(response.userHandle) : null,
+    },
+    clientExtensionResults: {},
+  };
+}
+
+/** A managed account reuses its login credential; standalone recovery stays local. */
+export async function accountPasskey(
+  prfSalt: Uint8Array<ArrayBuffer>,
+  createNew = false,
+): Promise<{
+  credential: PublicKeyCredential;
+  rpId: string;
+  existing: boolean;
+} | null> {
+  if (!hasManagedApi() || !(await getManagedAccount())) return null;
+  const status = await request('');
+  if (!Array.isArray(status.credential_ids))
+    throw new Error('Could not check your account passkeys.');
+  const existing = !createNew && status.credential_ids.length > 0;
+  const operation = existing ? 'use' : 'register';
+  const { publicKey } = await request(`/${operation}/start`, {});
+  const common = {
+    ...publicKey,
+    challenge: decode(publicKey.challenge),
+    extensions: { ...publicKey.extensions, prf: { eval: { first: prfSalt } } },
+  };
+  let credential: PublicKeyCredential | null;
+
+  if (existing) {
+    credential = (await navigator.credentials.get({
+      publicKey: {
+        ...common,
+        allowCredentials: publicKey.allowCredentials.map(
+          (c: { id: string; type: string }) => ({ ...c, id: decode(c.id) }),
+        ),
+      },
+    } as CredentialRequestOptions)) as PublicKeyCredential | null;
+  } else {
+    credential = (await navigator.credentials.create({
+      publicKey: {
+        ...common,
+        user: { ...publicKey.user, id: decode(publicKey.user.id) },
+        excludeCredentials: publicKey.excludeCredentials?.map(
+          (c: { id: string; type: string }) => ({ ...c, id: decode(c.id) }),
+        ),
+        authenticatorSelection: {
+          ...publicKey.authenticatorSelection,
+          residentKey: 'required',
+          requireResidentKey: true,
+        },
+      },
+    } as CredentialCreationOptions)) as PublicKeyCredential | null;
+  }
+
+  if (!credential) throw new Error('Passkey setup was cancelled.');
+  const response = credential.response as AuthenticatorAttestationResponse;
+  const payload = existing
+    ? authenticationResponse(credential)
+    : {
+        id: encode(credential.rawId),
+        rawId: encode(credential.rawId),
+        type: 'public-key',
+        response: {
+          clientDataJSON: encode(response.clientDataJSON),
+          attestationObject: encode(response.attestationObject),
+          transports: response.getTransports?.() ?? [],
+        },
+        clientExtensionResults: {},
+      };
+  await request(`/${operation}/finish`, payload);
+
+  return {
+    credential,
+    rpId: existing ? publicKey.rpId : publicKey.rp.id,
+    existing,
+  };
+}

--- a/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
@@ -1,10 +1,12 @@
 // @wc-ignore-file
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { webcrypto } from 'node:crypto';
+import { accountPasskey } from './accountPasskey';
 import { managedFetch } from './api';
 import { getManagedAccount } from './session';
 import {
   addPasskeyWrapper,
+  unifyAccountPasskey,
   buildEnvelopeWithPasskeyAndCode,
   decryptEnvelopeV2,
   decryptEnvelopeWithPasskey,
@@ -12,6 +14,9 @@ import {
   type RecoverySecret,
 } from './recovery';
 
+vi.mock('./accountPasskey', () => ({
+  accountPasskey: vi.fn().mockResolvedValue(null),
+}));
 vi.mock('./session', () => ({ getManagedAccount: vi.fn() }));
 vi.mock('./api', () => ({ managedFetch: vi.fn() }));
 vi.mock('../wasmUrls', () => ({
@@ -43,6 +48,7 @@ function credential(n: number) {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  vi.mocked(accountPasskey).mockResolvedValue(null);
   vi.stubGlobal('crypto', webcrypto);
   vi.stubGlobal('navigator', { credentials: { create, get } });
   credentialNumber = 0;
@@ -139,4 +145,76 @@ describe('recovery-code passkey enrollment', () => {
         .mock.calls.some(([, options]) => options?.method === 'PUT'),
     ).toBe(false);
   }, 60000);
+});
+
+it('migrates onto an existing account credential while preserving old recovery methods', async () => {
+  const original = structuredClone(stored);
+  vi.mocked(accountPasskey).mockResolvedValue({
+    credential: credential(2) as unknown as PublicKeyCredential,
+    rpId: 'localhost',
+    existing: true,
+  });
+  selectedCredential = 2;
+  vi.mocked(managedFetch).mockImplementation(async (path, options) => {
+    if (path.endsWith('/wrappers')) {
+      const body = JSON.parse(options!.body as string);
+      expect(body.encrypted_secret).toBe(original.encrypted_secret);
+      stored.wrappers.push({ ...body.wrapper, created_at: 2 });
+    }
+
+    return Response.json(stored);
+  });
+  const saved = await unifyAccountPasskey(subject, code);
+  expect(saved.wrappers.slice(0, original.wrappers.length)).toEqual(
+    original.wrappers,
+  );
+  expect(saved.encrypted_secret).toBe(original.encrypted_secret);
+  expect(await decryptEnvelopeV2(saved, code)).toBe('test-agent-secret');
+  expect(await decryptEnvelopeWithPasskey(saved)).toBe('test-agent-secret');
+  expect(create).toHaveBeenCalledTimes(1); // Only the original recovery credential.
+});
+it('failed migration leaves the original backup untouched', async () => {
+  const original = structuredClone(stored);
+  vi.mocked(accountPasskey).mockRejectedValue(new Error('cancelled'));
+  await expect(unifyAccountPasskey(subject, code)).rejects.toThrow('cancelled');
+  expect(stored).toEqual(original);
+  expect(
+    vi
+      .mocked(managedFetch)
+      .mock.calls.some(([, options]) => options?.method === 'POST'),
+  ).toBe(false);
+});
+
+it('keeps the right PRF salt when a credential has both legacy and account wrappers', async () => {
+  const old = stored.wrappers.find(w => w.wrapper_type === 'webauthn-prf')!;
+  const newer = {
+    ...old,
+    salt: btoa('a-different-salt'),
+    kdf_params: { account_passkey: true, rp_id: 'localhost' },
+  };
+  stored.wrappers.push(newer);
+  selectedCredential = 1;
+  expect(await decryptEnvelopeWithPasskey(stored)).toBe('test-agent-secret');
+  const options = get.mock.calls.at(-1)![0].publicKey;
+  expect(options.allowCredentials).toHaveLength(1);
+  expect(options.extensions.prf.evalByCredential.AQ.first).toEqual(
+    new TextEncoder().encode('a-different-salt'),
+  );
+});
+it('offers an explicit compatible-passkey upgrade when the login key has no PRF', async () => {
+  const original = structuredClone(stored);
+  const unsupported = {
+    ...credential(2),
+    getClientExtensionResults: () => ({}),
+  };
+  vi.mocked(accountPasskey).mockResolvedValue({
+    credential: unsupported as unknown as PublicKeyCredential,
+    rpId: 'localhost',
+    existing: true,
+  });
+  await expect(unifyAccountPasskey(subject, code)).rejects.toThrow(
+    'Create a compatible account passkey',
+  );
+  expect(stored).toEqual(original);
+  expect(create).toHaveBeenCalledTimes(1);
 });

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1,3 +1,4 @@
+import { accountPasskey } from './accountPasskey';
 import { getManagedAccount } from './session';
 import { isRunningInTauri } from '../tauri';
 import { wasmBinaryUrl, wasmJsUrl } from '../wasmUrls';
@@ -406,6 +407,14 @@ export class PrfUnsupportedError extends Error {
   }
 }
 
+export class AccountPasskeyUnsupportedError extends PrfUnsupportedError {
+  constructor() {
+    super(
+      'This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both.',
+    );
+  }
+}
+
 /**
  * Whether to offer the passkey path at all. `getClientCapabilities` answers
  * directly where it exists; otherwise the presence of a platform
@@ -470,6 +479,7 @@ function importPrfKey(
 async function evaluatePrf(
   credentialId: Uint8Array,
   salt: Uint8Array,
+  rpId = passkeyRpId(),
 ): Promise<ArrayBuffer> {
   const assertion = (await navigator.credentials.get({
     publicKey: {
@@ -477,7 +487,7 @@ async function evaluatePrf(
       // Must name the same RP the credential was created under, for the same
       // reason `create` does — see {@link passkeyRpId}. An assertion whose
       // rpId does not match the one in the credential is simply not found.
-      rpId: passkeyRpId(),
+      rpId,
       allowCredentials: [{ type: 'public-key', id: credentialId }],
       userVerification: 'required',
       // Without this the browser's own (multi-minute) default applies, and a
@@ -558,41 +568,52 @@ function readPasskeyDurability(
  */
 async function wrapDekWithPasskey(
   dek: Uint8Array<ArrayBuffer>,
-  { userName, userDisplayName }: { userName: string; userDisplayName: string },
+  {
+    userName,
+    userDisplayName,
+    createNew = false,
+  }: { userName: string; userDisplayName: string; createNew?: boolean },
 ): Promise<{ wrapper: RecoveryWrapperInput; durability: PasskeyDurability }> {
   // Generated up front so the same salt can be evaluated at creation time.
   const prfSalt = randomBytes(SALT_BYTES);
 
-  const credential = (await navigator.credentials.create({
-    publicKey: {
-      challenge: randomBytes(32),
-      rp: { name: PRODUCT_NAME, id: passkeyRpId() },
-      user: {
-        // Opaque by design — we never do discoverable-credential login, so
-        // this identifies nothing and leaks nothing.
-        id: randomBytes(32),
-        name: userName,
-        displayName: userDisplayName,
+  const account = await accountPasskey(prfSalt, createNew);
+  const credential =
+    account?.credential ??
+    ((await navigator.credentials.create({
+      publicKey: {
+        challenge: randomBytes(32),
+        rp: { name: PRODUCT_NAME, id: passkeyRpId() },
+        user: {
+          // Opaque by design — we never do discoverable-credential login, so
+          // this identifies nothing and leaks nothing.
+          id: randomBytes(32),
+          name: userName,
+          displayName: userDisplayName,
+        },
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -257 },
+        ],
+        authenticatorSelection: {
+          residentKey: 'preferred',
+          // PRF requires user verification.
+          userVerification: 'required',
+        },
+        timeout: WEBAUTHN_TIMEOUT_MS,
+        extensions: { prf: { eval: { first: prfSalt } } },
       },
-      pubKeyCredParams: [
-        { type: 'public-key', alg: -7 },
-        { type: 'public-key', alg: -257 },
-      ],
-      authenticatorSelection: {
-        residentKey: 'preferred',
-        // PRF requires user verification.
-        userVerification: 'required',
-      },
-      timeout: WEBAUTHN_TIMEOUT_MS,
-      extensions: { prf: { eval: { first: prfSalt } } },
-    },
-  } as CredentialCreationOptions)) as PublicKeyCredential | null;
+    } as CredentialCreationOptions)) as PublicKeyCredential | null);
 
   if (!credential) {
     throw new PrfUnsupportedError('Passkey creation was cancelled.');
   }
 
   const created = credential.getClientExtensionResults() as PrfExtensionOutputs;
+
+  if (account?.existing && !created.prf?.results?.first) {
+    throw new AccountPasskeyUnsupportedError();
+  }
 
   if (created.prf?.enabled === false) {
     throw new PrfUnsupportedError();
@@ -603,7 +624,8 @@ async function wrapDekWithPasskey(
   // Present on browsers that evaluate PRF at creation; otherwise fall back to
   // a second prompt. Either way the salt (and so the KEK) is identical.
   const prfOutput =
-    created.prf?.results?.first ?? (await evaluatePrf(credentialId, prfSalt));
+    created.prf?.results?.first ??
+    (await evaluatePrf(credentialId, prfSalt, account?.rpId));
   const wrapKey = await importPrfKey(prfOutput, ['encrypt']);
   const wrappedDek = await crypto.subtle.encrypt(
     { name: 'AES-GCM', iv: wrapNonce },
@@ -620,7 +642,7 @@ async function wrapDekWithPasskey(
     wrapper: {
       wrapper_type: 'webauthn-prf',
       kdf_algorithm: '',
-      kdf_params: {},
+      kdf_params: account ? { rp_id: account.rpId, account_passkey: true } : {},
       salt: bytesToBase64(prfSalt),
       wrapped_dek: bytesToBase64(new Uint8Array(wrappedDek)),
       wrap_nonce: bytesToBase64(wrapNonce),
@@ -855,16 +877,54 @@ async function openWithDekKey(
 
 /** Let the authenticator choose any registered passkey, including one added later. */
 async function unlockPasskeyWrapper(recovery: RecoverySecret) {
-  const wrappers = recovery.wrappers.filter(
+  const allWrappers = recovery.wrappers.filter(
     w => w.wrapper_type === 'webauthn-prf' && w.credential_id,
   );
 
-  if (!wrappers.length) throw new Error('This backup has no passkey.');
+  if (!allWrappers.length) throw new Error('This backup has no passkey.');
+  const groups = new Map<string | undefined, RecoveryWrapper[]>();
 
+  for (const wrapper of [...allWrappers].sort(
+    (a, b) =>
+      Number(Boolean(b.kdf_params.account_passkey)) -
+      Number(Boolean(a.kdf_params.account_passkey)),
+  )) {
+    const rp =
+      typeof wrapper.kdf_params.rp_id === 'string'
+        ? wrapper.kdf_params.rp_id
+        : passkeyRpId();
+    const group = groups.get(rp) ?? [];
+
+    // A migrated credential may have both old and new PRF salts. Offer one
+    // wrapper per credential so evalByCredential and the selected wrapper agree.
+    if (
+      !group.some(existing => existing.credential_id === wrapper.credential_id)
+    ) {
+      groups.set(rp, [...group, wrapper]);
+    }
+  }
+
+  let lastError: unknown;
+
+  for (const [rpId, wrappers] of groups) {
+    try {
+      return await unlockPasskeyGroup(rpId, wrappers);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+async function unlockPasskeyGroup(
+  rpId: string | undefined,
+  wrappers: RecoveryWrapper[],
+) {
   const assertion = (await navigator.credentials.get({
     publicKey: {
       challenge: randomBytes(32),
-      rpId: passkeyRpId(),
+      rpId,
       allowCredentials: wrappers.map(w => ({
         type: 'public-key',
         id: base64ToBytes(w.credential_id!),
@@ -1043,6 +1103,90 @@ export async function addRecoveryCodeWrapper(agentSubject?: string): Promise<{
   });
 
   return { recoveryCode, saved };
+}
+
+/** Add the account credential to an existing backup, preserving every old wrapper. */
+export async function unifyAccountPasskey(
+  agentSubject: string,
+  recoveryCode?: string,
+  createNew = false,
+): Promise<RecoverySecret> {
+  const recovery = await getRecoverySecret();
+
+  if (
+    !recovery ||
+    recovery.agent_subject !== agentSubject ||
+    recovery.format_version !== 2
+  ) {
+    throw new Error(
+      'Sign in to the account holding this backup before updating its passkey.',
+    );
+  }
+
+  let dek: ArrayBuffer;
+
+  if (recoveryCode) {
+    const wrapper = recovery.wrappers.find(
+      w => w.wrapper_type === 'recovery-code',
+    );
+    if (!wrapper) throw new Error('This backup has no recovery code.');
+    const key = await deriveKeyFromRecoveryCode(
+      normalizeRecoveryCodeInput(recoveryCode),
+      base64ToBytes(wrapper.salt),
+      ['decrypt'],
+      wrapper.kdf_params,
+    );
+    dek = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(wrapper.wrap_nonce) },
+      key,
+      base64ToBytes(wrapper.wrapped_dek),
+    );
+  } else {
+    const { wrapper, key } = await unlockPasskeyWrapper(recovery);
+    dek = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(wrapper.wrap_nonce) },
+      key,
+      base64ToBytes(wrapper.wrapped_dek),
+    );
+  }
+
+  const { wrapper } = await wrapDekWithPasskey(new Uint8Array(dek), {
+    userName: recovery.owner_email,
+    userDisplayName: recovery.owner_email,
+    createNew,
+  });
+  if (!wrapper.kdf_params.account_passkey)
+    throw new Error('Sign in to your account before updating its passkey.');
+  // Verify the new wrapper before persisting it. Existing wrappers are never retired here.
+  const output = await evaluatePrf(
+    base64ToBytes(wrapper.credential_id!),
+    base64ToBytes(wrapper.salt),
+    wrapper.kdf_params.rp_id as string,
+  );
+  const key = await importPrfKey(output, ['decrypt']);
+  await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBytes(wrapper.wrap_nonce) },
+    key,
+    base64ToBytes(wrapper.wrapped_dek),
+  );
+  const response = await managedFetch('/recovery-secret/wrappers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      agent_subject: recovery.agent_subject,
+      encrypted_secret: recovery.encrypted_secret,
+      nonce: recovery.nonce,
+      wrapper,
+    }),
+  });
+  if (!response.ok)
+    throw new Error(
+      'Could not update your backup. Your existing recovery methods still work.',
+    );
+  const saved = (await response.json()) as RecoverySecret;
+  cacheRecoverySecret(saved);
+
+  return saved;
 }
 
 /** Add a passkey without replacing the recovery code or existing passkeys. */

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -7857,3 +7857,23 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Manage this drive’s plan →"
 msgstr ""
+
+#: src/helpers/managed/recovery.ts
+msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Create a compatible account passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use one passkey for sign-in and recovery"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -7891,3 +7891,23 @@ msgstr "This status describes data synchronization. View this drive’s subscrip
 #: src/routes/SyncRoute.tsx
 msgid "Manage this drive’s plan →"
 msgstr "Manage this drive’s plan →"
+
+#: src/helpers/managed/recovery.ts
+msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
+msgstr "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey."
+msgstr "Could not update your passkey."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Create a compatible account passkey"
+msgstr "Create a compatible account passkey"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use one passkey for sign-in and recovery"
+msgstr "Use one passkey for sign-in and recovery"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -7857,3 +7857,23 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Manage this drive’s plan →"
 msgstr ""
+
+#: src/helpers/managed/recovery.ts
+msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Create a compatible account passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use one passkey for sign-in and recovery"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -7857,3 +7857,23 @@ msgstr ""
 #: src/routes/SyncRoute.tsx
 msgid "Manage this drive’s plan →"
 msgstr ""
+
+#: src/helpers/managed/recovery.ts
+msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Create a compatible account passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Use one passkey for sign-in and recovery"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""


### PR DESCRIPTION
Hosted onboarding now uses one account credential for portal sign-in and encrypted recovery. Existing account credentials are reused through a session-bound, server-verified assertion with client-side PRF; new credentials are registered once with the control plane. PRF output is excluded from authentication payloads.

Account settings offer an additive migration using the old passkey or recovery code. The new wrapper is verified before a transactional append, preserving ciphertext and existing access methods. Wrappers persist their RP ID, and duplicate credential IDs select one matching PRF salt. Unsupported old login credentials require an explicit compatible-passkey upgrade. Standalone recovery stays independent of SaaS.

Requires https://github.com/ontola/atomic-saas/pull/70. Merge this repository first, then SaaS; deploy together.

Validation: app production build (existing WASM reused), typecheck, changed-file lint/format, and 14 focused tests passed. Paired real-control-plane Chromium tests passed for app-first enrollment followed by portal login, portal-first credential reuse, additive migration and subsequent unlock, plus existing portal security and banner tests (6 scenarios total). Physical mobile/password-manager/native-shell acceptance remains untested. Password-manager entries are not deleted automatically.
