### PR TITLE
fix: restore develop e2e and profile editing after reload

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -713,3 +713,5 @@ check; real refresh/query timing remains a browser acceptance check.
 `store.test.ts` loads an offline profile with nontrivial persisted Loro history, edits it and merges into the original document, verifying the rename survives. `username-live.spec.ts` edits immediately through the enabled profile field and verifies existing remote chat authors update before and after reload. Profile controls stay disabled while the resource is loading. Managed-account E2Es explicitly configure the hosted runtime and API responses; the mocked same-origin dashboard test blocks the app service worker navigation fallback.
 
 `store.test.ts` also verifies that a buffered property snapshot materializes before `getProperty` reads its datatype. Computed-column resize, reorder and filter E2Es exercise this during table creation and reload.
+
+`store.test.ts` keeps property readers pending when a delta lacks base history; `sync-import.test.ts` checks the loading-to-error transition if recovery fails. `plugin.spec.ts` verifies installation completes without accessing an unmounted upload input.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -711,3 +711,5 @@ check; real refresh/query timing remains a browser acceptance check.
 ## Profile edit hydration
 
 `store.test.ts` loads an offline profile with nontrivial persisted Loro history, edits it and merges into the original document, verifying the rename survives. `username-live.spec.ts` edits immediately through the enabled profile field and verifies existing remote chat authors update before and after reload. Profile controls stay disabled while the resource is loading. Managed-account E2Es explicitly configure the hosted runtime and API responses; the mocked same-origin dashboard test blocks the app service worker navigation fallback.
+
+`store.test.ts` also verifies that a buffered property snapshot materializes before `getProperty` reads its datatype. Computed-column resize, reorder and filter E2Es exercise this during table creation and reload.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -675,7 +675,7 @@ Paired SaaS `portal/e2e/recovery-passkey.spec.ts` uses Chromium virtual PRF auth
 ## September 10 SaaS and browser invite regressions
 
 - `browser/lib/src/browser-peer-invite.test.ts`: signed invitation validation, expiry, target and issuer checks, recipient proof, and additive permission grants.
-- `browser/e2e/tests/browser-invite.spec.ts`: distinct signed-in identities join a local drive through the app without the server invite endpoint.
+- `browser/e2e/tests/browser-invite.spec.ts`: distinct signed-in identities create an invitation through the sharing UI and join a local drive using real WebRTC with an in-process signaling relay. Runs against production assets without Vite source imports or a SaaS dependency, and verifies received content and write rights. `store.test.ts` prevents explicit server refreshes from poisoning local-only drives with server errors.
 - `browser/e2e/scripts/verify-peer-sync.mjs` with `ATOMIC_PEER_INVITE=1`: invitation bootstrap and real WebRTC reconciliation with HTTP data access disabled.
 - `browser/e2e/tests/recovery-option.spec.ts`: recovery availability in the managed welcome flow.
 - Existing-drive migration to browser-only storage and fresh-account email onboarding through a peer invitation remain unverified.
