### PR TITLE
Fix implicit localhost managed account probes

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -577,6 +577,10 @@ current-drive behavior for ordinary resource links.
 - Managed Vault display metadata: `vaultAutoBackup.test.ts` now covers a drive
   present only in local storage, as well as rename/emoji refresh. Manual enable
   and automatic backup share `driveDisplayMetadata`; only name and emoji are sent.
+- Standalone account probes: `helpers/managed/session.test.ts` verifies that
+  no `/api/me` request is made without a configured control plane.
+  `helpers/managed/api.test.ts` covers localhost/127.0.0.1 without implicit SaaS
+  routing, explicit local API configuration, and discovered/build portal routing.
 - FOSS logout: `helpers/managed/session.test.ts` verifies that an installation
   with no configured control plane makes no SaaS logout request (the CI smoke
   test exposed a 405 at `/api/logout`).

--- a/browser/data-browser/src/helpers/managed/api.test.ts
+++ b/browser/data-browser/src/helpers/managed/api.test.ts
@@ -47,6 +47,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   inTauri.value = false;
 });
 
@@ -233,5 +235,45 @@ describe('a linked device', () => {
     const api = await freshApi();
 
     expect(api.getLinkedPortalOrigin()).toBeNull();
+  });
+});
+
+describe('browser control-plane routing', () => {
+  beforeEach(() => {
+    inTauri.value = false;
+    vi.stubGlobal('window', { location: { hostname: 'localhost' } });
+    vi.stubEnv('VITE_MANAGED_API_BASE', '');
+    vi.stubEnv('VITE_MANAGED_PORTAL_URL', '');
+  });
+
+  it.each(['localhost', '127.0.0.1'])(
+    'does not infer a SaaS backend from %s',
+    async hostname => {
+      vi.stubGlobal('window', { location: { hostname } });
+      const api = await freshApi();
+      expect(api.hasManagedApi()).toBe(false);
+      expect(api.getManagedApiBase()).toBe('/api');
+    },
+  );
+
+  it('uses an explicitly configured local SaaS backend', async () => {
+    vi.stubEnv('VITE_MANAGED_API_BASE', 'http://localhost:3030/api/');
+    const api = await freshApi();
+    expect(api.hasManagedApi()).toBe(true);
+    expect(api.getManagedApiBase()).toBe('http://localhost:3030/api');
+  });
+
+  it('uses a discovered portal in the browser', async () => {
+    const api = await freshApi();
+    api.rememberManagedPortalUrl(PORTAL);
+    expect(api.hasManagedApi()).toBe(true);
+    expect(api.getManagedApiBase()).toBe(`${PORTAL}/api`);
+  });
+
+  it('uses the build portal in the browser', async () => {
+    vi.stubEnv('VITE_MANAGED_PORTAL_URL', PORTAL);
+    const api = await freshApi();
+    expect(api.hasManagedApi()).toBe(true);
+    expect(api.getManagedApiBase()).toBe(`${PORTAL}/api`);
   });
 });

