### PR TITLE
fix: wait for property hydration before resolving reads

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -197,6 +197,7 @@ Not covered: table `contains`; Playwright search overlay on the KV path; Flutter
 | Sync page status renders | `browser/e2e/tests/sync.spec.ts` |
 | Offline edits persist and sync on reconnect | `sync.spec.ts` |
 | Second device cold-loads a drive from the server | `second-device-load.spec.ts` |
+| Property reads stay pending through loading-placeholder notifications until hydration completes | `browser/lib/src/store.test.ts` |
 
 ---
 

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -8,6 +8,59 @@ describe('Store', () => {
     vi.clearAllMocks();
   });
 
+  it('waits for property data after a loading-placeholder notification', async ({
+    expect,
+  }) => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    const resource = new Resource('did:ad:loading-property');
+    resource.loading = true;
+    store.addResource(resource);
+    const settled = vi.fn();
+    const result = store.getProperty(resource.subject).then(
+      value => {
+        settled();
+
+        return value;
+      },
+      error => {
+        settled();
+
+        return error;
+      },
+    );
+    // Mounted readers can notify subscribers before hydration finishes.
+    store.notifyResourceUpdated(resource);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const settledWhileLoading = settled.mock.calls.length;
+    await resource.set(core.properties.datatype, Datatype.STRING, false);
+    await resource.set(core.properties.shortname, 'title', false);
+    await resource.set(core.properties.description, 'Title', false);
+    resource.loading = false;
+    store.notifyResourceUpdated(resource);
+    const loaded = await result;
+    expect(settledWhileLoading).toBe(0);
+    expect(loaded).toMatchObject({
+      shortname: 'title',
+      datatype: Datatype.STRING,
+    });
+  });
+
+  it('reports a failed property load without waiting for the loading flag to clear', async ({
+    expect,
+  }) => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    const resource = new Resource('did:ad:failed-property');
+    resource.loading = true;
+    store.addResource(resource);
+    const result = store.getProperty(resource.subject);
+    const rejected = expect(result).rejects.toThrow(
+      'cannot be loaded: Error: unavailable',
+    );
+    resource.error = new Error('unavailable');
+    store.notifyResourceUpdated(resource);
+    await rejected;
+  });
+
   it('does not notify mounted readers while another reader takes its first snapshot', async ({
     expect,
   }) => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -3715,6 +3715,9 @@ export class Store {
         let timer: ReturnType<typeof setTimeout> | undefined;
 
         const cb: ResourceCallback<C> = res => {
+          // Snapshot notifications can precede hydration. Keep waiting for
+          // data, but let terminal errors reach the caller.
+          if (res.loading && !res.error) return;
           if (timer) clearTimeout(timer);
           this.unsubscribe(subjectRaw, cb);
           resolve(res);


### PR DESCRIPTION
A read of an already-loading resource currently resolves on the next Store notification, even if the resource is still loading. A notification about an empty placeholder therefore lets `getProperty()` inspect missing data and throw “Property … has no datatype: {}”. Both the table and kanban failures in run 34597676257 reported that error.

Keep the read subscribed through loading notifications; resolve once data is ready, or an error arrives. Preserve the existing timeout and strict Playwright browser diagnostics. No extra sleeps or retries are added to the table test.

Regression coverage exercises a loading-placeholder notification followed by hydration, and verifies that terminal load errors still reach callers. The first regression fails against develop because the property read settles before hydration, and passes with the fix. This deterministically reproduces the loader race; it does not establish that it is the only possible source of the intermittent CI error.

Validation:
- Store tests: **23 passed**, including both new regressions.
- `browser/lib` typecheck passed.
- Direct native Playwright, production frontend, fresh server data, one worker and zero retries: table and kanban smoke tests repeated three times each, **6 passed in 52.6 seconds**.
- Entire Chromium smoke suite: **17 passed in 2.3 minutes**.
- Normal staged browser lint/format hook passed.

Playwright commands from `browser/e2e`, with `CI=true FRONTEND_URL=http://localhost:19883 SERVER_URL=http://localhost:19883 PLAYWRIGHT_WORKERS=1 PLAYWRIGHT_RETRIES=0`:
```
pnpm exec playwright test tests/tables.spec.ts tests/kanban.spec.ts --grep @smoke --repeat-each=3 --project=chromium --reporter=line
pnpm exec playwright test --grep @smoke --project=chromium --reporter=line
```
The native server used a debug build with `--no-default-features --features light`. Full Dagger CI was not run locally.
