### PR TITLE
Refactor resource readiness, hydration and connection lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ artifact
 # Store for the e2e server (`browser/e2e/scripts/e2e-server.sh`) — test data
 # only, kept out of the dev store on purpose.
 /.e2e-store
+/.e2e-runs
 server/assets_tmp
 server/js-build.log
 .netlify

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -731,4 +731,5 @@ check; real refresh/query timing remains a browser acceptance check.
   intentional service-worker block are declared only in the tests causing them.
 - `pnpm test-e2e:local` builds JS, WASM and the native backend from the checkout,
   uses fresh test data and matching free ports, and preserves its report/build logs.
-  Real Cloud Vault integration still requires a separately running portal.
+  Failure traces are retained. Real Cloud Vault integration requires an explicitly
+  supplied `ATOMIC_VAULT_PORTAL_URL`; the runner never discovers unrelated portals.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -715,3 +715,20 @@ check; real refresh/query timing remains a browser acceptance check.
 `store.test.ts` also verifies that a buffered property snapshot materializes before `getProperty` reads its datatype. Computed-column resize, reorder and filter E2Es exercise this during table creation and reload.
 
 `store.test.ts` keeps property readers pending when a delta lacks base history; `sync-import.test.ts` checks the loading-to-error transition if recovery fails. `plugin.spec.ts` verifies installation completes without accessing an unmounted upload input.
+
+## Resource lifecycle and reproducible local E2E
+
+- `browser/lib/src/resource.test.ts`: explicit buffered/loading/recovering/ready/error
+  states, including readable cached values while recovery is in flight.
+- `browser/lib/src/store.test.ts`: local hydration publishes the original causal
+  snapshot in one ingress; immutable status snapshots retain the live mutation handle.
+- `browser/lib/src/websockets.test.ts`: close cancels pending authentication signing;
+  a reconnect to the same account cannot revive an old sync computation.
+- Production `e2e.spec.ts`, `browser-invite.spec.ts`, and `username-live.spec.ts`
+  exercise compiled profile and invitation readiness without a compiler opt-out.
+- `deployment-fixtures.ts` composes the console-diagnostics fixture for standalone,
+  managed, and managed-with-dev-drive modes. Expected mocked 401 responses and the
+  intentional service-worker block are declared only in the tests causing them.
+- `pnpm test-e2e:local` builds JS, WASM and the native backend from the checkout,
+  uses fresh test data and matching free ports, and preserves its report/build logs.
+  Real Cloud Vault integration still requires a separately running portal.

--- a/browser/data-browser/src/components/AgentProfileHeader.tsx
+++ b/browser/data-browser/src/components/AgentProfileHeader.tsx
@@ -4,7 +4,7 @@ import { FaArrowUpRightFromSquare, FaCamera, FaUser } from 'react-icons/fa6';
 import {
   core,
   dataBrowser,
-  useResource,
+  useResourceSnapshot,
   useString,
   useSubject,
 } from '@tomic/react';
