### PR TITLE
CI and integration certification hardening

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -273,23 +273,49 @@ export class AtomicServer {
    * Mount shared crates.io + git dependency caches under `cargoHome`, and
    * pin `CARGO_BUILD_JOBS` so rustc doesn't spawn one job per visible host
    * CPU (containers see the full Mancave SMT count). Registry content is
-   * identical across glibc/musl images, so both share the `cargo` /
-   * `cargo-git` volumes — only the mount path differs.
+   * identical across glibc/musl images, so both share dependency volumes
+   * and Cargo cache locks — only the mount path differs.
    */
   private withCargoHomeCache(
     container: Container,
     cargoHome: string,
   ): Container {
-    return container
-      .withMountedCache(`${cargoHome}/registry`, dag.cacheVolume('cargo'), {
-        // Shared: Locked serialized every parallel CI lane behind whichever
-        // job held the volume. Cargo's own flock handles concurrent writers.
-        sharing: CacheSharingMode.Shared,
-      })
-      .withMountedCache(`${cargoHome}/git`, dag.cacheVolume('cargo-git'), {
-        sharing: CacheSharingMode.Shared,
-      })
-      .withEnvVariable('CARGO_BUILD_JOBS', this.hostKnobs.cargoBuildJobs);
+    return (
+      container
+        .withMountedCache(
+          `${cargoHome}/registry`,
+          dag.cacheVolume('cargo-shared-locks-v1'),
+          {
+            sharing: CacheSharingMode.Shared,
+          },
+        )
+        .withMountedCache(
+          `${cargoHome}/git`,
+          dag.cacheVolume('cargo-git-shared-locks-v1'),
+          {
+            sharing: CacheSharingMode.Shared,
+          },
+        )
+        // Cargo locks live in CARGO_HOME, outside registry/git. Sharing only
+        // those directories leaves every container with independent locks and
+        // lets simultaneous downloads race while unpacking the same crate.
+        // Put both lock inodes in the shared registry volume; Cargo still only
+        // serializes downloads/mutations, not the entire parallel build lane.
+        // Fresh volume names keep older jobs with private locks out of this cache.
+        .withExec([
+          'ln',
+          '-sf',
+          'registry/.package-cache',
+          `${cargoHome}/.package-cache`,
+        ])
+        .withExec([
+          'ln',
+          '-sf',
+          'registry/.package-cache-mutate',
+          `${cargoHome}/.package-cache-mutate`,
+        ])
+        .withEnvVariable('CARGO_BUILD_JOBS', this.hostKnobs.cargoBuildJobs)
+    );
   }
 
   /**
@@ -730,7 +756,7 @@ export class AtomicServer {
           'atomic-server',
           '--no-default-features',
           '--features',
-          'light',
+          'light,wasm-plugins',
         ])
         .withExec([
           'cp',
@@ -1068,10 +1094,19 @@ export class AtomicServer {
       )
       // data-browser/src/helpers/pairing.test.ts reads a repo-root testdata
       // fixture the same way (`../../../../testdata/pairing-request.json`
-      // from /app/data-browser/src/helpers) — mount just this one file.
+      // from /app/data-browser/src/helpers). `/testdata` isn't an OS path
+      // (unlike `/lib` above), so mount the whole directory rather than
+      // picking files one at a time — lib/plugin-plan.fixtures.test.ts also
+      // needs to `readdirSync` the `plugin-plans/` subdirectory, which a
+      // single-file mount can't provide.
+      .withDirectory('/testdata', this.source.directory('testdata'))
+      // lib/src/task-schema.test.ts reads repo-root `lib/defaults/tasks.json`
+      // the same plain-`readFileSync` way as genesis_test_vectors.json above
+      // (`../../../lib/defaults/tasks.json` from /app/lib/src). Mount just
+      // this file, under the same /lib collision caution as above.
       .withFile(
-        '/testdata/pairing-request.json',
-        this.source.file('testdata/pairing-request.json'),
+        '/lib/defaults/tasks.json',
+        this.source.file('lib/defaults/tasks.json'),
       );
 
     // Build all packages since they may depend on each other's built artifacts
@@ -1145,7 +1180,17 @@ export class AtomicServer {
       )
       .withDirectory('/code/atomic-plugin', source.directory('atomic-plugin'))
       .withDirectory('/code/tools', source.directory('tools'))
-      .withMountedCache('/code/target', dag.cacheVolume('rust-target-v3'))
+      // v3 -> v4: `atomic-server`'s build.rs only declares
+      // `rerun-if-changed` on `plugin-runtime/{src,wit}` and
+      // `ATOMICSERVER_SKIP_PLUGIN_RUNTIME` — it has no way to know "the
+      // wasm32-wasip2 target just became installed". Adding the `rustup
+      // target add` step above changed the container, but every prior CI
+      // run had already fingerprinted build.rs's output (an empty embedded
+      // runtime, from before that target existed) into this cache volume,
+      // so cargo kept trusting the stale fingerprint and never re-ran
+      // build_plugin_runtime() to notice the target was now there. Bumping
+      // the volume forces one full rebuild that actually re-evaluates it.
+      .withMountedCache('/code/target', dag.cacheVolume('rust-target-v4'))
       .withExec(TOUCH_WORKSPACE_SOURCES)
       .withWorkdir('/code')
       .withExec(['cargo', 'fetch']);
@@ -1201,11 +1246,10 @@ export class AtomicServer {
     // `rustBuildSlim`'s glibc path (different symptom there — ABI mismatch,
     // not a missing binary — same root cause).
     //
-    // E2E exception: `plugin.spec.ts` needs `wasm-plugins` so the test
-    // plugin's `after_commit` can rename folders. `light` is https-only and
-    // silently makes that assertion hang until timeout. Defaults minus
-    // `vector-search` (the ort/musl gap above) is enough — wasmtime builds
-    // fine on this musl-cross image.
+    // All server builds include `wasm-plugins`: plugin handlers are compiled
+    // unconditionally, and the E2E suite also executes server-side plugins.
+    // `vector-search` remains excluded because of the ort/musl gap above.
+    let wasmPluginsEnabled = false;
     if (target.includes('musl')) {
       if (e2e) {
         buildArgs.push(
@@ -1213,8 +1257,14 @@ export class AtomicServer {
           '--features',
           'https,wasm-plugins',
         );
+        wasmPluginsEnabled = true;
       } else {
-        buildArgs.push('--no-default-features', '--features', 'light');
+        buildArgs.push(
+          '--no-default-features',
+          '--features',
+          'light,wasm-plugins',
+        );
+        wasmPluginsEnabled = true;
       }
     }
     // A named profile lands in `target/<triple>/<profile>/`, not `release/`.
@@ -1224,8 +1274,25 @@ export class AtomicServer {
         ? `/code/target/${target}/release/atomic-server`
         : `/code/target/${target}/debug/atomic-server`;
 
+    // `wasm-plugins`'s build.rs compiles `atomic-plugin-runtime` for
+    // `wasm32-wasip2` as a nested `cargo build`, separate from the rustc
+    // that's already on this image. Without the target's std lib installed,
+    // that nested build fails and build.rs treats it as "plugins are an
+    // optional degradation" — it swallows the failure and ships a server
+    // with an empty embedded runtime instead of erroring the build. Every
+    // e2e test that actually exercises server-side plugin execution
+    // (this one and `plugin.spec.ts`) then hangs until timeout on a 500
+    // from `/plugin-run`, with nothing in the build log to point at why.
+    // `rustTest()` already installs this target for the same reason —
+    // same fix, applied where the e2e server binary is actually built.
+    const containerReadyToBuild = wasmPluginsEnabled
+      ? containerWithAssets
+          .withExec(['rustup', 'target', 'add', 'wasm32-wasip2'])
+          .withEnvVariable('ATOMICSERVER_REQUIRE_PLUGIN_RUNTIME', 'true')
+      : containerWithAssets;
+
     return (
-      containerWithAssets
+      containerReadyToBuild
         .withExec(buildArgs)
         // .withExec([targetPath, "--version"])
         .withExec(['cp', targetPath, '/atomic-server-binary'])
@@ -1339,6 +1406,7 @@ export class AtomicServer {
     return (
       this.rustChecksContainer()
         .withExec(['rustup', 'target', 'add', 'wasm32-wasip2'])
+        .withEnvVariable('ATOMICSERVER_REQUIRE_PLUGIN_RUNTIME', 'true')
         // Persist nextest in the shared cargo-bin volume. Previously the
         // curl install sat *after* the source mount, so every Rust source
         // change re-downloaded it. The `linux-musl` URL is required: the
@@ -1401,12 +1469,11 @@ export class AtomicServer {
     // system OpenSSL we don't ship. Default features are what the release
     // binary already builds with.
     //
-    // `--no-default-features --features light`: same ort/musl/cuda gap as
-    // `rustTest` above — `vector-search`'s `ort` dep has no prebuilt binary
-    // for this target, so even a lint-only pass can't compile it. Means
-    // vector-search-gated code isn't clippy-checked on this path; the
-    // tradeoff was a deliberate call, not an oversight — see rustTest's
-    // comment for the full reasoning.
+    // `--no-default-features --features light,wasm-plugins`: same
+    // ort/musl/cuda gap as `rustTest` above — `vector-search`'s `ort` dep has
+    // no prebuilt binary for this target, so even a lint-only pass can't
+    // compile it. Vector-search-gated code isn't clippy-checked on this path;
+    // plugin code is included because rustTest uses the same feature set.
     return this.rustChecksContainer()
       .withExec([
         'cargo',
@@ -1418,7 +1485,7 @@ export class AtomicServer {
         '--all-targets',
         '--no-default-features',
         '--features',
-        'light',
+        'light,wasm-plugins',
       ])
       .stdout();
   }
@@ -1755,12 +1822,24 @@ export class AtomicServer {
      * guess the git ref. See `ci()` for why this is not named `e2eMode`.
      */
     @argument() playwrightMode: string = 'full',
+    /**
+     * Optional Playwright regular expression for one focused browser journey.
+     * A focused run stays on one server/shard, so an exact test does not run
+     * alongside unrelated E2E failures.
+     */
+    @argument() playwrightGrep: string = '',
   ): Promise<string> {
     // Shards × own atomic-server. Count comes from `--host-profile`
     // (Mancave hot / hosted conservative) plus `--playwright-mode` (light uses
     // fewer shards). Dagger dedupes the shared debug `rustBuild(e2e)` /
     // base-container graph.
     this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(playwrightMode));
