### PR TITLE
Fix local-drive unlock after app sign-out

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -791,3 +791,8 @@ page, never payload contents. A real local WebSocket exercises this collection.
 - `save-status-coordinator.test.ts` exercises narrow injected dependencies without a
   Store: overlapping owners, idempotent observer disposal, resource renaming, cached
   immutable snapshots, current outbox/connection state and failure accounting.
+## Signed-out local drive opened from the portal
+
+`browser/data-browser/src/helpers/isDriveSignInError.test.ts` covers a local-only missing-resource error with no app agent, including origins with a configured node. Signed-in users and unrelated transport failures retain their error handling.
+
+Paired SaaS `portal/e2e/passkey-open-drive.spec.ts` covers account/profile creation, passkey enrollment, recovery-code acknowledgement, completed app sign-out, portal passkey sign-in, and the Open link reaching the app unlock screen. It then unlocks and verifies the original drive title. Chromium virtual PRF state is tied to the original CDP target, so the unlock portion runs there after verifying the real popup handoff. Unlocking within the popup itself remains a physical-browser acceptance check.

--- a/browser/data-browser/src/helpers/isDriveSignInError.test.ts
+++ b/browser/data-browser/src/helpers/isDriveSignInError.test.ts
@@ -76,6 +76,19 @@ describe('isDriveSignInError', () => {
     ).toBe(true);
   });
 
+  it('a signed-out local-only drive requires unlock even when the app has a node', () => {
+    expect(
+      isDriveSignInError(res(DRIVE, localOnlyGone), undefined, BASE, {
+        originWithoutNode: false,
+      }),
+    ).toBe(true);
+    expect(
+      isDriveSignInError(res(DRIVE, localOnlyGone), someAgent, BASE, {
+        originWithoutNode: false,
+      }),
+    ).toBe(false);
+  });
+
   it('not held locally, but a node exists → just offline, no guard', () => {
     expect(isDriveSignInError(res(DRIVE, notLocal), undefined, BASE)).toBe(
       false,

--- a/browser/data-browser/src/helpers/isDriveSignInError.ts
+++ b/browser/data-browser/src/helpers/isDriveSignInError.ts
@@ -2,6 +2,7 @@ import {
   type Agent,
   type Resource,
   isNotAvailableLocally,
+  LOCAL_ONLY_NOT_FOUND_MESSAGE,
   isUnauthorized,
 } from '@tomic/react';
 import { isRootWelcomeResourceError } from './isRootWelcomeResourceError';
@@ -22,7 +23,8 @@ import { isRootWelcomeResourceError } from './isRootWelcomeResourceError';
  * available locally" instead. For a signed-out visitor that is the same
  * situation — the data can only arrive through a sign-in (a vault restore, or
  * a connected device) — so it gets the same guard. A drive opened from the
- * portal on a fresh phone is exactly this.
+ * portal on a fresh phone is exactly this. Local-only drives require the
+ * same unlock even on an origin with a node: that node does not hold them.
  */
 export function isDriveSignInError(
   resource: Resource,
@@ -36,6 +38,8 @@ export function isDriveSignInError(
 
   return (
     isUnauthorized(resource.error) ||
-    (!!options.originWithoutNode && isNotAvailableLocally(resource.error))
+    (isNotAvailableLocally(resource.error) &&
+      (options.originWithoutNode === true ||
+        resource.error?.message === LOCAL_ONLY_NOT_FOUND_MESSAGE))
   );
 }

--- a/browser/data-browser/src/views/ErrorPage.tsx
+++ b/browser/data-browser/src/views/ErrorPage.tsx
@@ -58,7 +58,10 @@ function ErrorPage({ resource }: ResourcePageProps): JSX.Element {
     resource.subject,
   ]);
 
-  if (isRootWelcomeResourceError(resource, agent, baseURL)) {
+  if (
+    shouldGoToWelcome ||
+    isRootWelcomeResourceError(resource, agent, baseURL)
+  ) {
     // Redirect effect above will handle the URL; render something safe meanwhile.
     return <RootWelcomeGate subject={baseURL || resource.subject} />;
   }

--- a/planning/passkey-local-drive-unlock.md
+++ b/planning/passkey-local-drive-unlock.md
@@ -1,0 +1,12 @@
+# App sign-out and local drive unlock
+
+- [x] Reproduce portal Open after completed app sign-out in the same browser.
+- [x] Route LOCAL_ONLY_NOT_FOUND_MESSAGE through the existing unlock flow even when the app origin has a configured node.
+- [x] Avoid rendering the transport error while the unlock redirect is pending.
+- [x] Unit regression and TypeScript check.
+- [x] Paired real-service browser regression: popup handoff, then virtual-passkey unlock on its original CDP target, original drive title restored.
+- [ ] Investigate original-tab direct navigation after sign-out: it can surface a different NotFound error (DID not found locally) instead of the local-only transport error. A speculative local-only guard did not resolve it and was removed.
+- [ ] Verify the complete new-tab unlock with a physical passkey provider.
+- [ ] Review and deploy.
+
+App sign-out clears the app identity and session database keys. A portal session does not unlock the encrypted app database. The fix reuses the existing unlock flow; it does not create a replacement drive or change Cloud Server routing.


### PR DESCRIPTION
Opening a local-only drive from the portal after signing out of the app could report “Could not reach the server” and “not found in local storage”. The portal session does not unlock the encrypted app database, and the sign-in guard incorrectly required a node-less app origin for this error.

Route this signed-out local-only error through the existing drive unlock flow even when a node is configured. Render the welcome gate while the redirect is pending so the transport error does not flash. Signed-in users and unrelated transport errors keep their existing handling.

Validation after rebasing onto develop `5c5d7794c` (head `ef33b1c7b`): all 854 frontend unit tests, including 11 focused sign-in guard cases, workspace TypeScript checks and full frontend lint pass. Six embedded-server Chromium account/managed/offline regressions pass with zero retries. Full hosted CI is running: https://github.com/ontola/atomic-server/actions/runs/34668362146.

Earlier real-service SaaS browser regression passed: completed app sign-out, portal passkey login, Open popup reaching unlock, then passkey unlock restoring the original drive title. This paired browser test was not rerun after the rebase. The only rebase conflict was TESTING_COVERAGE.md; both coverage sections were preserved.

Companion regression: https://github.com/ontola/atomic-saas/pull/78 (same branch name). Merge this server PR first. Chromium virtual PRF state is tied to its original CDP target, so the test verifies the popup handoff but performs unlock on the original target. Full physical-passkey popup acceptance remains outstanding. A separate original-tab direct-navigation NotFound failure remains unresolved and is tracked in planning/passkey-local-drive-unlock.md. This PR does not claim to fix that variant.

