### PR TITLE
Fix pnpm reinstall during staged pre-commit lint

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -16,11 +16,15 @@ caught it, and if the answer is "none", that is the row to add.
 ## Pre-commit lint gate
 
 `node --test scripts/pre-commit.test.mjs` exercises real Git commits with Oxlint
-in a temporary repository: initial commits, staged errors hidden by unstaged
+in a temporary repository using real pnpm 11.10.0 (via Corepack):
+initial commits, staged errors hidden by unstaged
 fixes, clean staged files with unstaged errors, filenames with spaces,
 documentation-only commits, missing dependencies, and preservation of the index
-and working tree. A stub Cargo command verifies Clippy dispatch, staged input,
-and failure propagation; this fixture does not compile the Rust workspace.
+and working tree. Noninteractive recursive lint runs with symlinked dependencies
+and incompatible pnpm metadata reproduce issue #1437; the fixture checks that
+installed metadata and a dependency sentinel remain untouched. Corepack must
+have this pnpm version cached or be able to download it. A stub Cargo command
+verifies Clippy dispatch, staged input, and failure propagation; this fixture does not compile the Rust workspace.
 
 ## Browser WebRTC transport (issue #1396)
 

--- a/scripts/pre-commit.mjs
+++ b/scripts/pre-commit.mjs
@@ -91,7 +91,14 @@ try {
     console.log('pre-commit: linting staged browser snapshot');
     execFileSync('pnpm', ['run', 'lint'], {
       cwd: join(snapshot, 'browser'),
-      env,
+      env: {
+        ...env,
+        // This snapshot borrows node_modules through symlinks. Never let pnpm
+        // repair/install them. Export both names for nested `pnpm run` calls:
+        // pnpm 11 reads pnpm_config_*; older versions use npm_config_*.
+        pnpm_config_verify_deps_before_run: 'false',
+        npm_config_verify_deps_before_run: 'false',
+      },
       stdio: 'inherit',
     });
   }

--- a/scripts/pre-commit.test.mjs
+++ b/scripts/pre-commit.test.mjs
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -16,7 +18,8 @@ import test from 'node:test';
 const scripts = dirname(fileURLToPath(import.meta.url));
 const oxlint = resolve(scripts, '../browser/node_modules/.bin/oxlint');
 
