### PR TITLE
Fix E2E formatting failure on develop

### DIFF
--- a/browser/e2e/tests/recovery-option.spec.ts
+++ b/browser/e2e/tests/recovery-option.spec.ts
@@ -1,35 +1,75 @@
 import { test, expect } from '@playwright/test';
 
 // A portal session is not evidence that an encrypted recovery backup exists.
-test('does not offer account recovery when the signed-in account has no backup', async ({ page }) => {
-  await page.route('**/api/me', route => route.fulfill({ json: { email: 'no-backup@example.com' } }));
-  await page.route('**/api/recovery-secret', route => route.fulfill({ status: 204 }));
-  const checked = page.waitForResponse(response => response.url().endsWith('/api/recovery-secret'));
-  await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome?next=did%3Aad%3Atest`);
+test('does not offer account recovery when the signed-in account has no backup', async ({
+  page,
+}) => {
+  await page.route('**/api/me', route =>
+    route.fulfill({ json: { email: 'no-backup@example.com' } }),
+  );
+  await page.route('**/api/recovery-secret', route =>
+    route.fulfill({ status: 204 }),
+  );
+  const checked = page.waitForResponse(response =>
+    response.url().endsWith('/api/recovery-secret'),
+  );
+  await page.goto(
+    `${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome?next=did%3Aad%3Atest`,
+  );
   await expect(page.getByLabel('Agent secret', { exact: true })).toBeVisible();
   await checked;
-  await expect(page.getByRole('heading', { name: 'Unlock this drive' })).toBeVisible();
-  await expect(page.getByText(/You’re signed in as no-backup@example.com/)).toBeVisible();
-  await expect(page.getByRole('button', { name: /^Forgot it\? Restore from/ })).toHaveCount(0);
-  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toHaveCount(0);
-  await page.route('**/dashboard', route => route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }));
+  await expect(
+    page.getByRole('heading', { name: 'Unlock this drive' }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/You’re signed in as no-backup@example.com/),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /^Forgot it\? Restore from/ }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole('button', { name: 'Create account', exact: true }),
+  ).toHaveCount(0);
+  await page.route('**/dashboard', route =>
+    route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }),
+  );
   await page.getByRole('button', { name: 'Back', exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Portal drives' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Portal drives' }),
+  ).toBeVisible();
 });
 
-test('managed welcome goes to the portal instead of standalone onboarding', async ({ page }) => {
+test('managed welcome goes to the portal instead of standalone onboarding', async ({
+  page,
+}) => {
   const welcomeFrames: string[] = [];
-  await page.exposeFunction('reportStandaloneWelcome', () => welcomeFrames.push('shown'));
+  await page.exposeFunction('reportStandaloneWelcome', () =>
+    welcomeFrames.push('shown'),
+  );
   await page.addInitScript(() => {
     new MutationObserver(() => {
-      if ([...document.querySelectorAll('button')].some(button => button.textContent?.includes('Try the live demo'))) {
-        (window as unknown as { reportStandaloneWelcome: () => void }).reportStandaloneWelcome();
+      if (
+        [...document.querySelectorAll('button')].some(button =>
+          button.textContent?.includes('Try the live demo'),
+        )
+      ) {
+        (
+          window as unknown as { reportStandaloneWelcome: () => void }
+        ).reportStandaloneWelcome();
       }
     }).observe(document, { childList: true, subtree: true });
   });
-  await page.route('**/dashboard', route => route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }));
-  await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome`);
-  await expect(page.getByRole('heading', { name: 'Portal drives' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Try the live demo' })).toHaveCount(0);
+  await page.route('**/dashboard', route =>
+    route.fulfill({ contentType: 'text/html', body: '<h1>Portal drives</h1>' }),
+  );
+  await page.goto(
+    `${process.env.FRONTEND_URL || 'http://localhost:6747'}/app/welcome`,
+  );
+  await expect(
+    page.getByRole('heading', { name: 'Portal drives' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Try the live demo' }),
+  ).toHaveCount(0);
   expect(welcomeFrames).toEqual([]);
 });


### PR DESCRIPTION
Develop run https://github.com/ontola/atomic-server/actions/runs/34593448489 failed after merging #1427.

The E2E package's formatting check rejects `tests/recovery-option.spec.ts`, stopping the main CI pipeline. Format that file with the lockfile-pinned oxfmt 0.51.0.

The test logic is unchanged: parsed TypeScript syntax trees match before and after formatting. This PR changes only that test file.

Validation:
- Reproduced the failing formatter check on develop at a1675620e.
- In a Linux Node 22 container, the entire E2E package passes oxlint 1.79.0 (47 existing warnings, zero errors) and oxfmt 0.51.0 (all 97 files). Tool versions match the lockfile; this is a targeted lint environment, not a full frozen workspace install.
- `git diff --check` passes.
- Full Dagger CI is not verified by these checks; other stages may uncover additional failures.