+    if (playwrightGrep)
+      this.e2eRun = {
+        ...this.e2eRun,
+        shardCount: 1,
+        grep: playwrightGrep,
+      };
     const shardCount = this.e2eRun.shardCount;
     const base = this.e2eBaseContainer();
     const shardIndexes = Array.from({ length: shardCount }, (_, i) => i + 1);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ on:
 # Queue instead of overlap; never cancel a run that is already going.
 concurrency:
   group: main-pipeline
+  # The default keeps only one pending run and replaces it on the next push.
+  queue: max
   cancel-in-progress: false
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.
@@ -235,6 +237,10 @@ jobs:
           token: ${{ secrets.ATOMIC_SAAS_DISPATCH_TOKEN }}
           path: atomic-saas
           clean: false
+          # Nothing below pushes to atomic-saas, so the PAT has no business
+          # staying in atomic-saas/.git/config on the self-hosted runner
+          # (where `clean: false` keeps the checkout around between runs).
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.98.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release (github, dockerhub, crates.io)
 
-permissions: write-all
+# Least privilege per job below; nothing here needs more than `contents`.
+# Creating the release and attaching assets need `contents: write`; the
+# crates.io publish authenticates with CARGO_REGISTRY_TOKEN, not GITHUB_TOKEN.
+permissions: {}
 
 on:
   push:
@@ -17,6 +20,8 @@ jobs:
     # reason. Self-hosted is for main.yml, where a warm Dagger cache is worth
     # having and a stall only costs slow CI.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -153,6 +158,8 @@ jobs:
   create-release:
     name: Create Release on GitHub
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.0.1
@@ -194,6 +201,8 @@ jobs:
     # Deliberately NOT CI_RUNNER, for the same reason the other release jobs
     # avoid it: a release must not wait on one machine being switched on.
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -237,6 +246,8 @@ jobs:
     # cannot serve the macos-latest leg. Pinning the whole matrix to it would
     # silently stop producing macOS binaries.
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -302,13 +302,20 @@ jobs:
         if: matrix.os == 'macos-latest' && needs.preflight.outputs.sign_apple != 'true'
         run: echo "APPLE_SIGNING_IDENTITY=-" >> "$GITHUB_ENV"
 
+      # The secrets reach the script through `env:`, not `${{ }}` inside
+      # `run:`: an expression is substituted into the script text before the
+      # shell sees it, so a value with a quote or `$` would become shell code.
       - name: Enable notarization
         if: matrix.os == 'macos-latest' && needs.preflight.outputs.notarize == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           {
-            echo "APPLE_ID=${{ secrets.APPLE_ID }}"
-            echo "APPLE_PASSWORD=${{ secrets.APPLE_PASSWORD }}"
-            echo "APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}"
+            echo "APPLE_ID=$APPLE_ID"
+            echo "APPLE_PASSWORD=$APPLE_PASSWORD"
+            echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
           } >> "$GITHUB_ENV"
 
       - name: Build and bundle

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -1,5 +1,10 @@
 # Testing coverage map
 
