### PR TITLE
Fix SaaS onboarding and share unhosted drives over WebRTC

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -640,3 +640,11 @@ no access to resource content. A live cross-app deployment acceptance is separat
 `helpers/managed/accountPasskey.test.ts` checks account-credential reuse, server-challenge registration, PRF-output exclusion from API payloads, cancellation and standalone fallback. `recovery-enrollment.test.ts` covers additive migration, old recovery-code preservation, failed upgrades, unsupported login credentials and duplicate-credential PRF-salt selection. These use simulated authenticators and real WebCrypto/Argon2id.
 
 Paired SaaS `portal/e2e/recovery-passkey.spec.ts` uses Chromium virtual PRF authenticators with the real control plane to verify app enrollment followed by portal login using one credential, reuse of a portal-created credential, and account-settings migration without replacing ciphertext or old wrappers. Physical Safari/iCloud, Android/password-manager and native-shell behavior remain device acceptance checks.
+
+## September 10 SaaS and browser invite regressions
+
+- `browser/lib/src/browser-peer-invite.test.ts`: signed invitation validation, expiry, target and issuer checks, recipient proof, and additive permission grants.
+- `browser/e2e/tests/browser-invite.spec.ts`: distinct signed-in identities join a local drive through the app without the server invite endpoint.
+- `browser/e2e/scripts/verify-peer-sync.mjs` with `ATOMIC_PEER_INVITE=1`: invitation bootstrap and real WebRTC reconciliation with HTTP data access disabled.
+- `browser/e2e/tests/recovery-option.spec.ts`: recovery availability in the managed welcome flow.
+- Existing-drive migration to browser-only storage and fresh-account email onboarding through a peer invitation remain unverified.

