### PR TITLE
Fix recovery enrollment test timeouts in CI

### DIFF
--- a/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
+++ b/browser/data-browser/src/helpers/managed/recovery-enrollment.test.ts
@@ -147,6 +147,7 @@ describe('recovery-code passkey enrollment', () => {
   }, 60000);
 });
 
+// These migration cases derive real Argon2 keys, like the enrollment cases above.
 it('migrates onto an existing account credential while preserving old recovery methods', async () => {
   const original = structuredClone(stored);
   vi.mocked(accountPasskey).mockResolvedValue({
@@ -172,7 +173,7 @@ it('migrates onto an existing account credential while preserving old recovery m
   expect(await decryptEnvelopeV2(saved, code)).toBe('test-agent-secret');
   expect(await decryptEnvelopeWithPasskey(saved)).toBe('test-agent-secret');
   expect(create).toHaveBeenCalledTimes(1); // Only the original recovery credential.
-});
+}, 60000);
 it('failed migration leaves the original backup untouched', async () => {
   const original = structuredClone(stored);
   vi.mocked(accountPasskey).mockRejectedValue(new Error('cancelled'));
@@ -183,7 +184,7 @@ it('failed migration leaves the original backup untouched', async () => {
       .mocked(managedFetch)
       .mock.calls.some(([, options]) => options?.method === 'POST'),
   ).toBe(false);
-});
+}, 60000);
 
 it('keeps the right PRF salt when a credential has both legacy and account wrappers', async () => {
   const old = stored.wrappers.find(w => w.wrapper_type === 'webauthn-prf')!;
@@ -217,7 +218,7 @@ it('offers an explicit compatible-passkey upgrade when the login key has no PRF'
   );
   expect(stored).toEqual(original);
   expect(create).toHaveBeenCalledTimes(1);
-});
+}, 60000);
 
 it('reports a wrong code before attempting account passkey registration', async () => {
   vi.mocked(accountPasskey).mockClear();
@@ -225,4 +226,4 @@ it('reports a wrong code before attempting account passkey registration', async 
     unifyAccountPasskey(subject, 'wrong-recovery-code'),
   ).rejects.toThrow('Wrong recovery code');
   expect(accountPasskey).not.toHaveBeenCalled();
-});
+}, 60000);


### PR DESCRIPTION
Three recovery-enrollment tests timed out at Vitest’s default 5 seconds in the CI run for #1430: https://github.com/ontola/atomic-server/actions/runs/34594171599. The older code-derivation tests and fixture setup already allow 60 seconds, but the newer account-passkey migration cases omitted that timeout.

Give the four newer tests that derive recovery-code keys the same 60-second timeout, including the failed-migration case that has the same expensive path. Keep the fast account-mismatch and PRF-only tests on the default timeout. Production cryptography, fixture parameters, assertions, and global test configuration are unchanged.

Validation:
- All 10 recovery-enrollment tests pass with real WebCrypto/Argon2 under Vitest 4.1.7 (34.62 seconds overall), using an isolated test configuration with the existing local dependencies.
- Formatting, lint, and `git diff --check` pass for the changed file.
- Full package typechecking is not verified: the pnpm launcher could not fetch its pinned version, and direct tsc with available local workspace dependencies reported missing @tomic/lib/@tomic/react exports and @tomic/service-ui. No reported error points to this test.
- A constrained emulated Linux reproduction was stopped because its Node runtime disables optimization and was not representative of CI timing. The baseline failure evidence is the actual CI log; full CI on this fix remains unverified.
