### PR TITLE
Fix lint in browser invitation tests

### DIFF
--- a/browser/e2e/scripts/verify-peer-sync.mjs
+++ b/browser/e2e/scripts/verify-peer-sync.mjs
@@ -73,24 +73,38 @@ try {
   const identities = await Promise.all(
     [a, b].map(page => page.evaluate(() => window.state.agent.subject)),
   );
-  const invitation = process.env.ATOMIC_PEER_INVITE === '1'
-    ? await a.evaluate(drive => window.harness.generateInviteToken(drive, window.state.agent, true, undefined, undefined, true), drive)
-    : undefined;
+  const invitation =
+    process.env.ATOMIC_PEER_INVITE === '1'
+      ? await a.evaluate(
+          drive =>
+            window.harness.generateInviteToken(
+              drive,
+              window.state.agent,
+              true,
+              undefined,
+              undefined,
+              true,
+            ),
+          drive,
+        )
+      : undefined;
+
   if (!invitation) {
-  await a.evaluate(
-    async ({ drive, identities }) => {
-      const resource = window.state.store.resources.get(drive);
-      for (const prop of ['read', 'write'])
-        await resource.set(
-          `https://atomicdata.dev/properties/${prop}`,
-          identities,
-          false,
-        );
-      await resource.save();
-    },
-    { drive, identities },
-  );
+    await a.evaluate(
+      async ({ drive, identities }) => {
+        const resource = window.state.store.resources.get(drive);
+        for (const prop of ['read', 'write'])
+          await resource.set(
+            `https://atomicdata.dev/properties/${prop}`,
+            identities,
+            false,
+          );
+        await resource.save();
+      },
+      { drive, identities },
+    );
   }
+
   const room = randomBytes(32).toString('hex');
   const connect = async page =>
     page.evaluate(

--- a/browser/e2e/tests/browser-invite.spec.ts
+++ b/browser/e2e/tests/browser-invite.spec.ts
@@ -4,31 +4,73 @@ import { devDrive, FRONTEND_URL } from './test-utils';
 
 // Real app routes and real SaaS signaling; no data-node invite redemption.
 // The separate peer harness additionally disables ALL data requests.
-test('joins an unhosted drive through its signed browser invitation', async ({ browser }) => {
+test('joins an unhosted drive through its signed browser invitation', async ({
+  browser,
+}) => {
   test.setTimeout(90000);
   const owner = await browser.newPage();
   const guest = await browser.newPage();
+
   try {
     await devDrive(owner);
     await devDrive(guest);
-    const invitation = await owner.evaluate(async inviteModule => {
-      const { generateInviteToken } = await import(inviteModule);
-      const { automaticPeerRoom, defaultPeerSignalingUrl, savePeerLink, resumePeerLinks } = await import('/src/helpers/browserPeerSync.ts');
-      const store = window.store;
-      const drive = await store.createDrive('Browser invite acceptance', { personal: false, localOnly: true });
-      const token = await generateInviteToken(drive.subject, store.getAgent(), true, undefined, undefined, true);
-      savePeerLink(store, { drive: drive.subject, room: await automaticPeerRoom(drive.subject), signalingUrl: defaultPeerSignalingUrl() });
-      resumePeerLinks(store);
-      return token;
-    }, `/@fs${resolve(__dirname, '../../lib/src/invites.ts')}`);
+    const invitation = await owner.evaluate(
+      async inviteModule => {
+        const { generateInviteToken } = await import(inviteModule);
+        const {
+          automaticPeerRoom,
+          defaultPeerSignalingUrl,
+          savePeerLink,
+          resumePeerLinks,
+        } = await import('/src/helpers/browserPeerSync.ts');
+        const store = window.store;
+        const drive = await store.createDrive('Browser invite acceptance', {
+          personal: false,
+          localOnly: true,
+        });
+        const token = await generateInviteToken(
+          drive.subject,
+          store.getAgent(),
+          true,
+          undefined,
+          undefined,
+          true,
+        );
+        savePeerLink(store, {
+          drive: drive.subject,
+          room: await automaticPeerRoom(drive.subject),
+          signalingUrl: defaultPeerSignalingUrl(),
+        });
+        resumePeerLinks(store);
+
+        return token;
+      },
+      `/@fs${resolve(__dirname, '../../lib/src/invites.ts')}`,
+    );
     const inviteRequests: string[] = [];
-    guest.on('request', request => { if (new URL(request.url()).pathname === '/invites') inviteRequests.push(request.method()); });
-    await guest.goto(`${FRONTEND_URL}/app/invite?${new URLSearchParams({ token: invitation })}`);
-    await expect(guest.getByRole('heading', { name: "You're invited to edit this drive" })).toBeVisible();
-    await guest.getByRole('button', { name: 'Join drive', exact: true }).click();
-    await expect(guest.getByRole('button', { name: 'Open drive', exact: true })).toBeVisible({ timeout: 45000 });
+    guest.on('request', request => {
+      if (new URL(request.url()).pathname === '/invites')
+        inviteRequests.push(request.method());
+    });
+    await guest.goto(
+      `${FRONTEND_URL}/app/invite?${new URLSearchParams({ token: invitation })}`,
+    );
+    await expect(
+      guest.getByRole('heading', { name: "You're invited to edit this drive" }),
+    ).toBeVisible();
+    await guest
+      .getByRole('button', { name: 'Join drive', exact: true })
+      .click();
+    await expect(
+      guest.getByRole('button', { name: 'Open drive', exact: true }),
+    ).toBeVisible({ timeout: 45000 });
     expect(inviteRequests).toEqual([]);
-    await guest.getByRole('button', { name: 'Open drive', exact: true }).click();
+    await guest
+      .getByRole('button', { name: 'Open drive', exact: true })
+      .click();
     await expect(guest).toHaveURL(/\/app\/show\?subject=/);
-  } finally { await owner.close(); await guest.close(); }
+  } finally {
+    await owner.close();
+    await guest.close();
+  }
 });


### PR DESCRIPTION
Fix four required blank lines and format the browser invitation harness and acceptance test. This changes test formatting only; application behavior is unchanged. Focused oxlint passes with existing console warnings.