### PR TITLE
Isolate branch CI scheduling and improve Cargo cache concurrency

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -275,27 +275,49 @@ export class AtomicServer {
    * Mount shared crates.io + git dependency caches under `cargoHome`, and
    * pin `CARGO_BUILD_JOBS` so rustc doesn't spawn one job per visible host
    * CPU (containers see the full Mancave SMT count). Registry content is
-   * identical across glibc/musl images, so both share the `cargo` /
-   * `cargo-git` volumes — only the mount path differs.
+   * identical across glibc/musl images, so both share dependency volumes
+   * and Cargo cache locks — only the mount path differs.
    */
   private withCargoHomeCache(
     container: Container,
     cargoHome: string,
   ): Container {
-    return container
-      .withMountedCache(`${cargoHome}/registry`, dag.cacheVolume('cargo'), {
-        // Cargo locks live outside this registry mount, so separate containers
-        // cannot coordinate extraction. Lock the mount to prevent concurrent
-        // unpack failures (including bzip2-sys .cargo-ok collisions).
-        sharing: CacheSharingMode.Locked,
-      })
-      .withMountedCache(`${cargoHome}/git`, dag.cacheVolume('cargo-git'), {
-        sharing: CacheSharingMode.Shared,
-      })
-      .withEnvVariable(
-        'CARGO_BUILD_JOBS',
-        this.hostKnobs.cargoBuildJobs,
-      );
+    return (
+      container
+        .withMountedCache(
+          `${cargoHome}/registry`,
+          dag.cacheVolume('cargo-shared-locks-v1'),
+          {
+            sharing: CacheSharingMode.Shared,
+          },
+        )
+        .withMountedCache(
+          `${cargoHome}/git`,
+          dag.cacheVolume('cargo-git-shared-locks-v1'),
+          {
+            sharing: CacheSharingMode.Shared,
+          },
+        )
+        // Cargo locks live in CARGO_HOME, outside registry/git. Sharing only
+        // those directories leaves every container with independent locks and
+        // lets simultaneous downloads race while unpacking the same crate.
+        // Put both lock inodes in the shared registry volume; Cargo still only
+        // serializes downloads/mutations, not the entire parallel build lane.
+        // Fresh volume names keep older jobs with private locks out of this cache.
+        .withExec([
+          'ln',
+          '-sf',
+          'registry/.package-cache',
+          `${cargoHome}/.package-cache`,
+        ])
+        .withExec([
+          'ln',
+          '-sf',
+          'registry/.package-cache-mutate',
+          `${cargoHome}/.package-cache-mutate`,
+        ])
+        .withEnvVariable('CARGO_BUILD_JOBS', this.hostKnobs.cargoBuildJobs)
+    );
   }
 
   /**
@@ -1689,12 +1711,24 @@ export class AtomicServer {
      * guess the git ref. See `ci()` for why this is not named `e2eMode`.
      */
     @argument() playwrightMode: string = 'full',
+    /**
+     * Optional Playwright regular expression for one focused browser journey.
+     * A focused run stays on one server/shard, so an exact test does not run
+     * alongside unrelated E2E failures.
+     */
+    @argument() playwrightGrep: string = '',
   ): Promise<string> {
     // Shards × own atomic-server. Count comes from `--host-profile`
     // (Mancave hot / hosted conservative) plus `--playwright-mode` (light uses
     // fewer shards). Dagger dedupes the shared debug `rustBuild(e2e)` /
     // base-container graph.
     this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(playwrightMode));