--- a/browser/data-browser/src/helpers/managed/api.ts
+++ b/browser/data-browser/src/helpers/managed/api.ts
@@ -28,8 +28,6 @@ export function getRuntimeManagedPortalUrl(): string | null {
 // `/api/recovery-secret`). The dev portal URL mirrors `managedServer.ts`.
 // VERIFY the production base against your real deployment.
 
-import { isRunningInTauri } from '../tauri';
-
 const PORTAL_URL_STORAGE_KEY = 'atomic-managed-portal-url';
 /** The portal the device token was issued by. See {@link getLinkedPortalOrigin}. */
 const LINKED_PORTAL_STORAGE_KEY = 'atomic-managed-portal-origin-linked';
@@ -216,34 +214,12 @@ export function getManagedApiBase(): string {
 
   if (fromEnv) return trimTrailingSlashes(fromEnv);
 
-  // Checked BEFORE the localhost branch below, deliberately: the desktop
-  // webview's origin is `tauri://localhost`, whose hostname is literally
-  // `localhost`. Falling through would point every desktop build — shipped
-  // ones included — at whatever happens to run on a dev machine's :3030.
-  // There is no same-origin `/api` here either, so the real answers are the
-  // control plane the connected managed node named, or the one the build was
-  // compiled against (the store apps; see tauri-release.yml). Before either
-  // (pure self-hosted, or nothing fetched yet) these fetches just fail, which
-  // every caller already treats as "no control plane".
-  if (isRunningInTauri()) {
-    const portalUrl = getRememberedManagedPortalUrl() ?? portalFromEnv();
+  // Localhost alone does not imply a SaaS backend. Browser and desktop
+  // clients use the discovered or configured portal; local SaaS development
+  // can explicitly set VITE_MANAGED_API_BASE=http://localhost:3030/api.
+  const portalUrl = getRememberedManagedPortalUrl() ?? portalFromEnv();
 
-    return portalUrl ? `${portalUrl}/api` : '/api';
-  }
-
-  if (typeof window !== 'undefined') {
-    const { hostname } = window.location;
-
-    if (hostname === 'localhost' || hostname === '127.0.0.1') {
-      // Local dev: the control-plane backend (`cargo run` binds
-      // 0.0.0.0:3030 and serves /api/*; its CORS allows :6747/:49237/:6747).
-      // The portal (:49237) is only the frontend and has no /api.
-      return 'http://localhost:3030/api';
-    }
-  }
-
-  // Same-origin deployment fallback.
-  return '/api';
+  return portalUrl ? `${portalUrl}/api` : '/api';
 }
 
 /**

--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import {
   evaluateServerReconciliation,
   localAgentIsDisposable,
@@ -56,6 +56,10 @@ function enrollment(
 }
 
 describe('evaluateServerReconciliation', () => {
+  beforeEach(() =>
+    vi.stubEnv('VITE_MANAGED_API_BASE', 'https://portal.example/api'),
+  );
+  afterEach(() => vi.unstubAllEnvs());
   const realFetch = globalThis.fetch;
 
   afterEach(() => {

--- a/browser/data-browser/src/helpers/managed/session.test.ts
+++ b/browser/data-browser/src/helpers/managed/session.test.ts
@@ -32,3 +32,10 @@ it('does not call the SaaS logout endpoint on a FOSS server', async () => {
   // The local token still goes, so a stale link cannot outlive the sign-out.
   expect(setTokenMock).toHaveBeenCalledWith(null);
 });
+
+it('does not probe for an account without a configured control plane', async () => {
+  configured.mockReturnValueOnce(false);
+  fetchMock.mockClear();
+  expect(await getManagedAccount()).toBeNull();
+  expect(fetchMock).not.toHaveBeenCalled();
+});

--- a/browser/data-browser/src/helpers/managed/session.ts
+++ b/browser/data-browser/src/helpers/managed/session.ts
@@ -19,7 +19,7 @@ let pendingLogouts = 0;
  * or null when not signed in. 204/401 both mean "no session".
  */
 export async function getManagedAccount(): Promise<ManagedAccount | null> {
-  if (pendingLogouts > 0) return null;
+  if (pendingLogouts > 0 || !hasManagedApi()) return null;
   const generation = sessionGeneration;
   const response = await managedFetch(`/me`, {});
   if (generation !== sessionGeneration) return null;

--- a/browser/e2e/scripts/vault-stack.sh
+++ b/browser/e2e/scripts/vault-stack.sh
@@ -275,4 +275,4 @@ fi
 
 echo
 echo "The SPA reaches the control plane at http://localhost:$SAAS_PORT"
-echo "(hardcoded for localhost origins in helpers/managed/api.ts — no vite env needed)."
+echo "Start Vite with VITE_MANAGED_API_BASE=http://localhost:$SAAS_PORT/api to enable SaaS requests."


### PR DESCRIPTION
Opening a standalone AtomicServer frontend on localhost triggered account probes at `http://localhost:3030/api/me`, even when no SaaS backend was configured. Skip account lookup when no managed API is known and remove the hostname-based port 3030 fallback.

Browser and desktop clients now use the configured or discovered portal consistently. Local SaaS development can explicitly set `VITE_MANAGED_API_BASE=http://localhost:3030/api`; the vault stack instructions document this.

Validation: reproduced five failing regression cases before the fix; all 231 managed-helper tests now pass. TypeScript (`tsc --noEmit -p tsconfig.json`), focused Oxlint/Oxfmt checks, shell syntax, and `git diff --check` pass. Used the installed binaries directly because the pnpm version bootstrap could not reach the registry. No UI text or translation catalogs changed.