@@ -30,10 +30,7 @@ const valueOpts = { commit: true, validate: false } as const;
  * need a trip to a separate edit form.
  */
 export function AgentProfileHeader({ subject }: { subject: string }) {
-  'use no memo';
-  // Resources mutate in place; compiler memoization by reference would
-  // freeze isReady() at the initial loading state.
-  const resource = useResource(subject);
+  const { resource, ready } = useResourceSnapshot(subject);
   const [name, setName] = useString(resource, core.properties.name, valueOpts);
   const [, setIcon] = useSubject(
     resource,
@@ -118,7 +115,7 @@ export function AgentProfileHeader({ subject }: { subject: string }) {
         type='button'
         onClick={() => inputRef.current?.click()}
         title={hasPicture ? 'Change your picture' : 'Add a picture'}
-        disabled={!resource.isReady()}
+        disabled={!ready}
         data-test='change-avatar'
       >
         {hasPicture ? (
@@ -141,7 +138,7 @@ export function AgentProfileHeader({ subject }: { subject: string }) {
         <NameInput
           id='agent-display-name'
           data-test='agent-name-input'
-          disabled={!resource.isReady()}
+          disabled={!ready}
           value={draft}
           placeholder='Add your name'
           onChange={e => setDraft(e.target.value)}

--- a/browser/data-browser/src/components/InviteForm.tsx
+++ b/browser/data-browser/src/components/InviteForm.tsx
@@ -1,6 +1,8 @@
 import { TeamProfileStep } from './TeamProfileStep';
 import {
   useResource,
+  useResourceSnapshot,
+  useString,
   useBoolean,
   useStore,
   Resource,
@@ -40,20 +42,25 @@ interface InviteFormProps {
  */
 export function InviteForm({ target, inDialog }: InviteFormProps) {
   const [agent] = useCurrentAgent();
-  const profile = useResource(agent?.subject);
+  const {
+    resource: profile,
+    ready,
+    error,
+  } = useResourceSnapshot(agent?.subject);
+  const [icon] = useString(profile, dataBrowser.properties.icon);
 
-  if (agent?.subject && profile.error) {
-    return <ErrorLook>{profile.error.message}</ErrorLook>;
+  if (agent?.subject && error) {
+    return <ErrorLook>{error.message}</ErrorLook>;
   }
 
-  if (agent?.subject && !profile.isReady()) return null;
+  if (agent?.subject && !ready) return null;
 
   return (
     <InviteFormContent
       key={agent?.subject}
       target={target}
       inDialog={inDialog}
-      skipProfile={!!profile.get(dataBrowser.properties.icon)}
+      skipProfile={!!icon}
     />
   );
 }

--- a/browser/data-browser/src/components/Searchbar/TagSuggestionOverlay.tsx
+++ b/browser/data-browser/src/components/Searchbar/TagSuggestionOverlay.tsx
@@ -1,4 +1,4 @@
-import { useResource, type DataBrowser } from '@tomic/react';
+import { useResourceSnapshot, type DataBrowser } from '@tomic/react';
 import { Column } from '../Row';
 import { styled } from 'styled-components';
 import type { TagWithTitle } from './SearchbarInput';
@@ -91,7 +91,7 @@ const TagSuggestionRow: React.FC<TagSuggestionRowProps> = ({
   onClick,
 }) => {
   const ref = useRef<HTMLButtonElement>(null);
-  const resource = useResource<DataBrowser.Tag>(subject);
+  const { resource, ready } = useResourceSnapshot<DataBrowser.Tag>(subject);
 
   useEffect(() => {
     if (selected && !blockAutoscroll) {
@@ -99,7 +99,7 @@ const TagSuggestionRow: React.FC<TagSuggestionRowProps> = ({
     }
   }, [selected, blockAutoscroll]);
 
-  if (!resource.isReady()) return <div>Loading...</div>;
+  if (!ready) return <div>Loading...</div>;
 
   return (
     <TagRow

--- a/browser/data-browser/src/components/Share/ShareDialog.tsx
+++ b/browser/data-browser/src/components/Share/ShareDialog.tsx
@@ -9,7 +9,7 @@ import {
   core,
   ResourceEvents,
   useCanWrite,
-  useResource,
+  useResourceSnapshot,
   useStore,
 } from '@tomic/react';
 
@@ -46,14 +46,14 @@ export function ShareDialog({
   trigger,
 }: ShareDialogProps): JSX.Element {
   const [dialogProps, show, , isOpen] = useDialog();
-  const resource = useResource(subject);
+  const { resource, ready } = useResourceSnapshot(subject);
   const canWrite = useCanWrite(resource);
   const isPrivateDrive = useIsPrivateDrive(subject);
   const [err, setErr] = useState<Error | undefined>(undefined);
   const inheritedRights = useInheritedRights(resource);
   const [resourceRights, updateResourceRights] = useRights(resource, setErr);
 
-  // Track `hasUnsavedChanges` locally. `useResource`'s `track` option also
+  // Track `hasUnsavedChanges` locally. `useResourceSnapshot`'s `track` option also
   // triggers re-renders on LocalChange, but every render creates a fresh
   // proxy that tears down the listener and the subscriber-store can trample
   // the dirty state. Keeping a dedicated flag here is simpler and resilient.
@@ -140,9 +140,7 @@ export function ShareDialog({
                         key={JSON.stringify(right)}
                         {...right}
                         handleSetRight={
-                          canWrite && resource.isReady()
-                            ? updateResourceRights
-                            : undefined
+                          canWrite && ready ? updateResourceRights : undefined
                         }
                       />
                     ))}

--- a/browser/data-browser/src/components/TeamProfileStep.tsx
+++ b/browser/data-browser/src/components/TeamProfileStep.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import {
   core,
   dataBrowser,
-  useResource,
+  useResourceSnapshot,
   useStore,
   useString,
 } from '@tomic/react';
@@ -25,7 +25,7 @@ export function TeamProfileStep({
   onContinue: () => void | Promise<void>;
 }) {
   const store = useStore();
-  const resource = useResource(subject);
+  const { resource, ready } = useResourceSnapshot(subject);
   const [name] = useString(resource, core.properties.name);
   const [draft, setDraft] = useState<string>();
   const [source, setSource] = useState<File>();
@@ -136,7 +136,7 @@ export function TeamProfileStep({
         <ErrorLook>{(error || resource.error)?.message}</ErrorLook>
       )}
       <Button
-        disabled={busy || !resource.isReady() || !(draft ?? name ?? '').trim()}
+        disabled={busy || !ready || !(draft ?? name ?? '').trim()}
         onClick={() => void save()}
       >
         {busy ? 'Saving…' : 'Save and continue'}

--- a/browser/data-browser/src/routes/Share/AgentRights.tsx
+++ b/browser/data-browser/src/routes/Share/AgentRights.tsx
@@ -1,4 +1,4 @@
-import { urls, useResource } from '@tomic/react';
+import { urls, useResourceSnapshot } from '@tomic/react';
 import { FaGlobe } from 'react-icons/fa6';
 import styled from 'styled-components';
 import { CardRow } from '../../components/Card';
@@ -22,8 +22,8 @@ export function AgentRights({
   write,
 }: AgentRightsProps): JSX.Element {
   const isPublicRight = agentSubject === urls.instances.publicAgent;
-  const resource = useResource(agentSubject);
-  const disabled = !resource.isReady() || !handleSetRight;
+  const { ready } = useResourceSnapshot(agentSubject);
+  const disabled = !ready || !handleSetRight;
 
   return (
     <CardRow>

--- a/browser/data-browser/src/routes/Share/ShareRoute.tsx
+++ b/browser/data-browser/src/routes/Share/ShareRoute.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState, type JSX } from 'react';
-import { core, ResourceEvents, useCanWrite, useResource } from '@tomic/react';
+import {
+  core,
+  ResourceEvents,
+  useCanWrite,
+  useResourceSnapshot,
+} from '@tomic/react';
 import { ContainerNarrow } from '../../components/Containers';
 import { Card, CardInsideFull } from '../../components/Card';
 import { Button } from '../../components/Button';
@@ -37,7 +42,7 @@ export const ShareRoute = createRoute({
 /** Form for managing and viewing rights for this resource */
 function SharePage(): JSX.Element {
   const { subject } = ShareRoute.useSearch();
-  const resource = useResource(subject);
+  const { resource, ready } = useResourceSnapshot(subject);
   const canWrite = useCanWrite(resource);
   const [showInviteForm, setShowInviteForm] = useState(false);
   const [err, setErr] = useState<Error | undefined>(undefined);
@@ -103,9 +108,7 @@ function SharePage(): JSX.Element {
                     key={JSON.stringify(right)}
                     {...right}
                     handleSetRight={
-                      canWrite && resource.isReady()
-                        ? updateResourceRights
-                        : undefined
+                      canWrite && ready ? updateResourceRights : undefined
                     }
                   />
                 ))}

--- a/browser/data-browser/src/views/ChatRoom/ChatRoomView.tsx
+++ b/browser/data-browser/src/views/ChatRoom/ChatRoomView.tsx
@@ -10,6 +10,7 @@ import {
   useCreatedAt,
   useCreatedBy,
   useResource,
+  useResourceSnapshot,
   useStore,
   useString,
   useSubject,
@@ -517,13 +518,13 @@ const MESSAGE_LINE_MAX_LEN = 50;
 
 /** Small single line preview of a message, useful in replies */
 function MessageLine({ subject }: MessageLineProps) {
-  const resource = useResource(subject);
+  const { resource, ready } = useResourceSnapshot(subject);
   const [description] = useString(resource, core.properties.description);
   // Author from the resource's own genesis metadata (createdBy) — not a commit
   // fetch, so it survives a refresh.
   const author = useCreatedBy(resource);
 
-  if (!resource.isReady()) {
+  if (!ready) {
     return <MessageLineStyled>loading...</MessageLineStyled>;
   }
 

--- a/browser/data-browser/src/views/InvitePage.tsx
+++ b/browser/data-browser/src/views/InvitePage.tsx
@@ -4,7 +4,7 @@ import { TeamProfileStep } from '../components/TeamProfileStep';
 import {
   useBoolean,
   useNumber,
-  useResource,
+  useResourceSnapshot,
   useTitle,
   useString,
   Agent,
@@ -67,7 +67,9 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
   const baseNavigate = useNavigate();
   const navigate = (to: string) => baseNavigate({ to });
   const { agent, setAgent, setDrive } = useSettings();
-  const agentResource = useResource(agent?.subject);
+  const { resource: agentResource, ready: agentReady } = useResourceSnapshot(
+    agent?.subject,
+  );
   const [agentTitle] = useTitle(agentResource, 15);
   const [redirectURL, setRedirectURL] = useState<string | undefined>(undefined);
   const [agentSecret, setAgentSecret] = useState<string | undefined>();
@@ -427,7 +429,6 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
     new URLSearchParams(window.location.search).get('accept') === 'true';
   const resumed = useRef(false);
   const [resumeError, setResumeError] = useState(false);
-  const agentReady = agentResource.isReady();
   const acceptAfterSignup = useEffectEvent(() => {
     void handleAccept().catch(error => {
       setResumeError(true);
@@ -480,7 +481,7 @@ function InvitePage({ resource }: ResourcePageProps): JSX.Element {
               {agentSubject ? (
                 <CtaButton
                   data-test='accept-existing'
-                  disabled={!agentResource.isReady()}
+                  disabled={!agentReady}
                   onClick={() => {
                     if (agentResource.get(dataBrowser.properties.icon)) {
                       void handleAccept().catch(error =>

--- a/browser/e2e/README.md
+++ b/browser/e2e/README.md
@@ -1,3 +1,36 @@
+## Reproducible local production run
+
+From `browser/`, run `pnpm test-e2e:local`. It installs locked dependencies,
+builds every JS package and WASM, then builds the native server from this
+checkout. It starts a fresh database and production preview on matching free
+ports, checks both the frontend and its backend proxy, and runs Chromium with
+one worker and zero retries. It stops only its own process groups. Build logs,
+test data and the HTML report remain in the git-ignored `.e2e-runs/` directory.
+
+Prerequisites: the repository's Rust toolchain, `wasm32-unknown-unknown`,
+`cargo-run-bin` (for the pinned wasm-pack), Node and pnpm. The first build may
+be slow; later runs reuse Cargo and pnpm caches while rebuilding changed code.
+Ports 3000 and 4174 must be free for generated Next.js/Svelte template tests.
+The runner refuses an occupied template port before running any tests.
+
+Pass Playwright filters directly, e.g. `pnpm test-e2e:local --grep @smoke`.
+`PLAYWRIGHT_WORKERS` can override concurrency. Cloud Vault integration needs a
+real portal at `ATOMIC_VAULT_PORTAL_URL` (default localhost:3030); those tests
+report skips when it is unavailable. Mocked managed-account tests do not
+require that portal.
+
+### Deployment fixtures
+
+Import `standaloneTest as test` or `managedTest as test` from
+`tests/deployment-fixtures.ts` when a spec depends on deployment behavior.
+Managed mode sets the runtime portal URL and mocks the account API before
+navigation; register endpoint-specific routes afterward. Standalone mode does
+not inject hosted configuration. Use `managedDriveTest` for a fresh dev-drive
+identity followed by hosted mode; the standalone dev-drive route cannot run
+under hosted onboarding. The other fixtures do not create an identity.
+For mocked portal navigation, disable service workers in the spec so routes
+can intercept the dashboard instead of the app's navigation fallback.
+
 # Atomic Data Browser E2E tests
 
 We use `playwright` to run end-to-end tests in the browser.

--- a/browser/e2e/README.md
+++ b/browser/e2e/README.md
@@ -5,7 +5,7 @@ builds every JS package and WASM, then builds the native server from this
 checkout. It starts a fresh database and production preview on matching free
 ports, checks both the frontend and its backend proxy, and runs Chromium with
 one worker and zero retries. It stops only its own process groups. Build logs,
-test data and the HTML report remain in the git-ignored `.e2e-runs/` directory.
+test data, failure traces and the HTML report remain in the git-ignored `.e2e-runs/` directory.
 
 Prerequisites: the repository's Rust toolchain, `wasm32-unknown-unknown`,
 `cargo-run-bin` (for the pinned wasm-pack), Node and pnpm. The first build may
@@ -15,8 +15,9 @@ The runner refuses an occupied template port before running any tests.
 
 Pass Playwright filters directly, e.g. `pnpm test-e2e:local --grep @smoke`.
 `PLAYWRIGHT_WORKERS` can override concurrency. Cloud Vault integration needs a
-real portal at `ATOMIC_VAULT_PORTAL_URL` (default localhost:3030); those tests
-report skips when it is unavailable. Mocked managed-account tests do not
+real portal explicitly selected with `ATOMIC_VAULT_PORTAL_URL`; this isolated
+runner skips those tests when it is unset or unavailable, and never discovers
+a portal from an unrelated local task. Mocked managed-account tests do not
 require that portal.
 
 ### Deployment fixtures

--- a/browser/e2e/scripts/local-e2e.mjs
+++ b/browser/e2e/scripts/local-e2e.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { mkdirSync, openSync, closeSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const root = resolvePath(dirname(fileURLToPath(import.meta.url)), '../../..');
+const playwrightArgs = process.argv.slice(2).filter(arg => arg !== '--');
+
+if (playwrightArgs.includes('--help')) {
+  console.info(
+    'Build and run isolated production Chromium E2E: pnpm test-e2e:local [Playwright arguments]\nRequires Cargo, cargo-run-bin/wasm-pack and the wasm32-unknown-unknown target.\nReports, build logs and fresh data are saved under .e2e-runs/. No existing services are stopped.',
+  );
+  process.exit(0);
+}
+
+const output = join(
+  root,
+  '.e2e-runs',
+  new Date().toISOString().replaceAll(':', '-'),
+);
+mkdirSync(output, { recursive: true });
+const active = new Set();
+
+async function freePort(port = 0, host = '127.0.0.1') {
+  const probe = createServer();
+  await new Promise((resolve, reject) => {
+    probe.once('error', reject);
+    probe.listen(port, host, resolve);
+  });
+  const result = probe.address().port;
+  await new Promise(resolve => probe.close(resolve));
+
+  return result;
+}
+
+function start(command, args, name, cwd, env) {
+  const log = join(output, `${name}.log`);
+  const fd = openSync(log, 'w');
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: ['ignore', fd, fd],
+  });
+  closeSync(fd);
+  const task = { child, log, done: undefined, exited: false };
+  task.done = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', code => {
+      task.exited = true;
+      resolve(code ?? 1);
+    });
+  });
+  // Background services may fail while another command is running.
+  task.done.catch(() => {});
+  active.add(task);
+
+  return task;
+}
+
+async function run(command, args, name, cwd, env) {
+  console.info(
+    `${name}: ${command} ${args.join(' ')} (log: ${join(output, `${name}.log`)})`,
+  );
+  const task = start(command, args, name, cwd, env);
+  const code = await task.done;
+  if (code !== 0) throw new Error(`${name} exited ${code}; see ${task.log}`);
+  active.delete(task);
+}
+
+async function healthy(url, task) {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    if (task.exited) throw new Error(`Service exited; see ${task.log}`);
+
+    try {
+      if ((await fetch(url, { signal: AbortSignal.timeout(1000) })).ok) return;
+    } catch {
+      /* Service may still be starting. */
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(`Service did not become healthy at ${url}; see ${task.log}`);
+}
+
+function signal(task, name) {
+  if (!task.child.pid) return;
+
+  try {
+    process.kill(-task.child.pid, name);
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+}
+
+async function cleanup() {
+  const tasks = [...active];
+  if (tasks.length === 0) return;
+  tasks.forEach(task => signal(task, 'SIGTERM'));
+  await Promise.race([
+    Promise.allSettled(tasks.map(task => task.done)),
+    delay(2000),
+  ]);
+  tasks.forEach(task => signal(task, 'SIGKILL'));
+}
+
+for (const event of ['SIGINT', 'SIGTERM']) {
+  process.once(event, () => {
+    void cleanup().finally(() => process.exit(130));
+  });
+}
+
+try {
+  // Generated template tests use these fixed ports and invoke kill-port.
+  // Refuse a conflicting setup before they can touch somebody else's server.
+  await freePort(3000);
+  await freePort(4174);
+
+  for (const port of [3000, 4174]) {
+    try {
+      await freePort(port, '::1');
+    } catch (error) {
+      if (!['EAFNOSUPPORT', 'EADDRNOTAVAIL'].includes(error.code)) throw error;
+    }
+  }
+
+  const serverPort = await freePort();
+  let frontendPort = await freePort();
+  while (frontendPort === serverPort) frontendPort = await freePort();
+  const serverURL = `http://localhost:${serverPort}`;
+  const frontendURL = `http://127.0.0.1:${frontendPort}`;
+  const env = {
+    ...process.env,
+    SERVER_URL: serverURL,
+    FRONTEND_URL: frontendURL,
+    VITE_ATOMIC_SERVER_URL: serverURL,
+    VITE_E2E: 'true',
+    PLAYWRIGHT_WORKERS: process.env.PLAYWRIGHT_WORKERS ?? '1',
+    PLAYWRIGHT_RETRIES: '0',
+    PLAYWRIGHT_HTML_OUTPUT_DIR: join(output, 'report'),
+    ATOMIC_DATA_DIR: join(output, 'data'),
+    ATOMIC_CONFIG_DIR: join(output, 'config'),
+    ATOMIC_CACHE_DIR: join(output, 'cache'),
+    ATOMIC_PORT: String(serverPort),
+    ATOMIC_DOMAIN: 'localhost',
+    ATOMIC_INITIALIZE: 'true',
+    ATOMICSERVER_SKIP_JS_BUILD: 'true',
+  };
+  // Never inherit a stale-artifact opt-out from the invoking shell.
+  delete env.SKIP_WASM_BUILD;
+  console.info(`E2E artifacts: ${output}`);
+  const browser = join(root, 'browser');
+  await run('pnpm', ['install', '--frozen-lockfile'], 'install', browser, env);
+  await run('pnpm', ['run', 'build'], 'build-browser', browser, env);
+  await run(
+    'cargo',
+    ['build', '--locked', '-p', 'atomic-server'],
+    'build-server',
+    root,
+    env,
+  );
+  await run(
+    'pnpm',
+    ['exec', 'playwright', 'install', 'chromium'],
+    'install-chromium',
+    join(browser, 'e2e'),
+    env,
+  );
+  const target = resolvePath(root, env.CARGO_TARGET_DIR ?? 'target');
+  const server = start(
+    join(target, 'debug/atomic-server'),
+    [],
+    'server',
+    root,
+    env,
+  );
+  await healthy(serverURL, server);
+  const preview = start(
+    'pnpm',
+    [
+      'exec',
+      'vite',
+      'preview',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(frontendPort),
+      '--strictPort',
+    ],
+    'preview',
+    join(browser, 'data-browser'),
+    env,
+  );
+  await healthy(frontendURL, preview);
+  await healthy(`${frontendURL}/server`, preview);
+  writeFileSync(
+    join(output, 'environment.json'),
+    JSON.stringify(
+      {
+        serverURL,
+        frontendURL,
+        vaultPortal: env.ATOMIC_VAULT_PORTAL_URL ?? 'http://localhost:3030',
+        retries: 0,
+      },
+      null,
+      2,
+    ),
+  );
+  await run(
+    'pnpm',
+    [
+      'exec',
+      'playwright',
+      'test',
+      '--project=chromium',
+      '--trace=off',
+      `--output=${join(output, 'results')}`,
+      '--reporter=line,html',
+      ...playwrightArgs,
+    ],
+    'e2e',
+    join(browser, 'e2e'),
+    env,
+  );
+  console.info(`E2E passed. Report: ${join(output, 'report/index.html')}`);
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+} finally {
+  await cleanup();
+}

--- a/browser/e2e/scripts/local-e2e.mjs
+++ b/browser/e2e/scripts/local-e2e.mjs
@@ -139,6 +139,8 @@ try {
     FRONTEND_URL: frontendURL,
     VITE_ATOMIC_SERVER_URL: serverURL,
     VITE_E2E: 'true',
+    // External services are opt-in: an unrelated portal may occupy :3030.
+    ATOMIC_VAULT_PORTAL_URL: process.env.ATOMIC_VAULT_PORTAL_URL ?? '',
     PLAYWRIGHT_WORKERS: process.env.PLAYWRIGHT_WORKERS ?? '1',
     PLAYWRIGHT_RETRIES: '0',
     PLAYWRIGHT_HTML_OUTPUT_DIR: join(output, 'report'),
@@ -203,7 +205,7 @@ try {
       {
         serverURL,
         frontendURL,
-        vaultPortal: env.ATOMIC_VAULT_PORTAL_URL ?? 'http://localhost:3030',
+        vaultPortal: env.ATOMIC_VAULT_PORTAL_URL || null,
         retries: 0,
       },
       null,
@@ -217,7 +219,7 @@ try {
       'playwright',
       'test',
       '--project=chromium',
-      '--trace=off',
+      '--trace=retain-on-failure',
       `--output=${join(output, 'results')}`,
       '--reporter=line,html',
       ...playwrightArgs,

--- a/browser/e2e/tests/browser-invite.spec.ts
+++ b/browser/e2e/tests/browser-invite.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type WebSocketRoute } from '@playwright/test';
+import type { WebSocketRoute } from '@playwright/test';
+import { standaloneTest as test, expect } from './deployment-fixtures';
 import { devDrive, FRONTEND_URL, topBarShareButton } from './test-utils';
 
 // Relay only discovery and SDP in-process. Authentication, invite redemption,

--- a/browser/e2e/tests/deployment-fixtures.ts
+++ b/browser/e2e/tests/deployment-fixtures.ts
@@ -1,0 +1,36 @@
+import { test as base, expect } from './fixtures';
+import { mockManagedPortal } from './managed-test-utils';
+import { devDrive } from './test-utils';
+
+/** Declare deployment behavior independently of the host/port under test. */
+type DeploymentFixtures = {
+  deployment: 'standalone' | 'managed';
+};
+
+export const standaloneTest: ReturnType<
+  typeof base.extend<DeploymentFixtures>
+> = base.extend<DeploymentFixtures>({
+  deployment: ['standalone', { option: true }],
+  page: async ({ page, deployment }, use) => {
+    if (deployment === 'managed') {
+      await mockManagedPortal(page);
+    }
+
+    await use(page);
+  },
+});
+
+export const managedTest: typeof standaloneTest = standaloneTest.extend({
+  deployment: 'managed',
+});
+/** Create an identity before entering mocked hosted mode. The dev-drive route
+ * is a standalone development entry point, not hosted onboarding.
+ */
+export const managedDriveTest: typeof standaloneTest = standaloneTest.extend({
+  page: async ({ page }, use) => {
+    await devDrive(page);
+    await mockManagedPortal(page);
+    await use(page);
+  },
+});
+export { expect };

--- a/browser/e2e/tests/managed-sync-presentation.spec.ts
+++ b/browser/e2e/tests/managed-sync-presentation.spec.ts
@@ -1,13 +1,11 @@
-import { mockManagedPortal } from './managed-test-utils';
-import { test, expect } from '@playwright/test';
-import { devDrive, FRONTEND_URL } from './test-utils';
+import { managedDriveTest as test, expect } from './deployment-fixtures';
+import { FRONTEND_URL } from './test-utils';
 
 for (const localOnly of [true, false]) {
   test(`managed sync keeps server state honest (localOnly=${localOnly})`, async ({
     page,
+    browserDiagnostics,
   }) => {
-    await devDrive(page);
-    await mockManagedPortal(page);
     await page.route('**/api/me', route =>
       route.fulfill({ json: { email: 'sync-test@example.com' } }),
     );
@@ -67,9 +65,17 @@ for (const localOnly of [true, false]) {
     if (!localOnly) {
       // This case checks the expired Vault-session message independently of
       // the account identity returned by /me.
-      await page.route('**/api/cloud-vault/drives', route =>
-        route.fulfill({ status: 401 }),
-      );
+      await page.route('**/api/cloud-vault/drives', route => {
+        browserDiagnostics.expect(
+          'error',
+          /^Failed to load resource:.*401 \(Unauthorized\)/,
+          'This request deliberately returns an expired Vault session.',
+          1,
+          /\/api\/cloud-vault\/drives$/,
+        );
+
+        return route.fulfill({ status: 401 });
+      });
     }
 
     const writes: string[] = [];

--- a/browser/e2e/tests/passkey-unavailable.spec.ts
+++ b/browser/e2e/tests/passkey-unavailable.spec.ts
@@ -1,12 +1,9 @@
-import { mockManagedPortal } from './managed-test-utils';
-import { test, expect } from '@playwright/test';
-import { devDrive, FRONTEND_URL } from './test-utils';
+import { managedDriveTest as test, expect } from './deployment-fixtures';
+import { FRONTEND_URL } from './test-utils';
 
 test('explains missing passkey support without offering a broken setup action', async ({
   page,
 }) => {
-  await devDrive(page);
-  await mockManagedPortal(page);
   const agent = await page.evaluate(
     () =>
       (

--- a/browser/e2e/tests/recovery-option.spec.ts
+++ b/browser/e2e/tests/recovery-option.spec.ts
@@ -1,12 +1,15 @@
-import { mockManagedPortal } from './managed-test-utils';
-import { test, expect } from '@playwright/test';
+import { managedTest as test, expect } from './deployment-fixtures';
 
 // The portal is mocked on this origin; its dashboard must reach page.route
 // rather than the app service worker's navigation fallback.
 test.use({ serviceWorkers: 'block' });
 
-test.beforeEach(async ({ page }) => {
-  await mockManagedPortal(page);
+test.beforeEach(({ browserDiagnostics }) => {
+  browserDiagnostics.expect(
+    'warning',
+    /^Service Worker registration blocked by Playwright$/,
+    'This spec disables the app worker so mocked portal navigation is intercepted.',
+  );
 });
 
 // A portal session is not evidence that an encrypted recovery backup exists.

--- a/browser/e2e/tests/username-live.spec.ts
+++ b/browser/e2e/tests/username-live.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { standaloneTest as test, expect } from './deployment-fixtures';
 import {
   before,
   newResource,

--- a/browser/e2e/tests/vault-backup-restore.spec.ts
+++ b/browser/e2e/tests/vault-backup-restore.spec.ts
@@ -51,6 +51,8 @@ const uniqueEmail = () => `vault-${randomUUID()}@example.com`;
  * the stack was never started.
  */
 async function portalIsUp(): Promise<boolean> {
+  if (!PORTAL_URL) return false;
+
   try {
     const res = await fetch(`${PORTAL_URL}/api/me`);
 

--- a/browser/lib/src/resource.test.ts
+++ b/browser/lib/src/resource.test.ts
@@ -9,8 +9,49 @@ import {
 import type { JSONValue } from './value.js';
 import { testStore } from './test-store.js';
 import { core } from './index.js';
+import { LoroLoader } from './loro-loader.js';
 
 describe('resource.ts', () => {
+  it('reports buffered snapshots separately until WASM can materialize them', ({
+    expect,
+  }) => {
+    const resource = new Resource('https://example.com/buffered');
+    const loaded = vi.spyOn(LoroLoader, 'isLoaded').mockReturnValue(false);
+
+    try {
+      resource.applyHydratedValues([
+        ['https://atomicdata.dev/properties/loroUpdate', new Uint8Array([1])],
+      ]);
+      expect(resource.readState).toBe('buffered');
+      expect(resource.isReady()).toBe(false);
+      resource.applyHydratedValues([[core.properties.name, 'Cached title']]);
+      expect(resource.readState).toBe('buffered');
+      expect(resource.isReady()).toBe(true);
+    } finally {
+      loaded.mockRestore();
+    }
+  });
+
+  it('distinguishes recovery from loading without hiding readable state', ({
+    expect,
+  }) => {
+    const resource = new Resource('https://example.com/read-state');
+    resource.loading = true;
+    expect(resource.readState).toBe('loading');
+    resource.setRecovering(true);
+    expect(resource.readState).toBe('recovering');
+    expect(resource.isReady()).toBe(false);
+    resource.loading = false;
+    expect(resource.readState).toBe('recovering');
+    expect(resource.isReady()).toBe(true);
+    resource.setError(new Error('Recovery failed'));
+    resource.setRecovering(false);
+    expect(resource.readState).toBe('error');
+    expect(resource.isReady()).toBe(false);
+    resource.error = undefined;
+    expect(resource.readState).toBe('ready');
+  });
+
   it('push propvals', ({ expect }) => {
     const resource = new Resource('test');
     const testsubject = 'https://example.com/testsubject';

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -143,6 +143,16 @@ export enum ResourceEvents {
   LoadingChange = 'loading-change',
 }
 
+/** Read lifecycle, independent of saving and the durable outbox.
+ * `recovering` can retain readable content; use `isReady()` before reads.
+ */
+export type ResourceReadState =
+  | 'loading'
+  | 'buffered'
+  | 'recovering'
+  | 'ready'
+  | 'error';
+
 type ResourceEventHandlers = {
   [ResourceEvents.LocalChange]: (prop: string, value: JSONValue) => void;
   [ResourceEvents.LoadingChange]: (loading: boolean) => void;
@@ -184,6 +194,7 @@ export class Resource<C extends OptionalClass = any> {
   public appliedCommitSignatures: Set<string> = new Set();
 
   private _loading = false;
+  private _recovering = false;
   private _dirty = false;
 
   #commitBuilder: CommitBuilder;
@@ -1741,6 +1752,28 @@ export class Resource<C extends OptionalClass = any> {
   /** Checks if the resource is both loaded and free from errors */
   public isReady(): boolean {
     return !this.loading && this.error === undefined;
+  }
+
+  public get readState(): ResourceReadState {
+    if (this.error !== undefined) return 'error';
+    if (this._recovering) return 'recovering';
+
+    if (
+      !this._loroDoc &&
+      this._loroSnapshotBytes?.length &&
+      !LoroLoader.isLoaded()
+    ) {
+      return 'buffered';
+    }
+
+    return this.loading ? 'loading' : 'ready';
+  }
+
+  /** @internal The Store owns missing-history recovery. */
+  public setRecovering(recovering: boolean): void {
+    if (this._recovering === recovering) return;
+    this._recovering = recovering;
+    this.eventManager.emit(ResourceEvents.LoadingChange, this.loading);
   }
 
   /** Get a Value by its property

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -5,6 +5,27 @@ import { bootstrapCoreVocab } from './test-vocab.js';
 import { testStore } from './test-store.js';
 
 describe('Store', () => {
+  it('captures immutable read status while retaining the stable mutation handle', ({
+    expect,
+  }) => {
+    const store = new Store();
+    const resource = new Resource('did:ad:status-snapshot');
+    resource.loading = true;
+    store.addResource(resource);
+    const before = store.getResourceSnapshot(resource.subject);
+    expect(before.ready).toBe(false);
+    expect(before.readState).toBe('loading');
+    expect(store.getResourceSnapshot(resource.subject)).toBe(before);
+    resource.loading = false;
+    store.notifyResourceUpdated(resource);
+    const after = store.getResourceSnapshot(resource.subject);
+    expect(after).not.toBe(before);
+    expect(after.ready).toBe(true);
+    expect(before.ready).toBe(false);
+    expect(after.resource).toBe(before.resource);
+    expect(Object.isFrozen(after)).toBe(true);
+  });
+
   it('publishes local hydration only after restoring the causal snapshot', async ({
     expect,
   }) => {

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -5,6 +5,43 @@ import { bootstrapCoreVocab } from './test-vocab.js';
 import { testStore } from './test-store.js';
 
 describe('Store', () => {
+  it('publishes local hydration only after restoring the causal snapshot', async ({
+    expect,
+  }) => {
+    await enableLoro();
+    const subject = 'did:ad:atomic-hydration';
+    const source = new Resource(subject);
+    await source.set(core.properties.name, 'Persisted', false);
+    const doc = source.getLoroDoc()!;
+    const snapshot = doc.export({ mode: 'snapshot' });
+    const version = doc.oplogVersion().toJSON();
+    const store = new Store({ serverUrl: 'https://example.com' });
+    store.setClientDb({
+      isReady: true,
+      isInitialized: true,
+      waitForInit: async () => {},
+      getResourceWithSnapshot: async () => ({
+        jsonAd: JSON.stringify({
+          '@id': subject,
+          [core.properties.name]: 'Persisted',
+        }),
+        snapshot,
+      }),
+    } as unknown as Parameters<Store['setClientDb']>[0]);
+    const published: unknown[] = [];
+    const apply = store.applyIncoming.bind(store);
+    vi.spyOn(store, 'applyIncoming').mockImplementation(change => {
+      if (change.source === 'offline-replay') {
+        published.push(change.resource?.getLoroDoc()?.oplogVersion().toJSON());
+      }
+
+      return apply(change);
+    });
+    store.getResourceLoading(subject);
+    await vi.waitFor(() => expect(published).toHaveLength(1));
+    expect(published).toEqual([version]);
+  });
+
   it('keeps property readers waiting while a delta with missing history is recovered', async ({
     expect,
   }) => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1854,6 +1854,7 @@ export class Store {
     if (this._gapRecoveries.has(subject)) return;
 
     this._gapRecoveries.add(subject);
+    this.getResolved(subject)?.setRecovering(true);
     console.info(
       `[Store] incomplete Loro import for ${subject.slice(0, 60)} ` +
         `(source: ${source ?? 'unknown'}) — missing base state, fetching a full ` +
@@ -1876,6 +1877,12 @@ export class Store {
       })
       .finally(() => {
         this._gapRecoveries.delete(subject);
+        const resource = this.getResolved(subject);
+
+        if (resource) {
+          resource.setRecovering(false);
+          this.notify(resource);
+        }
       });
   }
 

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -3017,68 +3017,23 @@ export class Store {
       try {
         const { jsonAd, snapshot } =
           await this.clientDb.getResourceWithSnapshot(subject);
-        const hasSnapshot = !!(snapshot && snapshot.length > 0);
 
         if (jsonAd) {
           hasLocalData = this.hydrateResourceFromJson(
             subject,
             JSON.parse(jsonAd),
+            snapshot ?? undefined,
           );
         }
 
-        let importComplete = true;
-
-        if (hasLocalData && hasSnapshot) {
-          const resource = this.resources.get(subject);
-
-          if (resource && !resource.hasUnsavedChanges()) {
-            // Capture `complete`: the snapshot may be an unapplyable delta
-            // (missing base ops, buffered by Loro as pending → nothing
-            // materialises). The WS path (`applyIncoming`) already acts on this
-            // signal; the OPFS path used to drop it on the floor.
-            // OPFS snapshots are authoritative full state — replace, don't
-            // merge into the JSON-AD-seeded doc. Merging minted a second
-            // LoroList per array and flashed table/sidebar order on open.
-            ({ complete: importComplete } = resource.importLoroUpdate(
-              snapshot,
-              true,
-            ));
-          }
-        }
-
-        // An OPFS hit is only authoritative if it actually hydrated to
-        // something RENDERABLE. Otherwise we'd render a contentless resource
-        // (bare subject as title, no body) with NO error that never recovers —
-        // the "deeply broken folder" bug. There are several routes into that
-        // contentless state, so we guard on the OUTCOME (is the resource
-        // renderable?) rather than on any single cause:
-        //   - nothing hydrated at all (`getEntries().length === 0`);
-        //   - a skeleton JSON-AD with no snapshot (only the server-managed
-        //     props survive, and no import ran to add a class);
-        //   - an unapplyable-delta snapshot (`!importComplete`) that buffers as
-        //     pending and materialises nothing, leaving only the skeleton.
-        // In all of these the resource carries at most the server-managed
-        // skeleton props that `rebuildCacheFromLoro` preserves
-        // (drive/parent/lastCommit/createdAt) — `length` is > 0, so the old
-        // `length === 0` guard missed it.
-        //
-        // Renderable ⇔ it has a class (`isA`) — covers commit-detail
-        // (`isA: Commit`, whose delta `loroUpdate` legitimately leaves
-        // `!importComplete`, mirroring the `applyIncoming` guard) — OR it has
-        // real content beyond the skeleton AND that content actually applied
-        // (a clean import). Anything else is treated as a miss: keep `loading`
-        // so the UI shows a spinner, drop `hasLocalData` so the server GET
-        // below repopulates it — or, offline, fails it with a real error
-        // instead of leaving it silently broken. The slow (cache-cold) reload
-        // dodges this naturally (ClientDb not initialized yet ⇒ OPFS skipped);
-        // the fast service-worker reload is what hits it.
+        // Hydration publishes JSON and causal state together. A skeleton-only
+        // record still needs a server fetch; commit-detail resources may carry
+        // a partial delta but remain renderable from their class metadata.
         if (hasLocalData) {
           const resource = this.resources.get(subject);
           const hasClass = !!resource?.get(core.properties.isA);
           const renderable =
-            !!resource &&
-            (hasClass ||
-              (importComplete && this.hasRenderableContent(resource)));
+            !!resource && (hasClass || this.hasRenderableContent(resource));
 
           if (!renderable) {
             hasLocalData = false;
@@ -3272,6 +3227,7 @@ export class Store {
   private hydrateResourceFromJson(
     subject: string,
     parsed: Record<string, unknown>,
+    snapshot?: Uint8Array,
   ): boolean {
     const existing = this.getResolved(subject);
 
@@ -3279,7 +3235,8 @@ export class Store {
     if (
       existing &&
       existing.get(commits.properties.loroUpdate) &&
-      !parsed[commits.properties.loroUpdate]
+      !parsed[commits.properties.loroUpdate] &&
+      !snapshot?.length
     ) {
       return true;
     }
@@ -3304,7 +3261,7 @@ export class Store {
       return true;
     }
 
-    this.hydrateOfflineReplay(subject, parsed);
+    this.hydrateOfflineReplay(subject, parsed, snapshot);
 
     // If the outbox holds a dirty bit for this subject (offline edit
     // restored from localStorage), kick a drain now that the resource

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -38,7 +38,11 @@ import { core } from './ontologies/core.js';
 import { server, type Server } from './ontologies/server.js';
 import type { OptionalClass, UnknownClass } from './ontology.js';
 import { JSONADParser } from './parse.js';
-import { Resource, unknownSubject } from './resource.js';
+import {
+  Resource,
+  unknownSubject,
+  type ResourceReadState,
+} from './resource.js';
 import {
   type SearchOpts,
   type SemanticSearchOpts,
@@ -5870,13 +5874,8 @@ export class Store {
     return url;
   }
 
-  /** Per-subject snapshot wrappers for `useSyncExternalStore`. Each
-   * snapshot's `resource` field is a fresh Proxy of the cached
-   * Resource, so `R.foo` reads stay reactive (Resource is mutated
-   * in place, but the Proxy identity changes per notify). The
-   * snapshot tuple identity changes too, which is what
-   * `useSyncExternalStore` checks. */
-  private snapshots = new Map<string, { resource: Resource }>();
+  /** Immutable read status and a stable mutation handle, replaced on notify. */
+  private snapshots = new Map<string, ResourceSnapshot>();
 
   /** Subject → content stamp of the last state written to the local DB, so
    *  `addResource` can skip re-writing state that is already there. Entries are
@@ -5888,7 +5887,7 @@ export class Store {
   public getResourceSnapshot(
     subject: string,
     opts: FetchOpts = {},
-  ): { resource: Resource } {
+  ): ResourceSnapshot {
     let r: Resource;
     this.snapshotReadDepth++;
 
@@ -5902,7 +5901,7 @@ export class Store {
     let snap = this.snapshots.get(key);
 
     if (!snap || snap.resource !== r.__internalObject) {
-      snap = { resource: r.__internalObject };
+      snap = captureResourceSnapshot(r);
       this.snapshots.set(key, snap);
     }
 
@@ -5968,7 +5967,7 @@ export class Store {
     // outer `{resource}` object is `!== ` the previous one, which is
     // all `Object.is` needs.
     const key = this.normalizeSubject(resource.subject);
-    this.snapshots.set(key, { resource: resource.__internalObject });
+    this.snapshots.set(key, captureResourceSnapshot(resource));
 
     this.eventManager.emit(StoreEvents.ResourceUpdated, resource);
 
@@ -6076,4 +6075,23 @@ function hashPersistedState(jsonAd: string, snapshot?: Uint8Array): number {
     Math.imul(h1 ^ (h1 >>> 13), 3266489909);
 
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+
+/** Captured scalar read state; `resource` remains the live mutation handle. */
+export interface ResourceSnapshot<C extends OptionalClass = UnknownClass> {
+  readonly resource: Resource<C>;
+  readonly readState: ResourceReadState;
+  readonly ready: boolean;
+  readonly loading: boolean;
+  readonly error: Error | undefined;
+}
+
+function captureResourceSnapshot(resource: Resource): ResourceSnapshot {
+  return Object.freeze({
+    resource: resource.__internalObject,
+    readState: resource.readState,
+    ready: resource.isReady(),
+    loading: resource.loading,
+    error: resource.error,
+  });
 }

--- a/browser/lib/src/sync-import.test.ts
+++ b/browser/lib/src/sync-import.test.ts
@@ -84,8 +84,10 @@ describe('applyIncoming — incomplete Loro import surfaces an error', () => {
     const r = store.resources.get(subject);
     expect(r).toBeDefined();
     expect(r!.loading).toBe(true);
+    expect(r!.readState).toBe('recovering');
     await vi.waitFor(() => expect(r!.error).toBeDefined());
     expect(r!.loading).toBe(false);
+    expect(r!.readState).toBe('error');
     expect(r!.error?.message).toMatch(/incomplete update|missing base state/i);
 
     // Crucially: it did NOT silently materialize as an empty resource.

--- a/browser/lib/src/websockets.test.ts
+++ b/browser/lib/src/websockets.test.ts
@@ -135,6 +135,37 @@ describe('WSClient handshake', () => {
     expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(0);
   });
 
+  it('settles authentication immediately when closed during signing', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    socket.receive(encodeChallenge('delayed-signature'));
+    let finish!: (signature: string) => void;
+    const signing = vi
+      .spyOn(store.getAgent()!, 'createSignature')
+      .mockImplementation(
+        () =>
+          new Promise(resolve => {
+            finish = resolve;
+          }),
+      );
+    let cancelled = false;
+    const authentication = client.authenticate().catch(() => {
+      cancelled = true;
+    });
+    await vi.waitFor(() => expect(signing).toHaveBeenCalled());
+    client.close();
+
+    try {
+      await vi.waitFor(() => expect(cancelled).toBe(true), { timeout: 200 });
+    } finally {
+      finish('late-signature');
+      await authentication;
+    }
+
+    expect(framesWithTag(socket, Tag.AUTH)).toHaveLength(0);
+  });
+
   it('does not warn or subscribe when closed before index-status authentication completes', async ({
     expect,
   }) => {
@@ -274,6 +305,7 @@ describe('WSClient drive sync probe', () => {
   afterEach(() => {
     globalThis.WebSocket = original;
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('does not send a sync probe computed for a previous identity', async ({
@@ -315,6 +347,42 @@ describe('WSClient drive sync probe', () => {
       client as unknown as { startVVSync: (drive: string) => Promise<void> }
     ).startVVSync('did:ad:drive');
     expect(framesWithTag(socket, Tag.SYNC)).toHaveLength(0);
+    client.close();
+  });
+
+  it('does not revive an old sync computation when the same client reconnects', async ({
+    expect,
+  }) => {
+    const { client, socket, store } = await connectedClient();
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(store, 'getAgent').mockReturnValue(undefined);
+    let finish!: (
+      value: Awaited<ReturnType<typeof store.computeDriveSyncState>>,
+    ) => void;
+    vi.spyOn(store, 'computeDriveSyncState').mockImplementation(
+      () =>
+        new Promise(resolve => {
+          finish = resolve;
+        }),
+    );
+    const pending = (
+      client as unknown as { startVVSync: (drive: string) => Promise<void> }
+    ).startVVSync('did:ad:drive');
+    socket.close();
+    socket.fire('close', { code: 1006, reason: '', wasClean: false });
+    await vi.advanceTimersByTimeAsync(1000);
+    const replacement = socketOf(client);
+    replacement.open();
+    finish({
+      drive: 'did:ad:drive',
+      driveHash: 'old',
+      peers: [],
+      resources: {},
+    } as never);
+    await pending;
+    expect(replacement).not.toBe(socket);
+    expect(framesWithTag(replacement, Tag.SYNC)).toHaveLength(0);
     client.close();
   });
 

--- a/browser/lib/src/websockets.ts
+++ b/browser/lib/src/websockets.ts
@@ -204,6 +204,7 @@ export class WSClient {
   private isAuthenticating = false;
 
   private _closed = false;
+  private connection = new AbortController();
   private _retryDelay = 1000;
   private _retryTimer: ReturnType<typeof setTimeout> | undefined;
   private _onlineListener: (() => void) | undefined;
@@ -351,13 +352,20 @@ export class WSClient {
     this.authPromise = Promise.resolve();
 
     const createSocket = () => {
+      this.connection.abort(new RequestCancelledError('WebSocket replaced'));
+      this.rejectAllPending('WebSocket replaced', true);
+      this.connection = new AbortController();
+      const { signal } = this.connection;
       const ws = new WebSocket(wsURL.toString(), [WS_PROTOCOL]);
       ws.binaryType = 'arraybuffer';
       let opened = false;
 
-      ws.addEventListener('message', this.handleMessage);
+      ws.addEventListener('message', event => {
+        if (!signal.aborted) this.handleMessage(event);
+      });
       ws.addEventListener('error', () => {
-        if (this._closed) return;
+        if (this._closed || ws !== this.ws) return;
+        this.connection.abort(new RequestCancelledError('WebSocket error'));
 
         if (!opened) {
           console.warn('[WS] Connection failed');
@@ -372,7 +380,8 @@ export class WSClient {
       ws.addEventListener('close', (ev: CloseEvent) => {
         // Explicit close already tears down this client synchronously. Its
         // later event must not overwrite a replacement socket's live state.
-        if (this._closed) return;
+        if (this._closed || ws !== this.ws) return;
+        this.connection.abort(new RequestCancelledError('WebSocket closed'));
 
         // Surface CloseEvent metadata so an unexplained reconnect loop
         // names its own cause: code 1000=normal, 1001=going away,
@@ -500,6 +509,9 @@ export class WSClient {
 
   public close(): void {
     this._closed = true;
+    this.connection.abort(
+      new RequestCancelledError('WebSocket closed by client'),
+    );
 
     if (this._retryTimer) {
       clearTimeout(this._retryTimer);
@@ -557,21 +569,29 @@ export class WSClient {
       if (this.authenticatedWith === agent.subject && !fetchAll) return;
     }
 
+    const { signal } = this.connection;
+    signal.throwIfAborted();
     this.isAuthenticating = true;
 
     this.authPromise = (async () => {
       try {
-        await this.openPromise;
+        await waitForConnection(this.openPromise, signal);
+        signal.throwIfAborted();
         // The server's CHALLENGE is its first frame; on a current server it
         // has arrived by the time anyone calls `authenticate`. The short wait
         // covers the race, and costs its full length only against a server
         // that predates the frame — which then gets the timestamp-only proof
         // it expects.
-        const nonce = await this.awaitChallenge();
+        const nonce = await waitForConnection(this.awaitChallenge(), signal);
+        signal.throwIfAborted();
         const subject = nonce
           ? `${this.serverOrigin}#${nonce}`
           : this.serverOrigin;
-        const json = await createAuthentication(subject, agent);
+        const json = await waitForConnection(
+          createAuthentication(subject, agent),
+          signal,
+        );
+        signal.throwIfAborted();
         // Challenge waiting/signing can finish after disconnect(). Never send
         // on that socket or install a new AUTH_OK waiter after close drained it.
         if (this._closed || this.readyState !== WebSocket.OPEN)
@@ -579,11 +599,13 @@ export class WSClient {
             'WebSocket closed during authentication',
           );
 
+        const authenticated = this.waitForTag(Tag.AUTH_OK);
         this.sendBinary(encodeAuth(JSON.stringify(json)));
 
         // Wait for AUTH_OK — rejected by the close handler if the socket
         // dies mid-handshake, otherwise waits as long as needed.
-        await this.waitForTag(Tag.AUTH_OK);
+        await waitForConnection(authenticated, signal);
+        signal.throwIfAborted();
 
         this.authenticatedWith = agent.subject;
         recordServerVersionFromWsProtocol(
@@ -1225,8 +1247,9 @@ export class WSClient {
           const clientDb = this.store.getClientDb();
 
           if (clientDb) {
+            const current = this.connectionGuard();
             clientDb.getBlob(hash).then(bytes => {
-              if (bytes) {
+              if (current() && bytes) {
                 this.sendBinary(encodeBlobResponse(hash, bytes));
               }
             });
@@ -1562,14 +1585,7 @@ export class WSClient {
   private async startVVSync(drive: string): Promise<void> {
     if (this.readyState !== WebSocket.OPEN) return;
 
-    const agent = this.store.getAgent()?.subject;
-    const selectedDrive = this.store.getDrive();
-    const authenticatedWith = this.authenticatedWith;
-    const current = () =>
-      this.readyState === WebSocket.OPEN &&
-      this.store.getAgent()?.subject === agent &&
-      this.store.getDrive() === selectedDrive &&
-      this.authenticatedWith === authenticatedWith;
+    const current = this.connectionGuard();
     const close = perfSpan('ws.computeDriveSyncState');
 
     try {
@@ -1614,14 +1630,8 @@ export class WSClient {
    */
   private async sendReducedSyncState(drive: string): Promise<void> {
     const agent = this.store.getAgent()?.subject;
-    const selectedDrive = this.store.getDrive();
-    const current = () =>
-      !this._closed &&
-      this.readyState === WebSocket.OPEN &&
-      this.store.getAgent()?.subject === agent &&
-      this.store.getDrive() === selectedDrive &&
-      (!agent || this.authenticatedWith === agent);
-    if (this.readyState !== WebSocket.OPEN || !current()) return;
+    const current = this.connectionGuard();
+    if (!current() || (agent && this.authenticatedWith !== agent)) return;
 
     // A response to a probe invalidated by a drive switch must not restart it.
     const syncState = this._pendingSyncState.get(drive);
@@ -1779,6 +1789,8 @@ export class WSClient {
     pullFrom?: Record<string, Record<string, number>>;
     removeCommits?: Record<string, string>;
   }) {
+    const current = this.connectionGuard();
+    if (!current()) return;
     const clientDb = this.store.getClientDb();
 
     for (const subject of diff.remove ?? []) {
@@ -1801,6 +1813,7 @@ export class WSClient {
         }
       }
 
+      if (!current()) return;
       this.store.removeResource(subject);
     }
 
@@ -1827,6 +1840,7 @@ export class WSClient {
       if ((!loroBytes || loroBytes.length === 0) && clientDb) {
         try {
           const stored = await clientDb.getLoroSnapshot(subject);
+          if (!current()) return;
 
           if (stored && stored.length > 0) {
             loroBytes = stored;
@@ -1840,6 +1854,8 @@ export class WSClient {
         entries.push({ subject, loroBytes });
       }
     }
+
+    if (!current()) return;
 
     if (entries.length > 0) {
       if (this.readyState !== WebSocket.OPEN) {
@@ -1864,6 +1880,23 @@ export class WSClient {
   }
 
   // ---- Private: helpers ----
+
+  /** A continuation belongs to one socket and identity, including reconnects
+   * to the same server/account. A later OPEN socket cannot revive old work.
+   */
+  private connectionGuard(): () => boolean {
+    const { signal } = this.connection;
+    const agent = this.store.getAgent()?.subject;
+    const drive = this.store.getDrive();
+    const authenticatedWith = this.authenticatedWith;
+
+    return () =>
+      !signal.aborted &&
+      this.readyState === WebSocket.OPEN &&
+      this.store.getAgent()?.subject === agent &&
+      this.store.getDrive() === drive &&
+      this.authenticatedWith === authenticatedWith;
+  }
 
   /** The drive a `SYNC_REJECTED` message is about. The server formats it
    *  as `SYNC_PUSH rejected for drive <drive>: <reason>`; when that shape
@@ -1965,4 +1998,28 @@ function syncStateToItems(state: DriveSyncState): Item[] {
   items.sort((a, b) => (a.subject < b.subject ? -1 : 1));
 
   return items;
+}
+
+/** Retire asynchronous work with its socket, even when the underlying signer
+ * or database operation cannot itself be aborted. Consume late rejections too.
+ */
+function waitForConnection<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    if (signal.aborted) abort();
+    else signal.addEventListener('abort', abort, { once: true });
+    work.then(
+      value => {
+        signal.removeEventListener('abort', abort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      },
+    );
+  });
 }

--- a/browser/package.json
+++ b/browser/package.json
@@ -34,7 +34,8 @@
     "start": "pnpm run -r --parallel start",
     "typedoc": "typedoc --options ./typedoc.json",
     "typedoc-publish": "pnpm run typedoc && if [ -z \"$NETLIFY_AUTH_TOKEN\" ]; then echo 'NETLIFY_AUTH_TOKEN not set — skipping deploy (typedoc built only)'; exit 0; fi && netlify link --id a628f703-2dc1-4305-93d2-4ddc16c13f75 --auth $NETLIFY_AUTH_TOKEN && netlify deploy --dir data-browser/publish/docs/ ${NETLIFY_PROD:+--prod} --auth $NETLIFY_AUTH_TOKEN",
-    "typecheck": "pnpm run -r --parallel typecheck"
+    "typecheck": "pnpm run -r --parallel typecheck",
+    "test-e2e:local": "node e2e/scripts/local-e2e.mjs"
   },
   "workspaces": {
     "packages": [

--- a/browser/react/README.md
+++ b/browser/react/README.md
@@ -56,3 +56,19 @@ const SomeComponent = () => {
 
 There are a lot more hooks and helpers available.
 See the [docs](https://docs.atomicdata.dev/usecases/react) for more information.
+
+### Resource status and React Compiler
+
+`useResource(subject)` returns a stable, mutable handle. Use property hooks
+(`useString`, `useArray`, etc.) for render-time values. For readiness and errors,
+use `useResourceSnapshot(subject)`:
+
+```tsx
+const { resource, ready, error, readState } = useResourceSnapshot(subject);
+const [name, setName] = useString(resource, core.properties.name);
+```
+
+The status fields are captured in an immutable snapshot that changes on store
+notifications. Do not memoize `resource.isReady()` or property getters by the
+Resource reference. `recovering` can retain readable content; `ready` says
+whether reads are usable, independently of the outbox/saving state.

--- a/browser/react/src/hooks.ts
+++ b/browser/react/src/hooks.ts
@@ -26,6 +26,7 @@ import {
   JSONArray,
   OptionalClass,
   type Core,
+  type ResourceSnapshot,
   ResourceEvents,
   LoroLoader,
   core,
@@ -39,17 +40,23 @@ const asError = (error: unknown): Error =>
 
 export type UseResourceOptions = FetchOpts;
 
-/**
- * Hook for getting a Resource in a React component. Wraps the
- * Store's per-subject snapshot via `useSyncExternalStore`: each
- * notify replaces the snapshot tuple, the Resource itself is
- * mutated in place, and reads like `resource.props.x` see the
- * latest values without us having to invalidate them.
+/** Stable live handle for mutation and property hooks. For render-time
+ * readiness/error checks use `useResourceSnapshot`'s captured scalar fields.
  */
 export function useResource<C extends OptionalClass = never>(
   subject: string = unknownSubject,
   opts: UseResourceOptions = {},
 ): Resource<C> {
+  return useResourceSnapshot<C>(subject, opts).resource;
+}
+
+/** Immutable status changes identity on store notifications. The contained
+ * Resource stays stable; read properties with useString/useArray/etc.
+ */
+export function useResourceSnapshot<C extends OptionalClass = never>(
+  subject: string = unknownSubject,
+  opts: UseResourceOptions = {},
+): ResourceSnapshot<C> {
   const store = useStore();
   const memoizedOpts = useMemoizedOpts(opts);
 
@@ -62,8 +69,11 @@ export function useResource<C extends OptionalClass = never>(
     [store, subject, memoizedOpts],
   );
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-    .resource as Resource<C>;
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  ) as ResourceSnapshot<C>;
 }
 
 const stableEmptyArray: string[] = [];

--- a/planning/react-compiler-resource-proxy.md
+++ b/planning/react-compiler-resource-proxy.md
@@ -1,132 +1,27 @@
-# React Compiler vs `Resource` proxy mismatch
+# React Compiler and mutable Resources
 
-> Status: planned 2026-05-28; **audit not started as of 2026-09-04**, while the React Compiler has been on since 2026-08-19 and `Resource.props` is still a `Proxy`. Bug class. See also
-> `memory/react-compiler-resource-proxy-pitfall.md` for the runbook-style
-> diagnostic.
->
-> **Current (2026-09-01).** Still open. The React Compiler has been enabled
-> in data-browser since `224bd4816` (2026-08-19, `oxcReactCompiler` in
-> `browser/data-browser/vite.config.ts`, skipped under Vitest), so the
-> mismatch is live, not hypothetical: `pairing-ux-field-test.md` M15a
-> (2026-08-16) was one instance (data arrived, table did not re-render). The
-> audit below has not started.
+## Current boundary
 
-## Symptom
+`Resource` remains a stable mutation handle. `Store.getResourceSnapshot` captures
+immutable `ready`, `loading`, `readState`, and `error` fields on each notification.
+`useResourceSnapshot` exposes these to React; property values still flow through
+`useString`, `useArray`, `useTitle`, and the other property hooks. An old snapshot's
+status does not change when its resource changes.
 
-Rendered UI shows stale state from the first render forever, despite
-subsequent store updates that should change it. Reproducible cases this
-session:
+Profile, invitation, sharing, tag and message-preview readiness consumers use
+the snapshot fields. AgentProfileHeader no longer needs `use no memo`; production
+E2E verifies profile editing, invitations, and live username updates. Library
+tests check stable mutation identity and immutable status across notifications.
 
-- `MetaSetter.tsx` — browser tab title stuck at "Atomic Data" because
-  `hasResource = resource.isReady() && resource.subject !== unknownSubject`
-  was memoized as `false` from a render that fired before the resource
-  finished loading. `useString(name)` updated correctly; `hasResource`
-  never re-computed.
-- `SidebarItemTitle.tsx` — sidebar row stuck on the old folder name
-  because `resource.title` (a Proxy getter) was memoized.
-- `PluginList.tsx` — plugin list not refreshing after install because
-  `drive.props.plugins` reads were memoized.
+## Remaining audit
 
-Every fix had the same shape: replace the proxy-read with a `useString`
-/ `useArray` / `useTitle` hook so the value flows through
-`useSyncExternalStore`.
+A direct `resource.get(...)`, `resource.props.foo`, or `resource.isReady()` read
+inside a component can still be memoized by Resource identity. Use property hooks
+for rendered values and `useResourceSnapshot` for status. Live reads in event
+handlers and asynchronous operations remain appropriate.
 
-## Root cause
-
-`useResource()` returns a `Resource` proxy whose **reference identity is
-preserved across renders by design** (so dependency arrays stay stable).
-Its internal `_loading`, `_error`, `_cache`, etc. mutate in place when
-`store.addResource()` fires `notify()`. React Compiler memoizes
-expressions whose only inputs are stable references — `resource` is
-stable, so its method/getter results are cached. The mutation the
-Compiler can't see locks the cached value in.
-
-This is unsafe by construction: the Compiler's central assumption
-("same input reference ⇒ same output") is violated by every read off
-`Resource`.
-
-## Proposal
-
-**Option A — Make the proxy version-stamped** (preferred):
-
-```ts
-// store.ts
-private snapshots = new Map<string, { resource: Resource; v: number }>();
-private notify(resource: Resource) {
-  const prev = this.snapshots.get(key)?.v ?? 0;
-  this.snapshots.set(key, { resource: resource.__internalObject, v: prev + 1 });
-  // ...
-}
-```
-
-The `v` field bumps on every notify, so `getSnapshot()` returns a new
-object reference even when `.resource` stays the same. Tighter: bump a
-proxy-level version flag that's part of the proxy's *own* identity (so
-`resource !== resource` after an update). That forces React Compiler
-caches keyed on `resource` to invalidate.
-
-This breaks dep-arrays that rely on `resource` being referentially
-stable across renders. Audit: `useLoroSync`, `useResource` consumers
-that pass `resource` to memoized callbacks. Most pass `subject` instead;
-the ones that don't can switch.
-
-**Option B — Delete the `.props` getter Proxy and force the hook path.**
-Right now `resource.props.X` returns the value of property `X` via a
-Proxy getter. Remove that ergonomic but harmful surface; require
-`useString(resource, X)` (or just `resource.get(X)` in non-render code).
-Add an ESLint rule that flags `.props.<identifier>` reads inside
-component bodies.
-
-**Option C — Both.** A and B aren't exclusive; Option B narrows what
-can be cached, Option A invalidates the cache when it would matter.
-
-## Risk
-
-- A: dep-array drift could trigger excessive effect re-runs across the
-  codebase. Mitigate by auditing every `useResource`-returning hook and
-  using `subject` (string) in deps where possible.
-- B: source-incompatible — every `.props.X` site needs a hook. Could be
-  staged: keep the Proxy but mark `@deprecated`, codemod incrementally.
-
-## Effort estimate
-
-- A: ~1 day to land + audit week to triage dep-array fallout.
-- B: ~3 days codemod + lint rule + cleanup PRs.
-
-## Concrete first steps
-
-1. Grep the data-browser for `\.props\.\w` and `\.isReady\(\)` and
-   `\.loading\b` *inside* component render bodies (excluding effect
-   callbacks where re-evaluation is implicit). Build a triage list.
-2. Pick one tab/screen with multiple hits, convert to hook-only, verify
-   the e2e tests for that screen stay green.
-3. Decide A vs B vs both based on what the triage shows.
-
-## Audit candidates already known
-
-From the session's session-end summary:
-- `views/ChatRoomPage.tsx:342` — `!resource.isReady() || !commitResource.isReady()`
-- `views/ResourceRow.tsx:33,37` — `resource.loading` / `resource.error`
-- `views/ResourcePage.tsx:79,88,90,101` — `resource.loading`
-- `views/Card/ResourceCard.tsx:95,99` — `resource.loading` / `resource.error`
-- `chunks/Plugins/UpdatePluginButton.tsx:97-162` — `plugin.props.{name,namespace,version,config}`
-- `chunks/TablePage/TableHeading.tsx:55` — `tableClass.props.requires`
-
-These work today only because of compiler heuristics that may tighten.
-
-## Audit headcount (2026-05-28)
-
-Across `browser/data-browser/src` (excluding test files):
-
-| Pattern | Hits |
-|---|---|
-| `.props.<ident>` reads | 103 |
-| `.isReady()` calls | 10 |
-| `resource.loading` / `resource.error` reads | 62 |
-| `.title` Proxy-getter reads (`*.title`) | 109 |
-
-~280 total suspect sites. Too many for site-by-site cleanup — confirms
-the need for a systemic fix (Option A version-stamping or Option B
-removing the `.props` getter), not a sweep. Recommend Option A first
-so it invalidates all of the above implicitly; Option B can then be
-done as cleanup with much lower urgency.
+Do not change the identity of every Resource to invalidate compiler caches:
+that would change effect dependencies throughout the app. Audit remaining
+render-time property getters incrementally, with a reproduced stale-UI test
+before migrating each flow. Saving/outbox state is separate from read readiness;
+see `unify-resource-dirty-signals.md`.


### PR DESCRIPTION
Resource hydration could expose JSON-derived state before restoring causal history, React Compiler could cache readiness on a stable mutable Resource, and asynchronous WebSocket work could outlive its connection.

This series:
- Exposes explicit read lifecycle states independently of saving/outbox state.
- Restores local JSON and Loro snapshots through one ingress before publishing.
- Adds immutable status snapshots and a React hook; migrates profile, invitation, sharing, tag and message-preview readiness checks while retaining stable mutation handles and property hooks.
- Cancels authentication with its socket and guards sync/blob continuations against reconnects and identity changes.
- Adds named standalone/managed fixtures composed with strict browser diagnostics, and `pnpm test-e2e:local` to build JS, WASM and the native backend, run against fresh data on matching ports, and preserve reports while cleaning up only its own processes.

Validation:
- 444 library tests and 850 app tests pass; workspace type checks and lint pass.
- Compiled production profile editing, browser/server invitations and live username checks: 4 passed.
- Deployment fixtures pass, including explicit expectations for deliberately mocked 401 responses and service-worker blocking.
- Runner checks prove occupied IPv4/IPv6 template ports are refused and failed-build descendants are cleaned up.
- Full production Chromium suite on the final commit: **206 passed, 8 skipped (13.4 minutes), one worker, zero retries**, using freshly built JS, WASM and native backend. The isolated runner requires an explicit `ATOMIC_VAULT_PORTAL_URL`; two real Cloud Vault tests were skipped. Mocked managed-account flows ran.
- An earlier full run had one localized-text edit failure. It did not recur in 40 normal-speed repetitions, 10 CPU-throttled repetitions, or the final full run. No product fix is claimed for that intermittent failure; the runner now retains failure traces for diagnosis.
- An earlier run also reached an unrelated portal on the default port. Explicit external-service opt-in now prevents that contamination.

The broader render-time property-getter audit remains incremental; this PR establishes the status boundary without changing every Resource identity or rebuilding the saving-state API.
