### PR TITLE
test(e2e): match the current drive unlock heading

### DIFF
--- a/browser/e2e/tests/second-device-load.spec.ts
+++ b/browser/e2e/tests/second-device-load.spec.ts
@@ -63,7 +63,7 @@ test(
     // generic root-page helper can mistake a public sidebar for a signed-in
     // session and return without ever entering the secret.
     await expect(
-      p2.getByRole('heading', { name: 'Sign in to access this drive' }),
+      p2.getByRole('heading', { name: 'Unlock this drive' }),
     ).toBeVisible();
     await p2.getByLabel('Agent secret').fill(secret);
 


### PR DESCRIPTION
The second-device smoke test waits for “Sign in to access this drive”, but the current sign-in UI renders “Unlock this drive”. It therefore fails before entering the agent secret. Update the heading assertion while retaining the secret-entry and cold-load assertions.

Validated directly with native Playwright against a fresh data directory and the production frontend built from develop e3df74d26 with VITE_E2E=true:

- Before: kanban passed; second-device reproduced the exact missing-heading CI failure (2 tests, 23.2 seconds).
- After: second-device passed (8.3 seconds).
- Entire Chromium @smoke suite: **17 passed in 2.3 minutes**, one worker, no retries; strict browser diagnostics enabled.
- Staged browser lint/format hook passed.

Command from browser/e2e:
```
CI=true FRONTEND_URL=http://localhost:19883 SERVER_URL=http://localhost:19883 PLAYWRIGHT_WORKERS=1 PLAYWRIGHT_RETRIES=0 pnpm exec playwright test --grep @smoke --project=chromium --reporter=line
```

This is native Playwright validation using a debug server with `--no-default-features --features light`, not a full Dagger CI result. The separate kanban missing-datatype error from run 34597676257 did not reproduce in these local runs and is not claimed fixed here.