--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -73,6 +73,7 @@ export function AccountRecoveryCard({
   const [needsCode, setNeedsCode] = useState(false);
   const [passkeyAdded, setPasskeyAdded] = useState(false);
   const [needsCompatiblePasskey, setNeedsCompatiblePasskey] = useState(false);
+  const [addingAccountPasskey, setAddingAccountPasskey] = useState(false);
   /**
    * The secret being enrolled, typed by the user.
    *
@@ -406,7 +407,9 @@ export function AccountRecoveryCard({
     if (!agentSubject || backup.phase !== 'ready') return;
 
     if (!envelopeWrapperKinds(backup.secret).hasPasskey && !codeInput.trim()) {
+      setAddingAccountPasskey(true);
       setNeedsCode(true);
+      setError(undefined);
 
       return;
     }
@@ -424,12 +427,15 @@ export function AccountRecoveryCard({
       setCodeInput('');
       setNeedsCode(false);
       setNeedsCompatiblePasskey(false);
+      setAddingAccountPasskey(false);
       setPasskeyAdded(true);
     } catch (e) {
       if (e instanceof AccountPasskeyUnsupportedError)
         setNeedsCompatiblePasskey(true);
       setError(
-        e instanceof Error ? e.message : 'Could not update your passkey.',
+        e instanceof Error && e.message.trim()
+          ? e.message
+          : 'Could not update your passkey. Please try again.',
       );
     } finally {
       setLoading(false);
@@ -437,7 +443,7 @@ export function AccountRecoveryCard({
   }
 
   async function handleAddPasskey() {
-    if (!needsCode || !codeInput.trim()) {
+    if (!codeInput.trim()) {
       setNeedsCode(true);
       setError(undefined);
 
@@ -536,6 +542,7 @@ export function AccountRecoveryCard({
 
   return (
     <Column gap='0.75rem'>
+      {error && <ErrorLook role='alert'>{error}</ErrorLook>}
       <Protections>
         {/* One expression, because JSX turns the newline between two of them
             into a space and the sentence read "your passkey ." */}
@@ -570,6 +577,7 @@ export function AccountRecoveryCard({
       ) : null}
 
       {hasSession &&
+      !addingAccountPasskey &&
       backup.secret.format_version === 2 &&
       !backup.secret.wrappers.some(w => w.kdf_params.account_passkey) ? (
         <Column gap='0.5rem'>
@@ -578,9 +586,11 @@ export function AccountRecoveryCard({
             onClick={handleUnifyPasskey}
             data-test='unify-passkey'
           >
-            {needsCompatiblePasskey
-              ? 'Create a compatible account passkey'
-              : 'Use one passkey for sign-in and recovery'}
+            {loading
+              ? 'Setting up passkey…'
+              : needsCompatiblePasskey
+                ? 'Create a compatible account passkey'
+                : 'Add a passkey'}
           </Button>
           <Hint>
             Unlock your backup, then choose your account passkey. Your existing
@@ -597,6 +607,15 @@ export function AccountRecoveryCard({
             type='password'
             placeholder='Recovery code'
             aria-label='Recovery code'
+            autoFocus
+            onKeyDown={event => {
+              if (event.key === 'Enter' && codeInput.trim() && !loading) {
+                event.preventDefault();
+                void (addingAccountPasskey
+                  ? handleUnifyPasskey()
+                  : handleReveal());
+              }
+            }}
           />
         </InputWrapper>
       ) : null}
@@ -605,15 +624,27 @@ export function AccountRecoveryCard({
           <Row gap='1rem' wrapItems>
             <Button
               subtle
-              disabled={loading}
+              disabled={loading || (needsCode && !codeInput.trim())}
               onClick={() => {
-                setNeedsCode(true);
-                setError(undefined);
+                if (needsCode) {
+                  void (addingAccountPasskey
+                    ? handleUnifyPasskey()
+                    : handleReveal());
+                } else {
+                  setNeedsCode(true);
+                  setError(undefined);
+                }
               }}
             >
-              Use recovery code
+              {loading
+                ? 'Unlocking…'
+                : addingAccountPasskey
+                  ? 'Continue with passkey'
+                  : needsCode
+                    ? 'Unlock with recovery code'
+                    : 'Use recovery code'}
             </Button>
-            {hasSession === true ? (
+            {hasSession === true && backup.secret.format_version !== 2 ? (
               <Button
                 subtle
                 disabled={loading || !agentSubject}
@@ -622,7 +653,7 @@ export function AccountRecoveryCard({
               >
                 Add a passkey
               </Button>
-            ) : portalUrl ? (
+            ) : hasSession !== true && portalUrl ? (
               <Button
                 subtle
                 onClick={() => window.open(`${portalUrl}/dashboard`, '_blank')}
@@ -717,8 +748,6 @@ export function AccountRecoveryCard({
           />
         </Column>
       ) : null}
-
-      {error && <ErrorLook>{error}</ErrorLook>}
     </Column>
   );
 }

--- a/browser/data-browser/src/components/BrowserPeerPanel.tsx
+++ b/browser/data-browser/src/components/BrowserPeerPanel.tsx
@@ -10,7 +10,12 @@ export function BrowserPeerPanel({ drive }: { drive?: string }) {
 
     return () => window.removeEventListener(PEER_LINK_CHANGED, update);
   }, [drive]);
-  if (!status.startsWith(/* @wc-ignore */ 'Connected to')) return null;
+  if (
+    !status ||
+    status === /* @wc-ignore */ 'Not connected' ||
+    status === /* @wc-ignore */ 'Disconnected'
+  )
+    return null;
 
-  return <small role='status'>{status}</small>;
+  return <small role='status'>Browser sync · {status}</small>;
 }

--- a/browser/data-browser/src/components/InviteForm.tsx
+++ b/browser/data-browser/src/components/InviteForm.tsx
@@ -13,6 +13,13 @@ import {
 import { generateInviteToken } from '@tomic/lib';
 import { useCallback, useState, type ReactNode } from 'react';
 import { Dialog } from './Dialog';
+import { managedFetch } from '../helpers/managed/api';
+import {
+  automaticPeerRoom,
+  defaultPeerSignalingUrl,
+  savePeerLink,
+  resumePeerLinks,
+} from '../helpers/browserPeerSync';
 import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
 import toast from 'react-hot-toast';
 import { ErrorLook } from './ErrorLook';
@@ -81,14 +88,59 @@ function InviteFormContent({
         urls.properties.invite.expiresAt,
       )) as number;
 
+      const isDrive = target.hasClasses(server.classes.drive);
+      let browserPeer = isDrive && store.isLocalOnlyDrive(target.subject);
+
+      if (isDrive && isSaas && !browserPeer) {
+        const response = await managedFetch('/sync-enrollments', {});
+        if (!response.ok || response.status === 204)
+          throw new Error(
+            'Sign in to your portal account to check this drive before sharing.',
+          );
+        const body = await response.json();
+        const enrollments = Array.isArray(body) ? body : body.enrollments;
+        if (!Array.isArray(enrollments))
+          throw new Error('Could not check Cloud Server status. Try again.');
+        browserPeer = !enrollments.some(
+          e => e.drive_subject === target.subject && e.status !== 'Disabled',
+        );
+      }
+
+      if (browserPeer && !store.isLocalOnlyDrive(target.subject)) {
+        throw new Error(
+          'This drive still uses a data server. A complete local copy must be verified before switching it to browser-only sharing. Its existing server connection has been kept.',
+        );
+      }
+
+      if (
+        browserPeer &&
+        !(await store.getClientDb()?.getResourceWithSnapshot(target.subject))
+          ?.snapshot
+      )
+        throw new Error(
+          'Wait for this drive to be saved on this device before sharing.',
+        );
       const tokenBase64 = await generateInviteToken(
         target.subject,
         agent,
         !!write,
         expiresAt,
+        invite.get(core.properties.description) as string | undefined,
+        browserPeer,
       );
 
-      const baseUrl = store.getServerUrl();
+      if (browserPeer) {
+        savePeerLink(store, {
+          drive: target.subject,
+          room: await automaticPeerRoom(target.subject),
+          signalingUrl: defaultPeerSignalingUrl(),
+        });
+        resumePeerLinks(store);
+      }
+
+      const baseUrl = browserPeer
+        ? window.location.origin
+        : store.getServerUrl();
       const finalUrl = `${baseUrl}/app/invite?token=${encodeURIComponent(
         tokenBase64,
       )}`;
@@ -100,7 +152,7 @@ function InviteFormContent({
     } catch (e) {
       setErr(e);
     }
-  }, [invite, agent, target, store]);
+  }, [invite, agent, target, store, isSaas]);
 
   if (agent?.subject && !profileReviewed) {
     return (
@@ -129,7 +181,7 @@ function InviteFormContent({
             <p>
               {allowEdits
                 ? 'Cloud Server: each editor uses one seat on this drive. An existing editor on this drive counts once. Viewers are free.'
-                : 'Viewers are free. Allowing edits requires a team editor seat for Cloud Server.'}
+                : 'Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server.'}
             </p>
           )}
           <ResourceField

--- a/browser/data-browser/src/components/NewIdentitySection.tsx
+++ b/browser/data-browser/src/components/NewIdentitySection.tsx
@@ -1,3 +1,4 @@
+import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Agent, JSCryptoProvider, core, useStore } from '@tomic/react';
@@ -153,7 +154,7 @@ export function NewIdentitySection({
       // guest uses; `enableCloudSyncForDrive` lifts it when a node is
       // assigned. Registered right after `setAgent` and before anything
       // async, so no consumer can mount `useResource(agent)` and fetch first.
-      if (isOriginWithoutNode(store.getServerUrl())) {
+      if (getManagedPortalUrl() || isOriginWithoutNode(store.getServerUrl())) {
         store.registerLocalOnlyDrive(agentDID);
         store.registerLocalOnlyDrive(await newAgent.privateDriveSubject());
       }

--- a/browser/data-browser/src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
+++ b/browser/data-browser/src/components/forms/NewForm/CustomCreateActions/CustomForms/NewDriveDialog.tsx
@@ -1,3 +1,4 @@
+import { getManagedPortalUrl } from '../../../../../helpers/managed/cloudSync';
 import { useStore } from '@tomic/react';
 import { useState, useCallback, FormEvent, FC, useEffect, useId } from 'react';
 import { styled } from 'styled-components';
@@ -39,6 +40,7 @@ export const NewDriveDialog: FC<CustomResourceDialogProps> = ({
         // An ADDITIONAL drive: linked into the switcher list, but it does not
         // replace the agent's personal/home drive.
         personal: false,
+        localOnly: !!getManagedPortalUrl(),
       });
 
       store.notifyResourceManuallyCreated(resource);

--- a/browser/data-browser/src/helpers/browserPeerSync.test.ts
+++ b/browser/data-browser/src/helpers/browserPeerSync.test.ts
@@ -138,3 +138,14 @@ it('automatically connects stored drives once, without bootstrapping unknown dri
   );
   stopPeerLinks(store);
 });
+
+it('keeps node-hosted staging apps on staging discovery', () => {
+  vi.stubEnv('VITE_ATOMIC_SIGNALING_URL', '');
+  vi.stubEnv('VITE_MANAGED_PORTAL_URL', '');
+  vi.stubGlobal('window', {
+    location: { hostname: 'node1.staging.atomicserver.eu' },
+  });
+  expect(defaultPeerSignalingUrl()).toBe(
+    'wss://staging.atomicserver.eu/webrtc-signal',
+  );
+});

--- a/browser/data-browser/src/helpers/browserPeerSync.ts
+++ b/browser/data-browser/src/helpers/browserPeerSync.ts
@@ -10,6 +10,7 @@ export interface SavedPeerLink {
   room: string;
   signalingUrl: string;
   expectedPeer?: string;
+  invitation?: string;
 }
 const active = new WeakMap<Store, Map<string, BrowserPeerSync>>();
 const statuses = new Map<string, string>();
@@ -54,6 +55,8 @@ export function savePeerLink(store: Store, link: SavedPeerLink): void {
   localStorage.setItem(key(store), JSON.stringify([...links, link]));
   active.get(store)?.get(link.drive)?.close();
   active.get(store)?.delete(link.drive);
+  active.get(store)?.get(`automatic:${link.drive}`)?.close();
+  active.get(store)?.delete(`automatic:${link.drive}`);
   window.dispatchEvent(new Event(PEER_LINK_CHANGED));
 }
 
@@ -111,7 +114,8 @@ export function stopPeerLinks(store: Store): void {
 export function defaultPeerSignalingUrl(): string {
   const portal =
     import.meta.env.VITE_MANAGED_PORTAL_URL ||
-    (window.location.hostname === 'app.staging.atomicserver.eu'
+    (window.location.hostname === 'staging.atomicserver.eu' ||
+    window.location.hostname.endsWith('.staging.atomicserver.eu')
       ? 'https://staging.atomicserver.eu'
       : 'https://atomicserver.eu');
   const endpoint = new URL(
@@ -208,7 +212,8 @@ export async function discoverPeerDrives(store: Store): Promise<void> {
         !resource.isReady() ||
         resource.error ||
         !resource.hasClasses(server.classes.drive) ||
-        links.has(id)
+        links.has(id) ||
+        savedPeerLinks(store).some(link => link.drive === drive)
       )
         continue;
 

--- a/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
@@ -218,3 +218,11 @@ it('offers an explicit compatible-passkey upgrade when the login key has no PRF'
   expect(stored).toEqual(original);
   expect(create).toHaveBeenCalledTimes(1);
 });
+
+it('reports a wrong code before attempting account passkey registration', async () => {
+  vi.mocked(accountPasskey).mockClear();
+  await expect(
+    unifyAccountPasskey(subject, 'wrong-recovery-code'),
+  ).rejects.toThrow('Wrong recovery code');
+  expect(accountPasskey).not.toHaveBeenCalled();
+});

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1136,11 +1136,18 @@ export async function unifyAccountPasskey(
       ['decrypt'],
       wrapper.kdf_params,
     );
-    dek = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: base64ToBytes(wrapper.wrap_nonce) },
-      key,
-      base64ToBytes(wrapper.wrapped_dek),
-    );
+
+    try {
+      dek = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: base64ToBytes(wrapper.wrap_nonce) },
+        key,
+        base64ToBytes(wrapper.wrapped_dek),
+      );
+    } catch {
+      throw new Error(
+        'Wrong recovery code. Use the recovery code saved for this account, not your agent secret.',
+      );
+    }
   } else {
     const { wrapper, key } = await unlockPasskeyWrapper(recovery);
     dek = await crypto.subtle.decrypt(

--- a/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
+++ b/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { core, server, useStore } from '@tomic/react';
+import { driveDisplayMetadata } from '../helpers/managed/driveDisplayMetadata';
 import { hasManagedApi, managedFetch } from '../helpers/managed/api';
 import { evaluateIdentityReconciliation } from '../helpers/managed/reconcile';
 import { readManagedAccountBinding } from '../helpers/managed/binding';
@@ -88,16 +89,17 @@ export function useAccountDriveCatalog(local: string[]) {
             subjects.push(resource.subject);
         }
 
-        const entries = [...new Set(subjects)].map(subject => {
-          const resource = store.resources.get(subject);
+        const entries = await Promise.all(
+          [...new Set(subjects)].map(async subject => {
+            const metadata = await driveDisplayMetadata(store, subject);
 
-          return {
-            drive_subject: subject,
-            drive_name: resource?.get(core.properties.name) as
-              | string
-              | undefined,
-          };
-        });
+            return {
+              drive_subject: subject,
+              drive_name: metadata.name,
+              drive_emoji: metadata.emoji,
+            };
+          }),
+        );
         await sync.refresh(entries);
       } catch {
         /* Keep the last successful list; reconnect/focus retries. */

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -910,7 +910,6 @@ msgid "App menu"
 msgstr ""
 
 #: src/components/SideBar/SideBarDrive.tsx
-#: src/views/ErrorPage.tsx
 msgid "Unauthorized"
 msgstr ""
 
@@ -1053,12 +1052,12 @@ msgstr ""
 
 #: src/views/ErrorPage.tsx
 #: src/views/ErrorPage.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/views/ErrorPage.tsx
-msgid "You don't have access to this, try signing in:"
-msgstr ""
+#~ msgid "You don't have access to this, try signing in:"
+#~ msgstr ""
 
 #. 0: resource.subject
 #: src/views/ErrorPage.tsx
@@ -3723,6 +3722,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+#: src/components/InviteForm.tsx
 #: src/helpers/managed/cloudSync.ts
 #: src/helpers/managed/reconcile.test.ts
 #: src/helpers/managed/reconcile.ts
@@ -3963,9 +3963,8 @@ msgstr ""
 msgid "Restore & sign in"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Sign in to access this drive"
-msgstr ""
+#~ msgid "Sign in to access this drive"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
@@ -4853,6 +4852,7 @@ msgstr ""
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 #: src/routes/SyncRoute.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Connecting…"
 msgstr ""
 
@@ -5668,6 +5668,7 @@ msgstr ""
 msgid "Could not show your secret."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlocking…"
 msgstr ""
@@ -6863,20 +6864,16 @@ msgstr ""
 msgid "Store it with {0}"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/AccountRecoveryCard.tsx
-msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
-msgstr ""
+#~ msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
 msgid "{0}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in."
 msgstr ""
 
-#. 0: ' '; 1: `${ [hasPasskey && 'your passkey', hasCode && 'your recovery code'] .filter(Boolean) .join(' or ') || 'your recovery password' }${deviceOnly ? ', on this device' \\: ''}.`
-#: src/components/AccountRecoveryCard.tsx
-msgid "You can get back in with:{0} {1}"
-msgstr ""
+#~ msgid "You can get back in with:{0} {1}"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "An always-on device has an address. One you carry has a code instead, shown below."
@@ -7614,9 +7611,8 @@ msgstr ""
 #~ msgid "Cloud Server: each new team editor needs one seat. Existing team editors count once across drives. Viewers are free."
 #~ msgstr ""
 
-#: src/components/InviteForm.tsx
-msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
-msgstr ""
+#~ msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
+#~ msgstr ""
 
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Local Ollama detected"
@@ -7742,6 +7738,7 @@ msgid "A recovery code is a spare key for when your passkey isn't available. You
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
@@ -7862,18 +7859,122 @@ msgstr ""
 msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Could not update your passkey."
-msgstr ""
+#~ msgid "Could not update your passkey."
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Create a compatible account passkey"
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Use one passkey for sign-in and recovery"
-msgstr ""
+#~ msgid "Use one passkey for sign-in and recovery"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Unlock this drive"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "You’re signed in as"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid ", but this browser needs your account key to open this private drive. Paste your saved agent secret below. No account recovery backup is available."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Loading account"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock with recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Setting up passkey…"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Continue with passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey. Please try again."
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "Use another account"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "This account does not have access"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "You’re signed in, but this account cannot read this resource. Open it with the account that owns it, or ask its owner to share it with you."
+msgstr ""
+
+#: src/components/InviteForm.tsx
+msgid "Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server."
+msgstr ""
+
+#: src/routes/InviteRoute.tsx
+msgid "Invalid invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Could not join this drive."
+msgstr ""
+
+#~ msgid "Connected to"
+#~ msgstr ""
+
+#~ msgid "You're invited to {0} this drive"
+#~ msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Invitation unavailable"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Join drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Looking for the inviter’s browser…"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Sign in to join"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Open drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This invitation is invalid or has expired. Ask for a new invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This drive syncs between browsers. The person who invited you needs to keep their browser open while you join."
+msgstr ""
+
+#~ msgid "Disconnected"
+#~ msgstr ""
+
+#. 0: status
+#: src/components/BrowserPeerPanel.tsx
+msgid "Browser sync · {0}"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to edit this drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to view this drive"
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -910,7 +910,6 @@ msgid "App menu"
 msgstr "App menu"
 
 #: src/components/SideBar/SideBarDrive.tsx
-#: src/views/ErrorPage.tsx
 msgid "Unauthorized"
 msgstr "Unauthorized"
 
@@ -1053,12 +1052,12 @@ msgstr "Copy secret to continue"
 
 #: src/views/ErrorPage.tsx
 #: src/views/ErrorPage.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Retry"
 msgstr "Retry"
 
-#: src/views/ErrorPage.tsx
-msgid "You don't have access to this, try signing in:"
-msgstr "You don't have access to this, try signing in:"
+#~ msgid "You don't have access to this, try signing in:"
+#~ msgstr "You don't have access to this, try signing in:"
 
 #. 0: resource.subject
 #: src/views/ErrorPage.tsx
@@ -3723,6 +3722,7 @@ msgstr "Enter an Atomic URL or search  (press \"/\")"
 msgid "Search"
 msgstr "Search"
 
+#: src/components/InviteForm.tsx
 #: src/helpers/managed/cloudSync.ts
 #: src/helpers/managed/reconcile.test.ts
 #: src/helpers/managed/reconcile.ts
@@ -3963,9 +3963,8 @@ msgstr "Restoring…"
 msgid "Restore & sign in"
 msgstr "Restore & sign in"
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Sign in to access this drive"
-msgstr "Sign in to access this drive"
+#~ msgid "Sign in to access this drive"
+#~ msgstr "Sign in to access this drive"
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
@@ -4887,6 +4886,7 @@ msgstr "Developer"
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 #: src/routes/SyncRoute.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Connecting…"
 msgstr "Connecting…"
 
@@ -5702,6 +5702,7 @@ msgstr "Account recovery"
 msgid "Could not show your secret."
 msgstr "Could not show your secret."
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlocking…"
 msgstr "Unlocking…"
@@ -6897,20 +6898,16 @@ msgstr "Storing…"
 msgid "Store it with {0}"
 msgstr "Store it with {0}"
 
-#. 0: PRODUCT_NAME
-#: src/components/AccountRecoveryCard.tsx
-msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
-msgstr "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
+#~ msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
+#~ msgstr "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
 msgid "{0}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in."
 msgstr "{0}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in."
 
-#. 0: ' '; 1: `${ [hasPasskey && 'your passkey', hasCode && 'your recovery code'] .filter(Boolean) .join(' or ') || 'your recovery password' }${deviceOnly ? ', on this device' \\: ''}.`
-#: src/components/AccountRecoveryCard.tsx
-msgid "You can get back in with:{0} {1}"
-msgstr "You can get back in with:{0} {1}"
+#~ msgid "You can get back in with:{0} {1}"
+#~ msgstr "You can get back in with:{0} {1}"
 
 #: src/routes/SyncRoute.tsx
 msgid "An always-on device has an address. One you carry has a code instead, shown below."
@@ -7648,9 +7645,8 @@ msgstr "Your selected avatar"
 #~ msgid "Cloud Server: each new team editor needs one seat. Existing team editors count once across drives. Viewers are free."
 #~ msgstr "Cloud Server: each new team editor needs one seat. Existing team editors count once across drives. Viewers are free."
 
-#: src/components/InviteForm.tsx
-msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
-msgstr "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
+#~ msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
+#~ msgstr "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
 
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Local Ollama detected"
@@ -7776,6 +7772,7 @@ msgid "A recovery code is a spare key for when your passkey isn't available. You
 msgstr "A recovery code is a spare key for when your passkey isn't available. You'll need your email to use it, so it's safe to keep on paper."
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 msgid "Add a passkey"
 msgstr "Add a passkey"
 
@@ -7896,18 +7893,122 @@ msgstr "Manage this drive’s plan →"
 msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
 msgstr "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Could not update your passkey."
-msgstr "Could not update your passkey."
+#~ msgid "Could not update your passkey."
+#~ msgstr "Could not update your passkey."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Create a compatible account passkey"
 msgstr "Create a compatible account passkey"
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Use one passkey for sign-in and recovery"
-msgstr "Use one passkey for sign-in and recovery"
+#~ msgid "Use one passkey for sign-in and recovery"
+#~ msgstr "Use one passkey for sign-in and recovery"
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
 msgstr "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Unlock this drive"
+msgstr "Unlock this drive"
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "You’re signed in as"
+msgstr "You’re signed in as"
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid ", but this browser needs your account key to open this private drive. Paste your saved agent secret below. No account recovery backup is available."
+msgstr ", but this browser needs your account key to open this private drive. Paste your saved agent secret below. No account recovery backup is available."
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Loading account"
+msgstr "Loading account"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock with recovery code"
+msgstr "Unlock with recovery code"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Setting up passkey…"
+msgstr "Setting up passkey…"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Continue with passkey"
+msgstr "Continue with passkey"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey. Please try again."
+msgstr "Could not update your passkey. Please try again."
+
+#: src/views/ErrorPage.tsx
+msgid "Use another account"
+msgstr "Use another account"
+
+#: src/views/ErrorPage.tsx
+msgid "This account does not have access"
+msgstr "This account does not have access"
+
+#: src/views/ErrorPage.tsx
+msgid "You’re signed in, but this account cannot read this resource. Open it with the account that owns it, or ask its owner to share it with you."
+msgstr "You’re signed in, but this account cannot read this resource. Open it with the account that owns it, or ask its owner to share it with you."
+
+#: src/components/InviteForm.tsx
+msgid "Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server."
+msgstr "Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server."
+
+#: src/routes/InviteRoute.tsx
+msgid "Invalid invitation."
+msgstr "Invalid invitation."
+
+#: src/views/PeerInvitePage.tsx
+msgid "Could not join this drive."
+msgstr "Could not join this drive."
+
+#~ msgid "Connected to"
+#~ msgstr "Connected to"
+
+#~ msgid "You're invited to {0} this drive"
+#~ msgstr "You're invited to {0} this drive"
+
+#: src/views/PeerInvitePage.tsx
+msgid "Invitation unavailable"
+msgstr "Invitation unavailable"
+
+#: src/views/PeerInvitePage.tsx
+msgid "Join drive"
+msgstr "Join drive"
+
+#: src/views/PeerInvitePage.tsx
+msgid "Looking for the inviter’s browser…"
+msgstr "Looking for the inviter’s browser…"
+
+#: src/views/PeerInvitePage.tsx
+msgid "Sign in to join"
+msgstr "Sign in to join"
+
+#: src/views/PeerInvitePage.tsx
+msgid "Open drive"
+msgstr "Open drive"
+
+#: src/views/PeerInvitePage.tsx
+msgid "This invitation is invalid or has expired. Ask for a new invitation."
+msgstr "This invitation is invalid or has expired. Ask for a new invitation."
+
+#: src/views/PeerInvitePage.tsx
+msgid "This drive syncs between browsers. The person who invited you needs to keep their browser open while you join."
+msgstr "This drive syncs between browsers. The person who invited you needs to keep their browser open while you join."
+
+#~ msgid "Disconnected"
+#~ msgstr "Disconnected"
+
+#. 0: status
+#: src/components/BrowserPeerPanel.tsx
+msgid "Browser sync · {0}"
+msgstr "Browser sync · {0}"
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to edit this drive"
+msgstr "You're invited to edit this drive"
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to view this drive"
+msgstr "You're invited to view this drive"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -910,7 +910,6 @@ msgid "App menu"
 msgstr "Menú de la aplicación"
 
 #: src/components/SideBar/SideBarDrive.tsx
-#: src/views/ErrorPage.tsx
 msgid "Unauthorized"
 msgstr "No autorizado"
 
@@ -1053,12 +1052,12 @@ msgstr "Copiar secreto para continuar"
 
 #: src/views/ErrorPage.tsx
 #: src/views/ErrorPage.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/views/ErrorPage.tsx
-msgid "You don't have access to this, try signing in:"
-msgstr "No tienes acceso a esto, intenta iniciar sesión:"
+#~ msgid "You don't have access to this, try signing in:"
+#~ msgstr "No tienes acceso a esto, intenta iniciar sesión:"
 
 #. 0: resource.subject
 #: src/views/ErrorPage.tsx
@@ -3723,6 +3722,7 @@ msgstr "Introduce una URL Atómica o busca (presiona \"/\")"
 msgid "Search"
 msgstr "Buscar"
 
+#: src/components/InviteForm.tsx
 #: src/helpers/managed/cloudSync.ts
 #: src/helpers/managed/reconcile.test.ts
 #: src/helpers/managed/reconcile.ts
@@ -3963,9 +3963,8 @@ msgstr ""
 msgid "Restore & sign in"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Sign in to access this drive"
-msgstr ""
+#~ msgid "Sign in to access this drive"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
@@ -4853,6 +4852,7 @@ msgstr ""
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 #: src/routes/SyncRoute.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Connecting…"
 msgstr ""
 
@@ -5668,6 +5668,7 @@ msgstr ""
 msgid "Could not show your secret."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlocking…"
 msgstr ""
@@ -6863,20 +6864,16 @@ msgstr ""
 msgid "Store it with {0}"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/AccountRecoveryCard.tsx
-msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
-msgstr ""
+#~ msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
 msgid "{0}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in."
 msgstr ""
 
-#. 0: ' '; 1: `${ [hasPasskey && 'your passkey', hasCode && 'your recovery code'] .filter(Boolean) .join(' or ') || 'your recovery password' }${deviceOnly ? ', on this device' \\: ''}.`
-#: src/components/AccountRecoveryCard.tsx
-msgid "You can get back in with:{0} {1}"
-msgstr ""
+#~ msgid "You can get back in with:{0} {1}"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "An always-on device has an address. One you carry has a code instead, shown below."
@@ -7614,9 +7611,8 @@ msgstr ""
 #~ msgid "Cloud Server: each new team editor needs one seat. Existing team editors count once across drives. Viewers are free."
 #~ msgstr ""
 
-#: src/components/InviteForm.tsx
-msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
-msgstr ""
+#~ msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
+#~ msgstr ""
 
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Local Ollama detected"
@@ -7742,6 +7738,7 @@ msgid "A recovery code is a spare key for when your passkey isn't available. You
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 msgid "Add a passkey"
 msgstr "Añadir una clave de acceso"
 
@@ -7862,18 +7859,122 @@ msgstr ""
 msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Could not update your passkey."
-msgstr ""
+#~ msgid "Could not update your passkey."
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Create a compatible account passkey"
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Use one passkey for sign-in and recovery"
-msgstr ""
+#~ msgid "Use one passkey for sign-in and recovery"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Unlock this drive"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "You’re signed in as"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid ", but this browser needs your account key to open this private drive. Paste your saved agent secret below. No account recovery backup is available."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Loading account"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock with recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Setting up passkey…"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Continue with passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey. Please try again."
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "Use another account"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "This account does not have access"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "You’re signed in, but this account cannot read this resource. Open it with the account that owns it, or ask its owner to share it with you."
+msgstr ""
+
+#: src/components/InviteForm.tsx
+msgid "Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server."
+msgstr ""
+
+#: src/routes/InviteRoute.tsx
+msgid "Invalid invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Could not join this drive."
+msgstr ""
+
+#~ msgid "Connected to"
+#~ msgstr ""
+
+#~ msgid "You're invited to {0} this drive"
+#~ msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Invitation unavailable"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Join drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Looking for the inviter’s browser…"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Sign in to join"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Open drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This invitation is invalid or has expired. Ask for a new invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This drive syncs between browsers. The person who invited you needs to keep their browser open while you join."
+msgstr ""
+
+#~ msgid "Disconnected"
+#~ msgstr ""
+
+#. 0: status
+#: src/components/BrowserPeerPanel.tsx
+msgid "Browser sync · {0}"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to edit this drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to view this drive"
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -910,7 +910,6 @@ msgid "App menu"
 msgstr "Menu de l'application"
 
 #: src/components/SideBar/SideBarDrive.tsx
-#: src/views/ErrorPage.tsx
 msgid "Unauthorized"
 msgstr "Non autorisé"
 
@@ -1053,12 +1052,12 @@ msgstr "Copier le secret pour continuer"
 
 #: src/views/ErrorPage.tsx
 #: src/views/ErrorPage.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Retry"
 msgstr "Réessayer"
 
-#: src/views/ErrorPage.tsx
-msgid "You don't have access to this, try signing in:"
-msgstr "Vous n'avez pas accès à ceci, essayez de vous connecter :"
+#~ msgid "You don't have access to this, try signing in:"
+#~ msgstr "Vous n'avez pas accès à ceci, essayez de vous connecter :"
 
 #. 0: resource.subject
 #: src/views/ErrorPage.tsx
@@ -3723,6 +3722,7 @@ msgstr "Entrez une URL Atomique ou recherchez (appuyez sur \"/\")"
 msgid "Search"
 msgstr "Rechercher"
 
+#: src/components/InviteForm.tsx
 #: src/helpers/managed/cloudSync.ts
 #: src/helpers/managed/reconcile.test.ts
 #: src/helpers/managed/reconcile.ts
@@ -3963,9 +3963,8 @@ msgstr ""
 msgid "Restore & sign in"
 msgstr ""
 
-#: src/views/getting-started/GettingStartedFlow.tsx
-msgid "Sign in to access this drive"
-msgstr ""
+#~ msgid "Sign in to access this drive"
+#~ msgstr ""
 
 #: src/views/getting-started/GettingStartedFlow.tsx
 msgid "Enter your agent secret to unlock this drive on this device."
@@ -4853,6 +4852,7 @@ msgstr ""
 
 #: src/chunks/Conference/ConferenceRoom.tsx
 #: src/routes/SyncRoute.tsx
+#: src/views/PeerInvitePage.tsx
 msgid "Connecting…"
 msgstr ""
 
@@ -5668,6 +5668,7 @@ msgstr ""
 msgid "Could not show your secret."
 msgstr ""
 
+#: src/components/AccountRecoveryCard.tsx
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlocking…"
 msgstr ""
@@ -6863,20 +6864,16 @@ msgstr ""
 msgid "Store it with {0}"
 msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/AccountRecoveryCard.tsx
-msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
-msgstr ""
+#~ msgid "This backup is sealed in this browser only. {0} is not holding a copy, so a new device could not get you back in."
+#~ msgstr ""
 
 #. 0: managedAccount.email
 #: src/routes/SyncRoute.tsx
 msgid "{0}. Your backup is sealed in this browser and nowhere else, so it unlocks here but a new device could not get you back in."
 msgstr ""
 
-#. 0: ' '; 1: `${ [hasPasskey && 'your passkey', hasCode && 'your recovery code'] .filter(Boolean) .join(' or ') || 'your recovery password' }${deviceOnly ? ', on this device' \\: ''}.`
-#: src/components/AccountRecoveryCard.tsx
-msgid "You can get back in with:{0} {1}"
-msgstr ""
+#~ msgid "You can get back in with:{0} {1}"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "An always-on device has an address. One you carry has a code instead, shown below."
@@ -7614,9 +7611,8 @@ msgstr ""
 #~ msgid "Cloud Server: each new team editor needs one seat. Existing team editors count once across drives. Viewers are free."
 #~ msgstr ""
 
-#: src/components/InviteForm.tsx
-msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
-msgstr ""
+#~ msgid "Viewers are free. Allowing edits requires a team editor seat for Cloud Server."
+#~ msgstr ""
 
 #: src/components/AI/LocalOllamaDiscovery.tsx
 msgid "Local Ollama detected"
@@ -7742,6 +7738,7 @@ msgid "A recovery code is a spare key for when your passkey isn't available. You
 msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
+#: src/components/AccountRecoveryCard.tsx
 msgid "Add a passkey"
 msgstr "Ajouter une clé d’accès"
 
@@ -7862,18 +7859,122 @@ msgstr ""
 msgid "This sign-in passkey cannot unlock backups. Create a compatible account passkey to use for both."
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Could not update your passkey."
-msgstr ""
+#~ msgid "Could not update your passkey."
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Create a compatible account passkey"
 msgstr ""
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Use one passkey for sign-in and recovery"
-msgstr ""
+#~ msgid "Use one passkey for sign-in and recovery"
+#~ msgstr ""
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Unlock your backup, then choose your account passkey. Your existing recovery methods keep working."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Unlock this drive"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "You’re signed in as"
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid ", but this browser needs your account key to open this private drive. Paste your saved agent secret below. No account recovery backup is available."
+msgstr ""
+
+#: src/views/getting-started/GettingStartedFlow.tsx
+msgid "Loading account"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Unlock with recovery code"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Setting up passkey…"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Continue with passkey"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Could not update your passkey. Please try again."
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "Use another account"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "This account does not have access"
+msgstr ""
+
+#: src/views/ErrorPage.tsx
+msgid "You’re signed in, but this account cannot read this resource. Open it with the account that owns it, or ask its owner to share it with you."
+msgstr ""
+
+#: src/components/InviteForm.tsx
+msgid "Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server."
+msgstr ""
+
+#: src/routes/InviteRoute.tsx
+msgid "Invalid invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Could not join this drive."
+msgstr ""
+
+#~ msgid "Connected to"
+#~ msgstr ""
+
+#~ msgid "You're invited to {0} this drive"
+#~ msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Invitation unavailable"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Join drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Looking for the inviter’s browser…"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Sign in to join"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "Open drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This invitation is invalid or has expired. Ask for a new invitation."
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "This drive syncs between browsers. The person who invited you needs to keep their browser open while you join."
+msgstr ""
+
+#~ msgid "Disconnected"
+#~ msgstr ""
+
+#. 0: status
+#: src/components/BrowserPeerPanel.tsx
+msgid "Browser sync · {0}"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to edit this drive"
+msgstr ""
+
+#: src/views/PeerInvitePage.tsx
+msgid "You're invited to view this drive"
 msgstr ""

--- a/browser/data-browser/src/routes/InviteRoute.tsx
+++ b/browser/data-browser/src/routes/InviteRoute.tsx
@@ -1,3 +1,4 @@
+import { PeerInvitePage } from '../views/PeerInvitePage';
 import { createRoute } from '@tanstack/react-router';
 import { useResource, useStore } from '@tomic/react';
 import InvitePage from '../views/InvitePage';
@@ -22,6 +23,20 @@ function InviteRouteComponent() {
   if (!token) {
     return <p>No invite token provided.</p>;
   }
+
+  let browserInvite = false;
+  let invalid = false;
+
+  try {
+    const data = JSON.parse(atob(token));
+    browserInvite =
+      data['https://atomicdata.dev/properties/invite/transport'] === 'webrtc';
+  } catch {
+    invalid = true;
+  }
+
+  if (invalid) return <p>Invalid invitation.</p>;
+  if (browserInvite) return <PeerInvitePage token={token} />;
 
   const subject = `${store.getServerUrl()}/invites?token=${encodeURIComponent(token)}`;
 

--- a/browser/data-browser/src/routes/NewDriveRoute.tsx
+++ b/browser/data-browser/src/routes/NewDriveRoute.tsx
@@ -1,3 +1,4 @@
+import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
 import { FormEvent, useEffect, useState, type JSX } from 'react';
 import { createRoute } from '@tanstack/react-router';
 import { useStore } from '@tomic/react';
@@ -59,7 +60,10 @@ function NewDrivePage(): JSX.Element {
     setError(undefined);
 
     try {
-      const resource = await store.createDrive(trimmed, { personal: false });
+      const resource = await store.createDrive(trimmed, {
+        personal: false,
+        localOnly: !!getManagedPortalUrl(),
+      });
       store.notifyResourceManuallyCreated(resource);
       setDrive(resource.subject);
 

--- a/browser/data-browser/src/views/ErrorPage.tsx
+++ b/browser/data-browser/src/views/ErrorPage.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from '@tanstack/react-router';
 import { ContainerWide } from '../components/Containers';
 import { ErrorBlock } from '../components/ErrorLook';
 import { Button } from '../components/Button';
-import { SignInButton } from '../components/SignInButton';
 import { useSettings } from '../helpers/AppSettings';
 import { ResourcePageProps } from './ResourcePage';
 import { Column, Row } from '../components/Row';
@@ -73,26 +72,30 @@ function ErrorPage({ resource }: ResourcePageProps): JSX.Element {
     return (
       <ContainerWide>
         <Column>
-          <h1>Unauthorized</h1>
-          {agent ? (
-            <>
-              <ErrorBlock error={resource.error!} />
-              <span>
-                <Button
-                  onClick={() =>
-                    store.fetchResourceFromServer(resource.subject)
-                  }
-                >
-                  Retry
-                </Button>
-              </span>
-            </>
-          ) : (
-            <>
-              <p>{"You don't have access to this, try signing in:"}</p>
-              <SignInButton />
-            </>
-          )}
+          <h1>This account does not have access</h1>
+          <p>
+            You’re signed in, but this account cannot read this resource. Open
+            it with the account that owns it, or ask its owner to share it with
+            you.
+          </p>
+          <Row wrapItems>
+            <Button
+              onClick={() =>
+                navigate({
+                  to: paths.welcome,
+                  search: { next: resource.subject, from_portal: undefined },
+                })
+              }
+            >
+              Use another account
+            </Button>
+            <Button
+              subtle
+              onClick={() => store.fetchResourceFromServer(resource.subject)}
+            >
+              Retry
+            </Button>
+          </Row>
         </Column>
       </ContainerWide>
     );

--- a/browser/data-browser/src/views/PeerInvitePage.tsx
+++ b/browser/data-browser/src/views/PeerInvitePage.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import { decodeBrowserInvite } from '@tomic/lib';
+import { useStore } from '@tomic/react';
+import { useSettings } from '../helpers/AppSettings';
+import { Button } from '../components/Button';
+import { ContainerNarrow } from '../components/Containers';
+import { Column } from '../components/Row';
+import { ErrorLook } from '../components/ErrorLook';
+import { getManagedPortalUrl } from '../helpers/managed/cloudSync';
+import {
+  automaticPeerRoom,
+  defaultPeerSignalingUrl,
+  savePeerLink,
+  resumePeerLinks,
+  peerLinkStatus,
+  PEER_LINK_CHANGED,
+} from '../helpers/browserPeerSync';
+
+export function PeerInvitePage({ token }: { token: string }) {
+  const store = useStore();
+  const { agent, setDrive } = useSettings();
+  const [status, setStatus] = useState('');
+  const [ready, setReady] = useState(false);
+  const [joining, setJoining] = useState(false);
+  const [error, setError] = useState<Error>();
+  let invite: ReturnType<typeof decodeBrowserInvite> | undefined;
+
+  try {
+    invite = decodeBrowserInvite(token);
+  } catch {
+    /* Render a safe error below. */
+  }
+
+  const drive = invite?.drive;
+  useEffect(() => {
+    const update = () => {
+      const current = drive ? peerLinkStatus(drive) : '';
+      setStatus(current);
+      setReady(
+        !!drive &&
+          !!store.resources.get(drive)?.isReady() &&
+          current.startsWith(/* @wc-ignore */ 'Connected to'),
+      );
+    };
+
+    update();
+    window.addEventListener(PEER_LINK_CHANGED, update);
+    const timer = setInterval(update, 500);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener(PEER_LINK_CHANGED, update);
+    };
+  }, [drive, store]);
+
+  const join = async () => {
+    try {
+      const checked = decodeBrowserInvite(token);
+      if (!store.getAgent() || !store.getClientDb())
+        throw new Error('Sign in and wait for local storage to be ready.');
+      // Only a newly received drive is made local-only. Existing server placement
+      // belongs to its explicit hosting flow, not to invitation routing.
+      if (
+        !(await store.getClientDb()!.getResourceWithSnapshot(checked.drive))
+          .snapshot
+      )
+        store.registerLocalOnlyDrive(checked.drive);
+      savePeerLink(store, {
+        drive: checked.drive,
+        room: await automaticPeerRoom(checked.drive),
+        signalingUrl: defaultPeerSignalingUrl(),
+        expectedPeer: checked.issuer,
+        invitation: token,
+      });
+      resumePeerLinks(store);
+      setJoining(true);
+      setError(undefined);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e : new Error('Could not join this drive.'),
+      );
+    }
+  };
+
+  const open = () => {
+    if (!drive) return;
+    setDrive(drive);
+    window.location.assign(
+      `/app/show?${new URLSearchParams({ subject: drive })}`,
+    );
+  };
+
+  const signIn = () => {
+    const portal = getManagedPortalUrl();
+    const url = new URL(portal ?? '/app/welcome', window.location.origin);
+    url.searchParams.set('invite', token);
+    window.location.assign(url.href);
+  };
+
+  return (
+    <ContainerNarrow>
+      <Column>
+        <h1>
+          {invite
+            ? invite.write
+              ? "You're invited to edit this drive"
+              : "You're invited to view this drive"
+            : 'Invitation unavailable'}
+        </h1>
+        {invite ? (
+          <>
+            <p>
+              This drive syncs between browsers. The person who invited you
+              needs to keep their browser open while you join.
+            </p>
+            {!agent ? (
+              <Button onClick={signIn}>Sign in to join</Button>
+            ) : ready ? (
+              <Button onClick={open}>Open drive</Button>
+            ) : (
+              <Button onClick={join} disabled={joining}>
+                {joining ? 'Connecting…' : 'Join drive'}
+              </Button>
+            )}
+            {joining && (
+              <p role='status'>
+                {status || 'Looking for the inviter’s browser…'}
+              </p>
+            )}
+            {joining && !ready && (
+              <Button subtle onClick={join}>
+                Retry
+              </Button>
+            )}
+          </>
+        ) : (
+          <p>
+            This invitation is invalid or has expired. Ask for a new invitation.
+          </p>
+        )}
+        {error && <ErrorLook>{error.message}</ErrorLook>}
+      </Column>
+    </ContainerNarrow>
+  );
+}

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '../../components/Spinner';
 import { resumeInviteUrl } from '../../helpers/inviteSignup';
 import { WorkspaceLoading } from './WorkspaceLoading';
 import {
@@ -147,7 +148,10 @@ export function GettingStartedFlow({
    * server has answered, which is the state a wiped browser is in. Null on a
    * self-hosted install, where the button stays hidden rather than dead.
    */
-  const [knownPortalUrl, setKnownPortalUrl] = useState<string | null>(null);
+  const [knownPortalUrl, setKnownPortalUrl] = useState<string | null>(
+    () =>
+      safePortalUrl(getManagedPortalUrl() ?? getRememberedProvider()) ?? null,
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -185,7 +189,10 @@ export function GettingStartedFlow({
   // sign-in step and return them to that drive afterwards (not their home).
   const inviteToken = new URLSearchParams(window.location.search).get('invite');
   const nextDrive =
-    new URLSearchParams(window.location.search).get('next') || undefined;
+    new URLSearchParams(window.location.search).get('next') ||
+    new URLSearchParams(window.location.search).get('drive') ||
+    new URLSearchParams(window.location.search).get('subject') ||
+    undefined;
   const [step, setStep] = useState<Step>(
     fromManaged
       ? 'create'
@@ -195,6 +202,13 @@ export function GettingStartedFlow({
           ? 'signin'
           : initialStep,
   );
+  useEffect(() => {
+    // A configured SaaS app uses the portal as its account entry point.
+    // A direct drive URL already starts at the unlock step above.
+    if (step === 'welcome' && knownPortalUrl) {
+      window.location.replace(new URL('/dashboard', knownPortalUrl).toString());
+    }
+  }, [step, knownPortalUrl]);
   const [loading, setLoading] = useState(false);
   const [workspaceStage, setWorkspaceStage] = useState<
     'identity' | 'local' | 'backup'
@@ -332,6 +346,12 @@ export function GettingStartedFlow({
 
   // ─── Restore ("Forgot your secret?") ─────────────────────────────────────
   const [restore, setRestore] = useState<RestoreState>({ phase: 'checking' });
+  const returnToPortal =
+    !!knownPortalUrl &&
+    (fromManaged ||
+      createTarget?.kind === 'portal' ||
+      restore.phase === 'ready' ||
+      restore.phase === 'no-backup');
   const [restoreCodeInput, setRestoreCodeInput] = useState('');
   // Set when a v1 (password-only) backup is lazily upgraded to envelope v2
   // during a restore — the user must save this new code before continuing,
@@ -792,7 +812,11 @@ export function GettingStartedFlow({
 
   return (
     <Shell>
-      {step === 'opening-workspace' ? (
+      {step === 'welcome' && (!createTarget || knownPortalUrl) ? (
+        <div role='status' aria-label='Loading account'>
+          <Spinner />
+        </div>
+      ) : step === 'opening-workspace' ? (
         <Swap key='opening-workspace'>
           <OnboardingWrap>
             <OnboardingCard>
@@ -910,11 +934,23 @@ export function GettingStartedFlow({
             <OnboardingCard key='card'>
               <Column gap='1rem'>
                 <CardTitle key='title'>
-                  {nextDrive ? 'Sign in to access this drive' : 'Sign in'}
+                  {nextDrive ? 'Unlock this drive' : 'Sign in'}
                 </CardTitle>
                 {nextDrive && !restoreUnlock.showPasskey ? (
                   <CardSubtitle key='subtitle'>
-                    Enter your agent secret to unlock this drive on this device.
+                    {restore.phase === 'no-backup' ? (
+                      <>
+                        You’re signed in as {restore.email}, but this browser
+                        needs your account key to open this private drive. Paste
+                        your saved agent secret below. No account recovery
+                        backup is available.
+                      </>
+                    ) : (
+                      <>
+                        Enter your agent secret to unlock this drive on this
+                        device.
+                      </>
+                    )}
                   </CardSubtitle>
                 ) : null}
 
@@ -1021,13 +1057,12 @@ export function GettingStartedFlow({
                         {secretError ?? error?.message}
                       </CardError>
                     ) : null}
-                    {/* Hidden once accounts are listed above: that picker is
-                        already the "recover via my account" route, and a
-                        second door to the same room just adds a button. Also
-                        hidden when no portal is known — a source build with
-                        nothing to restore from — because the step behind it
-                        can then only say "sign in first" with nowhere to. */}
-                    {knownAccounts.length === 0 && knownPortalUrl ? (
+                    {/* A portal URL or session alone does not mean there is a
+                        backup to restore. Wait for the encrypted backup check;
+                        known accounts already have their own picker above. */}
+                    {knownAccounts.length === 0 &&
+                    knownPortalUrl &&
+                    restore.phase === 'ready' ? (
                       <Button
                         key='forgot'
                         type='button'
@@ -1043,7 +1078,7 @@ export function GettingStartedFlow({
                         {`Forgot it? Restore from ${PRODUCT_NAME}`}
                       </Button>
                     ) : null}
-                    {nextDrive ? (
+                    {nextDrive && !returnToPortal ? (
                       // The sign-in guard (ErrorPage → here with `next`) can't
                       // tell a returning user on a new device from a total
                       // stranger who's never had an account — both hit an
@@ -1089,7 +1124,14 @@ export function GettingStartedFlow({
                 onClick={() => {
                   setError(undefined);
                   setSecretValue('');
-                  setStep('welcome');
+
+                  if (returnToPortal && knownPortalUrl) {
+                    window.location.assign(
+                      new URL('/dashboard', knownPortalUrl).toString(),
+                    );
+                  } else {
+                    setStep('welcome');
+                  }
                 }}
               >
                 <BackLabel>
@@ -1373,7 +1415,15 @@ export function GettingStartedFlow({
                 key='back'
                 subtle
                 type='button'
-                onClick={() => setStep('welcome')}
+                onClick={() => {
+                  if (knownPortalUrl) {
+                    window.location.assign(
+                      new URL('/dashboard', knownPortalUrl).toString(),
+                    );
+                  } else {
+                    setStep('welcome');
+                  }
+                }}
               >
                 <BackLabel>
                   <FaArrowLeft key='icon' aria-hidden />

--- a/browser/e2e/scripts/peer-sync-harness.ts
+++ b/browser/e2e/scripts/peer-sync-harness.ts
@@ -66,3 +66,4 @@ export async function createDrive(store: Store) {
   return drive.subject;
 }
 export { BrowserPeerSync, core };
+export { generateInviteToken } from '../../lib/src/invites.js';

--- a/browser/e2e/scripts/verify-peer-sync.mjs
+++ b/browser/e2e/scripts/verify-peer-sync.mjs
@@ -73,6 +73,10 @@ try {
   const identities = await Promise.all(
     [a, b].map(page => page.evaluate(() => window.state.agent.subject)),
   );
+  const invitation = process.env.ATOMIC_PEER_INVITE === '1'
+    ? await a.evaluate(drive => window.harness.generateInviteToken(drive, window.state.agent, true, undefined, undefined, true), drive)
+    : undefined;
+  if (!invitation) {
   await a.evaluate(
     async ({ drive, identities }) => {
       const resource = window.state.store.resources.get(drive);
@@ -86,10 +90,11 @@ try {
     },
     { drive, identities },
   );
+  }
   const room = randomBytes(32).toString('hex');
   const connect = async page =>
     page.evaluate(
-      ({ drive, room, expectedPeer, signalingUrl }) => {
+      ({ drive, room, expectedPeer, signalingUrl, invitation }) => {
         const { store } = window.state;
         store.registerLocalOnlyDrive(drive);
         store.setDrive(drive);
@@ -98,6 +103,7 @@ try {
           room,
           signalingUrl,
           expectedPeer,
+          invitation,
           iceServers: [],
           onStatus: status => {
             window.peerStatus = status;
@@ -109,6 +115,7 @@ try {
         drive,
         room,
         signalingUrl,
+        invitation: page === b ? invitation : undefined,
         expectedPeer: page === a ? identities[1] : identities[0],
       },
     );

--- a/browser/e2e/tests/browser-invite.spec.ts
+++ b/browser/e2e/tests/browser-invite.spec.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'node:path';
+import { test, expect } from '@playwright/test';
+import { devDrive, FRONTEND_URL } from './test-utils';
+
+// Real app routes and real SaaS signaling; no data-node invite redemption.
+// The separate peer harness additionally disables ALL data requests.
+test('joins an unhosted drive through its signed browser invitation', async ({ browser }) => {
+  test.setTimeout(90000);
+  const owner = await browser.newPage();
+  const guest = await browser.newPage();
+  try {
+    await devDrive(owner);
+    await devDrive(guest);
+    const invitation = await owner.evaluate(async inviteModule => {
+      const { generateInviteToken } = await import(inviteModule);
+      const { automaticPeerRoom, defaultPeerSignalingUrl, savePeerLink, resumePeerLinks } = await import('/src/helpers/browserPeerSync.ts');
+      const store = window.store;
+      const drive = await store.createDrive('Browser invite acceptance', { personal: false, localOnly: true });
+      const token = await generateInviteToken(drive.subject, store.getAgent(), true, undefined, undefined, true);
+      savePeerLink(store, { drive: drive.subject, room: await automaticPeerRoom(drive.subject), signalingUrl: defaultPeerSignalingUrl() });
+      resumePeerLinks(store);
+      return token;
+    }, `/@fs${resolve(__dirname, '../../lib/src/invites.ts')}`);
+    const inviteRequests: string[] = [];
+    guest.on('request', request => { if (new URL(request.url()).pathname === '/invites') inviteRequests.push(request.method()); });
+    await guest.goto(`${FRONTEND_URL}/app/invite?${new URLSearchParams({ token: invitation })}`);
+    await expect(guest.getByRole('heading', { name: "You're invited to edit this drive" })).toBeVisible();
+    await guest.getByRole('button', { name: 'Join drive', exact: true }).click();
+    await expect(guest.getByRole('button', { name: 'Open drive', exact: true })).toBeVisible({ timeout: 45000 });
+    expect(inviteRequests).toEqual([]);
+    await guest.getByRole('button', { name: 'Open drive', exact: true }).click();
+    await expect(guest).toHaveURL(/\/app\/show\?subject=/);
+  } finally { await owner.close(); await guest.close(); }
+});

--- a/browser/e2e/tests/recovery-option.spec.ts
+++ b/browser/e2e/tests/recovery-option.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// A portal session is not evidence that an encrypted recovery backup exists.
+test('does not offer account recovery when the signed-in account has no backup', async ({ page }) => {
+  await page.route('**/api/me', route => route.fulfill({ json: { email: 'no-backup@example.com' } }));
+  await page.route('**/api/recovery-secret', route => route.fulfill({ status: 204 }));
+  const checked = page.waitForResponse(response => response.url().endsWith('/api/recovery-secret'));
+  await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome?next=did%3Aad%3Atest`);
+  await expect(page.getByLabel('Agent secret', { exact: true })).toBeVisible();
+  await checked;
+  await expect(page.getByRole('heading', { name: 'Unlock this drive' })).toBeVisible();
+  await expect(page.getByText(/You’re signed in as no-backup@example.com/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /^Forgot it\? Restore from/ })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toHaveCount(0);
+  await page.route('**/dashboard', route => route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }));
+  await page.getByRole('button', { name: 'Back', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Portal drives' })).toBeVisible();
+});
+
+test('managed welcome goes to the portal instead of standalone onboarding', async ({ page }) => {
+  const welcomeFrames: string[] = [];
+  await page.exposeFunction('reportStandaloneWelcome', () => welcomeFrames.push('shown'));
+  await page.addInitScript(() => {
+    new MutationObserver(() => {
+      if ([...document.querySelectorAll('button')].some(button => button.textContent?.includes('Try the live demo'))) {
+        (window as unknown as { reportStandaloneWelcome: () => void }).reportStandaloneWelcome();
+      }
+    }).observe(document, { childList: true, subtree: true });
+  });
+  await page.route('**/dashboard', route => route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }));
+  await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome`);
+  await expect(page.getByRole('heading', { name: 'Portal drives' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Try the live demo' })).toHaveCount(0);
+  expect(welcomeFrames).toEqual([]);
+});

--- a/browser/lib/src/browser-peer-invite.test.ts
+++ b/browser/lib/src/browser-peer-invite.test.ts
@@ -1,0 +1,107 @@
+import { expect, it, vi } from 'vitest';
+import { Agent } from './agent.js';
+import { generateInviteToken } from './invites.js';
+import { createAuthentication } from './authentication.js';
+import { authorizeBrowserInvite } from './browser-peer-invite.js';
+import type { Store } from './store.js';
+
+async function newAgent() {
+  const keys = await Agent.generateKeyPair();
+
+  return Agent.fromSecret(
+    Agent.buildSecret(keys.privateKey, `did:ad:agent:${keys.publicKey}`),
+  );
+}
+
+async function fixture() {
+  const issuer = await newAgent();
+  const recipient = await newAgent();
+  const drive = 'did:ad:private-drive';
+  const challenge = `${drive}#channel-bound-challenge`;
+  const resource = {
+    isReady: () => true,
+    canWrite: async () => [true],
+    push: vi.fn(),
+    save: vi.fn(),
+    hasClasses: () => true,
+  };
+  const store = {
+    getAgent: () => issuer,
+    resources: new Map([[drive, resource]]),
+    getClientDb: () => ({ flush: vi.fn() }),
+  } as unknown as Store;
+  const token = await generateInviteToken(drive, issuer, true);
+  const auth = await createAuthentication(challenge, recipient);
+
+  return { issuer, recipient, drive, challenge, resource, store, token, auth };
+}
+
+it('grants a valid invite to the identity proving this channel, with a signed save', async () => {
+  const f = await fixture();
+  await authorizeBrowserInvite(f.store, f.drive, f.token, f.auth, f.challenge);
+  expect(f.resource.push).toHaveBeenCalledWith(
+    'https://atomicdata.dev/properties/read',
+    [f.recipient.subject],
+    true,
+  );
+  expect(f.resource.push).toHaveBeenCalledWith(
+    'https://atomicdata.dev/properties/write',
+    [f.recipient.subject],
+    true,
+  );
+  expect(f.resource.save).toHaveBeenCalledOnce();
+});
+it.each([
+  'expired',
+  'wrong-drive',
+  'wrong-channel',
+  'forged',
+  'revoked',
+  'wrong-recipient',
+])('rejects %s before granting access', async kind => {
+  const f = await fixture();
+  if (kind === 'expired')
+    f.token = await generateInviteToken(
+      f.drive,
+      f.issuer,
+      true,
+      Date.now() - 1000,
+    );
+  if (kind === 'wrong-drive')
+    f.token = await generateInviteToken('did:ad:other', f.issuer, true);
+  if (kind === 'wrong-channel') f.challenge += 'other';
+
+  if (kind === 'forged') {
+    const token = JSON.parse(atob(f.token));
+    token['https://atomicdata.dev/properties/invite/write'] = false;
+    f.token = btoa(JSON.stringify(token));
+  }
+
+  if (kind === 'revoked') f.resource.canWrite = async () => [false];
+  if (kind === 'wrong-recipient')
+    f.auth['https://atomicdata.dev/properties/auth/agent'] = f.issuer.subject!;
+  await expect(
+    authorizeBrowserInvite(f.store, f.drive, f.token, f.auth, f.challenge),
+  ).rejects.toThrow();
+  expect(f.resource.push).not.toHaveBeenCalled();
+});
+
+it('a viewer invitation grants read access only', async () => {
+  const f = await fixture();
+  f.token = await generateInviteToken(f.drive, f.issuer, false);
+  await authorizeBrowserInvite(f.store, f.drive, f.token, f.auth, f.challenge);
+  expect(f.resource.push).toHaveBeenCalledTimes(1);
+  expect(f.resource.push).toHaveBeenCalledWith(
+    'https://atomicdata.dev/properties/read',
+    [f.recipient.subject],
+    true,
+  );
+});
+it('does not accept an invitation issued by another identity', async () => {
+  const f = await fixture();
+  f.token = await generateInviteToken(f.drive, f.recipient, true);
+  await expect(
+    authorizeBrowserInvite(f.store, f.drive, f.token, f.auth, f.challenge),
+  ).rejects.toThrow();
+  expect(f.resource.push).not.toHaveBeenCalled();
+});

--- a/browser/lib/src/browser-peer-invite.ts
+++ b/browser/lib/src/browser-peer-invite.ts
@@ -1,0 +1,89 @@
+import stringify from 'fast-json-stable-stringify';
+import { verify } from '@noble/ed25519';
+import { decodeB64 } from './base64.js';
+import { core } from './ontologies/core.js';
+import { server } from './ontologies/server.js';
+import { properties } from './urls.js';
+import type { Store } from './store.js';
+
+const AUTH = 'https://atomicdata.dev/properties/auth/';
+const EXPIRES = 'https://atomicdata.dev/properties/invite/expiresAt';
+
+/** Verify locally without fetching an issuer profile from a data server. */
+export function decodeBrowserInvite(token: string) {
+  if (token.length > 4096) throw new Error('Invite is too large');
+  const data = JSON.parse(atob(token));
+  const drive = data[server.properties.target];
+  const issuer = data[properties.commit.signer];
+  if (
+    typeof drive !== 'string' ||
+    !drive.startsWith('did:ad:') ||
+    /[?#]/.test(drive) ||
+    typeof issuer !== 'string' ||
+    !issuer.startsWith('did:ad:agent:') ||
+    typeof data[server.properties.write] !== 'boolean' ||
+    !Number.isSafeInteger(data[EXPIRES]) ||
+    data[EXPIRES] <= Date.now()
+  )
+    throw new Error('Invalid or expired browser invite');
+  const signature = data[properties.commit.signature];
+  delete data[properties.commit.signature];
+  if (
+    typeof signature !== 'string' ||
+    !verify(
+      decodeB64(signature),
+      new TextEncoder().encode(stringify(data)),
+      decodeB64(issuer.slice('did:ad:agent:'.length)),
+    )
+  )
+    throw new Error('Invalid invite signature');
+
+  return { drive, issuer, write: data[server.properties.write] as boolean };
+}
+
+/** The issuer grants rights through a normal signed commit, never an unsafe
+ * snapshot edit. Called before Rust AUTH, which independently checks the grant.
+ * The bearer token is released only after the recipient authenticates the issuer. */
+export async function authorizeBrowserInvite(
+  store: Store,
+  drive: string,
+  token: string,
+  auth: Record<string, unknown>,
+  challenge: string,
+): Promise<void> {
+  const invite = decodeBrowserInvite(token);
+  const issuer = store.getAgent();
+  if (invite.drive !== drive || invite.issuer !== issuer?.subject)
+    throw new Error('This browser cannot accept that invitation');
+  const recipient = auth[`${AUTH}agent`];
+  const timestamp = auth[`${AUTH}timestamp`];
+  const signature = auth[`${AUTH}signature`];
+  if (
+    typeof recipient !== 'string' ||
+    !recipient.startsWith('did:ad:agent:') ||
+    auth[`${AUTH}requestedSubject`] !== challenge ||
+    auth[`${AUTH}publicKey`] !== recipient.slice('did:ad:agent:'.length) ||
+    typeof timestamp !== 'number' ||
+    !Number.isSafeInteger(timestamp) ||
+    Math.abs(Date.now() - timestamp) > 60000 ||
+    typeof signature !== 'string' ||
+    !verify(
+      decodeB64(signature),
+      new TextEncoder().encode(`${challenge} ${timestamp}`),
+      decodeB64(recipient.slice('did:ad:agent:'.length)),
+    )
+  )
+    throw new Error('Invalid invite recipient authentication');
+  const resource = store.resources.get(drive);
+  if (
+    !resource?.isReady() ||
+    !resource.hasClasses(server.classes.drive) ||
+    !(await resource.canWrite(issuer.subject))[0]
+  )
+    throw new Error('Invite issuer no longer has access');
+  if (store.getAgent() !== issuer) throw new Error('Account changed');
+  resource.push(core.properties.read, [recipient], true);
+  if (invite.write) resource.push(core.properties.write, [recipient], true);
+  await resource.save();
+  await store.getClientDb()?.flush();
+}

--- a/browser/lib/src/browser-peer-sync.ts
+++ b/browser/lib/src/browser-peer-sync.ts
@@ -1,3 +1,4 @@
+import { authorizeBrowserInvite } from './browser-peer-invite.js';
 import type { Agent } from './agent.js';
 import type { ClientDbWorker } from './client-db.js';
 import type { Store } from './store.js';
@@ -12,6 +13,8 @@ export interface BrowserPeerOptions {
   signalingUrl: string;
   /** Trusted agent for bootstrapping an unknown drive; stored drive ACLs govern subsequent peers. */
   expectedPeer?: string;
+  /** Signed bearer invite; sent only after authenticating expectedPeer. */
+  invitation?: string;
   iceServers?: RTCIceServer[];
   onStatus?: (status: string) => void;
 }
@@ -303,11 +306,13 @@ class BrowserPeerConnection {
       this.store.getClientDb() === this.db;
     const binding = await peer.channelBinding();
     const challenge = `${binding}:${randomPeerToken()}`;
+    const hasSnapshot = !!(
+      await this.db.getResourceWithSnapshot(this.options.drive)
+    ).snapshot;
+    const invitation = hasSnapshot ? undefined : this.options.invitation;
     const session = await this.db!.createPeerSession(
       this.options.drive,
-      (await this.db.getResourceWithSnapshot(this.options.drive)).snapshot
-        ? undefined
-        : this.options.expectedPeer,
+      hasSnapshot && !invitation ? undefined : this.options.expectedPeer,
       challenge,
     );
 
@@ -325,6 +330,7 @@ class BrowserPeerConnection {
     let authenticated = false;
     let accepted = false;
     let started = false;
+    let pendingAuth: Record<string, unknown> | undefined;
     const timeout = setTimeout(() => {
       if (!started) this.fail(new Error('Peer authentication timed out'));
     }, 15000);
@@ -346,14 +352,52 @@ class BrowserPeerConnection {
             `${this.options.drive}#${remoteChallenge}`,
             this.agent!,
           );
-          await pipe.send(encodeAuth(JSON.stringify(auth)));
+
+          if (invitation) {
+            if (!this.options.expectedPeer)
+              throw new Error('Invite issuer is required');
+            pendingAuth = { ...auth, browserInvite: invitation };
+          } else {
+            await pipe.send(encodeAuth(JSON.stringify(auth)));
+          }
         } else if (frame[0] === Tag.AUTH_OK) {
           if (!challenged || accepted)
             throw new Error('Unexpected authentication acknowledgement');
           accepted = true;
         } else {
+          if (frame[0] === Tag.AUTH && !authenticated) {
+            if (frame.length > 8192)
+              throw new Error('Peer authentication is too large');
+            const auth = JSON.parse(
+              new TextDecoder().decode(frame.subarray(1)),
+            );
+
+            if (auth.browserInvite !== undefined) {
+              if (typeof auth.browserInvite !== 'string')
+                throw new Error('Invalid browser invite');
+              await authorizeBrowserInvite(
+                this.store,
+                this.options.drive,
+                auth.browserInvite,
+                auth,
+                `${this.options.drive}#${challenge}`,
+              );
+            }
+          }
+
           const output = await this.db!.handlePeerFrame(session, frame);
-          if (frame[0] === Tag.AUTH) authenticated = true;
+
+          if (frame[0] === Tag.AUTH) {
+            authenticated = true;
+
+            // Rust verified the issuer against the link's pinned identity. Only
+            // now may this connection receive the bearer invitation.
+            if (pendingAuth) {
+              await pipe.send(encodeAuth(JSON.stringify(pendingAuth)));
+              pendingAuth = undefined;
+            }
+          }
+
           for (const bytes of output.frames)
             await pipe.send(Uint8Array.from(bytes));
 

--- a/browser/lib/src/index.ts
+++ b/browser/lib/src/index.ts
@@ -106,3 +106,5 @@ export {
   randomPeerToken,
   type BrowserPeerOptions,
 } from './browser-peer-sync.js';
+
+export { decodeBrowserInvite } from './browser-peer-invite.js';

--- a/browser/lib/src/invites.ts
+++ b/browser/lib/src/invites.ts
@@ -17,6 +17,7 @@ export async function generateInviteToken(
   write = false,
   expiresAt?: number,
   description?: string,
+  browserPeer = false,
 ): Promise<string> {
   const expires = expiresAt ?? Date.now() + 1000 * 60 * 60 * 24 * 30; // 30 days default
 
@@ -32,6 +33,9 @@ export async function generateInviteToken(
   if (description && description.trim().length > 0) {
     signable[core.properties.description] = description.trim();
   }
+
+  if (browserPeer)
+    signable['https://atomicdata.dev/properties/invite/transport'] = 'webrtc';
 
   const serialized = stringify(signable);
   const signature = await agent.sign(serialized);

--- a/browser/lib/src/store.saved-drives.test.ts
+++ b/browser/lib/src/store.saved-drives.test.ts
@@ -50,3 +50,20 @@ describe('recording a new drive on the personal drive', () => {
     expect(store.getAllSubjects().length).toBe(before);
   });
 });
+
+it('a local-only additional drive never posts its data to the selected server', async () => {
+  const { store, posted } = await testStore();
+  await store.ensurePrivateDrive();
+  posted.length = 0;
+  const drive = await store.createDrive('Browser collaboration', {
+    personal: false,
+    localOnly: true,
+  });
+  expect(store.isLocalOnlyDrive(drive.subject)).toBe(true);
+  const ontology = drive.get(server.properties.defaultOntology);
+  expect(
+    posted.some(
+      commit => commit.subject === drive.subject || commit.subject === ontology,
+    ),
+  ).toBe(false);
+});

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -308,6 +308,8 @@ function searchDebug(...args: unknown[]): void {
 }
 
 export interface CreateDriveOpts {
+  /** Keep a newly created drive local until explicit hosting enrollment. */
+  localOnly?: boolean;
   /** Shown on the drive page. Personal drives default to 'Your personal drive.'. */
   description?: string;
   /** Subdomain to serve the drive on (e.g. 'my-drive'). */
@@ -2340,6 +2342,7 @@ export class Store {
       subject: personalSubject,
     });
 
+    if (opts.localOnly) this.registerLocalOnlyDrive(drive.subject);
     await drive.save();
 
     if (personal) {

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -1041,3 +1041,20 @@ Corrections to what this page previously claimed:
 - `UNSUB` was said to work. It did not, until this revision.
 - `SYNC_DIFF.remove` was said to be optional. The encoder always emits it;
   only decoders tolerate its absence.
+
+### Browser invitation bootstrap over WebRTC
+
+Browser-only drive invitations are signed JSON-AD invite tokens with
+`https://atomicdata.dev/properties/invite/transport` set to `webrtc`. The
+transport marker is included in the signature. These are not redeemed at a
+data node's `/invites` endpoint.
+
+The recipient pins the token issuer as its expected peer for the unknown drive.
+After verifying that issuer's channel-bound AUTH, it sends its own channel-bound
+AUTH with an optional `browserInvite` string carrying the signed token. This
+field is sent only over the authenticated WebRTC connection, never signaling.
+The issuer validates its own token, expiry, target and recipient proof, checks
+its current write authority, and saves a normal signed ACL commit granting the
+requested access. Ordinary peer AUTH/ACL checks then run before any sync data is
+sent. Other peers cannot redeem an issuer's token. Reconnecting after a trusted
+local snapshot exists uses normal ACL authentication without re-redeeming it.

--- a/planning/README.md
+++ b/planning/README.md
@@ -33,6 +33,13 @@ now live in [`completed/`](./completed/):
 
 Remaining work, not "this file exists."
 
+Cross-repository account recovery: the canonical active plan is
+`atomic-saas/planning/BACKUP_SECURITY.md`, section “SaaS password sign-in and
+assisted recovery — September 10 direction”. Product direction is agreed;
+password authentication and server-assisted recovery are not implemented.
+It owns the security review, migration and acceptance checklist for the managed
+browser flow; standalone recovery remains self-managed.
+
 | Document | Status |
 | --- | --- |
 | [`sentry-feedback-readiness.md`](./sentry-feedback-readiness.md) | **Active.** Sidebar feedback and React error capture implemented and locally verified against Sentry. Staging rollout, email receipt and private source-map upload remain release gates. |

--- a/planning/serverless-p2p.md
+++ b/planning/serverless-p2p.md
@@ -372,3 +372,41 @@ the work is hardening and consolidation the codebase needs anyway.
    confirm is P3.
 4. **Drive enrollment on pairing** — pair grants which drives? All of the
    agent's, or picked at pair time (`KnownPeer.drives`)?
+
+## Unhosted browser invitations (2026-09-10, active)
+
+- [x] Reproduce and test invite validation at the client-library layer.
+- [x] Authenticate the issuer before releasing a bearer invite; grant the
+  recipient access with an ordinary issuer-signed commit before peer sync.
+- [x] Route new local-only drive invites through the app and SaaS discovery, without
+  invoking the managed data-node invite endpoint.
+- [ ] Preserve invitations through account onboarding and use existing sync UI.
+- [x] Verify a new identity joins, edits and reconnects with data HTTP disabled;
+  reject expired/forged/wrong-drive invites and unauthorized peers.
+- [ ] Audit managed-node admission and source placement separately from billing
+  labels. Do not hide a real node connection or drop existing drive data.
+
+The issuer must currently be online to redeem an unhosted invitation. Discovery
+only locates peers; no private snapshots travel before authentication and grant.
+
+Implementation notes: new SaaS identities and additional drives now stay local
+from their first save, including when the app is served from a node origin.
+The issuer grants a signed invitation through an ordinary signed ACL commit;
+the recipient releases the bearer token only after verifying the pinned issuer
+on the WebRTC channel. Browser invites require the issuer online. Old server
+invite links do not gain this protocol retroactively.
+
+Remaining legacy migration: an unsubscribed drive may already have data on a
+managed node, admitted under its 600-second bootstrap grace. Do not treat a
+root-resource snapshot or the account's enrollment list as proof of a complete
+local copy. Invite creation refuses browser-only conversion of such drives
+until an authenticated full-drive + attachment verification/migration exists.
+Keep the actual connection visible and existing copies intact. Need staging
+inspection to establish the reported drive's placement and deployed policy;
+the local policy default is evidence of a possible path, not proof of that
+specific staging node's configuration. No managed admission defaults changed.
+
+Validation: client-library negative invite tests, real WebRTC/OPFS invite
+acceptance with all AtomicServer data fetches disabled, and a two-identity app
+route test without `/invites` requests. Account creation/email roundtrip for a
+brand-new invited SaaS user remains a separate acceptance check.


### PR DESCRIPTION
Unhosted SaaS drives now stay local and can be shared through signed WebRTC invitations. Recipients authenticate the inviter before sending the invitation; the inviter grants permissions through a signed commit. Existing server-backed drives retain their connection until a complete local migration can be verified.

Also fixes managed welcome navigation, conditional recovery availability, recovery/passkey action feedback, and drive catalog icons.

Validation: app TypeScript, browser/lib lint (warnings remain), 42 focused unit tests, and five browser tests passed locally. The real WebRTC harness with HTTP data access disabled passed during implementation. Existing-drive migration and fresh-account email signup through a peer invite remain unverified.

Paired with the same branch in ontola/atomic-saas. Password recovery is documented as a proposal only; the separate staging feedback delivery issue remains unresolved.