-test('Git commits lint the index, preserve local edits, and fail closed', () => {
+const version = '11.10.0';
+test(`pnpm ${version}: Git commits lint the index, preserve local edits, and fail closed`, () => {
   const root = mkdtempSync(join(tmpdir(), 'atomic-hook-test-'));
   // Do not inherit an outer commit's Git index/worktree or Husky bypass.
   const env = { ...process.env };
@@ -30,6 +33,7 @@ test('Git commits lint the index, preserve local edits, and fail closed', () => 
       cwd: root,
       env,
       encoding: 'utf8',
+      timeout: 30_000,
     });
 
   const git = (...args) => {
@@ -41,14 +45,29 @@ test('Git commits lint the index, preserve local edits, and fail closed', () => 
 
   const write = (file, contents) => writeFileSync(join(root, file), contents);
 
-  const commit = expected => {
+  const commit = (expected, diagnostic) => {
     const before = git('diff', '--cached', '--binary');
     const working = readFileSync(
       join(root, 'browser/src/with spaces.js'),
       'utf8',
     );
+    const modules = join(root, 'browser/node_modules');
+    const metadata = existsSync(modules)
+      ? readFileSync(join(modules, '.modules.yaml'), 'utf8')
+      : null;
     const result = run('git', ['commit', '-m', 'fixture']);
+    if (metadata !== null) {
+      assert.equal(
+        readFileSync(join(modules, '.modules.yaml'), 'utf8'),
+        metadata,
+      );
+      assert.equal(
+        readFileSync(join(modules, 'sentinel'), 'utf8'),
+        'preserve installed dependencies\n',
+      );
+    }
     assert.equal(result.status === 0, expected, result.stdout + result.stderr);
+    if (diagnostic) assert.match(result.stdout + result.stderr, diagnostic);
     assert.equal(
       readFileSync(join(root, 'browser/src/with spaces.js'), 'utf8'),
       working,
@@ -65,7 +84,40 @@ test('Git commits lint the index, preserve local edits, and fail closed', () => 
     mkdirSync(join(root, '.hooks'));
     mkdirSync(join(root, 'scripts'));
     mkdirSync(join(root, 'browser/src'), { recursive: true });
-    mkdirSync(join(root, 'browser/node_modules'));
+    mkdirSync(join(root, 'browser/node_modules/.bin'), { recursive: true });
+    mkdirSync(join(root, 'pnpm-tools'));
+    writeFileSync(
+      join(root, 'pnpm-tools/pnpm'),
+      `#!/bin/sh\nexec corepack pnpm@${version} "$@"\n`,
+      { mode: 0o755 },
+    );
+    env.PATH = `${join(root, 'pnpm-tools')}:${env.PATH}`;
+    // A real pnpm 11 workspace with linked, incompatible installed metadata.
+    // Any automatic install must fail without a TTY, never purge the modules.
+    delete env.CI;
+    delete env.pnpm_config_verify_deps_before_run;
+    write(
+      'browser/pnpm-workspace.yaml',
+      'packages: [src]\nverifyDepsBeforeRun: install\n',
+    );
+    write(
+      'browser/node_modules/.modules.yaml',
+      'layoutVersion: 5\nstoreDir: /nonexistent-hook-test-store\n',
+    );
+    write('browser/node_modules/sentinel', 'preserve installed dependencies\n');
+    symlinkSync(oxlint, join(root, 'browser/node_modules/.bin/oxlint'));
+    symlinkSync(
+      resolve(scripts, '../browser/node_modules/oxlint'),
+      join(root, 'browser/node_modules/oxlint'),
+    );
+    write(
+      'browser/src/package.json',
+      JSON.stringify({
+        name: 'hook-lint-fixture',
+        scripts: { lint: 'oxlint --deny no-debugger .' },
+      }),
+    );
+    write('.gitignore', 'node_modules/\npnpm-tools/\n');
     copyFileSync(
       join(scripts, 'pre-commit.mjs'),
       join(root, 'scripts/pre-commit.mjs'),
@@ -73,20 +125,23 @@ test('Git commits lint the index, preserve local edits, and fail closed', () => 
     writeFileSync(
       join(root, '.hooks/pre-commit'),
       '#!/bin/sh\nnode scripts/pre-commit.mjs\n',
-      { mode: 0o755 },
+      {
+        mode: 0o755,
+      },
     );
     write(
       'browser/package.json',
       JSON.stringify({
         private: true,
-        scripts: { lint: `"${oxlint}" --deny no-debugger src` },
+        packageManager: `pnpm@${version}`,
+        scripts: { lint: 'pnpm run -r lint' },
       }),
     );
     write('browser/src/with spaces.js', 'debugger;\n');
     git('add', '.');
     // An unstaged fix must not conceal a staged error (including first commit).
     write('browser/src/with spaces.js', 'console.log("fixed");\n');
-    commit(false);
+    commit(false, /no-debugger/);
     git('add', 'browser/src/with spaces.js');
     // Unstaged errors must not block a clean staged snapshot.
     write('browser/src/with spaces.js', 'debugger;\n');
@@ -129,7 +184,7 @@ exit "$HOOK_TEST_CARGO_STATUS"
     rmSync(join(root, 'browser/node_modules'), { recursive: true });
     write('browser/src/with spaces.js', 'console.log("another fix");\n');
     git('add', 'browser/src/with spaces.js');
-    commit(false);
+    commit(false, /Browser dependencies missing/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes #1437.

The staged-snapshot pre-commit hook could trigger pnpm 11 dependency installation before linting, failing without a TTY and potentially modifying dependencies borrowed through symlinks. Disable dependency verification for the lint subprocess and nested pnpm calls using both pnpm and legacy npm configuration environment variables.

Extend the regression fixture to run real pnpm 11.10.0 with recursive lint scripts and incompatible dependency metadata. It checks staged content, lint failure propagation, and preservation of installed metadata and a dependency sentinel. Update the coverage documentation with the Corepack requirement.

## Validation

- Reproduced `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` before the fix.
- `node --test scripts/pre-commit.test.mjs` passes after the fix.
- Oxlint on both hook scripts: no errors; one existing style warning.
- `git diff --check` passes.