@@ -703,3 +703,11 @@ Table loading feedback: `browser/data-browser/src/chunks/TableEditor/TableEditor
 checks that a busy grid with only an entry row renders a visible spinner/status,
 and that settled empty and populated grids remove it. This is a component render
 check; real refresh/query timing remains a browser acceptance check.
+
+## WebSocket disconnect cancellation
+
+`websockets.test.ts` covers closing during authentication and range reconciliation, and index-status subscription cancellation. `file-upload-offline.spec.ts`, `offline-chatroom.spec.ts` and `offline-create-then-online.spec.ts` verify disconnect, local writes, reload and reconnect without unexpected browser diagnostics.
+
+## Profile edit hydration
+
+`store.test.ts` loads an offline profile with nontrivial persisted Loro history, edits it and merges into the original document, verifying the rename survives. `username-live.spec.ts` edits immediately through the enabled profile field and verifies existing remote chat authors update before and after reload. Profile controls stay disabled while the resource is loading. Managed-account E2Es explicitly configure the hosted runtime and API responses; the mocked same-origin dashboard test blocks the app service worker navigation fallback.

--- a/browser/data-browser/src/chunks/Plugins/NewPluginButton.tsx
+++ b/browser/data-browser/src/chunks/Plugins/NewPluginButton.tsx
@@ -35,7 +35,7 @@ const NewPluginButton: React.FC<NewPluginButtonProps> = ({ drive }) => {
     setMetadata(undefined);
     setConfig(undefined);
     setConfigValid(true);
-    fileInputRef.current!.value = '';
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const [dialogProps, show, hide] = useDialog({

--- a/browser/data-browser/src/components/AgentProfileHeader.tsx
+++ b/browser/data-browser/src/components/AgentProfileHeader.tsx
@@ -30,6 +30,9 @@ const valueOpts = { commit: true, validate: false } as const;
  * need a trip to a separate edit form.
  */
 export function AgentProfileHeader({ subject }: { subject: string }) {
+  'use no memo';
+  // Resources mutate in place; compiler memoization by reference would
+  // freeze isReady() at the initial loading state.
   const resource = useResource(subject);
   const [name, setName] = useString(resource, core.properties.name, valueOpts);
   const [, setIcon] = useSubject(
@@ -115,6 +118,7 @@ export function AgentProfileHeader({ subject }: { subject: string }) {
         type='button'
         onClick={() => inputRef.current?.click()}
         title={hasPicture ? 'Change your picture' : 'Add a picture'}
+        disabled={!resource.isReady()}
         data-test='change-avatar'
       >
         {hasPicture ? (
@@ -137,6 +141,7 @@ export function AgentProfileHeader({ subject }: { subject: string }) {
         <NameInput
           id='agent-display-name'
           data-test='agent-name-input'
+          disabled={!resource.isReady()}
           value={draft}
           placeholder='Add your name'
           onChange={e => setDraft(e.target.value)}

--- a/browser/e2e/tests/browser-invite.spec.ts
+++ b/browser/e2e/tests/browser-invite.spec.ts
@@ -1,52 +1,94 @@
-import { resolve } from 'node:path';
-import { test, expect } from '@playwright/test';
-import { devDrive, FRONTEND_URL } from './test-utils';
+import { test, expect, type WebSocketRoute } from '@playwright/test';
+import { devDrive, FRONTEND_URL, topBarShareButton } from './test-utils';
 
-// Real app routes and real SaaS signaling; no data-node invite redemption.
-// The separate peer harness additionally disables ALL data requests.
+// Relay only discovery and SDP in-process. Authentication, invite redemption,
+// resource sync and persistence still travel over real WebRTC data channels.
+// This runs against the production bundle without Vite source imports or SaaS.
 test('joins an unhosted drive through its signed browser invitation', async ({
   browser,
 }) => {
   test.setTimeout(90000);
-  const owner = await browser.newPage();
-  const guest = await browser.newPage();
+  const rooms = new Map<string, Map<string, WebSocketRoute>>();
+  const ownerContext = await browser.newContext({
+    permissions: ['clipboard-write'],
+  });
+  const guestContext = await browser.newContext();
+
+  for (const context of [ownerContext, guestContext]) {
+    await context.routeWebSocket('**/webrtc-signal', socket => {
+      let room: Map<string, WebSocketRoute> | undefined;
+      let peer: string | undefined;
+      socket.onMessage(raw => {
+        const message = JSON.parse(String(raw));
+
+        if (message.type === 'join') {
+          room = rooms.get(message.room) ?? new Map();
+          rooms.set(message.room, room);
+          peer = message.peer;
+          socket.send(
+            JSON.stringify({
+              type: 'joined',
+              peers: [...room.keys()],
+              iceServers: [],
+            }),
+          );
+          for (const other of room.values())
+            other.send(JSON.stringify({ type: 'peer', peer }));
+          room.set(peer!, socket);
+        } else if (room && peer && ['offer', 'answer'].includes(message.type)) {
+          room.get(message.to)?.send(
+            JSON.stringify({
+              type: message.type,
+              from: peer,
+              sdp: message.sdp,
+            }),
+          );
+        }
+      });
+      socket.onClose(() => {
+        if (!room || !peer) return;
+        room.delete(peer);
+        for (const other of room.values())
+          other.send(JSON.stringify({ type: 'left', peer }));
+      });
+    });
+  }
+
+  const owner = await ownerContext.newPage();
+  const guest = await guestContext.newPage();
 
   try {
     await devDrive(owner);
     await devDrive(guest);
-    const invitation = await owner.evaluate(
-      async inviteModule => {
-        const { generateInviteToken } = await import(inviteModule);
-        const {
-          automaticPeerRoom,
-          defaultPeerSignalingUrl,
-          savePeerLink,
-          resumePeerLinks,
-        } = await import('/src/helpers/browserPeerSync.ts');
-        const store = window.store;
-        const drive = await store.createDrive('Browser invite acceptance', {
+    const drive = await owner.evaluate(async () => {
+      const resource = await window.store.createDrive(
+        'Browser invite acceptance',
+        {
           personal: false,
           localOnly: true,
-        });
-        const token = await generateInviteToken(
-          drive.subject,
-          store.getAgent(),
-          true,
-          undefined,
-          undefined,
-          true,
-        );
-        savePeerLink(store, {
-          drive: drive.subject,
-          room: await automaticPeerRoom(drive.subject),
-          signalingUrl: defaultPeerSignalingUrl(),
-        });
-        resumePeerLinks(store);
+        },
+      );
 
-        return token;
-      },
-      `/@fs${resolve(__dirname, '../../lib/src/invites.ts')}`,
+      return resource.subject;
+    });
+    await owner.goto(
+      `${FRONTEND_URL}/app/show?subject=${encodeURIComponent(drive)}`,
     );
+    await topBarShareButton(owner).click();
+    await owner
+      .getByRole('button', { name: 'Create Invite', exact: true })
+      .click();
+    await owner.getByLabel('Full name', { exact: true }).fill('Drive Owner');
+    await owner
+      .getByRole('button', { name: 'Save and continue', exact: true })
+      .click();
+    await owner.getByLabel('Allow edits', { exact: true }).check();
+    await owner.getByRole('button', { name: 'Create', exact: true }).click();
+    const code = owner.locator('[data-code-content]');
+    await expect(code).toHaveAttribute('data-code-content', /token=/);
+    const invitation = new URL(
+      (await code.getAttribute('data-code-content'))!,
+    ).searchParams.get('token')!;
     const inviteRequests: string[] = [];
     guest.on('request', request => {
       if (new URL(request.url()).pathname === '/invites')
@@ -69,8 +111,27 @@ test('joins an unhosted drive through its signed browser invitation', async ({
       .getByRole('button', { name: 'Open drive', exact: true })
       .click();
     await expect(guest).toHaveURL(/\/app\/show\?subject=/);
+    await expect
+      .poll(() =>
+        guest.evaluate(async driveSubject => {
+          const resource = window.store?.resources.get(driveSubject);
+
+          return {
+            ready: resource?.isReady(),
+            name: resource?.get('https://atomicdata.dev/properties/name'),
+            writable: (
+              await resource?.canWrite(window.store?.getAgent()?.subject)
+            )?.[0],
+          };
+        }, drive),
+      )
+      .toEqual({
+        ready: true,
+        name: 'Browser invite acceptance',
+        writable: true,
+      });
   } finally {
-    await owner.close();
-    await guest.close();
+    await ownerContext.close();
+    await guestContext.close();
   }
 });

--- a/browser/e2e/tests/managed-sync-presentation.spec.ts
+++ b/browser/e2e/tests/managed-sync-presentation.spec.ts
@@ -1,3 +1,4 @@
+import { mockManagedPortal } from './managed-test-utils';
 import { test, expect } from '@playwright/test';
 import { devDrive, FRONTEND_URL } from './test-utils';
 
@@ -6,6 +7,7 @@ for (const localOnly of [true, false]) {
     page,
   }) => {
     await devDrive(page);
+    await mockManagedPortal(page);
     await page.route('**/api/me', route =>
       route.fulfill({ json: { email: 'sync-test@example.com' } }),
     );
@@ -59,6 +61,14 @@ for (const localOnly of [true, false]) {
       );
       await page.evaluate(() =>
         window.store.registerLocalOnlyDrive(window.store.getDrive()!),
+      );
+    }
+
+    if (!localOnly) {
+      // This case checks the expired Vault-session message independently of
+      // the account identity returned by /me.
+      await page.route('**/api/cloud-vault/drives', route =>
+        route.fulfill({ status: 401 }),
       );
     }
 

--- a/browser/e2e/tests/managed-test-utils.ts
+++ b/browser/e2e/tests/managed-test-utils.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test';
+import { FRONTEND_URL } from './test-utils';
+
+/** Explicitly opt into the hosted app; localhost by itself is standalone.
+ * Endpoint-specific mocks registered afterwards override this empty account API.
+ * Using the test origin also keeps the fixture independent of a local portal.
+ */
+export async function mockManagedPortal(page: Page): Promise<void> {
+  await page.addInitScript(portalUrl => {
+    (
+      window as unknown as Window & {
+        __ATOMIC_MANAGED__: { portalUrl: string };
+      }
+    ).__ATOMIC_MANAGED__ = { portalUrl };
+  }, new URL(FRONTEND_URL).origin);
+  await page.route('**/api/**', route => route.fulfill({ json: [] }));
+}

--- a/browser/e2e/tests/passkey-unavailable.spec.ts
+++ b/browser/e2e/tests/passkey-unavailable.spec.ts
@@ -1,3 +1,4 @@
+import { mockManagedPortal } from './managed-test-utils';
 import { test, expect } from '@playwright/test';
 import { devDrive, FRONTEND_URL } from './test-utils';
 
@@ -5,6 +6,7 @@ test('explains missing passkey support without offering a broken setup action', 
   page,
 }) => {
   await devDrive(page);
+  await mockManagedPortal(page);
   const agent = await page.evaluate(
     () =>
       (

--- a/browser/e2e/tests/recovery-option.spec.ts
+++ b/browser/e2e/tests/recovery-option.spec.ts
@@ -1,4 +1,13 @@
+import { mockManagedPortal } from './managed-test-utils';
 import { test, expect } from '@playwright/test';
+
+// The portal is mocked on this origin; its dashboard must reach page.route
+// rather than the app service worker's navigation fallback.
+test.use({ serviceWorkers: 'block' });
+
+test.beforeEach(async ({ page }) => {
+  await mockManagedPortal(page);
+});
 
 // A portal session is not evidence that an encrypted recovery backup exists.
 test('does not offer account recovery when the signed-in account has no backup', async ({

--- a/browser/e2e/tests/resource-context-menu.spec.ts
+++ b/browser/e2e/tests/resource-context-menu.spec.ts
@@ -58,9 +58,15 @@ test.describe('resource context menu', () => {
   }) => {
     // A plain table with one row.
     await newResource('table', page);
-    await page.getByRole('button', { name: /Blank/ }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: /Blank/ })
+      .click();
     await page.getByPlaceholder('New Table').fill('Widgets');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: 'Create', exact: true })
+      .click();
 
     // --- Sidebar link (AtomicLink seam) ---
     const sidebarLink = page
@@ -159,9 +165,15 @@ test.describe('resource context menu', () => {
     expect(driveDid).toBeTruthy();
 
     await newResource('table', page);
-    await page.getByRole('button', { name: /Blank/ }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: /Blank/ })
+      .click();
     await page.getByPlaceholder('New Table').fill('Widgets');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: 'Create', exact: true })
+      .click();
     await expect(page.getByRole('columnheader').nth(1)).toBeVisible();
     // Leave the table's cell editor — hotkeys are ignored while an input has
     // focus (`pressShortcut` also blurs whatever is left).

--- a/browser/e2e/tests/sync-devices.spec.ts
+++ b/browser/e2e/tests/sync-devices.spec.ts
@@ -73,12 +73,12 @@ test.describe('sync page devices', () => {
     await expect(recovery).toContainText('Sign in to your');
     await expect(recovery).not.toContainText('Not set up');
     await expect(page.locator('body')).not.toContainText('[i18n-404:');
-    await expect(
-      cloud.getByRole('button', { name: 'Set up Cloud Server', exact: true }),
-    ).toBeVisible();
     accountConnected = true;
     await page.evaluate(() => window.dispatchEvent(new Event('focus')));
     await expect(recovery).toContainText('sync-account@example.com');
+    await expect(
+      cloud.getByRole('button', { name: 'Set up Cloud Server', exact: true }),
+    ).toBeVisible();
     await expect(page.getByTestId('link-provider-panel')).not.toBeVisible();
   });
 

--- a/browser/e2e/tests/table-create-perf.spec.ts
+++ b/browser/e2e/tests/table-create-perf.spec.ts
@@ -64,12 +64,18 @@ test.describe('table create perf', () => {
   for (const template of ['Project tasks', 'Issue Tracker', 'Expenses']) {
     test(`create from "${template}"`, async ({ page }) => {
       await newResource('table', page);
-      await page.getByRole('button', { name: new RegExp(template) }).click();
+      await page
+        .locator('dialog[open]')
+        .getByRole('button', { name: new RegExp(template) })
+        .click();
       await page.getByPlaceholder('New Table').fill(`Perf ${template}`);
 
       await resetPerfTrace(page);
       const started = Date.now();
-      await page.getByRole('button', { name: 'Create' }).click();
+      await page
+        .locator('dialog[open]')
+        .getByRole('button', { name: 'Create', exact: true })
+        .click();
       // The table page, whichever view the template defaults to — a kanban
       // template opens on its board, not on a grid.
       await expect(

--- a/browser/e2e/tests/table-templates.spec.ts
+++ b/browser/e2e/tests/table-templates.spec.ts
@@ -66,9 +66,15 @@ test.describe('table templates', () => {
     // afterwards, which left the user on the previous page with no sign that
     // anything was happening.
     await newResource('table', page);
-    await page.getByRole('button', { name: /Project tasks/ }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: /Project tasks/ })
+      .click();
     await page.getByPlaceholder('New Table').fill('Busy check');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page
+      .locator('dialog[open]')
+      .getByRole('button', { name: 'Create', exact: true })
+      .click();
 
     const busy = page.getByRole('button', { name: 'Creating table…' });
     await expect(busy).toBeVisible();

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1054,7 +1054,7 @@ export async function newResource(klass: string, page: Page) {
     // appearance IS the "class is searchable" readiness signal — with a budget
     // that tolerates a slow index flush instead of a blind pre-sleep.
     const classLabel = klass.toLowerCase() === 'chatroom' ? 'Chat room' : klass;
-    const classButton = page.getByRole('button', {
+    const classButton = page.getByRole('main').getByRole('button', {
       name: new RegExp(
         `^${classLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
         'i',

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1054,7 +1054,12 @@ export async function newResource(klass: string, page: Page) {
     // appearance IS the "class is searchable" readiness signal — with a budget
     // that tolerates a slow index flush instead of a blind pre-sleep.
     const classLabel = klass.toLowerCase() === 'chatroom' ? 'Chat room' : klass;
-    const classButton = page.locator(`button:has-text("${classLabel}")`);
+    const classButton = page.getByRole('button', {
+      name: new RegExp(
+        `^${classLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
+        'i',
+      ),
+    });
     await classButton.waitFor({ state: 'visible', timeout: 30000 });
     await classButton.click();
     // Wait for any of: URL leaves /app/new (basic-instance handlers), a

--- a/browser/e2e/tests/test-utils.ts
+++ b/browser/e2e/tests/test-utils.ts
@@ -1041,6 +1041,7 @@ export async function newResource(klass: string, page: Page) {
   };
 
   if (klass.startsWith('https://')) {
+    await page.getByText('Choose a class by URL', { exact: true }).click();
     await fillSearchBox(page, 'Search for a class or enter a URL', klass);
     await page.keyboard.press('Enter');
     await waitForResourceForm();
@@ -1052,7 +1053,8 @@ export async function newResource(klass: string, page: Page) {
     // click times out. Gate on the button's visibility explicitly — its
     // appearance IS the "class is searchable" readiness signal — with a budget
     // that tolerates a slow index flush instead of a blind pre-sleep.
-    const classButton = page.locator(`button:has-text("${klass}")`);
+    const classLabel = klass.toLowerCase() === 'chatroom' ? 'Chat room' : klass;
+    const classButton = page.locator(`button:has-text("${classLabel}")`);
     await classButton.waitFor({ state: 'visible', timeout: 30000 });
     await classButton.click();
     // Wait for any of: URL leaves /app/new (basic-instance handlers), a
@@ -1123,14 +1125,16 @@ export async function createTableFromDialog(
   await newResource('table', page);
 
   if (template) {
-    await page.getByRole('button', { name: template }).click();
+    await currentDialog(page).getByRole('button', { name: template }).click();
   }
 
   if (name !== undefined) {
     await page.getByPlaceholder('New Table').fill(name);
   }
 
-  await page.getByRole('button', { name: 'Create' }).click();
+  await currentDialog(page)
+    .getByRole('button', { name: 'Create', exact: true })
+    .click();
   await waitForTableBuild(page);
 }
 

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -736,6 +736,8 @@ export class Resource<C extends OptionalClass = any> {
 
   /** Returns all property entries (cache + binary aux values) as a flat array. */
   public getEntries(): [string, AtomicValue][] {
+    this.materializeBufferedSnapshot();
+
     if (this.#cacheDirty && this._loroDoc) {
       this.rebuildCacheFromLoro();
       this.#cacheDirty = false;
@@ -1751,6 +1753,8 @@ export class Resource<C extends OptionalClass = any> {
   public get<Prop extends string, Returns = InferTypeOfValueInTriple<C, Prop>>(
     propUrl: Prop,
   ): Returns {
+    this.materializeBufferedSnapshot();
+
     if (this.#cacheDirty && this._loroDoc) {
       this.rebuildCacheFromLoro();
       this.#cacheDirty = false;
@@ -1765,6 +1769,8 @@ export class Resource<C extends OptionalClass = any> {
    * The returned object is a copy; mutating it does not change the resource.
    */
   public getPropVals(): Record<string, AtomicValue> {
+    this.materializeBufferedSnapshot();
+
     if (this.#cacheDirty && this._loroDoc) {
       this.rebuildCacheFromLoro();
       this.#cacheDirty = false;
@@ -1774,6 +1780,14 @@ export class Resource<C extends OptionalClass = any> {
       ...this.#cache,
       ...Object.fromEntries(this._auxValues.entries()),
     };
+  }
+
+  private materializeBufferedSnapshot(): void {
+    // Hydration can supply bytes before a document exists. Once WASM is
+    // ready, reads must materialize them rather than expose the empty cache.
+    if (!this._loroDoc && this._loroSnapshotBytes && LoroLoader.isLoaded()) {
+      this.getLoroDoc();
+    }
   }
 
   /**

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -1,3 +1,4 @@
+import { enableLoro } from './loro-loader.js';
 import { describe, it, vi, afterEach } from 'vitest';
 import { Resource, Store, core, Core, Datatype } from './index.js';
 import { bootstrapCoreVocab } from './test-vocab.js';
@@ -6,6 +7,57 @@ import { testStore } from './test-store.js';
 describe('Store', () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('preserves persisted Loro history when getResource loads a profile offline', async ({
+    expect,
+  }) => {
+    await enableLoro();
+    const subject = 'did:ad:agent:offline-profile';
+    const serverProfile = new Resource(subject);
+    const doc = serverProfile.getLoroDoc()!;
+
+    for (let i = 0; i < 20; i++) {
+      await serverProfile.set(core.properties.name, `Name ${i}`, false);
+      doc.commit();
+    }
+
+    const snapshot = doc.export({ mode: 'snapshot' });
+    const jsonAd = JSON.stringify({
+      '@id': subject,
+      [core.properties.name]: 'Name 19',
+    });
+    const store = new Store({ serverUrl: 'https://example.com' });
+    store.setClientDb({
+      isReady: true,
+      isInitialized: true,
+      waitForInit: async () => {},
+      getResource: async () => jsonAd,
+      getResourceWithSnapshot: async () => ({ jsonAd, snapshot }),
+    } as unknown as Parameters<Store['setClientDb']>[0]);
+    const profile = await store.getResource(subject);
+    await profile.set(core.properties.name, 'Renamed', false);
+    doc.import(profile.getLoroDoc()!.export({ mode: 'snapshot' }));
+    expect(doc.getMap('properties').get(core.properties.name)).toBe('Renamed');
+  });
+
+  it('keeps a local-only drive ready when a reader requests a server refresh', async ({
+    expect,
+  }) => {
+    const store = new Store({ serverUrl: 'https://example.com' });
+    const drive = new Resource('did:ad:local-drive');
+    await drive.set(core.properties.name, 'Local drive', false);
+    drive.loading = false;
+    store.addResource(drive);
+    store.registerLocalOnlyDrive(drive.subject);
+    const fetch = vi.fn(async () => new Response('not found', { status: 404 }));
+    store.injectFetch(fetch);
+    const result = await store.fetchResourceFromServer(drive.subject, {
+      setLoading: true,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.isReady()).toBe(true);
+    expect(result.get(core.properties.name)).toBe('Local drive');
   });
 
   it('waits for property data after a loading-placeholder notification', async ({

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -5,6 +5,26 @@ import { bootstrapCoreVocab } from './test-vocab.js';
 import { testStore } from './test-store.js';
 
 describe('Store', () => {
+  it('materializes a buffered property snapshot before returning its datatype', async ({
+    expect,
+  }) => {
+    await enableLoro();
+    const store = new Store();
+    const source = new Resource('did:ad:buffered-property');
+    await source.set(core.properties.datatype, Datatype.STRING, false);
+    await source.set(core.properties.shortname, 'title', false);
+    await source.set(core.properties.description, 'Title', false);
+    const snapshot = source.getLoroDoc()!.export({ mode: 'snapshot' });
+    const loaded = new Resource(source.subject);
+    loaded.applyHydratedValues([
+      ['https://atomicdata.dev/properties/loroUpdate', snapshot],
+    ]);
+    store.addResource(loaded);
+    expect(await store.getProperty(source.subject)).toMatchObject({
+      datatype: Datatype.STRING,
+    });
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -5,6 +5,62 @@ import { bootstrapCoreVocab } from './test-vocab.js';
 import { testStore } from './test-store.js';
 
 describe('Store', () => {
+  it('keeps property readers waiting while a delta with missing history is recovered', async ({
+    expect,
+  }) => {
+    await enableLoro();
+    const store = new Store({ serverUrl: 'https://example.com' });
+    const source = new Resource('did:ad:partial-property');
+    await source.set(core.properties.isA, [core.classes.property], false);
+    const doc = source.getLoroDoc()!;
+    doc.commit();
+    const base = doc.oplogVersion();
+    await source.set(core.properties.datatype, Datatype.STRING, false);
+    await source.set(core.properties.shortname, 'title', false);
+    await source.set(core.properties.description, 'Title', false);
+    doc.commit();
+    const placeholder = new Resource(source.subject);
+    placeholder.loading = true;
+    store.addResource(placeholder);
+    let recover!: () => void;
+    vi.spyOn(store, 'fetchResourceFromServer').mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        recover = resolve;
+      });
+      store.applyIncoming({
+        subject: source.subject,
+        resource: source,
+        source: 'http-fetch',
+      });
+
+      return source;
+    });
+    const settled = vi.fn();
+    const result = store.getProperty(source.subject).then(
+      value => {
+        settled();
+
+        return value;
+      },
+      error => {
+        settled();
+
+        return error;
+      },
+    );
+    store.applyIncoming({
+      subject: source.subject,
+      loroBytes: doc.export({ mode: 'update', from: base }),
+      source: 'ws-sub-push',
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const early = settled.mock.calls.length;
+    recover();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(await result).toMatchObject({ datatype: Datatype.STRING });
+    expect(early).toBe(0);
+  });
+
   it('materializes a buffered property snapshot before returning its datatype', async ({
     expect,
   }) => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1660,10 +1660,15 @@ export class Store {
     }
 
     try {
-      const jsonAd = await this.clientDb.getResource(subject);
+      const { jsonAd, snapshot } =
+        await this.clientDb.getResourceWithSnapshot(subject);
       if (!jsonAd) return null;
 
-      return this.hydrateOfflineReplay(subject, JSON.parse(jsonAd));
+      return this.hydrateOfflineReplay(
+        subject,
+        JSON.parse(jsonAd),
+        snapshot ?? undefined,
+      );
     } catch {
       return null;
     }
@@ -1676,6 +1681,7 @@ export class Store {
   private hydrateOfflineReplay(
     subject: string,
     parsed: Record<string, unknown>,
+    snapshot?: Uint8Array,
   ): Resource {
     const resource = new Resource(subject);
     resource.applyHydratedValues(
@@ -1684,7 +1690,11 @@ export class Store {
         JSONValue,
       ][],
     );
-    resource.getLoroDoc();
+    // JSON is a read cache, not a replacement for the document's causal
+    // history. Reconstructing it as fresh ops makes later edits lose LWW
+    // against the existing server document (notably agent profile renames).
+    if (snapshot?.length) resource.importLoroUpdate(snapshot, true);
+    else resource.getLoroDoc();
     resource.loading = false;
     this.applyIncoming({
       subject: resource.subject,
@@ -3329,6 +3339,16 @@ export class Store {
     } = {},
   ): Promise<Resource<C>> {
     const normalizedSubject = this.normalizeSubject(subject);
+
+    // A server cannot refresh a browser-only resource. In particular, explicit
+    // refresh callers must not turn a valid local drive into a server 404.
+    if (this.isLocalOnlySubject(normalizedSubject)) {
+      const local = this.resources.get(normalizedSubject);
+      if (local?.isReady()) return local as Resource<C>;
+      const stored = await this.fetchResourceFromClientDb(normalizedSubject);
+      if (stored) return stored as Resource<C>;
+      throw new AtomicError(LOCAL_ONLY_NOT_FOUND_MESSAGE, ErrorType.Transport);
+    }
 
     // In-flight dedup. SideBarDrive and DrivePage both call
     // `useResource(drive)` on the same render → two parallel

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -2015,8 +2015,8 @@ export class Store {
       // Deliberately NOT stamping `lastCommit` here. We did not apply that
       // commit, and claiming it would make the echo-dedup at the top of this
       // method drop the very fetch being issued to repair the gap.
+      resource.loading = !this.hasRenderableContent(resource);
       this.recoverFromIncompleteImport(subject, change.source);
-      resource.loading = false;
       this.addResource(resource, { skipCommitCompare: true });
 
       return 'invalid';
@@ -3794,6 +3794,10 @@ export class Store {
     }
 
     const result = await this.fetchResourceFromServer(resolved);
+
+    // A delta response may have started recovery of missing base history.
+    // Do not return its empty placeholder while the full snapshot is pending.
+    if (result.loading && !result.error) return this.getResource(resolved);
 
     // If the resource was not in the store yet, subscribe to changes so we don't return stale results when the resource is updated.
     // Commits are immutable — no need to subscribe for push updates.

--- a/browser/lib/src/sync-import.test.ts
+++ b/browser/lib/src/sync-import.test.ts
@@ -83,8 +83,9 @@ describe('applyIncoming — incomplete Loro import surfaces an error', () => {
     // be a loaded-but-empty resource.
     const r = store.resources.get(subject);
     expect(r).toBeDefined();
-    expect(r!.loading).toBe(false);
+    expect(r!.loading).toBe(true);
     await vi.waitFor(() => expect(r!.error).toBeDefined());
+    expect(r!.loading).toBe(false);
     expect(r!.error?.message).toMatch(/incomplete update|missing base state/i);
 
     // Crucially: it did NOT silently materialize as an empty resource.

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -1,6 +1,6 @@
 import { Resource } from './resource.js';
 import { AtomicError, ErrorType } from './error.js';
-import { describe, it, vi, afterEach } from 'vitest';
+import { describe, it, vi, afterEach, expect as assert } from 'vitest';
 import { testStore } from './test-store.js';
 import { WSClient } from './websockets.js';
 import {
@@ -61,7 +61,9 @@ class FakeWebSocket {
     }
   }
 
-  public close(): void {}
+  public close(): void {
+    this.readyState = 3;
+  }
 
   public fire(type: string, event: unknown): void {
     for (const cb of this.#listeners.get(type) ?? []) cb(event);
@@ -119,6 +121,34 @@ describe('WSClient handshake', () => {
     globalThis.WebSocket = original;
     vi.restoreAllMocks();
     vi.useRealTimers();
+  });
+
+  it('cancels authentication when closed while awaiting the server challenge', async ({
+    expect,
+  }) => {
+    const { client, socket } = await connectedClient();
+    const authentication = client.authenticate();
+    const rejected = expect(authentication).rejects.toThrow(/closed/i);
+    await Promise.resolve();
+    client.close();
+    await rejected;
+    expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(0);
+  });
+
+  it('does not warn or subscribe when closed before index-status authentication completes', async ({
+    expect,
+  }) => {
+    const { client, socket } = await connectedClient();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    client.subscribeIndexStatus('did:ad:drive');
+    client.close();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(
+      socket.sent.some(frame =>
+        new TextDecoder().decode(frame).startsWith('SUBSCRIBE_INDEX_STATUS'),
+      ),
+    ).toBe(false);
+    expect(warning).not.toHaveBeenCalled();
   });
 
   it('a replaced socket cannot mark the new connection offline on its late close', async ({
@@ -288,43 +318,46 @@ describe('WSClient drive sync probe', () => {
     client.close();
   });
 
-  it('stops range reconciliation when the identity changes between replies', async ({
-    expect,
-  }) => {
-    const { client, socket, store } = await connectedClient();
-    socket.receive(encodeChallenge('cancel-sync'));
-    const auth = client.authenticate();
-    await vi.waitFor(() =>
-      expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
-    );
-    socket.receive(encodeAuthOk([]));
-    await auth;
-    vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
-      drive: 'did:ad:drive',
-      driveHash: 'hash',
-      peers: [],
-      resources: {},
-    } as never);
-    const internal = client as unknown as {
-      sendReducedSyncState: (drive: string) => Promise<void>;
-      startVVSync: (drive: string) => Promise<void>;
-      rbsrFingerprints: () => Promise<string[]>;
-      rbsrItems: () => Promise<never[]>;
-    };
-    vi.spyOn(internal, 'rbsrFingerprints').mockImplementation(async () => {
-      store.setAgent(undefined);
+  it.each(['identity change', 'disconnect'])(
+    'stops range reconciliation after %s between replies',
+    async reason => {
+      const expect = assert;
+      const { client, socket, store } = await connectedClient();
+      socket.receive(encodeChallenge('cancel-sync'));
+      const auth = client.authenticate();
+      await vi.waitFor(() =>
+        expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(1),
+      );
+      socket.receive(encodeAuthOk([]));
+      await auth;
+      vi.spyOn(store, 'computeDriveSyncState').mockResolvedValue({
+        drive: 'did:ad:drive',
+        driveHash: 'hash',
+        peers: [],
+        resources: {},
+      } as never);
+      const internal = client as unknown as {
+        sendReducedSyncState: (drive: string) => Promise<void>;
+        startVVSync: (drive: string) => Promise<void>;
+        rbsrFingerprints: () => Promise<string[]>;
+        rbsrItems: () => Promise<never[]>;
+      };
+      vi.spyOn(internal, 'rbsrFingerprints').mockImplementation(async () => {
+        if (reason === 'disconnect') client.close();
+        else store.setAgent(undefined);
 
-      return ['ff'.repeat(32)];
-    });
-    const items = vi.spyOn(internal, 'rbsrItems').mockResolvedValue([]);
-    const warning = vi.spyOn(console, 'warn');
-    await internal.startVVSync('did:ad:drive');
-    await internal.sendReducedSyncState('did:ad:drive');
-    expect(items).not.toHaveBeenCalled();
-    expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(1);
-    expect(warning).not.toHaveBeenCalled();
-    client.close();
-  });
+        return ['ff'.repeat(32)];
+      });
+      const items = vi.spyOn(internal, 'rbsrItems').mockResolvedValue([]);
+      const warning = vi.spyOn(console, 'warn');
+      await internal.startVVSync('did:ad:drive');
+      await internal.sendReducedSyncState('did:ad:drive');
+      expect(items).not.toHaveBeenCalled();
+      expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(1);
+      expect(warning).not.toHaveBeenCalled();
+      client.close();
+    },
+  );
 
   it('probes with a binary SYNC and reconciles on SYNC_RESEND', async ({
     expect,

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -535,6 +535,8 @@ export class WSClient {
   // ---- Authentication ----
 
   public async authenticate(fetchAll?: boolean): Promise<void> {
+    if (this._closed)
+      throw new RequestCancelledError('WebSocket closed by client');
     const agent = this.store.getAgent();
 
     if (!agent?.subject) return;
@@ -570,6 +572,12 @@ export class WSClient {
           ? `${this.serverOrigin}#${nonce}`
           : this.serverOrigin;
         const json = await createAuthentication(subject, agent);
+        // Challenge waiting/signing can finish after disconnect(). Never send
+        // on that socket or install a new AUTH_OK waiter after close drained it.
+        if (this._closed || this.readyState !== WebSocket.OPEN)
+          throw new RequestCancelledError(
+            'WebSocket closed during authentication',
+          );
 
         this.sendBinary(encodeAuth(JSON.stringify(json)));
 
@@ -651,20 +659,13 @@ export class WSClient {
 
   /** Subscribe to vector index status updates for a drive root (see server `SUBSCRIBE_INDEX_STATUS`). */
   public subscribeIndexStatus(drive: string): void {
-    this.authPromise
-      .catch(() => {
-        // Authentication errors are handled in authenticate()
-      })
-      .finally(() => {
-        if (this.readyState !== WebSocket.OPEN) {
-          console.warn(
-            'WebSocket is not open, cannot subscribe to index status',
-          );
-
-          return;
-        }
-
+    void this.authenticate()
+      .then(() => {
+        if (this._closed || this.readyState !== WebSocket.OPEN) return;
         this.ws.send('SUBSCRIBE_INDEX_STATUS ' + JSON.stringify({ drive }));
+      })
+      .catch(() => {
+        // The handshake reports failures; disconnect is a normal cancellation.
       });
   }
 
@@ -1615,6 +1616,8 @@ export class WSClient {
     const agent = this.store.getAgent()?.subject;
     const selectedDrive = this.store.getDrive();
     const current = () =>
+      !this._closed &&
+      this.readyState === WebSocket.OPEN &&
       this.store.getAgent()?.subject === agent &&
       this.store.getDrive() === selectedDrive &&
       (!agent || this.authenticatedWith === agent);


### PR DESCRIPTION
Profile edits after reload could lose against existing Loro history, local-only drive refreshes could poison a valid drive with a server 404, and intentional WebSocket disconnects could leave authentication/sync work running. Preserve and materialize stored snapshots, keep incomplete resources loading during missing-history recovery, keep local-only refreshes local, cancel closed-socket work, and keep profile controls disabled until loading completes without compiler-caching that state. Also avoid resetting an unmounted file input after plugin installation.

Repair E2E setup for production browser invitations using real WebRTC with an in-process signaling relay, explicit hosted-account fixtures, and selectors matching the current creation catalog.

Validation:
- 438 library tests and 850 app tests pass.
- Workspace type checks, lint, and production frontend/WASM build pass.
- Focused invitation/offline, managed account, table/calendar/canvas regressions pass; live username test passes three consecutive runs. Computed-column, plugin and performance tests pass 30/30 across three repeats.
- Full Chromium suite on 127595996: 206 passed, 8 skipped, zero failures in 13.5 minutes, with one worker, zero retries, and trace recording off. Six existing skips plus two Cloud Vault tests requiring a standalone portal. Local backend is the existing cached binary; frontend and WASM are rebuilt from this checkout. Hosted CI is still running.