+`integrations/tooling/certify.test.mjs` rebuilds every certified provider through
+a symlinked repository layout and compares the shipped bytes, covering CI mount
+paths and package-manager symlinks. Provider Vitest configurations use explicit
+package roots so certification also works when invoked from `/`.
+
 What is tested, at which layer, and — the part that matters — **what is not**.
 
 This exists because the protocol is far better tested than the glue around it,

--- a/integrations/clockify/vitest.config.ts
+++ b/integrations/clockify/vitest.config.ts
@@ -1,4 +1,5 @@
 export default {
+  root: new URL('.', import.meta.url).pathname,
   resolve: {
     alias: {
       vitest: new URL(
@@ -7,5 +8,5 @@ export default {
       ).pathname,
     },
   },
-  test: { include: ['integrations/clockify/*.test.ts'] },
+  test: { include: ['*.test.ts'] },
 };

--- a/integrations/github-issues/adapter.test.ts
+++ b/integrations/github-issues/adapter.test.ts
@@ -1,8 +1,12 @@
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { preview, project, manifest, type Issue } from './adapter.js';
 import { validateManifest } from '../../browser/lib/src/plugin-manifest.js';
 import { readFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+const root = fileURLToPath(new URL('../../', import.meta.url));
 const issue = (number: number): Issue => ({
   number,
   title: `Issue ${number}`,
@@ -18,19 +22,25 @@ describe('GitHub package', () => {
   });
   it('ships exactly the artifact tested by the sandbox', async () => {
     const built = execFileSync(
-      './browser/node_modules/.bin/esbuild',
+      existsSync(resolve(root, 'browser/node_modules/.bin/esbuild'))
+        ? resolve(root, 'browser/node_modules/.bin/esbuild')
+        : resolve(root, 'browser/node_modules/.pnpm/node_modules/.bin/esbuild'),
       [
         'integrations/github-issues/plugin.ts',
+        '--preserve-symlinks',
         '--bundle',
         '--format=esm',
         '--platform=neutral',
         '--target=es2022',
       ],
-      { encoding: 'utf8' },
+      { encoding: 'utf8', cwd: root },
     );
-    expect(await readFile('integrations/github-issues/plugin.js', 'utf8')).toBe(
-      built,
-    );
+    expect(
+      await readFile(
+        resolve(root, 'integrations/github-issues/plugin.js'),
+        'utf8',
+      ),
+    ).toBe(built);
   });
   it('reads every page and excludes pull requests', async () => {
     const issues = Array.from({ length: 101 }, (_, i) => issue(i + 1));
@@ -75,7 +85,7 @@ it('keeps the sandbox action manifest fixture current', async () => {
   expect(
     JSON.parse(
       await readFile(
-        'integrations/github-issues/manifest.fixture.json',
+        resolve(root, 'integrations/github-issues/manifest.fixture.json'),
         'utf8',
       ),
     ),

--- a/integrations/github-issues/plugin.js
+++ b/integrations/github-issues/plugin.js
@@ -28,9 +28,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// browser/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify/index.js
+// browser/lib/node_modules/fast-json-stable-stringify/index.js
 var require_fast_json_stable_stringify = __commonJS({
-  "browser/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify/index.js"(exports, module) {
+  "browser/lib/node_modules/fast-json-stable-stringify/index.js"(exports, module) {
     "use strict";
     module.exports = function(data, opts) {
       if (!opts) opts = {};

--- a/integrations/github-issues/vitest.config.ts
+++ b/integrations/github-issues/vitest.config.ts
@@ -1,4 +1,5 @@
 export default {
+  root: new URL('.', import.meta.url).pathname,
   resolve: {
     alias: {
       vitest: new URL(
@@ -7,5 +8,5 @@ export default {
       ).pathname,
     },
   },
-  test: { include: ['integrations/github-issues/*.test.ts'] },
+  test: { include: ['*.test.ts'] },
 };

--- a/integrations/mt940/README.md
+++ b/integrations/mt940/README.md
@@ -56,5 +56,5 @@ offline peers still need collision resolution after synchronization.
 Reference: https://bankrec.westpac.com.au/docs/statements/mt940/
 
 Tests: `./browser/node_modules/.bin/vitest run --config integrations/mt940/vitest.config.ts`
-Bundle: `./browser/node_modules/.bin/esbuild integrations/mt940/plugin.ts --bundle --format=esm --platform=neutral --target=es2022 > integrations/mt940/plugin.js`
+Bundle: `./browser/node_modules/.bin/esbuild integrations/mt940/plugin.ts --preserve-symlinks --bundle --format=esm --platform=neutral --target=es2022 > integrations/mt940/plugin.js`
 Browser: `browser/e2e/tests/mt940.spec.ts` (synthetic file, real runtime/persistence).

--- a/integrations/mt940/vitest.config.ts
+++ b/integrations/mt940/vitest.config.ts
@@ -1,4 +1,5 @@
 export default {
+  root: new URL('.', import.meta.url).pathname,
   resolve: {
     alias: {
       vitest: new URL(
@@ -7,5 +8,5 @@ export default {
       ).pathname,
     },
   },
-  test: { include: ['integrations/mt940/*.test.ts'] },
+  test: { include: ['*.test.ts'] },
 };

--- a/integrations/notion/README.md
+++ b/integrations/notion/README.md
@@ -60,7 +60,7 @@ be blindly retried.
 From the repository root:
 
 ```sh
-./browser/node_modules/.bin/esbuild integrations/notion/plugin.ts --bundle --format=esm --platform=neutral --target=es2022 --outfile=integrations/notion/plugin.js
+./browser/node_modules/.bin/esbuild integrations/notion/plugin.ts --preserve-symlinks --bundle --format=esm --platform=neutral --target=es2022 --outfile=integrations/notion/plugin.js
 ./browser/node_modules/.bin/vitest run --config integrations/notion/vitest.config.ts
 ./browser/node_modules/.bin/tsc -p integrations/notion/tsconfig.json
 ATOMICSERVER_SKIP_JS_BUILD=true cargo test -p atomic-server --lib notion_bundle --no-default-features --features light,wasm-plugins

--- a/integrations/notion/package.test.ts
+++ b/integrations/notion/package.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import { it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
@@ -5,6 +7,7 @@ import { manifest } from './model.js';
 import { validateManifest } from '../../browser/lib/src/plugin-manifest.js';
 import { install } from './atomic.js';
 import type { Store } from '../../browser/lib/src/index.js';
+const root = fileURLToPath(new URL('../../', import.meta.url));
 it('rejects a missing provider before touching the store or credentials', async () => {
   await expect(
     install(
@@ -18,23 +21,29 @@ it('rejects a missing provider before touching the store or credentials', async 
 });
 it('ships the reproducible bundle that runtime tests execute', () => {
   const built = execFileSync(
-    './browser/node_modules/.bin/esbuild',
+    resolve(root, 'browser/node_modules/.bin/esbuild'),
     [
       'integrations/notion/plugin.ts',
+      '--preserve-symlinks',
       '--bundle',
       '--format=esm',
       '--platform=neutral',
       '--target=es2022',
     ],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', cwd: root },
   );
-  expect(readFileSync('integrations/notion/plugin.js', 'utf8')).toBe(built);
+  expect(
+    readFileSync(resolve(root, 'integrations/notion/plugin.js'), 'utf8'),
+  ).toBe(built);
 });
 it('declares POST queries as reads and row updates as journaled writes', () => {
   const m = validateManifest(manifest('11111111-1111-1111-1111-111111111111'));
   expect(
     JSON.parse(
-      readFileSync('integrations/notion/manifest.fixture.json', 'utf8'),
+      readFileSync(
+        resolve(root, 'integrations/notion/manifest.fixture.json'),
+        'utf8',
+      ),
     ),
   ).toEqual(m);
   expect(m.operations.find(o => o.id === 'query')?.effect).toBe('read');

--- a/integrations/notion/plugin.js
+++ b/integrations/notion/plugin.js
@@ -28,9 +28,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// browser/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify/index.js
+// browser/lib/node_modules/fast-json-stable-stringify/index.js
 var require_fast_json_stable_stringify = __commonJS({
-  "browser/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify/index.js"(exports, module) {
+  "browser/lib/node_modules/fast-json-stable-stringify/index.js"(exports, module) {
     "use strict";
     module.exports = function(data, opts) {
       if (!opts) opts = {};

--- a/integrations/notion/vitest.config.ts
+++ b/integrations/notion/vitest.config.ts
@@ -1,4 +1,5 @@
 export default {
+  root: new URL('.', import.meta.url).pathname,
   resolve: {
     alias: {
       vitest: new URL(
@@ -7,5 +8,5 @@ export default {
       ).pathname,
     },
   },
-  test: { include: ['integrations/notion/*.test.ts'] },
+  test: { include: ['*.test.ts'] },
 };

--- a/integrations/tooling/certify.mjs
+++ b/integrations/tooling/certify.mjs
@@ -11,6 +11,18 @@ import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
 export const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+export function bundleArguments(entry) {
+  // CI aliases /browser to /app. Keep source comments relative to the logical
+  // repository paths so the shipped bytes do not depend on mount locations.
+  return [
+    entry,
+    '--preserve-symlinks',
+    '--bundle',
+    '--format=esm',
+    '--platform=neutral',
+    '--target=es2022',
+  ];
+}
 export function discover(base = root) {
   return readdirSync(resolve(base, 'integrations'), { withFileTypes: true })
     .filter(
@@ -79,6 +91,22 @@ export function evaluateJs(report) {
 export function evaluateRust(output) {
   return /test result: ok\. 1 passed; 0 failed; 0 ignored;/.test(output);
 }
+export function summarizeFailure({ error, stderr, stdout }) {
+  const line = [error, stderr, stdout]
+    .flatMap(value => String(value ?? '').split(/\r?\n/))
+    .map(value => value.trim())
+    .find(Boolean);
+  if (!line) return 'command failed without output';
+  return line.length > 240 ? `${line.slice(0, 237)}...` : line;
+}
+export function formatFailureSummary(checks) {
+  return checks
+    .filter(check => check.status === 'failed')
+    .map(check =>
+      check.detail ? `${check.name}: ${check.detail}` : check.name,
+    )
+    .join('; ');
+}
 export function certify({
   layer = 'all',
   output = resolve(root, 'artifacts/integration-certification'),
@@ -132,7 +160,13 @@ export function certify({
     });
     const text = `${r.stdout ?? ''}${r.stderr ?? ''}${r.error ? '\n' + r.error.message : ''}\nexit=${r.status} signal=${r.signal ?? 'none'}`;
     writeFileSync(resolve(output, log), text);
-    return { ok: r.status === 0, text, stdout: r.stdout };
+    return {
+      ok: r.status === 0,
+      text,
+      stdout: r.stdout,
+      stderr: r.stderr,
+      error: r.error?.message,
+    };
   };
   for (const p of packages.filter(p => !only || p.id === only)) {
     const shipped = readFileSync(resolve(root, p.path, 'plugin.js'));
@@ -148,24 +182,31 @@ export function certify({
       status: 'pending',
     };
     report.integrations.push(item);
-    const check = (name, r, extra = true) =>
-      item.checks.push({ name, status: r.ok && extra ? 'passed' : 'failed' });
+    const check = (name, r, extra = true, failedValidation) => {
+      const passed = r.ok && extra;
+      item.checks.push({
+        name,
+        status: passed ? 'passed' : 'failed',
+        ...(passed
+          ? {}
+          : {
+              detail: r.ok
+                ? failedValidation || 'validation failed'
+                : summarizeFailure(r),
+            }),
+      });
+    };
     if (layer !== 'sandbox') {
       const bundle = run(
         resolve(root, 'browser/node_modules/.bin/esbuild'),
-        [
-          `${p.path}/plugin.ts`,
-          '--bundle',
-          '--format=esm',
-          '--platform=neutral',
-          '--target=es2022',
-        ],
+        bundleArguments(`${p.path}/plugin.ts`),
         `${p.id}-bundle.log`,
       );
       check(
         'reproducible-bundle',
         bundle,
         bundle.stdout === shipped.toString(),
+        'generated bundle differs from committed plugin.js',
       );
       check(
         'typecheck',
@@ -192,7 +233,12 @@ export function certify({
       try {
         counts = JSON.parse(readFileSync(resultPath, 'utf8'));
       } catch {}
-      check('fixtures', tests, evaluateJs(counts));
+      check(
+        'fixtures',
+        tests,
+        evaluateJs(counts),
+        'test report did not contain a successful executed test',
+      );
       item.fixtureCounts = {
         passed: counts.numPassedTests ?? 0,
         skipped: counts.numPendingTests ?? 0,
@@ -217,7 +263,12 @@ export function certify({
           ],
           `${p.id}-${test.split('::').at(-1)}.log`,
         );
-        check(test, r, evaluateRust(r.text));
+        check(
+          test,
+          r,
+          evaluateRust(r.text),
+          'sandbox output did not report exactly one passing test',
+        );
       }
     item.status = item.checks.every(c => c.status === 'passed')
       ? 'passed'
@@ -226,7 +277,10 @@ export function certify({
       resolve(output, 'report.json'),
       JSON.stringify({ ...report, status: 'running' }, null, 2) + '\n',
     );
-    console.log(`${p.id}: ${item.status} (${layer}; live not run)`);
+    const failures = formatFailureSummary(item.checks);
+    console.log(
+      `${p.id}: ${item.status} (${layer}; live not run)${failures ? ` — ${failures}` : ''}`,
+    );
   }
   report.status =
     report.integrations.length &&

--- a/integrations/tooling/certify.test.mjs
+++ b/integrations/tooling/certify.test.mjs
@@ -1,9 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+  readFileSync,
+} from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { discover, evaluateJs, evaluateRust } from './certify.mjs';
+import {
+  discover,
+  root,
+  bundleArguments,
+  evaluateJs,
+  evaluateRust,
+  formatFailureSummary,
+  summarizeFailure,
+} from './certify.mjs';
 test('zero executed tests cannot certify an integration', () => {
   assert.equal(
     evaluateJs({ success: true, numPassedTests: 0, numFailedTests: 0 }),
@@ -39,6 +55,28 @@ test('new packages cannot silently escape certification', () => {
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+test('failed certification checks surface a concise useful diagnostic', () => {
+  assert.equal(
+    summarizeFailure({
+      error: 'spawnSync /browser/node_modules/.bin/esbuild ENOENT',
+      stderr: 'ignored stderr',
+      stdout: 'ignored stdout',
+    }),
+    'spawnSync /browser/node_modules/.bin/esbuild ENOENT',
+  );
+  assert.equal(
+    formatFailureSummary([
+      { name: 'typecheck', status: 'passed' },
+      {
+        name: 'reproducible-bundle',
+        status: 'failed',
+        detail: 'generated bundle differs from committed plugin.js',
+      },
+      { name: 'fixtures', status: 'failed' },
+    ]),
+    'reproducible-bundle: generated bundle differs from committed plugin.js; fixtures',
+  );
 });
 test('both current providers are discovered with exact sandbox tests', () => {
   const ids = discover().map(p => p.id);
@@ -114,4 +152,26 @@ test('store evidence rejects partial, failed and changed bundles; labels old evi
     assessEvidence(report, 'test', 'expected', now - 86400000),
     null,
   );
+});
+
+test('bundles are reproducible with CI browser and integration symlinks', () => {
+  const base = mkdtempSync(join(tmpdir(), 'atomic-bundle-paths-'));
+  try {
+    symlinkSync(join(root, 'browser'), join(base, 'browser'));
+    symlinkSync(join(root, 'integrations'), join(base, 'integrations'));
+    for (const provider of discover()) {
+      const generated = execFileSync(
+        join(root, 'browser/node_modules/.bin/esbuild'),
+        bundleArguments(`${provider.path}/plugin.ts`),
+        { cwd: base, encoding: 'utf8' },
+      );
+      assert.equal(
+        generated,
+        readFileSync(join(root, provider.path, 'plugin.js'), 'utf8'),
+        provider.id,
+      );
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/server/build.rs
+++ b/server/build.rs
@@ -595,18 +595,27 @@ fn is_newer_than_dist(dir_entry: &walkdir::DirEntry, dist_time: Duration) -> boo
 /// server-side plugins is a degraded server, not a broken build, and failing
 /// here would block anyone who never touches plugins. The absence is reported
 /// at the point someone tries to use it, not swallowed.
+/// CI sets ATOMICSERVER_REQUIRE_PLUGIN_RUNTIME=true to fail the build instead
+/// of allowing this degradation in jobs that exercise server-side plugins.
 fn build_plugin_runtime() {
     const TARGET: &str = "wasm32-wasip2";
     const CRATE: &str = "atomic-plugin-runtime";
 
     println!("cargo:rerun-if-changed=../plugin-runtime/src");
     println!("cargo:rerun-if-changed=../plugin-runtime/wit");
+    println!("cargo:rerun-if-changed=../plugin-runtime/Cargo.toml");
     println!("cargo:rerun-if-env-changed=ATOMICSERVER_SKIP_PLUGIN_RUNTIME");
+    println!("cargo:rerun-if-env-changed=ATOMICSERVER_REQUIRE_PLUGIN_RUNTIME");
+    let required = std::env::var("ATOMICSERVER_REQUIRE_PLUGIN_RUNTIME").is_ok_and(|v| v == "true");
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is set by cargo");
     let embedded = PathBuf::from(&out_dir).join("plugin_runtime.wasm");
 
     if std::env::var("ATOMICSERVER_SKIP_PLUGIN_RUNTIME").is_ok_and(|v| v == "true") {
+        assert!(
+            !required,
+            "the plugin runtime cannot be both required and skipped"
+        );
         p!("ATOMICSERVER_SKIP_PLUGIN_RUNTIME is set, skipping the plugin runtime.");
         let _ = std::fs::write(&embedded, []);
 
@@ -624,6 +633,10 @@ fn build_plugin_runtime() {
         .unwrap_or(false);
 
     if !has_target {
+        assert!(
+            !required,
+            "the required {TARGET} plugin runtime target is unavailable"
+        );
         p!("{TARGET} is unknown to this toolchain; plugins will not run server-side.");
         let _ = std::fs::write(&embedded, []);
 
@@ -640,6 +653,16 @@ fn build_plugin_runtime() {
             .env_remove("CARGO_ENCODED_RUSTFLAGS")
             .env_remove("RUSTFLAGS")
             .env_remove("CARGO_BUILD_TARGET")
+            // rust-musl-cross exports TARGET_CC/AR for the native server.
+            // cc-rs prefers these over the CC/AR selected by rquickjs's
+            // WASI SDK, so leaking them compiles QuickJS with the Linux
+            // toolchain instead of clang for WebAssembly.
+            .env_remove("TARGET_CC")
+            .env_remove("TARGET_CXX")
+            .env_remove("TARGET_AR")
+            .env_remove("TARGET_RANLIB")
+            .env_remove("TARGET_CFLAGS")
+            .env_remove("TARGET_CXXFLAGS")
             .current_dir("..")
             .status();
 
@@ -658,6 +681,10 @@ fn build_plugin_runtime() {
             );
         }
         _ => {
+            assert!(
+                !required,
+                "could not build the required {CRATE} for {TARGET}; see the nested cargo build error above"
+            );
             p!(
                 "could not build {CRATE} for {TARGET}; plugins will not run server-side. \
                  Install the target with `rustup target add {TARGET}`.",


### PR DESCRIPTION
Separates general CI infrastructure changes from #1387 so the LocalThought integration feature can be tested against the existing CI setup independently.

Includes shared Cargo cache locks, plugin-runtime build safeguards and target setup, fixture mounts, focused Playwright selection, workflow credential/permission hardening, and path-independent provider certification. The two regenerated provider bundles differ only in dependency path labels.

Validation: all four existing providers pass JavaScript certification (bundle reproducibility, typecheck, fixtures); six certification tooling tests pass, including rebuilding through symlinks. The complementary code patch applies cleanly to the narrowed #1387. Full CI is pending.

Both PRs target `feat/plugin-model`; this PR does not depend on the LocalThought feature. No CI checks are disabled.
