### PR TITLE
perf(ci): size the hosted profile for a 4-vCPU runner

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -201,14 +201,29 @@ const HOST_PROFILES: Record<HostProfile, HostKnobs> = {
     nextestBuildJobs: '4',
     cargoBuildJobs: '8',
   },
+  // Sized for GitHub's standard hosted runner. The widths below said 2 for
+  // every knob, which matched the 2-vCPU runner this profile was written
+  // against; public repositories have had 4 vCPU / 16GB since 2024, so half
+  // the box sat idle through every compile.
+  //
+  // Only the *build* widths move. Rust compilation is the dominant cost here
+  // and scales cleanly with cores. The test widths stay where they are on
+  // purpose: `ci()` runs endToEnd concurrently with clippy, nextest, flutter
+  // and vitest, so raising those would stack more browsers and more test
+  // threads onto the same four cores — the starvation the mancave notes
+  // above describe. Build jobs mostly occupy phases the tests are not in.
+  //
+  // This profile is not the fallback it reads as: `CI_RUNNER` has been set to
+  // `["ubuntu-latest"]` since 2026-09-08, and `pick` treats that as an
+  // explicit escape hatch, so *every* run currently lands here.
   hosted: {
     e2eShardCount: 2,
     e2ePlaywrightWorkers: '1',
     e2ePlaywrightRetries: '2',
     nextestTestThreads: '2',
     nextestRetries: '2',
-    nextestBuildJobs: '2',
-    cargoBuildJobs: '2',
+    nextestBuildJobs: '4',
+    cargoBuildJobs: '4',
   },
 };
 

--- a/browser/e2e/playwright.config.ts
+++ b/browser/e2e/playwright.config.ts
@@ -153,9 +153,14 @@ const config: PlaywrightTestConfig = {
   // `pnpm test-e2e` and develop/tag CI run the unfiltered suite.
   // Worker count:
   // - local (no CI): 2
-  // - CI without override: 1 (safe for 2-vCPU hosted runners)
-  // - dagger Main on Mancave (12c/64GB WSL): PLAYWRIGHT_WORKERS=3 per
-  //   shard, 4 shards in `.dagger/src/index.ts` (≈12 browsers total)
+  // - CI without override: 1 (safe on the smallest hosted runner)
+  // - dagger Main on Mancave (24 cores / 31GB WSL): PLAYWRIGHT_WORKERS=2 per
+  //   shard, 4 shards in `.dagger/src/index.ts` (≈8 browsers total)
+  //
+  // The figures above were stale in both directions: the box reports 24 cores
+  // and 31GB (not 12c/64GB), and the per-shard width was walked back from 3
+  // to 2 after 12 browsers starved the host. `.dagger/src/index.ts` is the
+  // source of truth for both — see HOST_PROFILES there.
   //
   // Per-shard limit is contention on that shard's atomic-server. Raise
   // via the env var rather than changing the hosted-runner default.


### PR DESCRIPTION
## The headline finding is not in this diff

`CI_RUNNER` has been set to `["ubuntu-latest"]` since 2026-09-08. `pick` treats that value as an explicit escape hatch and forces `host=hosted` *before* it ever queries the runner API:

```bash
if [ "$FORCE_RUNNER" = '["ubuntu-latest"]' ]; then
  echo "CI_RUNNER escape hatch — forcing GitHub-hosted"
  echo "host=hosted" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

So every run lands on a 4-core hosted runner, `Main (Mancave)` has been skipped on every recent run, and the 24-core self-hosted box sits idle. **Clearing that variable is a far larger speedup than this PR** — the detection logic below it is already correct and handles a busy or offline runner properly. It is a repo-variable change rather than a code change, and someone set it deliberately three days ago, so it is left alone here.

## What this PR does

Every knob in `HOST_PROFILES.hosted` was `'2'`, matching the 2-vCPU runner the profile was written against. Public repositories have had 4 vCPU / 16GB standard runners since 2024, so half the box has been idle through every compile — and per the above, this profile is currently taking *all* the traffic, not acting as a rare fallback.

```diff
   hosted: {
     e2eShardCount: 2,
     e2ePlaywrightWorkers: '1',
     e2ePlaywrightRetries: '2',
     nextestTestThreads: '2',
     nextestRetries: '2',
-    nextestBuildJobs: '2',
-    cargoBuildJobs: '2',
+    nextestBuildJobs: '4',
+    cargoBuildJobs: '4',
   },
```

**Only the build widths move.** Rust compilation dominates this pipeline and scales cleanly with cores. The test widths deliberately stay put: `ci()` runs `endToEnd` concurrently with clippy, nextest, flutter and vitest, so raising those stacks more browsers and more test threads onto the same four cores — exactly the starvation documented in the `mancave` notes directly above this block.

## Comment corrections

`browser/e2e/playwright.config.ts` described Mancave as `12c/64GB WSL` running `PLAYWRIGHT_WORKERS=3` across 4 shards (≈12 browsers). Both figures were stale: the box reports **24 cores / 31GB**, and the per-shard width was already walked back to 2 after 12 browsers starved the host. Points at `HOST_PROFILES` as the source of truth instead of restating numbers that drift.

## Verification

No behaviour change to verify locally — these are container parallelism widths. The effect is visible in the next run's compile phases. Reverting is a one-line change, and nothing here alters test selection, retries, or sharding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfzzMzRyyBMRCr8qputpTT


Rebase validation (2026-09-12): clean rebase onto develop `5c5d7794c`, head `3f110fa35`. Both changed TypeScript files pass syntax transpilation and git diff --check. CI_RUNNER is still explicitly ["ubuntu-latest"]. Full hosted CI: https://github.com/ontola/atomic-server/actions/runs/34668498082. This run must establish correctness; no new performance improvement measurement is claimed.