+    if (playwrightGrep)
+      this.e2eRun = {
+        ...this.e2eRun,
+        shardCount: 1,
+        grep: playwrightGrep,
+      };
     const shardCount = this.e2eRun.shardCount;
     const base = this.e2eBaseContainer();
     const shardIndexes = Array.from({ length: shardCount }, (_, i) => i + 1);

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1711,24 +1711,12 @@ export class AtomicServer {
      * guess the git ref. See `ci()` for why this is not named `e2eMode`.
      */
     @argument() playwrightMode: string = 'full',
-    /**
-     * Optional Playwright regular expression for one focused browser journey.
-     * A focused run stays on one server/shard, so an exact test does not run
-     * alongside unrelated E2E failures.
-     */
-    @argument() playwrightGrep: string = '',
   ): Promise<string> {
     // Shards × own atomic-server. Count comes from `--host-profile`
     // (Mancave hot / hosted conservative) plus `--playwright-mode` (light uses
     // fewer shards). Dagger dedupes the shared debug `rustBuild(e2e)` /
     // base-container graph.
     this.e2eRun = e2eRunKnobs(this.hostProfile, resolveE2eMode(playwrightMode));
-    if (playwrightGrep)
-      this.e2eRun = {
-        ...this.e2eRun,
-        shardCount: 1,
-        grep: playwrightGrep,
-      };
     const shardCount = this.e2eRun.shardCount;
     const base = this.e2eBaseContainer();
     const shardIndexes = Array.from({ length: shardCount }, (_, i) => i + 1);

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -36,6 +36,13 @@ jobs:
   ci:
     name: CI
     runs-on: ${{ fromJSON(inputs.runner) }}
+    # Serialize heavy work on Mancave, including downstream-saas in main.yml.
+    # Hosted runners have separate machines and need no shared hardware lock.
+    # This group must differ from the caller's per-ref workflow group.
+    concurrency:
+      group: ${{ inputs.host-profile == 'mancave' && 'main-mancave-heavy' || format('main-hosted-{0}-{1}', github.run_id, github.run_attempt) }}
+      queue: max
+      cancel-in-progress: false
     env:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
     steps:

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -36,13 +36,6 @@ jobs:
   ci:
     name: CI
     runs-on: ${{ fromJSON(inputs.runner) }}
-    # Serialize heavy work on Mancave, including downstream-saas in main.yml.
-    # Hosted runners have separate machines and need no shared hardware lock.
-    # This group must differ from the caller's per-ref workflow group.
-    concurrency:
-      group: ${{ inputs.host-profile == 'mancave' && 'main-mancave-heavy' || format('main-hosted-{0}-{1}', github.run_id, github.run_attempt) }}
-      queue: max
-      cancel-in-progress: false
     env:
       NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,12 +187,6 @@ jobs:
       github.event_name != 'pull_request' &&
       github.event_name != 'pull_request_target'
     runs-on: ${{ fromJSON(vars.CI_RUNNER || '["self-hosted", "Linux", "X64"]') }}
-    # Share the hardware queue with the main Mancave CI job. Queue all refs
-    # here so one branch cannot evict another branch's waiting build.
-    concurrency:
-      group: main-mancave-heavy
-      queue: max
-      cancel-in-progress: false
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ on:
 # Queue instead of overlap; never cancel a run that is already going.
 concurrency:
   group: main-pipeline
+  # Keep pending runs instead of replacing them on each push.
+  queue: max
   cancel-in-progress: false
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,10 @@ on:
           - full
         default: auto
 
-# One pipeline at a time on the shared runner. Mancave picks up several jobs
-# at once, and a full suite is 4 shards x 2 browsers plus four debug servers
-# next to clippy and nextest; two of those overlapping is what turns the e2e
-# suite red run to run (reload-heavy specs time out waiting for the server).
-# Queue instead of overlap; never cancel a run that is already going.
+# Keep the newest pending run per ref. A push to a feature branch must not
+# replace develop's pending run. Already-started workflows finish normally.
 concurrency:
-  group: main-pipeline
-  # Keep pending runs instead of replacing them on each push.
-  queue: max
+  group: main-pipeline-${{ github.ref }}
   cancel-in-progress: false
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.
@@ -192,6 +187,12 @@ jobs:
       github.event_name != 'pull_request' &&
       github.event_name != 'pull_request_target'
     runs-on: ${{ fromJSON(vars.CI_RUNNER || '["self-hosted", "Linux", "X64"]') }}
+    # Share the hardware queue with the main Mancave CI job. Queue all refs
+    # here so one branch cannot evict another branch's waiting build.
+    concurrency:
+      group: main-mancave-heavy
+      queue: max
+      cancel-in-progress: false
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
A push to one branch can currently replace another branch’s pending CI run because every ref shares `main-pipeline`. Use `main-pipeline-${{ github.ref }}` so each branch or tag has its own running slot and newest pending run. Keep `cancel-in-progress: false` so started workflows finish.

Share Cargo’s cache lock files across containers instead of locking the registry mount for an entire build. Both lock files reside in the shared registry volume, allowing Cargo to coordinate dependency writes while build lanes overlap. Fresh volume names isolate these caches from older jobs with private locks.

Scope is limited to these two changes. There is no job-level Mancave scheduling change or focused Playwright option. Per-ref scheduling removes the existing cross-branch workflow serialization, so workflows from different branches may overlap on available runners, including Mancave. This PR does not impose a replacement global hardware limit.

Extracted from #1424 onto develop. Plugin-specific certification, runtime, and fixture fixes remain in #1424.

Validation:
- Workflow YAML parsing and `git diff --check` passed.
- Reusable main CI workflow and downstream job configuration match develop; only the top-level concurrency group and its comment change in the workflow diff.
- The retained Cargo helper previously passed TypeScript syntax validation and a Linux check that both lock paths share inodes and exclude competing locks across Cargo homes.
- Full Dagger CI and live branch scheduling remain unverified. The first builds use cold Cargo cache volumes.
