### PR TITLE
Unify cloud service settings and repair managed sync states

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -648,3 +648,22 @@ Paired SaaS `portal/e2e/recovery-passkey.spec.ts` uses Chromium virtual PRF auth
 - `browser/e2e/scripts/verify-peer-sync.mjs` with `ATOMIC_PEER_INVITE=1`: invitation bootstrap and real WebRTC reconciliation with HTTP data access disabled.
 - `browser/e2e/tests/recovery-option.spec.ts`: recovery availability in the managed welcome flow.
 - Existing-drive migration to browser-only storage and fresh-account email onboarding through a peer invitation remain unverified.
+
+- `browser/data-browser/src/helpers/passkeySupport.test.ts` checks secure-context and credential API availability. `browser/e2e/tests/passkey-unavailable.spec.ts` removes WebAuthn from the browser and verifies that account settings explain the limitation, hide passkey setup, and preserve recovery-code access. Native credential-provider failures with the API present remain outside this check.
+
+
+## Managed sync presentation and local transition
+
+`syncPresentation.test.ts` covers Vault-aware summaries and hiding unrelated
+saved managed nodes. `enrollmentApi.test.ts` distinguishes unknown hosting from a
+successful empty enrollment list. `client-db.test.ts` covers nested WASM Map
+normalization, and `local-drive-copy.test.ts` rejects incomplete history and
+missing/corrupt attachments.
+
+`managed-sync-presentation.spec.ts` uses a real local node and OPFS with mocked
+account/enrollment/Vault responses. It reproduces both reported connection states,
+checks refusal when local history cannot be read, switches to browser-only sync,
+and verifies an edit plus attachment survive reload without HTTP/WS data writes.
+It also exercises the compiled Vault session error path (no React hook in an
+error constructor). Actual staging billing/admission and multi-device migration
+remain separate acceptance checks.

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -101,7 +101,8 @@
     "workbox-window": "^7.4.1",
     "wuchale": "^0.25.6",
     "yjs": "^13.6.30",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@tomic/service-ui": "workspace:*"
   },
   "devDependencies": {
     "@tanstack/router-devtools": "^1.167.0",

--- a/browser/data-browser/src/components/AccountRecoveryCard.tsx
+++ b/browser/data-browser/src/components/AccountRecoveryCard.tsx
@@ -3,6 +3,7 @@ import { styled } from 'styled-components';
 import { FaKey } from 'react-icons/fa6';
 import { Agent, useStore } from '@tomic/react';
 import { Button } from './Button';
+import { hasPasskeyApi } from '../helpers/passkeySupport';
 import { Column, Row } from './Row';
 import { CodeBlock } from './CodeBlock';
 import { SecretCodeBlock } from './SecretCodeBlock';
@@ -66,6 +67,7 @@ export function AccountRecoveryCard({
   /** Picks this account's backup out of a device holding several. */
   agentSubject?: string;
 }) {
+  const passkeyAvailable = hasPasskeyApi();
   const [backup, setBackup] = useState<BackupState>({ phase: 'loading' });
   const [secret, setSecret] = useState<string | null>(null);
   const [newCode, setNewCode] = useState<string | null>(null);
@@ -404,6 +406,8 @@ export function AccountRecoveryCard({
   }
 
   async function handleUnifyPasskey() {
+    if (!passkeyAvailable) return;
+
     if (!agentSubject || backup.phase !== 'ready') return;
 
     if (!envelopeWrapperKinds(backup.secret).hasPasskey && !codeInput.trim()) {
@@ -443,6 +447,8 @@ export function AccountRecoveryCard({
   }
 
   async function handleAddPasskey() {
+    if (!passkeyAvailable) return;
+
     if (!codeInput.trim()) {
       setNeedsCode(true);
       setError(undefined);
@@ -576,7 +582,16 @@ export function AccountRecoveryCard({
         </Column>
       ) : null}
 
-      {hasSession &&
+      {!passkeyAvailable && (
+        <Hint role='status'>
+          This browser does not expose passkey support. Open this site directly
+          in a browser with passkey support, such as Chrome or Safari. Sign in
+          there with an email link to add a passkey. An embedded browser may not
+          support this.
+        </Hint>
+      )}
+      {passkeyAvailable &&
+      hasSession &&
       !addingAccountPasskey &&
       backup.secret.format_version === 2 &&
       !backup.secret.wrappers.some(w => w.kdf_params.account_passkey) ? (
@@ -644,7 +659,9 @@ export function AccountRecoveryCard({
                     ? 'Unlock with recovery code'
                     : 'Use recovery code'}
             </Button>
-            {hasSession === true && backup.secret.format_version !== 2 ? (
+            {passkeyAvailable &&
+            hasSession === true &&
+            backup.secret.format_version !== 2 ? (
               <Button
                 subtle
                 disabled={loading || !agentSubject}
@@ -653,7 +670,7 @@ export function AccountRecoveryCard({
               >
                 Add a passkey
               </Button>
-            ) : hasSession !== true && portalUrl ? (
+            ) : passkeyAvailable && hasSession !== true && portalUrl ? (
               <Button
                 subtle
                 onClick={() => window.open(`${portalUrl}/dashboard`, '_blank')}
@@ -664,8 +681,8 @@ export function AccountRecoveryCard({
           </Row>
           {needsCode ? (
             <Hint>
-              Enter your recovery code to show your secret or add a passkey on
-              this device. Your existing recovery code will keep working.
+              Enter your recovery code to unlock your backup. Your existing
+              recovery code will keep working.
             </Hint>
           ) : null}
           {passkeyAdded ? (

--- a/browser/data-browser/src/components/Vault/VaultPanel.tsx
+++ b/browser/data-browser/src/components/Vault/VaultPanel.tsx
@@ -1,8 +1,17 @@
+import {
+  ServiceSection,
+  ServiceIcon,
+  ServiceBody,
+  ServiceTitle,
+  ServiceDescription,
+  CLOUD_VAULT_DESCRIPTION,
+  CLOUD_VAULT_ON,
+} from '@tomic/service-ui';
+import '@tomic/service-ui/styles.css';
 import { styled } from 'styled-components';
-import { FaLock, FaRotateLeft, FaCloudArrowUp } from 'react-icons/fa6';
+import { FaRotateLeft, FaCloudArrowUp } from 'react-icons/fa6';
 import {
   cardSurface,
-  CardIcon,
   CARD_ACTIONS_GAP,
   CARD_BODY_GAP,
   CARD_SUB_FONT,
@@ -66,9 +75,7 @@ export function VaultPanel({
         data-vault-state='loading'
         $embedded={embedded}
       >
-        <CardIcon>
-          <FaLock />
-        </CardIcon>
+        <ServiceIcon kind='vault' />
         <Body>
           <Title>Cloud Vault</Title>
           <Sub>Checking this workspace’s backup…</Sub>
@@ -91,9 +98,7 @@ export function VaultPanel({
         data-vault-state='unavailable'
         $embedded={embedded}
       >
-        <CardIcon>
-          <FaLock />
-        </CardIcon>
+        <ServiceIcon kind='vault' />
         <Body>
           <Title>Cloud Vault</Title>
           <Sub data-testid='vault-unavailable-reason'>{status.reason}</Sub>
@@ -118,15 +123,10 @@ export function VaultPanel({
         {/* Neutral: an offer is not a service. Blue on this page means "on",
             so a vault that is off must not wear it, or the row's own answer
             contradicts its glyph. */}
-        <CardIcon>
-          <FaLock />
-        </CardIcon>
+        <ServiceIcon kind='vault' />
         <Body>
           <Title>Cloud Vault</Title>
-          <Sub>
-            Keep an encrypted copy of this workspace in {PRODUCT_NAME}. It is
-            sealed on this device, so we store it without being able to read it.
-          </Sub>
+          <Sub>{CLOUD_VAULT_DESCRIPTION}</Sub>
           {error && <ErrorText data-testid='vault-error'>{error}</ErrorText>}
           <Actions>
             <Button
@@ -167,11 +167,9 @@ export function VaultPanel({
       $accent={!embedded}
       $embedded={embedded}
     >
-      <CardIcon $tone='provider'>
-        <FaLock />
-      </CardIcon>
+      <ServiceIcon kind='vault' active={!suspended} />
       <Body>
-        <Title>Cloud Vault is on</Title>
+        <Title>{CLOUD_VAULT_ON}</Title>
         {/* The object count is an attribute as well as prose: a test asserting
             that a second backup actually stored something should read the
             number, not parse a sentence that is free to be reworded. */}
@@ -274,7 +272,10 @@ function formatWhen(unixSeconds: number): string {
 // from `theme.size(2)` (8px) while the cards around it used 0.9rem (14.4px),
 // and left its body text at the inherited 1rem against their 0.82rem — close
 // enough to look like a mistake rather than a distinction.
-const Panel = styled.div<{ $accent?: boolean; $embedded?: boolean }>`
+const Panel = styled(ServiceSection)<{
+  $accent?: boolean;
+  $embedded?: boolean;
+}>`
   ${cardSurface}
   border-color: ${p => (p.$accent ? p.theme.colors.main : undefined)};
   background: ${p => (p.$accent ? `${p.theme.colors.main}0a` : undefined)};
@@ -291,20 +292,20 @@ const Panel = styled.div<{ $accent?: boolean; $embedded?: boolean }>`
     `}
 `;
 
-const Body = styled.div`
+const Body = styled(ServiceBody)`
   display: flex;
   flex-direction: column;
   gap: ${CARD_BODY_GAP};
   min-width: 0;
 `;
 
-const Title = styled.h3`
+const Title = styled(ServiceTitle)`
   margin: 0;
   font-size: ${CARD_TITLE_FONT};
   font-weight: 600;
 `;
 
-const Sub = styled.p`
+const Sub = styled(ServiceDescription)`
   margin: 0;
   color: ${p => p.theme.colors.textLight};
   font-size: ${CARD_SUB_FONT};

--- a/browser/data-browser/src/helpers/managed/cloudSync.ts
+++ b/browser/data-browser/src/helpers/managed/cloudSync.ts
@@ -60,11 +60,11 @@ export function isCloudSyncAvailable(info?: ManagedInfo | null): boolean {
 
 /**
  * Whether `drive` already has a live enrollment on the control plane. Returns
- * false without a session or when the control plane is unreachable (both mean
- * "not backed up yet"), so the CTA shows rather than hides on a transient error.
+ * throws when the account or enrollment lookup is unavailable. Callers must
+ * keep that state unknown; it is not evidence that hosting is disabled.
  */
 export async function driveHasCloudEnrollment(drive: string): Promise<boolean> {
-  const enrollments = await getManagedEnrollments();
+  const enrollments = await getManagedEnrollments(true);
 
   return enrollments.some(
     e => e.drive_subject === drive && e.status !== 'Disabled',

--- a/browser/data-browser/src/helpers/managed/enrollmentApi.test.ts
+++ b/browser/data-browser/src/helpers/managed/enrollmentApi.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getManagedEnrollments } from './enrollmentApi';
+import { managedFetch } from './api';
+import { getManagedAccount } from './session';
+vi.mock('./api', () => ({ managedFetch: vi.fn() }));
+vi.mock('./session', () => ({ getManagedAccount: vi.fn() }));
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getManagedAccount).mockResolvedValue({
+    email: 'test@example.com',
+  } as Awaited<ReturnType<typeof getManagedAccount>>);
+});
+describe('hosting lookup uncertainty', () => {
+  it('does not treat failed requests as no hosting', async () => {
+    vi.mocked(managedFetch).mockResolvedValue(
+      new Response('', { status: 503 }),
+    );
+    await expect(getManagedEnrollments(true)).rejects.toThrow(
+      'Could not check',
+    );
+  });
+  it('does not treat signed-out sessions as no hosting', async () => {
+    vi.mocked(getManagedAccount).mockResolvedValue(null);
+    await expect(getManagedEnrollments(true)).rejects.toThrow('Sign in');
+  });
+  it('accepts a successful empty list', async () => {
+    vi.mocked(managedFetch).mockResolvedValue(Response.json([]));
+    await expect(getManagedEnrollments(true)).resolves.toEqual([]);
+  });
+  it('rejects an unexpected response shape', async () => {
+    vi.mocked(managedFetch).mockResolvedValue(Response.json({}));
+    await expect(getManagedEnrollments(true)).rejects.toThrow('Invalid');
+  });
+});

--- a/browser/data-browser/src/helpers/managed/enrollmentApi.ts
+++ b/browser/data-browser/src/helpers/managed/enrollmentApi.ts
@@ -32,15 +32,35 @@ export type ManagedEnrollmentSummary = {
  * there is no session or the control plane is unreachable (callers treat "no
  * enrollments" as "nothing to reconcile").
  */
-export async function getManagedEnrollments(): Promise<
-  ManagedEnrollmentSummary[]
-> {
-  if (!(await getManagedAccount())) return [];
+export async function getManagedEnrollments(
+  strict = false,
+): Promise<ManagedEnrollmentSummary[]> {
+  if (!(await getManagedAccount())) {
+    if (strict) throw new Error('Sign in to check Cloud Server hosting.');
+
+    return [];
+  }
+
   const response = await managedFetch(`/sync-enrollments`, {});
 
-  if (!response.ok) return [];
+  if (!response.ok) {
+    if (strict) throw new Error('Could not check Cloud Server hosting.');
+
+    return [];
+  }
 
   const body = (await response.json()) as unknown;
+
+  if (
+    strict &&
+    !Array.isArray(body) &&
+    !(
+      body &&
+      typeof body === 'object' &&
+      Array.isArray((body as { enrollments?: unknown }).enrollments)
+    )
+  )
+    throw new Error('Invalid Cloud Server hosting response.');
 
   const list = Array.isArray(body)
     ? body

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -253,9 +253,15 @@ export type VaultCapableDb = {
   ): Promise<void> | void;
 };
 
+// A plain function uses Wuchale's non-reactive runtime. Translating directly
+// in an Error constructor incorrectly injects a React hook outside a component.
+function vaultSessionEndedMessage(): string {
+  return 'Your account session has ended. Sign in again to resume backup.';
+}
+
 export class VaultSessionEndedError extends Error {
   constructor() {
-    super('Your account session has ended. Sign in again to resume backup.');
+    super(vaultSessionEndedMessage());
     this.name = /* @wc-ignore */ 'VaultSessionEndedError';
   }
 }

--- a/browser/data-browser/src/helpers/passkeySupport.test.ts
+++ b/browser/data-browser/src/helpers/passkeySupport.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hasPasskeyApi } from './passkeySupport';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('passkey API availability', () => {
+  it('rejects embedded browsers without PublicKeyCredential', () => {
+    vi.stubGlobal('window', { isSecureContext: true });
+    vi.stubGlobal('navigator', { credentials: { create() {}, get() {} } });
+    expect(hasPasskeyApi()).toBe(false);
+  });
+
+  it('requires both credential operations and a secure context', () => {
+    vi.stubGlobal('window', {
+      isSecureContext: true,
+      PublicKeyCredential: class {},
+    });
+    vi.stubGlobal('navigator', { credentials: { get() {} } });
+    expect(hasPasskeyApi()).toBe(false);
+    vi.stubGlobal('navigator', { credentials: { create() {}, get() {} } });
+    expect(hasPasskeyApi()).toBe(true);
+    vi.stubGlobal('window', {
+      isSecureContext: false,
+      PublicKeyCredential: class {},
+    });
+    expect(hasPasskeyApi()).toBe(false);
+  });
+});

--- a/browser/data-browser/src/helpers/passkeySupport.ts
+++ b/browser/data-browser/src/helpers/passkeySupport.ts
@@ -1,0 +1,12 @@
+/** API availability only; this does not promise that a credential provider
+ * supports passkeys or the PRF extension used for encrypted recovery. */
+export function hasPasskeyApi(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.isSecureContext === true &&
+    typeof window.PublicKeyCredential === 'function' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.credentials?.create === 'function' &&
+    typeof navigator.credentials?.get === 'function'
+  );
+}

--- a/browser/data-browser/src/helpers/syncPresentation.test.ts
+++ b/browser/data-browser/src/helpers/syncPresentation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { showSavedServer, syncSummary } from './syncPresentation';
+const base = {
+  missing: false,
+  local: true,
+  serverSync: false,
+  hosting: false,
+  managed: true,
+  vaultOn: false,
+};
+describe('drive-specific sync presentation', () => {
+  it('does not describe a vault-enabled local drive as unprotected', () => {
+    expect(syncSummary({ ...base, vaultOn: true })).toContain(
+      'Cloud Vault is on',
+    );
+  });
+  it('keeps legacy server sync visible without claiming paid hosting', () => {
+    expect(syncSummary({ ...base, serverSync: true })).toContain(
+      'hosting has not been confirmed',
+    );
+    expect(showSavedServer({ managed: true, activeForDrive: true })).toBe(true);
+  });
+  it('hides unrelated saved servers in SaaS but preserves standalone connections', () => {
+    expect(showSavedServer({ managed: true, activeForDrive: false })).toBe(
+      false,
+    );
+    expect(showSavedServer({ managed: false, activeForDrive: false })).toBe(
+      true,
+    );
+  });
+});

--- a/browser/data-browser/src/helpers/syncPresentation.ts
+++ b/browser/data-browser/src/helpers/syncPresentation.ts
@@ -1,0 +1,27 @@
+export function syncSummary(input: {
+  missing: boolean;
+  local: boolean;
+  serverSync: boolean;
+  hosting: boolean | null;
+  managed: boolean;
+  vaultOn: boolean;
+}): string {
+  if (input.missing)
+    return 'This device does not have this workspace yet. Fetch it from a device that has it.';
+  if (input.managed && input.serverSync && input.hosting === false)
+    return 'This drive is still syncing with a server, but Cloud Server hosting has not been confirmed.';
+  if (!input.local) return 'Your data lives on the device you’re connected to.';
+  if (input.vaultOn)
+    return 'Your data lives on this device. Cloud Vault is on; browser sync connects your open devices.';
+  if (input.serverSync)
+    return 'Your data lives on this device and syncs with a server.';
+
+  return 'Your data lives on this device. Browser sync connects when another browser is available.';
+}
+
+export function showSavedServer(input: {
+  managed: boolean;
+  activeForDrive: boolean;
+}): boolean {
+  return !input.managed || input.activeForDrive;
+}

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -4786,9 +4786,8 @@ msgstr ""
 msgid "Setting up your demo…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device — it isn’t syncing anywhere yet."
-msgstr ""
+#~ msgid "Your data lives on this device — it isn’t syncing anywhere yet."
+#~ msgstr ""
 
 #. 0: status.lastDriveSync.count.toLocaleString()
 #: src/routes/SyncRoute.tsx
@@ -4856,9 +4855,8 @@ msgstr ""
 msgid "Connecting…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
-msgstr ""
+#~ msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sync this workspace"
@@ -5184,7 +5182,7 @@ msgstr ""
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "Your data lives on the device you’re connected to."
 msgstr ""
 
@@ -5221,10 +5219,8 @@ msgstr ""
 msgid "Always-on device"
 msgstr ""
 
-#. 0: connectionCount; 1: connectionCount === 1 ? 'device' \\: 'devices'
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device and syncs with {0} other {1}."
-msgstr ""
+#~ msgid "Your data lives on this device and syncs with {0} other {1}."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Codes only route — your key still decides what syncs. Show yours, or take theirs."
@@ -6460,10 +6456,8 @@ msgstr ""
 msgid "Bearer {0}"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-#: src/routes/SyncRoute.tsx
-msgid "Set up Cloud Server"
-msgstr ""
+#~ msgid "Set up Cloud Server"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -6473,10 +6467,8 @@ msgstr ""
 #~ msgid "Timed out connecting to the Cloud Server node."
 #~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/Vault/VaultPanel.tsx
-msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
-msgstr ""
+#~ msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Working…"
@@ -6643,14 +6635,11 @@ msgstr ""
 msgid "Turn on Cloud Vault"
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Cloud Vault is on"
-msgstr ""
+#~ msgid "Cloud Vault is on"
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+#~ msgstr ""
 
 #. 0: missing.join(', ')
 #: src/helpers/managed/useVaultBackup.ts
@@ -7717,7 +7706,7 @@ msgstr ""
 msgid "We found your workspace"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "This device does not have this workspace yet. Fetch it from a device that has it."
 msgstr ""
 
@@ -7725,9 +7714,8 @@ msgstr ""
 msgid "Could not add a passkey."
 msgstr "Der Passkey konnte nicht hinzugefügt werden."
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
-msgstr "Gib deinen Wiederherstellungscode ein, um deinen geheimen Schlüssel anzuzeigen oder diesem Gerät einen Passkey hinzuzufügen. Dein bisheriger Wiederherstellungscode bleibt gültig."
+#~ msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+#~ msgstr "Gib deinen Wiederherstellungscode ein, um deinen geheimen Schlüssel anzuzeigen oder diesem Gerät einen Passkey hinzuzufügen. Dein bisheriger Wiederherstellungscode bleibt gültig."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Passkey added. Your recovery code still works."
@@ -7798,9 +7786,8 @@ msgstr ""
 msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
-msgstr ""
+#~ msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
@@ -7977,4 +7964,40 @@ msgstr ""
 
 #: src/views/PeerInvitePage.tsx
 msgid "You're invited to view this drive"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "This browser does not expose passkey support. Open this site directly in a browser with passkey support, such as Chrome or Safari. Sign in there with an email link to add a passkey. An embedded browser may not support this."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to unlock your backup. Your existing recovery code will keep working."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "This drive is still syncing with a server, but Cloud Server hosting has not been confirmed."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Cloud Vault is on; browser sync connects your open devices."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device and syncs with a server."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Browser sync connects when another browser is available."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking local copy…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use browser sync only on this device"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not verify the local copy. The server connection has been kept."
 msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -4820,9 +4820,8 @@ msgstr "Recently visited"
 msgid "Setting up your demo…"
 msgstr "Setting up your demo…"
 
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device — it isn’t syncing anywhere yet."
-msgstr "Your data lives on this device — it isn’t syncing anywhere yet."
+#~ msgid "Your data lives on this device — it isn’t syncing anywhere yet."
+#~ msgstr "Your data lives on this device — it isn’t syncing anywhere yet."
 
 #. 0: status.lastDriveSync.count.toLocaleString()
 #: src/routes/SyncRoute.tsx
@@ -4890,9 +4889,8 @@ msgstr "Developer"
 msgid "Connecting…"
 msgstr "Connecting…"
 
-#: src/routes/SyncRoute.tsx
-msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
-msgstr "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
+#~ msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
+#~ msgstr "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
 
 #: src/routes/SyncRoute.tsx
 msgid "Sync this workspace"
@@ -5218,7 +5216,7 @@ msgstr "Copy {0}"
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it."
 msgstr "You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it."
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "Your data lives on the device you’re connected to."
 msgstr "Your data lives on the device you’re connected to."
 
@@ -5255,10 +5253,8 @@ msgstr "Always-on · in use"
 msgid "Always-on device"
 msgstr "Always-on device"
 
-#. 0: connectionCount; 1: connectionCount === 1 ? 'device' \\: 'devices'
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device and syncs with {0} other {1}."
-msgstr "Your data lives on this device and syncs with {0} other {1}."
+#~ msgid "Your data lives on this device and syncs with {0} other {1}."
+#~ msgstr "Your data lives on this device and syncs with {0} other {1}."
 
 #: src/routes/SyncRoute.tsx
 msgid "Codes only route — your key still decides what syncs. Show yours, or take theirs."
@@ -6494,10 +6490,8 @@ msgstr "Documents, tables, files, chat and custom apps in one place. AtomicServe
 msgid "Bearer {0}"
 msgstr "Bearer {0}"
 
-#: src/routes/SyncRoute.tsx
-#: src/routes/SyncRoute.tsx
-msgid "Set up Cloud Server"
-msgstr "Set up Cloud Server"
+#~ msgid "Set up Cloud Server"
+#~ msgstr "Set up Cloud Server"
 
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -6507,10 +6501,8 @@ msgstr "Cloud Server"
 #~ msgid "Timed out connecting to the Cloud Server node."
 #~ msgstr "Timed out connecting to the Cloud Server node."
 
-#. 0: PRODUCT_NAME
-#: src/components/Vault/VaultPanel.tsx
-msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
-msgstr "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
+#~ msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
+#~ msgstr "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Working…"
@@ -6677,14 +6669,11 @@ msgstr "Cloud Vault"
 msgid "Turn on Cloud Vault"
 msgstr "Turn on Cloud Vault"
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Cloud Vault is on"
-msgstr "Cloud Vault is on"
+#~ msgid "Cloud Vault is on"
+#~ msgstr "Cloud Vault is on"
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
-msgstr "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+#~ msgstr "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
 
 #. 0: missing.join(', ')
 #: src/helpers/managed/useVaultBackup.ts
@@ -7751,7 +7740,7 @@ msgstr "This may take a little while. Please keep this window open."
 msgid "We found your workspace"
 msgstr "We found your workspace"
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "This device does not have this workspace yet. Fetch it from a device that has it."
 msgstr "This device does not have this workspace yet. Fetch it from a device that has it."
 
@@ -7759,9 +7748,8 @@ msgstr "This device does not have this workspace yet. Fetch it from a device tha
 msgid "Could not add a passkey."
 msgstr "Could not add a passkey."
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
-msgstr "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+#~ msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+#~ msgstr "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Passkey added. Your recovery code still works."
@@ -7832,9 +7820,8 @@ msgstr "Sign in to check recovery"
 msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
 msgstr "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
 
-#: src/routes/SyncRoute.tsx
-msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
-msgstr "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+#~ msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+#~ msgstr "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
 
 #: src/routes/SyncRoute.tsx
 msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
@@ -8012,3 +7999,39 @@ msgstr "You're invited to edit this drive"
 #: src/views/PeerInvitePage.tsx
 msgid "You're invited to view this drive"
 msgstr "You're invited to view this drive"
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "This browser does not expose passkey support. Open this site directly in a browser with passkey support, such as Chrome or Safari. Sign in there with an email link to add a passkey. An embedded browser may not support this."
+msgstr "This browser does not expose passkey support. Open this site directly in a browser with passkey support, such as Chrome or Safari. Sign in there with an email link to add a passkey. An embedded browser may not support this."
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to unlock your backup. Your existing recovery code will keep working."
+msgstr "Enter your recovery code to unlock your backup. Your existing recovery code will keep working."
+
+#: src/helpers/syncPresentation.ts
+msgid "This drive is still syncing with a server, but Cloud Server hosting has not been confirmed."
+msgstr "This drive is still syncing with a server, but Cloud Server hosting has not been confirmed."
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Cloud Vault is on; browser sync connects your open devices."
+msgstr "Your data lives on this device. Cloud Vault is on; browser sync connects your open devices."
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device and syncs with a server."
+msgstr "Your data lives on this device and syncs with a server."
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Browser sync connects when another browser is available."
+msgstr "Your data lives on this device. Browser sync connects when another browser is available."
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking local copy…"
+msgstr "Checking local copy…"
+
+#: src/routes/SyncRoute.tsx
+msgid "Use browser sync only on this device"
+msgstr "Use browser sync only on this device"
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not verify the local copy. The server connection has been kept."
+msgstr "Could not verify the local copy. The server connection has been kept."

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -4786,9 +4786,8 @@ msgstr ""
 msgid "Setting up your demo…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device — it isn’t syncing anywhere yet."
-msgstr ""
+#~ msgid "Your data lives on this device — it isn’t syncing anywhere yet."
+#~ msgstr ""
 
 #. 0: status.lastDriveSync.count.toLocaleString()
 #: src/routes/SyncRoute.tsx
@@ -4856,9 +4855,8 @@ msgstr ""
 msgid "Connecting…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
-msgstr ""
+#~ msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sync this workspace"
@@ -5184,7 +5182,7 @@ msgstr ""
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "Your data lives on the device you’re connected to."
 msgstr ""
 
@@ -5221,10 +5219,8 @@ msgstr ""
 msgid "Always-on device"
 msgstr ""
 
-#. 0: connectionCount; 1: connectionCount === 1 ? 'device' \\: 'devices'
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device and syncs with {0} other {1}."
-msgstr ""
+#~ msgid "Your data lives on this device and syncs with {0} other {1}."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Codes only route — your key still decides what syncs. Show yours, or take theirs."
@@ -6460,10 +6456,8 @@ msgstr ""
 msgid "Bearer {0}"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-#: src/routes/SyncRoute.tsx
-msgid "Set up Cloud Server"
-msgstr ""
+#~ msgid "Set up Cloud Server"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -6473,10 +6467,8 @@ msgstr ""
 #~ msgid "Timed out connecting to the Cloud Server node."
 #~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/Vault/VaultPanel.tsx
-msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
-msgstr ""
+#~ msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Working…"
@@ -6643,14 +6635,11 @@ msgstr ""
 msgid "Turn on Cloud Vault"
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Cloud Vault is on"
-msgstr ""
+#~ msgid "Cloud Vault is on"
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+#~ msgstr ""
 
 #. 0: missing.join(', ')
 #: src/helpers/managed/useVaultBackup.ts
@@ -7717,7 +7706,7 @@ msgstr ""
 msgid "We found your workspace"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "This device does not have this workspace yet. Fetch it from a device that has it."
 msgstr ""
 
@@ -7725,9 +7714,8 @@ msgstr ""
 msgid "Could not add a passkey."
 msgstr "No se pudo añadir una clave de acceso."
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
-msgstr "Introduce tu código de recuperación para mostrar tu secreto o añadir una clave de acceso en este dispositivo. Tu código de recuperación actual seguirá funcionando."
+#~ msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+#~ msgstr "Introduce tu código de recuperación para mostrar tu secreto o añadir una clave de acceso en este dispositivo. Tu código de recuperación actual seguirá funcionando."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Passkey added. Your recovery code still works."
@@ -7798,9 +7786,8 @@ msgstr ""
 msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
-msgstr ""
+#~ msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
@@ -7977,4 +7964,40 @@ msgstr ""
 
 #: src/views/PeerInvitePage.tsx
 msgid "You're invited to view this drive"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "This browser does not expose passkey support. Open this site directly in a browser with passkey support, such as Chrome or Safari. Sign in there with an email link to add a passkey. An embedded browser may not support this."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to unlock your backup. Your existing recovery code will keep working."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "This drive is still syncing with a server, but Cloud Server hosting has not been confirmed."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Cloud Vault is on; browser sync connects your open devices."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device and syncs with a server."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Browser sync connects when another browser is available."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking local copy…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use browser sync only on this device"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not verify the local copy. The server connection has been kept."
 msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -4786,9 +4786,8 @@ msgstr ""
 msgid "Setting up your demo…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device — it isn’t syncing anywhere yet."
-msgstr ""
+#~ msgid "Your data lives on this device — it isn’t syncing anywhere yet."
+#~ msgstr ""
 
 #. 0: status.lastDriveSync.count.toLocaleString()
 #: src/routes/SyncRoute.tsx
@@ -4856,9 +4855,8 @@ msgstr ""
 msgid "Connecting…"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
-msgstr ""
+#~ msgid "This workspace is stored only on this device — it isn’t backed up or synced anywhere."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Sync this workspace"
@@ -5184,7 +5182,7 @@ msgstr ""
 msgid "You’re signed in, but this device doesn’t have your workspace yet. Scan the code below with the device that has it."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "Your data lives on the device you’re connected to."
 msgstr ""
 
@@ -5221,10 +5219,8 @@ msgstr ""
 msgid "Always-on device"
 msgstr ""
 
-#. 0: connectionCount; 1: connectionCount === 1 ? 'device' \\: 'devices'
-#: src/routes/SyncRoute.tsx
-msgid "Your data lives on this device and syncs with {0} other {1}."
-msgstr ""
+#~ msgid "Your data lives on this device and syncs with {0} other {1}."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Codes only route — your key still decides what syncs. Show yours, or take theirs."
@@ -6460,10 +6456,8 @@ msgstr ""
 msgid "Bearer {0}"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-#: src/routes/SyncRoute.tsx
-msgid "Set up Cloud Server"
-msgstr ""
+#~ msgid "Set up Cloud Server"
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 #: src/routes/SyncRoute.tsx
@@ -6473,10 +6467,8 @@ msgstr ""
 #~ msgid "Timed out connecting to the Cloud Server node."
 #~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/components/Vault/VaultPanel.tsx
-msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
-msgstr ""
+#~ msgid "Keep an encrypted copy of this workspace in {0}. It is sealed on this device, so we store it without being able to read it."
+#~ msgstr ""
 
 #: src/components/Vault/VaultPanel.tsx
 msgid "Working…"
@@ -6643,14 +6635,11 @@ msgstr ""
 msgid "Turn on Cloud Vault"
 msgstr ""
 
-#: src/components/Vault/VaultPanel.tsx
-msgid "Cloud Vault is on"
-msgstr ""
+#~ msgid "Cloud Vault is on"
+#~ msgstr ""
 
-#. 0: PRODUCT_NAME
-#: src/routes/SyncRoute.tsx
-msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
-msgstr ""
+#~ msgid "A hosted workspace on {0}: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here."
+#~ msgstr ""
 
 #. 0: missing.join(', ')
 #: src/helpers/managed/useVaultBackup.ts
@@ -7717,7 +7706,7 @@ msgstr ""
 msgid "We found your workspace"
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
+#: src/helpers/syncPresentation.ts
 msgid "This device does not have this workspace yet. Fetch it from a device that has it."
 msgstr ""
 
@@ -7725,9 +7714,8 @@ msgstr ""
 msgid "Could not add a passkey."
 msgstr "Impossible d’ajouter une clé d’accès."
 
-#: src/components/AccountRecoveryCard.tsx
-msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
-msgstr "Saisissez votre code de récupération pour afficher votre secret ou ajouter une clé d’accès sur cet appareil. Votre code de récupération actuel restera valide."
+#~ msgid "Enter your recovery code to show your secret or add a passkey on this device. Your existing recovery code will keep working."
+#~ msgstr "Saisissez votre code de récupération pour afficher votre secret ou ajouter une clé d’accès sur cet appareil. Votre code de récupération actuel restera valide."
 
 #: src/components/AccountRecoveryCard.tsx
 msgid "Passkey added. Your recovery code still works."
@@ -7798,9 +7786,8 @@ msgstr ""
 msgid "This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again."
 msgstr ""
 
-#: src/routes/SyncRoute.tsx
-msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
-msgstr ""
+#~ msgid "Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free."
+#~ msgstr ""
 
 #: src/routes/SyncRoute.tsx
 msgid "Existing content stays in this drive. Hosting uses the Server plan or invitation for this drive. If a purchase is needed, you will see the price at checkout before paying."
@@ -7977,4 +7964,40 @@ msgstr ""
 
 #: src/views/PeerInvitePage.tsx
 msgid "You're invited to view this drive"
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "This browser does not expose passkey support. Open this site directly in a browser with passkey support, such as Chrome or Safari. Sign in there with an email link to add a passkey. An embedded browser may not support this."
+msgstr ""
+
+#: src/components/AccountRecoveryCard.tsx
+msgid "Enter your recovery code to unlock your backup. Your existing recovery code will keep working."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "This drive is still syncing with a server, but Cloud Server hosting has not been confirmed."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Cloud Vault is on; browser sync connects your open devices."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device and syncs with a server."
+msgstr ""
+
+#: src/helpers/syncPresentation.ts
+msgid "Your data lives on this device. Browser sync connects when another browser is available."
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Checking local copy…"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Use browser sync only on this device"
+msgstr ""
+
+#: src/routes/SyncRoute.tsx
+msgid "Could not verify the local copy. The server connection has been kept."
 msgstr ""

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1,3 +1,18 @@
+import {
+  ServiceGroup,
+  ServiceSection,
+  ServiceIcon,
+  ServiceBody,
+  ServiceTitle,
+  ServiceDescription,
+  CLOUD_SERVER_DESCRIPTION,
+  CLOUD_SERVER_PLAN_DESCRIPTION,
+  CLOUD_SERVER_SETUP,
+} from '@tomic/service-ui';
+import '@tomic/service-ui/styles.css';
+import { Column } from '../components/Row';
+import { resumePeerLinks } from '../helpers/browserPeerSync';
+import { syncSummary, showSavedServer } from '../helpers/syncPresentation';
 import { driveBillingUrl } from '../helpers/driveBillingUrl';
 import {
   deriveNodeStatuses,
@@ -557,6 +572,11 @@ function SyncPage() {
   const { setServer, setDrive, baseURL } = useSettings();
   const { drive: requestedDrive } = SyncRoute.useSearch();
   const [confirmCloud, setConfirmCloud] = useState(false);
+  const [localizing, setLocalizing] = useState(false);
+  const [localizeError, setLocalizeError] = useState<{
+    drive: string;
+    message: string;
+  } | null>(null);
   const [hostedCopy, setHostedCopy] = useState<{
     drive: string;
     origin: string;
@@ -1039,7 +1059,8 @@ function SyncPage() {
   // server it reads from can — and reports who, over `/server`. So a phone
   // paired with your server shows up here, as the server sees it. These are
   // display-only: reaching them is the server's job, not this tab's.
-  const serverPeers = isNode ? [] : (managedInfo.peers ?? []);
+  const serverPeers =
+    !isNode && showServerConn ? (managedInfo.peers ?? []) : [];
   const connectionCount =
     (showServerConn ? 1 : 0) + pairedPeers.length + serverPeers.length;
 
@@ -1109,25 +1130,14 @@ function SyncPage() {
   const cloudServerBlocked = cloudServerBlocker();
 
   function summaryLine(): string {
-    if (driveMissing) {
-      return 'This device does not have this workspace yet. Fetch it from a device that has it.';
-    }
-
-    if (localOnlyDrive) {
-      return 'This workspace is stored only on this device — it isn’t backed up or synced anywhere.';
-    }
-
-    if (!isNode && !clientDbOn) {
-      return 'Your data lives on the device you’re connected to.';
-    }
-
-    if (connectionCount === 0) {
-      return 'Your data lives on this device — it isn’t syncing anywhere yet.';
-    }
-
-    return `Your data lives on this device and syncs with ${connectionCount} other ${
-      connectionCount === 1 ? 'device' : 'devices'
-    }.`;
+    return syncSummary({
+      missing: driveMissing,
+      local: hasWorkingLocalStore,
+      serverSync: showServerConn,
+      hosting: cloudEnrolled,
+      managed: isCloudSyncAvailable(managedInfo),
+      vaultOn: vault.status.state === 'on',
+    });
   }
 
   const cloudHosted = hasHostedDriveConnection(
@@ -1460,6 +1470,44 @@ function SyncPage() {
       <ContainerNarrow>
         <h1>Sync</h1>
         <Lead>{summaryLine()}</Lead>
+        {showServerConn &&
+          cloudEnrolled === false &&
+          isCloudSyncAvailable(managedInfo) &&
+          !isNode && (
+            <Column>
+              <Button
+                subtle
+                disabled={localizing || !hasWorkingLocalStore}
+                onClick={async () => {
+                  if (!status.drive) return;
+                  setLocalizing(true);
+                  setLocalizeError(null);
+
+                  try {
+                    await store.makeDriveLocal(status.drive);
+                    resumePeerLinks(store);
+                  } catch (error) {
+                    setLocalizeError({
+                      drive: status.drive,
+                      message:
+                        error instanceof Error
+                          ? error.message
+                          : 'Could not verify the local copy. The server connection has been kept.',
+                    });
+                  } finally {
+                    setLocalizing(false);
+                  }
+                }}
+              >
+                {localizing
+                  ? 'Checking local copy…'
+                  : 'Use browser sync only on this device'}
+              </Button>
+              {localizeError && localizeError.drive === status.drive && (
+                <p role='alert'>{localizeError.message}</p>
+              )}
+            </Column>
+          )}
 
         {/* Everything our paid services own, in one card.
 
@@ -1635,24 +1683,19 @@ function SyncPage() {
                     one of ours, but the reader scans this column to find out
                     what they have, and the header above already says whose
                     services these are. */}
-                <CardIcon $tone={hostedCopyOrigin ? 'provider' : 'neutral'}>
-                  <FaCloud />
-                </CardIcon>
-                <ConnBody>
-                  <ConnTitle>
+                <ServiceIcon kind='server' active={!!hostedCopyOrigin} />
+                <ServiceBody>
+                  <ServiceTitle>
                     {hostedCopyOrigin ? 'Cloud Server is on' : 'Cloud Server'}
-                  </ConnTitle>
-                  <ConnSub>
-                    A hosted workspace on {PRODUCT_NAME}: shareable links,
-                    search across everything, API access, and no waiting on
-                    another device to be awake. Unlike Cloud Vault, our servers
-                    process what you put here.
-                  </ConnSub>
+                  </ServiceTitle>
+                  <ServiceDescription>
+                    {CLOUD_SERVER_DESCRIPTION}
+                  </ServiceDescription>
                   <ConnMeta>
                     {subscriptionStatus === 'active' ||
                     subscriptionStatus === 'trialing'
                       ? 'This drive already has a Server plan. Connecting it uses that plan; you do not need to buy it again.'
-                      : 'Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free.'}
+                      : CLOUD_SERVER_PLAN_DESCRIPTION}
                   </ConnMeta>
                   {hostedCopyOrigin && (
                     <ConnMeta>
@@ -1680,7 +1723,7 @@ function SyncPage() {
                             ? 'Sync again'
                             : cloudEnrolled
                               ? 'Finish Cloud Server setup'
-                              : 'Set up Cloud Server'}
+                              : CLOUD_SERVER_SETUP}
                       </Button>
                     )}
                     {/* This tier costs money and reads our copy of your data,
@@ -1700,14 +1743,14 @@ function SyncPage() {
                       See plans
                     </LearnMore>
                   </ConnActions>
-                </ConnBody>
+                </ServiceBody>
               </ProviderService>
             )}
           </ProviderCard>
         )}
 
         <ConfirmationDialog
-          title='Set up Cloud Server'
+          title={CLOUD_SERVER_SETUP}
           confirmLabel='Agree and enable Cloud Server'
           show={confirmCloud}
           bindShow={setConfirmCloud}
@@ -1885,7 +1928,15 @@ function SyncPage() {
               this drive live" are different questions and it was answering the
               second while looking like the first. */}
           {connectionServers
-            .filter(server => !isManagedServer(server))
+            .filter(
+              server =>
+                !isManagedServer(server) &&
+                showSavedServer({
+                  managed: isCloudSyncAvailable(managedInfo),
+                  activeForDrive:
+                    showServerConn && sameOrigin(server, status.serverUrl),
+                }),
+            )
             .map(server => (
               <ServerCard
                 key={server}
@@ -2072,44 +2123,48 @@ function SyncPage() {
         {/* Pairing is the point of this page on a peer node, so it's shown
             outright rather than hidden behind a button: the code is routing
             only, and safe to leave on screen. */}
-        {pairNodeId && (
-          <Section>
-            <SectionTitle>Sync a device</SectionTitle>
-            {/* One line, not three: the card above already said what
+        {pairNodeId &&
+          (isNode ||
+            (showServerConn &&
+              (!isCloudSyncAvailable(managedInfo) ||
+                cloudEnrolled === true))) && (
+            <Section>
+              <SectionTitle>Sync a device</SectionTitle>
+              {/* One line, not three: the card above already said what
                 `localhost:9883` is, and a paragraph on how keys work belongs
                 where someone asks — not over a QR they came here to scan. */}
-            <ConnNote>
-              {isNode
-                ? 'Codes only route — your key still decides what syncs. Show yours, or take theirs.'
-                : `Scan from your other device to sync with ${serverLabel(status.serverUrl ?? '')}. Safe to show: a code only routes.`}
-            </ConnNote>
-            <PairCard>
-              <PairSide>
-                {isNode && <PairLabel>Show this code</PairLabel>}
-                <QrCentered>
-                  <PairingCode nodeDid={rawToNodeDid(pairNodeId)} />
-                </QrCentered>
-              </PairSide>
+              <ConnNote>
+                {isNode
+                  ? 'Codes only route — your key still decides what syncs. Show yours, or take theirs.'
+                  : `Scan from your other device to sync with ${serverLabel(status.serverUrl ?? '')}. Safe to show: a code only routes.`}
+              </ConnNote>
+              <PairCard>
+                <PairSide>
+                  {isNode && <PairLabel>Show this code</PairLabel>}
+                  <QrCentered>
+                    <PairingCode nodeDid={rawToNodeDid(pairNodeId)} />
+                  </QrCentered>
+                </PairSide>
 
-              {/* Taking someone else's code needs a node to dial from, which a
+                {/* Taking someone else's code needs a node to dial from, which a
                   browser tab is not. */}
-              {isNode && (
-                <>
-                  <PairDivider aria-hidden />
+                {isNode && (
+                  <>
+                    <PairDivider aria-hidden />
 
-                  <PairSide>
-                    <PairLabel>
-                      {isMobileTauri() ? 'Or scan theirs' : 'Or paste theirs'}
-                    </PairLabel>
-                    {/* Same path a scanned deep link takes (PairingLinkHandler):
+                    <PairSide>
+                      <PairLabel>
+                        {isMobileTauri() ? 'Or scan theirs' : 'Or paste theirs'}
+                      </PairLabel>
+                      {/* Same path a scanned deep link takes (PairingLinkHandler):
                         validate, persist the peer, start a sync. */}
-                    <ConnectToDeviceForm onCode={deliverDeepLink} />
-                  </PairSide>
-                </>
-              )}
-            </PairCard>
-          </Section>
-        )}
+                      <ConnectToDeviceForm onCode={deliverDeepLink} />
+                    </PairSide>
+                  </>
+                )}
+              </PairCard>
+            </Section>
+          )}
 
         {/* Developer: diagnostics + advanced toggles, tucked away. */}
         <DevDetails>
@@ -2389,7 +2444,11 @@ const Lead = styled.p`
  * reads blue, so a glance separates "this is yours and local" from "this
  * involves your account".
  */
-const ProviderCard = styled.div`
+const ProviderCard = styled(ServiceGroup)`
+  --service-accent: ${p => p.theme.colors.main};
+  --service-muted: ${p => p.theme.colors.textLight};
+  --service-text: ${p => p.theme.colors.text};
+  --service-neutral: ${p => p.theme.colors.bg1};
   ${cardSurface}
   flex-direction: column;
   align-items: stretch;
@@ -2414,7 +2473,7 @@ const ProviderHeader = styled.div`
  * account above them, and whitespace alone made them read as neighbours of it
  * instead of contents.
  */
-const ProviderService = styled.div`
+const ProviderService = styled(ServiceSection)`
   display: flex;
   align-items: flex-start;
   gap: 0.9rem;

--- a/browser/e2e/tests/managed-sync-presentation.spec.ts
+++ b/browser/e2e/tests/managed-sync-presentation.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from '@playwright/test';
+import { devDrive, FRONTEND_URL } from './test-utils';
+
+for (const localOnly of [true, false]) {
+  test(`managed sync keeps server state honest (localOnly=${localOnly})`, async ({
+    page,
+  }) => {
+    await devDrive(page);
+    await page.route('**/api/me', route =>
+      route.fulfill({ json: { email: 'sync-test@example.com' } }),
+    );
+    await page.route('**/api/sync-enrollments', route =>
+      route.fulfill({ json: [] }),
+    );
+    await page.route('**/api/recovery-secret', route =>
+      route.fulfill({ status: 204 }),
+    );
+
+    const attachment = localOnly
+      ? null
+      : await page.evaluate(async () => {
+          const store = window.store;
+          const [subject] = await store.uploadFiles(
+            [
+              new File(['Keep these attachment bytes'], 'migration.txt', {
+                type: 'text/plain',
+              }),
+            ],
+            store.getDrive()!,
+          );
+
+          return subject;
+        });
+
+    if (localOnly) {
+      const drive = await page.evaluate(() => window.store.getDrive());
+      const enrollment = {
+        id: 'vault-test',
+        drive_subject: drive,
+        drive_pseudonym: 'vault-test',
+        status: 'active',
+        used_bytes: 453000,
+        quota_bytes: 5000000000,
+        last_backup_at: Date.now(),
+      };
+      await page.route('**/api/cloud-vault/drives', route =>
+        route.fulfill({ json: [enrollment] }),
+      );
+      await page.route('**/api/cloud-vault/vault-test/state', route =>
+        route.fulfill({
+          json: {
+            enrollment,
+            lanes: {},
+            checkpoints: [],
+            pending_uploads: 0,
+            confirmed_objects: 59,
+          },
+        }),
+      );
+      await page.evaluate(() =>
+        window.store.registerLocalOnlyDrive(window.store.getDrive()!),
+      );
+    }
+
+    const writes: string[] = [];
+    let switched = false;
+    page.on('request', request => {
+      if (switched && new URL(request.url()).pathname === '/commit')
+        writes.push('HTTP commit');
+    });
+    page.on('websocket', socket =>
+      socket.on('framesent', ({ payload }) => {
+        if (
+          switched &&
+          Buffer.isBuffer(payload) &&
+          [0x13, 0x33].includes(payload[0])
+        )
+          writes.push('WebSocket mutation');
+      }),
+    );
+
+    await page.goto(`${FRONTEND_URL}/app/sync`);
+    await expect(
+      page.getByRole('heading', { name: 'Sync', exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Sync a device', exact: true }),
+    ).toHaveCount(0);
+
+    if (localOnly) {
+      await expect(
+        page.getByText(
+          'Cloud Vault is on; browser sync connects your open devices.',
+          { exact: false },
+        ),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Switch', exact: true }),
+      ).toHaveCount(0);
+    } else {
+      await expect(
+        page.getByText(
+          'Your account session has ended. Sign in again to resume backup.',
+          { exact: true },
+        ),
+      ).toBeVisible();
+      await expect(
+        page.getByText('Invalid hook call.', { exact: false }),
+      ).toHaveCount(0);
+
+      await expect(
+        page.getByText(
+          'This drive is still syncing with a server, but Cloud Server hosting has not been confirmed.',
+          { exact: true },
+        ),
+      ).toBeVisible();
+      await page.waitForFunction(() => {
+        const status = window.store.getSyncStatus();
+
+        return !status.syncInProgress && !status.pendingDirtyCount;
+      });
+
+      // A failed local read must keep the existing connection and routing.
+      const refused = await page.evaluate(async () => {
+        const store = window.store;
+        const db = store.getClientDb()!;
+        const read = db.getResourceWithSnapshot;
+        db.getResourceWithSnapshot = async () => ({
+          jsonAd: null,
+          snapshot: null,
+        });
+
+        try {
+          await store.makeDriveLocal(store.getDrive()!);
+
+          return {
+            error: '',
+            local: store.isLocalOnlyDrive(store.getDrive()!),
+          };
+        } catch (error) {
+          return {
+            error: String(error),
+            local: store.isLocalOnlyDrive(store.getDrive()!),
+          };
+        } finally {
+          db.getResourceWithSnapshot = read;
+        }
+      });
+      expect(refused.error).toContain('missing its local history');
+      expect(refused.local).toBe(false);
+
+      await page
+        .getByRole('button', {
+          name: 'Use browser sync only on this device',
+          exact: true,
+        })
+        .click();
+      await page.waitForFunction(() =>
+        window.store.isLocalOnlyDrive(window.store.getDrive()!),
+      );
+      switched = true;
+      await page.evaluate(async () => {
+        const store = window.store;
+        const drive = await store.getResource(store.getDrive()!);
+        await drive.set(
+          'https://atomicdata.dev/properties/description',
+          'Saved after switching to browser sync',
+        );
+        await drive.save();
+        await store.getClientDb()!.flush();
+      });
+      await page.reload();
+      await expect(
+        page.getByText(
+          'Browser sync connects when another browser is available.',
+          { exact: false },
+        ),
+      ).toBeVisible();
+      const persisted = await page.evaluate(async subject => {
+        const store = window.store;
+        const drive = await store.getResource(store.getDrive()!);
+        const file = await store.getResource(subject!);
+        const blob = file.get(
+          'https://atomicdata.dev/properties/blob',
+        ) as string;
+        const hash = Uint8Array.from(
+          blob.slice('did:ad:blob:'.length).match(/../g)!,
+          part => parseInt(part, 16),
+        );
+        const bytes = await store.getClientDb()!.getBlob(hash);
+
+        return {
+          description: drive.get(
+            'https://atomicdata.dev/properties/description',
+          ),
+          attachment: new TextDecoder().decode(bytes!),
+        };
+      }, attachment);
+      expect(persisted).toEqual({
+        description: 'Saved after switching to browser sync',
+        attachment: 'Keep these attachment bytes',
+      });
+      expect(writes).toEqual([]);
+    }
+  });
+}

--- a/browser/e2e/tests/passkey-unavailable.spec.ts
+++ b/browser/e2e/tests/passkey-unavailable.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { devDrive, FRONTEND_URL } from './test-utils';
+
+test('explains missing passkey support without offering a broken setup action', async ({
+  page,
+}) => {
+  await devDrive(page);
+  const agent = await page.evaluate(
+    () =>
+      (
+        window as unknown as { store: { getAgent(): { subject: string } } }
+      ).store.getAgent().subject,
+  );
+  await page.addInitScript(() => {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+  await page.route('**/api/me', route =>
+    route.fulfill({ json: { email: 'passkey-test@example.com' } }),
+  );
+  await page.route('**/api/recovery-secret', route =>
+    route.fulfill({
+      json: {
+        agent_subject: agent,
+        format_version: 2,
+        encrypted_secret: 'test',
+        wrappers: [{ wrapper_type: 'recovery-code', kdf_params: {} }],
+      },
+    }),
+  );
+  await page.goto(`${FRONTEND_URL}/app/agent`);
+  await expect(
+    page.getByText('This browser does not expose passkey support.', {
+      exact: false,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Add a passkey', exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole('button', { name: 'Use recovery code', exact: true }),
+  ).toBeEnabled();
+});

--- a/browser/lib/src/client-db.node.ts
+++ b/browser/lib/src/client-db.node.ts
@@ -7,6 +7,7 @@
  * use, keep `ClientDbWorker`.
  */
 
+import { versionVectorRecords } from './version-vector-records.js';
 import {
   parseHistoryAttribution,
   type HistoryAttribution,
@@ -278,7 +279,7 @@ export class NodeClientDb {
   > {
     const r = this.requireDb().getAllVersionVectors();
 
-    return (r as Record<string, Record<string, number>>) ?? {};
+    return versionVectorRecords(r);
   }
 
   async getVersionVectorsForDrive(
@@ -286,7 +287,7 @@ export class NodeClientDb {
   ): Promise<Record<string, Record<string, number>>> {
     const r = await this.requireDb().getVersionVectorsForDrive(drive);
 
-    return (r as Record<string, Record<string, number>>) ?? {};
+    return versionVectorRecords(r);
   }
 
   private requireDb(): WasmModule {

--- a/browser/lib/src/client-db.test.ts
+++ b/browser/lib/src/client-db.test.ts
@@ -74,3 +74,21 @@ describe('ClientDbWorker cold initialization', () => {
     }
   });
 });
+
+describe('ClientDbWorker version vectors', () => {
+  it('converts the nested Rust maps for drive and database inventories', async () => {
+    const db = new ClientDbWorker('wasm-url', 'worker-url');
+    const transport = db as unknown as {
+      send(message: unknown): Promise<unknown>;
+    };
+    vi.spyOn(transport, 'send').mockResolvedValue(
+      new Map([['did:ad:drive', new Map([['12345678901234567890', 42]])]]),
+    );
+    const expected = { 'did:ad:drive': { '12345678901234567890': 42 } };
+    expect(await db.getVersionVectorsForDrive('did:ad:drive')).toEqual(
+      expected,
+    );
+    expect(await db.getAllVersionVectors()).toEqual(expected);
+    vi.restoreAllMocks();
+  });
+});

--- a/browser/lib/src/client-db.ts
+++ b/browser/lib/src/client-db.ts
@@ -25,6 +25,7 @@
  * ```
  */
 
+import { versionVectorRecords } from './version-vector-records.js';
 import {
   parseHistoryAttribution,
   type HistoryAttribution,
@@ -818,7 +819,7 @@ export class ClientDbWorker {
   > {
     const r = await this.send({ type: 'getAllVersionVectors' });
 
-    return (r as Record<string, Record<string, number>>) ?? {};
+    return versionVectorRecords(r);
   }
 
   /** Version vectors for one drive's resources only (parent-index walk),
@@ -828,7 +829,7 @@ export class ClientDbWorker {
   ): Promise<Record<string, Record<string, number>>> {
     const r = await this.send({ type: 'getVersionVectorsForDrive', drive });
 
-    return (r as Record<string, Record<string, number>>) ?? {};
+    return versionVectorRecords(r);
   }
 
   /**

--- a/browser/lib/src/local-drive-copy.test.ts
+++ b/browser/lib/src/local-drive-copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientDbWorker } from './client-db.js';
+import { verifyLocalDriveCopy } from './local-drive-copy.js';
+const drive = 'did:ad:drive';
+const inventory = [{ subject: drive, vv: { a: 2 } }];
+
+function fixture() {
+  const db = {
+    flush: vi.fn().mockResolvedValue(undefined),
+    getVersionVectorsForDrive: vi.fn().mockResolvedValue({ [drive]: { a: 2 } }),
+    getResourceWithSnapshot: vi
+      .fn()
+      .mockResolvedValue({ jsonAd: '{}', snapshot: new Uint8Array([1]) }),
+    getBlob: vi.fn().mockResolvedValue(null),
+    blake3Hash: vi.fn().mockResolvedValue(new Uint8Array(32)),
+  };
+
+  return {
+    db,
+    verify: (items = inventory) =>
+      verifyLocalDriveCopy(db as unknown as ClientDbWorker, drive, items),
+  };
+}
+
+describe('verified local drive copy', () => {
+  it('accepts a complete local history', async () => {
+    await expect(fixture().verify()).resolves.toBeUndefined();
+  });
+  it('rejects an empty or incomplete server inventory', async () => {
+    await expect(fixture().verify([])).rejects.toThrow('inventory');
+  });
+  it('rejects missing history even with a cached resource', async () => {
+    const f = fixture();
+    f.db.getVersionVectorsForDrive.mockResolvedValue({ [drive]: { a: 1 } });
+    await expect(f.verify()).rejects.toThrow('not fully stored');
+  });
+  it('rejects a missing attachment', async () => {
+    const f = fixture();
+    f.db.getResourceWithSnapshot.mockResolvedValue({
+      jsonAd: JSON.stringify({
+        'https://atomicdata.dev/properties/blob': `did:ad:blob:${'00'.repeat(32)}`,
+      }),
+      snapshot: new Uint8Array([1]),
+    });
+    await expect(f.verify()).rejects.toThrow('attachment is missing');
+    f.db.getBlob.mockResolvedValue(new Uint8Array([2]));
+    await expect(f.verify()).resolves.toBeUndefined();
+    f.db.blake3Hash.mockResolvedValue(new Uint8Array(32).fill(1));
+    await expect(f.verify()).rejects.toThrow('could not be verified');
+  });
+});

--- a/browser/lib/src/local-drive-copy.ts
+++ b/browser/lib/src/local-drive-copy.ts
@@ -1,0 +1,59 @@
+import type { ClientDbWorker } from './client-db.js';
+import type { Item } from './rbsr.js';
+
+/** Verify every readable remote resource and its content-addressed attachment.
+ * A root snapshot or matching resource count is not proof of a complete copy. */
+export async function verifyLocalDriveCopy(
+  db: ClientDbWorker,
+  drive: string,
+  remote: Item[],
+): Promise<void> {
+  if (!remote.some(item => item.subject === drive))
+    throw new Error('The server did not provide a complete drive inventory.');
+  await db.flush();
+  const local = await db.getVersionVectorsForDrive(drive);
+
+  for (const item of remote) {
+    const vv = local[item.subject];
+    if (
+      !vv ||
+      Object.entries(item.vv).some(
+        ([peer, counter]) =>
+          !Number.isSafeInteger(counter) ||
+          counter < 0 ||
+          (vv[peer] ?? 0) < counter,
+      )
+    )
+      throw new Error(
+        'Some resources are not fully stored on this device yet. Keep the server connected and retry after syncing.',
+      );
+    const { jsonAd, snapshot } = await db.getResourceWithSnapshot(item.subject);
+    if (!jsonAd || !snapshot?.length)
+      throw new Error(
+        'A resource is missing its local history. Keep the server connected.',
+      );
+    const blob = JSON.parse(jsonAd)['https://atomicdata.dev/properties/blob'];
+    if (blob === undefined || blob === null) continue;
+    if (typeof blob !== 'string' || !/^did:ad:blob:[0-9a-f]{64}$/.test(blob))
+      throw new Error(
+        'An attachment is not stored as a portable blob. Keep the server connected.',
+      );
+    const hash = Uint8Array.from(
+      blob.slice('did:ad:blob:'.length).match(/../g)!,
+      part => parseInt(part, 16),
+    );
+    const bytes = await db.getBlob(hash);
+    if (!bytes)
+      throw new Error(
+        'An attachment is missing on this device. Open it to download it, then retry.',
+      );
+    const actual = await db.blake3Hash(bytes);
+    if (
+      actual.length !== hash.length ||
+      actual.some((byte, index) => byte !== hash[index])
+    )
+      throw new Error(
+        'An attachment could not be verified. Keep the server connected.',
+      );
+  }
+}

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1,3 +1,4 @@
+import { verifyLocalDriveCopy } from './local-drive-copy.js';
 import {
   encodeCommit as encodePeerCommit,
   encodeEphemeral as encodePeerEphemeral,
@@ -811,14 +812,53 @@ export class Store {
   /** Mark a drive as local-only. Must be called BEFORE the drive's first
    *  `save()` — registration is what routes saves away from the outbox. */
   public registerLocalOnlyDrive(drive: string): void {
-    this.localOnlyDrives.add(drive);
-
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(
         'atomic.localOnlyDrives',
-        JSON.stringify([...this.localOnlyDrives]),
+        JSON.stringify([...new Set([...this.localOnlyDrives, drive])]),
       );
     }
+
+    this.localOnlyDrives.add(drive);
+  }
+
+  /** Switch this client to browser-only sync after verifying its local copy.
+   * Does not delete data from the server or alter other devices' configuration. */
+  public async makeDriveLocal(drive: string): Promise<void> {
+    const db = this.getClientDb();
+    const agent = this.getAgent();
+    const serverUrl = this.serverUrl;
+    const ws = this.getDefaultWebSocket();
+    if (!db?.isReady || !agent || !ws || this.getDrive() !== drive)
+      throw new Error(
+        'Open this drive with local storage available before disconnecting.',
+      );
+
+    const current = () => {
+      const status = this.getSyncStatus();
+      if (
+        this.getClientDb() !== db ||
+        this.getAgent() !== agent ||
+        this.serverUrl !== serverUrl ||
+        this.getDrive() !== drive ||
+        status.syncInProgress ||
+        status.pendingDirtyCount ||
+        status.blockedCount
+      )
+        throw new Error(
+          'Wait for changes to finish syncing before disconnecting.',
+        );
+    };
+
+    current();
+    const inventory = await ws.rbsrItems(drive, '');
+    await verifyLocalDriveCopy(db, drive, inventory);
+    // A second inventory catches changes made while attachment verification ran.
+    await verifyLocalDriveCopy(db, drive, await ws.rbsrItems(drive, ''));
+    current();
+    this.registerLocalOnlyDrive(drive);
+    ws.unsubscribeFromDrive(drive);
+    this.emitSyncStatus();
   }
 
   /** Forget a local-only drive (e.g. after deleting a demo workspace),

--- a/browser/lib/src/version-vector-records.ts
+++ b/browser/lib/src/version-vector-records.ts
@@ -1,0 +1,14 @@
+/** serde-wasm-bindgen serializes Rust maps as JS Maps. Convert both levels
+ * at the ClientDb boundary so all sync consumers receive the declared records. */
+export function versionVectorRecords(
+  value: unknown,
+): Record<string, Record<string, number>> {
+  const vectors = value instanceof Map ? Object.fromEntries(value) : value;
+
+  return Object.fromEntries(
+    Object.entries(vectors ?? {}).map(([subject, vector]) => [
+      subject,
+      vector instanceof Map ? Object.fromEntries(vector) : vector,
+    ]),
+  );
+}

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -1729,7 +1729,7 @@ export class WSClient {
   }
 
   /** Send an RBSR range-items query and await the server's items. */
-  private rbsrItems(drive: string, lo: string, hi?: string): Promise<Item[]> {
+  public rbsrItems(drive: string, lo: string, hi?: string): Promise<Item[]> {
     return new Promise<Item[]>((resolve, reject) => {
       if (this.readyState !== WebSocket.OPEN) {
         reject(new Error('WebSocket is not open'));

--- a/browser/pnpm-lock.yaml
+++ b/browser/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@tomic/react':
         specifier: workspace:*
         version: link:../react
+      '@tomic/service-ui':
+        specifier: workspace:*
+        version: link:../service-ui
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.10
         version: 4.25.10(@codemirror/language@6.12.3)(@codemirror/state@6.7.4)(@codemirror/view@6.43.0)
@@ -580,6 +583,18 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.28)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+  service-ui:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.5
+        version: 19.2.15
+      react:
+        specifier: ^19.2.0
+        version: 19.2.6
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/browser/service-ui/README.md
+++ b/browser/service-ui/README.md
@@ -1,0 +1,16 @@
+# @tomic/service-ui
+
+Shared Cloud Vault / Cloud Server presentation for the SaaS portal and Sync page.
+Owns product copy, service icons, row/body/title/description layout, group surface,
+and primary action styling. Import `@tomic/service-ui/styles.css` once per host.
+Hosts can map `--service-accent`, `--service-muted`, `--service-neutral` and
+`--service-text` to their theme.
+
+This package has no account, billing, routing, or cryptography dependencies.
+Hosts supply real state and actions. The portal must link to Sync for operations
+requiring the local drive and keys; it must not pretend to run a local backup.
+Canonical copy lives here instead of separate product-name constants per app.
+
+Build before building either consumer: `pnpm --dir browser/service-ui build`.
+The workspace build does this in dependency order. The paired SaaS checkout uses
+a file dependency, like its existing `@tomic/lib` and `@tomic/edit-mode` dependencies.

--- a/browser/service-ui/package.json
+++ b/browser/service-ui/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tomic/service-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./styles.css": "./src/styles.css"
+  },
+  "files": [
+    "dist",
+    "src/styles.css"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "react": "^19.2.0",
+    "@types/react": "^19.2.5",
+    "typescript": "^6.0.3"
+  }
+}

--- a/browser/service-ui/src/index.tsx
+++ b/browser/service-ui/src/index.tsx
@@ -1,0 +1,74 @@
+import type { HTMLAttributes } from 'react';
+
+export const CLOUD_VAULT = 'Cloud Vault';
+export const CLOUD_SERVER = 'Cloud Server';
+export const CLOUD_VAULT_DESCRIPTION =
+  'Keep an encrypted copy of this workspace in AtomicServer.eu. It is sealed on this device, so we store it without being able to read it.';
+export const CLOUD_SERVER_DESCRIPTION =
+  'A hosted workspace on AtomicServer.eu: shareable links, search across everything, API access, and no waiting on another device to be awake. Unlike Cloud Vault, our servers process what you put here.';
+export const CLOUD_SERVER_PLAN_DESCRIPTION =
+  'Server plans apply to one drive. If this drive needs a plan, checkout shows the price before you pay. Connecting your account is free.';
+export const CLOUD_SERVER_SETUP = 'Set up Cloud Server';
+export const CLOUD_VAULT_ON = 'Cloud Vault is on';
+
+export function ServiceSection({
+  className = '',
+  ...props
+}: HTMLAttributes<HTMLElement>) {
+  return (
+    <section {...props} className={`atomic-service-section ${className}`} />
+  );
+}
+export function ServiceBody({
+  className = '',
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props} className={`atomic-service-body ${className}`} />;
+}
+export function ServiceTitle({
+  className = '',
+  children,
+  ...props
+}: HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3 {...props} className={`atomic-service-title ${className}`}>
+      {children}
+    </h3>
+  );
+}
+export function ServiceDescription({
+  className = '',
+  ...props
+}: HTMLAttributes<HTMLParagraphElement>) {
+  return <p {...props} className={`atomic-service-description ${className}`} />;
+}
+export function ServiceIcon({
+  kind,
+  active = false,
+}: {
+  kind: 'vault' | 'server';
+  active?: boolean;
+}) {
+  return (
+    <span
+      className='atomic-service-icon'
+      data-active={active}
+      aria-hidden='true'
+    >
+      <svg viewBox='0 0 24 24' width='20' height='20' fill='currentColor'>
+        {kind === 'vault' ? (
+          <path d='M7 10V7a5 5 0 0 1 10 0v3h1a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2zm2 0h6V7a3 3 0 0 0-6 0z' />
+        ) : (
+          <path d='M7 19a5 5 0 0 1-1-9.9 6 6 0 0 1 11.7-1.6A5.8 5.8 0 0 1 18 19z' />
+        )}
+      </svg>
+    </span>
+  );
+}
+
+export function ServiceGroup({
+  className = '',
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props} className={`atomic-service-group ${className}`} />;
+}

--- a/browser/service-ui/src/styles.css
+++ b/browser/service-ui/src/styles.css
@@ -1,0 +1,64 @@
+.atomic-service-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+  cursor: auto;
+}
+.atomic-service-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+.atomic-service-title {
+  margin: 0;
+  font-size: 1em;
+  line-height: 1.4;
+  font-weight: 600;
+}
+.atomic-service-description {
+  margin: 0;
+  color: var(--service-muted, var(--color-text-light, #666));
+  font-size: 0.875em;
+  line-height: 1.65;
+}
+.atomic-service-icon {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 40px;
+  border-radius: 50%;
+  background: var(--service-neutral, var(--color-bg-1, #eee));
+  color: var(--service-text, var(--color-text, #111));
+}
+.atomic-service-icon[data-active='true'] {
+  background: var(--service-accent, var(--color-main, #204ce4));
+  color: white;
+}
+.atomic-service-group {
+  border: 1px solid var(--service-accent, var(--color-main, #204ce4));
+  border-radius: 10px;
+  background: color-mix(
+    in srgb,
+    var(--service-accent, var(--color-main, #204ce4)) 4%,
+    var(--color-bg, transparent)
+  );
+  overflow: hidden;
+}
+.atomic-service-primary {
+  background: var(--service-accent, var(--color-main, #204ce4));
+  color: white;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  padding: 7px 12px;
+  font: inherit;
+  cursor: pointer;
+}
+.atomic-service-primary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/browser/service-ui/tsconfig.json
+++ b/browser/service-ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM", "DOM.AsyncIterable"]
+  },
+  "include": ["src"]
+}

--- a/planning/serverless-p2p.md
+++ b/planning/serverless-p2p.md
@@ -400,7 +400,7 @@ Remaining legacy migration: an unsubscribed drive may already have data on a
 managed node, admitted under its 600-second bootstrap grace. Do not treat a
 root-resource snapshot or the account's enrollment list as proof of a complete
 local copy. Invite creation refuses browser-only conversion of such drives
-until an authenticated full-drive + attachment verification/migration exists.
+unless the user completes the checked per-device transition below.
 Keep the actual connection visible and existing copies intact. Need staging
 inspection to establish the reported drive's placement and deployed policy;
 the local policy default is evidence of a possible path, not proof of that
@@ -410,3 +410,26 @@ Validation: client-library negative invite tests, real WebRTC/OPFS invite
 acceptance with all AtomicServer data fetches disabled, and a two-identity app
 route test without `/invites` requests. Account creation/email roundtrip for a
 brand-new invited SaaS user remains a separate acceptance check.
+
+
+## Existing server connections (2026-09-11)
+
+- [x] Reproduce saved-but-disconnected and active-server states locally against
+  a real node, with a successful empty account enrollment response.
+- [x] Hide unrelated saved nodes and server pairing codes in managed local mode;
+  keep real active server connections visible, including unconfirmed hosting.
+- [x] Account enrollment failures remain unknown instead of implying no hosting.
+  An account list is not proof that nobody else pays for a shared drive.
+- [x] Offer an explicit browser-only transition for the current device. Check
+  authenticated server inventories against durable local version vectors and
+  snapshots, verify referenced blob bytes and hashes, recheck the inventory,
+  refuse pending writes/identity changes, then unsubscribe and persist routing.
+- [x] Normalize nested WASM Maps at the ClientDb boundary; otherwise history
+  inventory consumers see an empty record despite durable snapshots.
+- [x] Verify refusal on missing local history and preservation of edits and an
+  attachment across reload, with no HTTP or WebSocket data writes after switching.
+- [ ] Deploy and verify the reported staging drive with its actual subscription
+  and node admission policy. No automatic deletion of existing server copies,
+  subscription cancellation, or migration of other devices is performed.
+- [ ] Review bootstrap grace/admission separately so old data placement cannot
+  be mistaken for a paid hosting entitlement. New SaaS drives already start local.


### PR DESCRIPTION
Cloud service settings in the portal and Sync page now share components, icons, and canonical descriptions through `@tomic/service-ui`.

Also fixes misleading managed sync states and missing passkey support. Switching an existing server-backed drive to local browser sync verifies durable resource history and attachment bytes before disconnecting; an incomplete copy keeps the server connection.

Validation: 1,267 library/application unit tests and focused sync/passkey browser tests passed locally during implementation. The final paired UI checks passed (10 portal and 2 Sync tests), as did typechecks, portal build, and focused lint (existing warnings only). Staging deployment: https://github.com/ontola/atomic-saas/actions/runs/34575816852

Paired with the atomic-saas `codex/cloud-services-staging` branch.
