### PR TITLE
Show a loading spinner while table rows arrive

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -698,3 +698,8 @@ and verifies an edit plus attachment survive reload without HTTP/WS data writes.
 It also exercises the compiled Vault session error path (no React hook in an
 error constructor). Actual staging billing/admission and multi-device migration
 remain separate acceptance checks.
+
+Table loading feedback: `browser/data-browser/src/chunks/TableEditor/TableEditor.test.tsx`
+checks that a busy grid with only an entry row renders a visible spinner/status,
+and that settled empty and populated grids remove it. This is a component render
+check; real refresh/query timing remains a browser acceptance check.

--- a/browser/data-browser/src/chunks/TableEditor/TableEditor.test.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/TableEditor.test.tsx
@@ -1,0 +1,55 @@
+// @wc-ignore-file
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ThemeProvider, type DefaultTheme } from 'styled-components';
+import { FancyTable } from './TableEditor';
+
+vi.mock('./DndWrapper', () => ({
+  DndWrapper: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('./TableHeader', () => ({ TableHeader: () => <div role='row' /> }));
+
+// Only the theme fields used by this grid fixture.
+const theme = {
+  colors: { main: '#4C6FA5' },
+  animation: { duration: '0s' },
+  size: () => '8px',
+} as unknown as DefaultTheme;
+
+function renderGrid(busy: boolean, itemCount = 1) {
+  return renderToStaticMarkup(
+    <ThemeProvider theme={theme}>
+      <FancyTable
+        busy={busy}
+        columns={[]}
+        itemCount={itemCount}
+        columnToKey={String}
+        labelledBy='table-title'
+        HeadingComponent={() => <></>}
+        NewColumnButtonComponent={() => null}
+      >
+        {() => <div role='row' />}
+      </FancyTable>
+    </ThemeProvider>,
+  );
+}
+
+describe('table loading feedback', () => {
+  it('shows a visible loading status while only the entry row is available', () => {
+    const html = renderGrid(true);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('Loading');
+    expect(html).toContain('<svg');
+  });
+
+  it.each([0, 1, 5])(
+    'removes loading feedback once %i rows have settled',
+    count => {
+      const html = renderGrid(false, count);
+      expect(html).toContain('aria-busy="false"');
+      expect(html).not.toContain('role="status"');
+      expect(html).not.toContain('Loading');
+    },
+  );
+});

--- a/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
+++ b/browser/data-browser/src/chunks/TableEditor/TableEditor.tsx
@@ -35,6 +35,7 @@ import { useClearCommands } from './hooks/useClearCommands';
 import { usePasteCommand } from './hooks/usePasteCommand';
 import { DndWrapper } from './DndWrapper';
 import { VisuallyHidden } from '@components/VisuallyHidden';
+import { Spinner } from '@components/Spinner';
 import { useClickAwayListener } from '../../hooks/useClickAwayListener';
 import { KeyboardInteraction } from './helpers/keyboardHandlers';
 import { useAvailableHeight } from './hooks/useAvailableHeight';
@@ -52,7 +53,7 @@ interface FancyTableProps<T> {
   columnToKey: (column: T) => string;
   labelledBy: string;
   /**
-   * The rows are still being fetched. Rendered as `aria-busy` on the grid so
+   * The rows are still being fetched. Shows a spinner and `aria-busy` so
    * assistive tech, and tests, can tell a loading grid from a settled one:
    * the placeholder row is drawn before the collection answers, so "a row is
    * visible" no longer means "the data has arrived".
@@ -361,6 +362,16 @@ function FancyTableInner<T>({
             />
           </PercentageInsanityFix>
         </RelativeScrollArea>
+        {busy && (
+          <div role='row'>
+            <LoadingCell role='gridcell' aria-colspan={columns.length + 2}>
+              <span role='status'>
+                <Spinner size='20px' />
+                Loading
+              </span>
+            </LoadingCell>
+          </div>
+        )}
       </Table>
     </DndWrapper>
   );
@@ -406,6 +417,17 @@ const Table = styled.div.attrs<TableProps>(p => ({
   &:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px ${p => p.theme.colors.main};
+  }
+`;
+
+const LoadingCell = styled.div`
+  padding: ${p => p.theme.size()};
+
+  > span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: ${p => p.theme.size()};
   }
 `;
 

--- a/browser/data-browser/src/chunks/TablePage/useTableData.ts
+++ b/browser/data-browser/src/chunks/TablePage/useTableData.ts
@@ -98,7 +98,7 @@ export function useTableData(
     queryFilters: queryFilter.filters,
     queryExpressionFilters: expressionFilters,
     collection,
-    ready,
+    ready: classReady && ready,
     invalidateCollection,
     mapAll,
   };

--- a/browser/data-browser/src/locales/de.po
+++ b/browser/data-browser/src/locales/de.po
@@ -8095,3 +8095,7 @@ msgstr ""
 #: src/routes/NewResource/NewRoute.tsx
 msgid "Ask AI"
 msgstr ""
+
+#: src/chunks/TableEditor/TableEditor.tsx
+msgid "<0/> Loading"
+msgstr ""

--- a/browser/data-browser/src/locales/en.po
+++ b/browser/data-browser/src/locales/en.po
@@ -8129,3 +8129,7 @@ msgstr "No matches. Try another search or ask AI to build it."
 #: src/routes/NewResource/NewRoute.tsx
 msgid "Ask AI"
 msgstr "Ask AI"
+
+#: src/chunks/TableEditor/TableEditor.tsx
+msgid "<0/> Loading"
+msgstr "<0/> Loading"

--- a/browser/data-browser/src/locales/es.po
+++ b/browser/data-browser/src/locales/es.po
@@ -8095,3 +8095,7 @@ msgstr ""
 #: src/routes/NewResource/NewRoute.tsx
 msgid "Ask AI"
 msgstr ""
+
+#: src/chunks/TableEditor/TableEditor.tsx
+msgid "<0/> Loading"
+msgstr ""

--- a/browser/data-browser/src/locales/fr.po
+++ b/browser/data-browser/src/locales/fr.po
@@ -8095,3 +8095,7 @@ msgstr ""
 #: src/routes/NewResource/NewRoute.tsx
 msgid "Ask AI"
 msgstr ""
+
+#: src/chunks/TableEditor/TableEditor.tsx
+msgid "<0/> Loading"
+msgstr ""


### PR DESCRIPTION
After a page refresh, the table can display an empty entry row before its row query finishes, making a populated table look empty. Show the shared spinner with a “Loading” status inside the grid until the query completes, including the period before the table class resolves. The entry row remains usable.

Adds a component regression test for loading and settled empty/populated grids, translation catalog entries, and a testing coverage note.

Validation: all 4 component checks pass; frontend TypeScript check and `git diff --check` pass. The supplied recording was inspected; live refresh timing has not been browser-tested.

## Related Issues

User-reported refresh loading gap; no linked issue.

## Checklist
- [x] Add or update tests if needed
- [x] Update docs if needed (testing coverage)
- [ ] Changelog entry (no API changes)
