### PR TITLE
Improve CI feedback and centralize browser save scheduling

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -451,7 +451,7 @@ export class AtomicServer {
 
   @func()
   async jsLint(): Promise<string> {
-    const depsContainer = this.jsBuild();
+    const depsContainer = this.jsSource();
 
     return depsContainer
       .withWorkdir('/app')
@@ -962,8 +962,8 @@ export class AtomicServer {
       .stdout();
   }
 
-  @func()
-  private jsBuild(e2e: boolean = false): Container {
+  /** Installed workspace sources; deliberately has no build or WASM dependency. */
+  private jsSource(): Container {
     const browser = this.source.directory('browser');
     // Create a container with PNPM installed
     const pnpmContainer = dag
@@ -1015,11 +1015,6 @@ export class AtomicServer {
     const sourceContainer = workspaceContainer
       .withDirectory('/app', browser)
       .withDirectory('/app/lib-defaults', this.source.directory('lib/defaults'))
-      // Provide the prebuilt WASM artifacts so data-browser's `build` can skip
-      // wasm-pack when `SKIP_WASM_BUILD=1` (`wasm-pack` isn't available in this
-      // Node-only container, and mounting the Rust toolchain just for this would
-      // bloat the JS image significantly).
-      .withDirectory('/app/data-browser/public/wasm', this.wasmBuild())
       // data-browser imports the repo-root logo from `../../../../logo.svg`
       // and `../../../../../logo.svg`. Browser mount sits at /app, so those
       // resolve to /logo.svg. Place the asset there.
@@ -1042,11 +1037,15 @@ export class AtomicServer {
         this.source.file('testdata/pairing-request.json'),
       );
 
-    // Build all packages since they may depend on each other's built artifacts
-    let buildContainer = sourceContainer.withEnvVariable(
-      'SKIP_WASM_BUILD',
-      '1',
-    );
+    return sourceContainer;
+  }
+
+  @func()
+  private jsBuild(e2e: boolean = false): Container {
+    // Only builds depend on WASM. Static lint must not wait for Rust compilation.
+    let buildContainer = this.jsSource()
+      .withDirectory('/app/data-browser/public/wasm', this.wasmBuild())
+      .withEnvVariable('SKIP_WASM_BUILD', '1');
 
     if (e2e) {
       // Surfaces /app/dev-drive and /app/prunetests in the production

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,12 @@ on:
           - full
         default: auto
 
-# Keep the newest pending run per ref. A push to a feature branch must not
-# replace develop's pending run. Already-started workflows finish normally.
+# Superseded feature-branch runs can stop immediately. Keep develop and tag
+# validation running to completion because deployments consume their results.
+# Per-ref groups keep a feature push from replacing develop validation.
 concurrency:
   group: main-pipeline-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref_type == 'branch' && github.ref_name != 'develop' }}
 
 # Main prefers Mancave (self-hosted) so Dagger cache volumes stay warm.
 # GitHub-hosted runs ONLY when Mancave is unavailable — never as a retry

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -740,3 +740,7 @@ check; real refresh/query timing remains a browser acceptance check.
   values and signed payloads. The diagnostic fixture attaches this before closing pages.
 - CI lint uses installed sources without JS/WASM builds; feature-branch pushes cancel
   superseded runs while develop and tags retain completed validation for deployment.
+
+- `scheduled-save.test.ts` covers coalescing, idempotent cancellation, flushing,
+  concurrent in-flight work and failures. `store.test.ts` covers immutable save
+  snapshots, identity renaming, offline queueing and direct-save notifications.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -744,3 +744,6 @@ check; real refresh/query timing remains a browser acceptance check.
 - `scheduled-save.test.ts` covers coalescing, idempotent cancellation, flushing,
   concurrent in-flight work and failures. `store.test.ts` covers immutable save
   snapshots, identity renaming, offline queueing and direct-save notifications.
+
+- `data-save-state.spec.ts` reproduces a compiled inspector missing an unsaved-edit
+  warning, then verifies the subscribed warning clears after saving/reconnecting.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -733,3 +733,10 @@ check; real refresh/query timing remains a browser acceptance check.
   uses fresh test data and matching free ports, and preserves its report/build logs.
   Failure traces are retained. Real Cloud Vault integration requires an explicitly
   supplied `ATOMIC_VAULT_PORTAL_URL`; the runner never discovers unrelated portals.
+
+## CI quality and failure evidence
+
+- `failure-state.spec.ts` checks bounded failure metadata and omission of resource
+  values and signed payloads. The diagnostic fixture attaches this before closing pages.
+- CI lint uses installed sources without JS/WASM builds; feature-branch pushes cancel
+  superseded runs while develop and tags retain completed validation for deployment.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -747,3 +747,6 @@ check; real refresh/query timing remains a browser acceptance check.
 
 - `data-save-state.spec.ts` reproduces a compiled inspector missing an unsaved-edit
   warning, then verifies the subscribed warning clears after saving/reconnecting.
+
+Failure attachments include up to 30 recent WebSocket frame metadata records per
+page, never payload contents. A real local WebSocket exercises this collection.

--- a/browser/data-browser/src/chunks/TablePage/useMaterializeWhenDeselected.ts
+++ b/browser/data-browser/src/chunks/TablePage/useMaterializeWhenDeselected.ts
@@ -1,5 +1,5 @@
 import { Resource, useStore } from '@tomic/react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   CursorMode,
   useTableEditorContext,
@@ -58,102 +58,36 @@ export function useMaterializeWhenDeselected(
 ): void {
   const { selectedRow, cursorMode } = useTableEditorContext();
   const store = useStore();
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const counted = useRef(false);
-  const unmounted = useRef(false);
-
-  // Declared before the effect below so that on unmount its cleanup runs
-  // first — React destroys effects in the order they were created — and the
-  // cleanup there can tell "my dependencies changed" from "this row is gone".
-  useEffect(
-    () => () => {
-      unmounted.current = true;
-    },
-    [],
+  const scheduler = useMemo(
+    () =>
+      store.createSaveScheduler(resource, {
+        shouldSave: () =>
+          resource.subject.startsWith('_new:') &&
+          resource.getEntries().length > 2,
+        onError: () => undefined,
+      }),
+    [store, resource],
   );
 
+  // Flush before the following effect cancels its slot on unmount. Virtualized
+  // rows can leave the screen while their last edit exists only in memory.
+  useEffect(
+    () => () => {
+      void scheduler.flush();
+    },
+    [scheduler],
+  );
   useEffect(() => {
-    // The row's only copy lives in this timer until it fires, so the store has
-    // to count it as pending work — `pendingDirtyCount === 0` is documented to
-    // mean "safe to reload/navigate — nothing will be lost", and a row waiting
-    // on `setTimeout` is neither in the outbox nor saving. `useDebouncedSave`
-    // reports its own window the same way; this path had no equivalent, so a
-    // reload during it dropped the row while sync status read as settled.
-    const stopCounting = () => {
-      if (counted.current) {
-        counted.current = false;
-        store.finishScheduledSave();
-      }
-    };
-
-    // Actively editing THIS row — keep it virtual and cancel any pending
-    // materialize (the user came back to it before the timer fired).
     if (selectedRow === index && cursorMode === CursorMode.Edit) {
-      if (timer.current !== undefined) {
-        clearTimeout(timer.current);
-        timer.current = undefined;
-      }
-
-      stopCounting();
+      scheduler.cancel();
 
       return;
     }
 
-    // Leaving Edit mode is the calm "done" signal → flush promptly. Moving
-    // between rows while still editing is the rapid-entry path → debounce.
-    const delay =
-      cursorMode === CursorMode.Edit ? MATERIALIZE_DEBOUNCE : MATERIALIZE_FLUSH;
+    scheduler.schedule(
+      cursorMode === CursorMode.Edit ? MATERIALIZE_DEBOUNCE : MATERIALIZE_FLUSH,
+    );
 
-    if (!counted.current) {
-      counted.current = true;
-      store.startScheduledSave();
-    }
-
-    timer.current = setTimeout(() => {
-      timer.current = undefined;
-
-      // Already materialized (subject renamed on a prior save), or an empty
-      // placeholder (only the seeded `isA` + `parent`) — nothing to persist.
-      if (
-        !resource.subject.startsWith('_new:') ||
-        resource.getEntries().length <= 2
-      ) {
-        stopCounting();
-
-        return;
-      }
-
-      void resource
-        .save()
-        .catch(() => undefined)
-        .then(stopCounting);
-    }, delay);
-
-    return () => {
-      if (timer.current === undefined) {
-        return;
-      }
-
-      // The row is gone, not merely deselected: the grid is virtualized, so
-      // scrolling a row past the fold unmounts it. Cancelling here would be
-      // the last word — nothing re-arms a timer for a row that no longer
-      // renders — so the pending save is left to fire. `setTimeout` does not
-      // belong to React and does not care that the component went away, and
-      // the resource it closes over is the store's, which outlives the row.
-      //
-      // Leaving it counted matters just as much: a row cancelled this way was
-      // dropped from `pendingDirtyCount` too, so the app reported "nothing
-      // pending, safe to reload" while rows existed in this tab and nowhere
-      // else. Under fast entry that silently lost 7 rows in 40.
-      if (unmounted.current) {
-        return;
-      }
-
-      // Only release what this cleanup actually cancels: a save already in
-      // flight releases itself when it settles.
-      clearTimeout(timer.current);
-      timer.current = undefined;
-      stopCounting();
-    };
-  }, [selectedRow, cursorMode, index, resource, store]);
+    return () => scheduler.cancel();
+  }, [selectedRow, cursorMode, index, scheduler]);
 }

--- a/browser/data-browser/src/routes/DataRoute.tsx
+++ b/browser/data-browser/src/routes/DataRoute.tsx
@@ -1,6 +1,7 @@
 import { useState, type JSX } from 'react';
 import {
   useResource,
+  useSaveState,
   useCreatedAt,
   useCreatedBy,
   signRequest,
@@ -41,6 +42,7 @@ export const DataRoute = createRoute({
 function Data(): JSX.Element {
   const [subject] = useCurrentSubject();
   const resource = useResource(subject);
+  const saveState = useSaveState(resource);
   // Creation metadata derived from the signed genesis commit (the resource
   // identity), materialized into propvals — not a refetched commit.
   const createdAt = useCreatedAt(resource);
@@ -133,16 +135,19 @@ function Data(): JSX.Element {
             </PropValRow>
           )}
           <AllProps resource={resource} editable columns />
-          {resource.hasUnsavedChanges() ? (
+          {saveState.kind !== 'idle' ? (
             <>
               <h2>⚠️ contains uncommitted changes</h2>
               <p>
                 This means that (some) of your local changes are not yet saved.
               </p>
-              {resource.commitError && (
-                <ErrMessage>{resource.commitError.message}</ErrMessage>
-              )}
-              <Button onClick={() => resource.save()}>save</Button>
+              {saveState.error && <ErrMessage>{saveState.error}</ErrMessage>}
+              <Button
+                disabled={saveState.kind === 'saving'}
+                onClick={() => resource.save()}
+              >
+                save
+              </Button>
             </>
           ) : null}
           <h2>Code</h2>

--- a/browser/e2e/tests/data-save-state.spec.ts
+++ b/browser/e2e/tests/data-save-state.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from './fixtures';
+import { before, FRONTEND_URL, waitForSynced } from './test-utils';
+
+test('data inspector reacts to an unsaved edit without replacing its resource', async ({
+  page,
+  context,
+}) => {
+  await before({ page });
+  const subject = await page.evaluate(async () => {
+    const resource = await window.store.newResource({
+      isA: 'https://atomicdata.dev/classes/Folder',
+      parent: window.store.getDrive(),
+      propVals: {
+        'https://atomicdata.dev/properties/name': 'Save-state inspection',
+      },
+    });
+    await resource.save();
+
+    return resource.subject;
+  });
+  await page.goto(
+    `${FRONTEND_URL}/app/data?subject=${encodeURIComponent(subject)}`,
+  );
+  await expect(
+    page.getByRole('heading', { name: /Save-state inspection/ }).first(),
+  ).toBeVisible();
+  await context.setOffline(true);
+  await page.evaluate(async rowSubject => {
+    const resource = window.store.getResourceLoading(rowSubject);
+    await resource.set(
+      'https://atomicdata.dev/properties/description',
+      'An unsaved edit',
+      false,
+    );
+  }, subject);
+  const warning = page.getByRole('heading', {
+    name: /contains uncommitted changes/,
+  });
+  await expect(warning).toBeVisible();
+  await page.getByRole('button', { name: 'save', exact: true }).click();
+  await expect(warning).toBeVisible();
+  await context.setOffline(false);
+  await waitForSynced(page);
+  await expect(warning).not.toBeVisible();
+});

--- a/browser/e2e/tests/failure-state.spec.ts
+++ b/browser/e2e/tests/failure-state.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './fixtures';
+import { collectFailureState } from './failure-state';
+
+test('failure state is bounded and excludes values and signed payloads', async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const resource = {
+      subject: 'did:ad:test',
+      readState: 'ready',
+      isSaving: false,
+      hasPendingCommits: true,
+      hasUnsavedChanges: () => true,
+      getEntries: () => [['secret', 'DO_NOT_ATTACH']],
+    };
+    window.store = {
+      resources: new Map(
+        Array.from({ length: 100 }, (_, i) => [String(i), resource]),
+      ),
+      getSyncStatus: () => ({ pendingDirtyCount: 1 }),
+      getCommitLog: () =>
+        Array.from({ length: 100 }, () => ({
+          subject: 'did:ad:test',
+          direction: 'outgoing',
+          status: 'pending',
+          summary: 'DO_NOT_ATTACH',
+          loroUpdate: 'DO_NOT_ATTACH',
+        })),
+    } as unknown as typeof window.store;
+  });
+  const state = (await collectFailureState(page)) as {
+    resources: unknown[];
+    recentCommits: unknown[];
+  };
+  expect(state.resources).toHaveLength(50);
+  expect(state.recentCommits).toHaveLength(20);
+  expect(JSON.stringify(state)).not.toContain('DO_NOT_ATTACH');
+});

--- a/browser/e2e/tests/failure-state.spec.ts
+++ b/browser/e2e/tests/failure-state.spec.ts
@@ -1,3 +1,6 @@
+import { createServer } from 'node:http';
+import { createHash } from 'node:crypto';
+import type { Duplex } from 'node:stream';
 import { test, expect } from './fixtures';
 import { collectFailureState } from './failure-state';
 
@@ -18,6 +21,7 @@ test('failure state is bounded and excludes values and signed payloads', async (
         Array.from({ length: 100 }, (_, i) => [String(i), resource]),
       ),
       getSyncStatus: () => ({ pendingDirtyCount: 1 }),
+      getSaveState: () => ({ kind: 'queued' }),
       getCommitLog: () =>
         Array.from({ length: 100 }, () => ({
           subject: 'did:ad:test',
@@ -35,4 +39,50 @@ test('failure state is bounded and excludes values and signed payloads', async (
   expect(state.resources).toHaveLength(50);
   expect(state.recentCommits).toHaveLength(20);
   expect(JSON.stringify(state)).not.toContain('DO_NOT_ATTACH');
+});
+
+test('failure attachments retain transport metadata without frame payloads', async ({
+  page,
+}) => {
+  test.fail(
+    true,
+    'The synthetic warning triggers diagnostic attachment teardown',
+  );
+  const server = createServer();
+  const sockets = new Set<Duplex>();
+  server.on('upgrade', (request, socket) => {
+    sockets.add(socket);
+    const accept = createHash('sha1')
+      .update(
+        `${request.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
+      )
+      .digest('base64');
+    socket.write(
+      `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    const payload = Buffer.from('DO_NOT_ATTACH');
+    socket.write(Buffer.concat([Buffer.from([0x81, payload.length]), payload]));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('Missing test socket');
+
+  try {
+    await page.evaluate(async port => {
+      await new Promise<void>(resolve => {
+        const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+        socket.onopen = () => socket.send('DO_NOT_ATTACH');
+
+        socket.onmessage = () => {
+          console.warn('Synthetic transport failure');
+          socket.close();
+          resolve();
+        };
+      });
+    }, address.port);
+  } finally {
+    sockets.forEach(socket => socket.destroy());
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
 });

--- a/browser/e2e/tests/failure-state.ts
+++ b/browser/e2e/tests/failure-state.ts
@@ -26,6 +26,8 @@ export async function collectFailureState(page: Page): Promise<unknown> {
         dirty: r.hasUnsavedChanges(),
         saving: r.isSaving,
         pending: r.hasPendingCommits,
+        saveState: store.getSaveState(r).kind,
+        scheduledCount: store.getSaveState(r).scheduledCount,
         readError: r.error?.name,
         saveError: r.commitError?.name,
         properties: r

--- a/browser/e2e/tests/failure-state.ts
+++ b/browser/e2e/tests/failure-state.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test';
+
+/** Metadata only: never serialize agent secrets, resource bodies or commit payloads. */
+export async function collectFailureState(page: Page): Promise<unknown> {
+  return page.evaluate(() => {
+    const store = window.store;
+    if (!store) return { url: location.href, store: 'unavailable' };
+    const subject = new URL(location.href).searchParams.get('subject');
+    const resources = Array.from(store.resources.values());
+    const relevant = resources.filter(
+      r =>
+        r.subject === subject ||
+        r.hasUnsavedChanges() ||
+        r.isSaving ||
+        r.error ||
+        r.commitError,
+    );
+
+    return {
+      url: location.href,
+      sync: store.getSyncStatus(),
+      resourceCount: resources.length,
+      resources: relevant.slice(0, 50).map(r => ({
+        subject: r.subject,
+        readState: r.readState,
+        dirty: r.hasUnsavedChanges(),
+        saving: r.isSaving,
+        pending: r.hasPendingCommits,
+        readError: r.error?.name,
+        saveError: r.commitError?.name,
+        properties: r
+          .getEntries()
+          .map(([key]) => key)
+          .slice(0, 50),
+      })),
+      recentCommits: store
+        .getCommitLog()
+        .slice(0, 20)
+        .map(entry => ({
+          timestamp: entry.timestamp,
+          subject: entry.subject,
+          direction: entry.direction,
+          status: entry.status,
+          destroy: entry.destroy,
+          hasLoroUpdate: entry.hasLoroUpdate,
+        })),
+    };
+  });
+}

--- a/browser/e2e/tests/fixtures.ts
+++ b/browser/e2e/tests/fixtures.ts
@@ -1,5 +1,7 @@
 import { test as base, expect, type BrowserContext } from '@playwright/test';
 
+import { collectFailureState } from './failure-state';
+
 export * from '@playwright/test';
 
 type Kind = 'warning' | 'error' | 'pageerror';
@@ -127,6 +129,42 @@ export const test = base.extend<{
       } finally {
         browser.newContext = newContext;
         cleanups.forEach(cleanup => cleanup());
+        const unexpected = entries.filter(entry => !entry.expected);
+        const missing = expected.filter(rule => rule.seen !== rule.count);
+
+        if (
+          testInfo.status !== testInfo.expectedStatus ||
+          unexpected.length ||
+          missing.length
+        ) {
+          for (const [index, page] of [...watched]
+            .flatMap(c => c.pages())
+            .entries()) {
+            // A broken page must not mask the original failure or stall teardown.
+            let timer: ReturnType<typeof setTimeout> | undefined;
+
+            try {
+              const state = await Promise.race([
+                collectFailureState(page),
+                new Promise(resolve => {
+                  timer = setTimeout(
+                    () => resolve({ unavailable: 'page did not respond' }),
+                    2000,
+                  );
+                }),
+              ]);
+              await testInfo.attach(`failure-state-${index}`, {
+                body: JSON.stringify(state, null, 2),
+                contentType: 'application/json',
+              });
+            } catch {
+              // Closed/crashed pages are already represented in the trace.
+            } finally {
+              clearTimeout(timer);
+            }
+          }
+        }
+
         // Match Playwright's default-context teardown for extra test-owned
         // contexts. Otherwise their live tabs leak into the next test.
         await Promise.all([...ownedContexts].map(context => context.close()));
@@ -149,8 +187,6 @@ export const test = base.extend<{
           });
         }
 
-        const unexpected = entries.filter(entry => !entry.expected);
-        const missing = expected.filter(rule => rule.seen !== rule.count);
         expect(
           unexpected.slice(0, 20),
           `Unexpected browser warnings/errors (${unexpected.length}); first 20 shown, full browser-diagnostics attached`,

--- a/browser/e2e/tests/fixtures.ts
+++ b/browser/e2e/tests/fixtures.ts
@@ -1,4 +1,9 @@
-import { test as base, expect, type BrowserContext } from '@playwright/test';
+import {
+  test as base,
+  expect,
+  type BrowserContext,
+  type Page,
+} from '@playwright/test';
 
 import { collectFailureState } from './failure-state';
 
@@ -34,6 +39,35 @@ export const test = base.extend<{
       const cleanups: (() => void)[] = [];
       const watched = new Set<BrowserContext>();
       const ownedContexts = new Set<BrowserContext>();
+      const transportEvents = new Map<Page, unknown[]>();
+
+      const watchPage = (page: Page) => {
+        if (transportEvents.has(page)) return;
+        const events: unknown[] = [];
+        transportEvents.set(page, events);
+
+        const recordFrame = (direction: string, payload: string | Buffer) => {
+          events.push({
+            at: Date.now(),
+            direction,
+            bytes: Buffer.byteLength(payload),
+            tag: typeof payload === 'string' ? 'text' : payload[0],
+          });
+          if (events.length > 30) events.shift();
+        };
+
+        const onSocket = (socket: import('@playwright/test').WebSocket) => {
+          // Payloads can contain signed edits or authentication. Keep only frame metadata.
+          socket.on('framesent', ({ payload }) => recordFrame('sent', payload));
+          socket.on('framereceived', ({ payload }) =>
+            recordFrame('received', payload),
+          );
+          socket.on('close', () => recordFrame('closed', ''));
+        };
+
+        page.on('websocket', onSocket);
+        cleanups.push(() => page.off('websocket', onSocket));
+      };
 
       const record = (entry: Entry) => {
         const match = expected.find(rule => {
@@ -54,6 +88,9 @@ export const test = base.extend<{
       const watch = async (context: BrowserContext) => {
         if (watched.has(context)) return;
         watched.add(context);
+        context.pages().forEach(watchPage);
+        context.on('page', watchPage);
+        cleanups.push(() => context.off('page', watchPage));
 
         // General UI tests use an empty discovery room, independent of public
         // service availability. verify-peer-mesh.mjs separately exercises real
@@ -139,6 +176,7 @@ export const test = base.extend<{
         ) {
           for (const [index, page] of [...watched]
             .flatMap(c => c.pages())
+            .slice(0, 5)
             .entries()) {
             // A broken page must not mask the original failure or stall teardown.
             let timer: ReturnType<typeof setTimeout> | undefined;
@@ -154,7 +192,11 @@ export const test = base.extend<{
                 }),
               ]);
               await testInfo.attach(`failure-state-${index}`, {
-                body: JSON.stringify(state, null, 2),
+                body: JSON.stringify(
+                  { state, transportEvents: transportEvents.get(page) ?? [] },
+                  null,
+                  2,
+                ),
                 contentType: 'application/json',
               });
             } catch {

--- a/browser/lib/src/index.ts
+++ b/browser/lib/src/index.ts
@@ -108,3 +108,5 @@ export {
 } from './browser-peer-sync.js';
 
 export { decodeBrowserInvite } from './browser-peer-invite.js';
+
+export * from './scheduled-save.js';

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -141,6 +141,7 @@ function nextEditToken(): string {
 export enum ResourceEvents {
   LocalChange = 'local-change',
   LoadingChange = 'loading-change',
+  SaveStateChange = 'save-state-change',
 }
 
 /** Read lifecycle, independent of saving and the durable outbox.
@@ -154,6 +155,7 @@ export type ResourceReadState =
   | 'error';
 
 type ResourceEventHandlers = {
+  [ResourceEvents.SaveStateChange]: () => void;
   [ResourceEvents.LocalChange]: (prop: string, value: JSONValue) => void;
   [ResourceEvents.LoadingChange]: (loading: boolean) => void;
 };
@@ -3246,6 +3248,7 @@ export class Resource<C extends OptionalClass = any> {
     }
 
     this._saveDepth++;
+    this.eventManager.emit(ResourceEvents.SaveStateChange);
     const closeSave = perfSpan('resource.save');
 
     try {
@@ -3253,6 +3256,7 @@ export class Resource<C extends OptionalClass = any> {
     } finally {
       closeSave();
       this._saveDepth--;
+      this.eventManager.emit(ResourceEvents.SaveStateChange);
     }
   }
 

--- a/browser/lib/src/scheduled-save.test.ts
+++ b/browser/lib/src/scheduled-save.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScheduledSave } from './scheduled-save.js';
+
+describe('scheduled save ownership', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('coalesces timers, balances cancellation once, and flushes on owner disposal', async () => {
+    vi.useFakeTimers();
+    let pending = 0;
+    const save = vi.fn(async () => undefined);
+    const owner = new ScheduledSave(
+      save,
+      n => {
+        pending += n;
+      },
+      () => undefined,
+    );
+    owner.schedule(100);
+    owner.schedule(100);
+    expect(pending).toBe(1);
+    owner.cancel();
+    owner.cancel();
+    await vi.runAllTimersAsync();
+    expect(pending).toBe(0);
+    expect(save).not.toHaveBeenCalled();
+    owner.schedule(100);
+    await owner.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(pending).toBe(0);
+  });
+
+  it('allows a synchronous subscriber to cancel newly scheduled work', async () => {
+    vi.useFakeTimers();
+    let pending = 0;
+    const save = vi.fn(async () => undefined);
+    const owner = new ScheduledSave(
+      save,
+      delta => {
+        pending += delta;
+        if (delta === 1) owner.cancel();
+      },
+      () => undefined,
+    );
+    owner.schedule(10);
+    expect(pending).toBe(0);
+    await vi.runAllTimersAsync();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('keeps an in-flight save counted when a later edit is cancelled', async () => {
+    vi.useFakeTimers();
+    let finish!: () => void;
+    let pending = 0;
+    const owner = new ScheduledSave(
+      () =>
+        new Promise<void>(r => {
+          finish = r;
+        }),
+      n => {
+        pending += n;
+      },
+      () => undefined,
+    );
+    owner.schedule(10);
+    await vi.advanceTimersByTimeAsync(10);
+    owner.schedule(10);
+    expect(pending).toBe(2);
+    owner.cancel();
+    expect(pending).toBe(1);
+    const flushed = owner.flush();
+    finish();
+    await flushed;
+    expect(pending).toBe(0);
+  });
+
+  it('releases accounting and reports failed saves', async () => {
+    vi.useFakeTimers();
+    let pending = 0;
+    const onError = vi.fn();
+    const owner = new ScheduledSave(
+      async () => {
+        throw new Error('offline persistence failed');
+      },
+      n => {
+        pending += n;
+      },
+      onError,
+    );
+    owner.schedule(10);
+    await owner.flush();
+    expect(pending).toBe(0);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+});

--- a/browser/lib/src/scheduled-save.ts
+++ b/browser/lib/src/scheduled-save.ts
@@ -1,0 +1,65 @@
+/** Owns one debounce slot and any saves already started from it.
+ * Cancellation affects only the slot; in-flight persistence always settles.
+ */
+export class ScheduledSave {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private running = new Set<Promise<void>>();
+
+  constructor(
+    private save: () => Promise<unknown>,
+    private changePending: (delta: number) => void,
+    private onError: (error: Error) => void,
+  ) {}
+
+  setErrorHandler(handler: (error: Error) => void): void {
+    this.onError = handler;
+  }
+
+  schedule(delay: number): void {
+    const newlyQueued = this.timer === undefined;
+    if (!newlyQueued) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      void this.flush();
+    }, delay);
+    // Publish only after cancel/flush can see the slot. Subscribers can run synchronously.
+    if (newlyQueued) this.changePending(1);
+  }
+
+  cancel(): void {
+    if (this.timer === undefined) return;
+    clearTimeout(this.timer);
+    this.timer = undefined;
+    this.changePending(-1);
+  }
+
+  /** Flush on unmount when cancelling would discard the owner's last edit. */
+  async flush(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+      const task = Promise.resolve()
+        .then(async () => {
+          await this.save();
+        })
+        .catch(error => {
+          this.onError(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        })
+        .finally(() => {
+          this.running.delete(task);
+          this.changePending(-1);
+        });
+      this.running.add(task);
+    }
+
+    await Promise.all(this.running);
+  }
+}
+
+export interface ResourceSaveState {
+  readonly kind: 'idle' | 'dirty' | 'scheduled' | 'saving' | 'queued' | 'error';
+  readonly scheduledCount: number;
+  readonly error: string | undefined;
+  readonly reason: 'offline' | 'retry' | undefined;
+}

--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -5,6 +5,67 @@ import { bootstrapCoreVocab } from './test-vocab.js';
 import { testStore } from './test-store.js';
 
 describe('Store', () => {
+  it('tracks immutable save status across cancellation and offline queueing', async ({
+    expect,
+  }) => {
+    vi.useFakeTimers();
+
+    try {
+      const store = new Store();
+      const resource = new Resource('_new:save-state');
+      resource.setStore(store);
+      const idle = store.getSaveState(resource);
+      const changed = vi.fn();
+      const unsubscribe = store.subscribeSaveState(resource, changed);
+      const scheduler = store.createSaveScheduler(resource);
+      scheduler.schedule(100);
+      const queuedTimer = store.getSaveState(resource);
+      expect(queuedTimer.kind).toBe('scheduled');
+      expect(store.getSaveState(resource)).toBe(queuedTimer);
+      expect(idle.kind).toBe('idle');
+      expect(Object.isFrozen(queuedTimer)).toBe(true);
+      // A temporary row keeps the same owner after acquiring its DID.
+      resource.setSubject('did:ad:saved-row');
+      expect(store.getSaveState(resource).scheduledCount).toBe(1);
+      scheduler.cancel();
+      expect(store.getSyncStatus().pendingDirtyCount).toBe(0);
+      store.outbox.markDirty(resource.subject);
+      expect(store.getSaveState(resource)).toMatchObject({
+        kind: 'queued',
+        reason: 'offline',
+      });
+      expect(changed).toHaveBeenCalled();
+      unsubscribe();
+      changed.mockClear();
+      scheduler.schedule(100);
+      scheduler.cancel();
+      expect(changed).not.toHaveBeenCalled();
+      store.outbox.clearDirty(resource.subject);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('publishes direct save start and finish without changing read readiness', async ({
+    expect,
+  }) => {
+    const { store } = await testStore();
+    const resource = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Folder',
+      propVals: { [core.properties.name]: 'Save status' },
+      parent: 'https://example.com/drive',
+    });
+    const states: string[] = [];
+    const unsubscribe = store.subscribeSaveState(resource, () =>
+      states.push(store.getSaveState(resource).kind),
+    );
+    await resource.save();
+    expect(states).toContain('saving');
+    expect(store.getSaveState(resource).kind).toBe('idle');
+    expect(resource.isReady()).toBe(true);
+    unsubscribe();
+  });
+
   it('captures immutable read status while retaining the stable mutation handle', ({
     expect,
   }) => {

--- a/browser/lib/src/store.ts
+++ b/browser/lib/src/store.ts
@@ -1,3 +1,4 @@
+import { ScheduledSave, type ResourceSaveState } from './scheduled-save.js';
 import { verifyLocalDriveCopy } from './local-drive-copy.js';
 import {
   encodeCommit as encodePeerCommit,
@@ -40,6 +41,7 @@ import type { OptionalClass, UnknownClass } from './ontology.js';
 import { JSONADParser } from './parse.js';
 import {
   Resource,
+  ResourceEvents,
   unknownSubject,
   type ResourceReadState,
 } from './resource.js';
@@ -3947,6 +3949,79 @@ export class Store {
         }
       });
     }
+  }
+
+  private scheduledByResource = new WeakMap<Resource, number>();
+  private saveSnapshots = new WeakMap<Resource, ResourceSaveState>();
+
+  /** One owner per debounce slot. Resource identity survives genesis renaming. */
+  public createSaveScheduler(
+    resource: Resource,
+    options: {
+      shouldSave?: () => boolean;
+      onError?: (error: Error) => void;
+    } = {},
+  ): ScheduledSave {
+    const target = resource.__internalObject;
+
+    return new ScheduledSave(
+      async () => {
+        if (options.shouldSave?.() !== false) await target.save();
+      },
+      delta => {
+        this.scheduledByResource.set(
+          target,
+          (this.scheduledByResource.get(target) ?? 0) + delta,
+        );
+        this._scheduledSaves += delta;
+        this.emitSyncStatus();
+      },
+      options.onError ?? (error => this.notifyError(error)),
+    );
+  }
+
+  /** Read status is separate: a queued offline edit can still be fully readable. */
+  public getSaveState(resource: Resource): ResourceSaveState {
+    const target = resource.__internalObject;
+    const scheduledCount = this.scheduledByResource.get(target) ?? 0;
+    const entry = this.outbox.getEntry(target.subject);
+    const error = entry?.lastAttemptError ?? target.commitError?.message;
+    let kind: ResourceSaveState['kind'];
+    if (target.isSaving) kind = 'saving';
+    else if (scheduledCount) kind = 'scheduled';
+    else if (entry?.blocked) kind = 'error';
+    else if (entry) kind = 'queued';
+    else if (error) kind = 'error';
+    else if (target.hasUnsavedChanges()) kind = 'dirty';
+    else kind = 'idle';
+    const queuedReason = this._serverConnected ? 'retry' : 'offline';
+    const reason = kind === 'queued' ? queuedReason : undefined;
+    const previous = this.saveSnapshots.get(target);
+    if (
+      previous?.kind === kind &&
+      previous.scheduledCount === scheduledCount &&
+      previous.error === error &&
+      previous.reason === reason
+    )
+      return previous;
+    const state = Object.freeze({ kind, scheduledCount, error, reason });
+    this.saveSnapshots.set(target, state);
+
+    return state;
+  }
+
+  public subscribeSaveState(
+    resource: Resource,
+    callback: () => void,
+  ): () => void {
+    const target = resource.__internalObject;
+    const unsubscribers = [
+      this.on(StoreEvents.SyncStatusChanged, callback),
+      target.on(ResourceEvents.LocalChange, callback),
+      target.on(ResourceEvents.SaveStateChange, callback),
+    ];
+
+    return () => unsubscribers.forEach(unsubscribe => unsubscribe());
   }
 
   public startDriveSync(): void {

--- a/browser/react/README.md
+++ b/browser/react/README.md
@@ -72,3 +72,9 @@ The status fields are captured in an immutable snapshot that changes on store
 notifications. Do not memoize `resource.isReady()` or property getters by the
 Resource reference. `recovering` can retain readable content; `ready` says
 whether reads are usable, independently of the outbox/saving state.
+
+`useSaveState(resource)` returns a stable immutable persistence snapshot with
+`kind` (`idle`, `dirty`, `scheduled`, `saving`, `queued`, `error`),
+`scheduledCount`, `error`, and queued `reason`. It is independent of read status.
+`useDebouncedSave` and committed `useValue` edits flush their scheduled work when
+the owning component unmounts; pending data is not silently cancelled.

--- a/browser/react/src/hooks.ts
+++ b/browser/react/src/hooks.ts
@@ -243,7 +243,6 @@ export function useValue(
   propertyURL: string,
   opts: useValueOptions = {},
 ): [JSONValue | undefined, SetValue] {
-  const timeoutId = useRef<ReturnType<typeof setTimeout>>(undefined);
   const {
     commit = false,
     validate = true,
@@ -275,33 +274,19 @@ export function useValue(
   const getSnapshot = () => resource.get(propertyURL);
   const val = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
+  const scheduler = useMemo(
+    () => store.createSaveScheduler(stable),
+    [store, stable],
+  );
+  useEffect(
+    () => () => {
+      void scheduler.flush();
+    },
+    [scheduler],
+  );
   const saveResource = useCallback(() => {
-    if (!commit) {
-      return;
-    }
-
-    // While the debounce timer is armed, the edit exists only in memory —
-    // report it to the store so `getSyncStatus().pendingDirtyCount` stays
-    // > 0 until the save settles (otherwise "synced" is a lie during the
-    // debounce window and a reload drops the write).
-    if (timeoutId.current !== undefined) {
-      clearTimeout(timeoutId.current);
-    } else {
-      store.startScheduledSave();
-    }
-
-    timeoutId.current = setTimeout(async () => {
-      timeoutId.current = undefined;
-
-      try {
-        await resource.__internalObject.save();
-      } catch (e) {
-        store.notifyError(asError(e));
-      } finally {
-        store.finishScheduledSave();
-      }
-    }, commitDebounce);
-  }, [resource.__internalObject, store, commitDebounce, commit]);
+    if (commit) scheduler.schedule(commitDebounce);
+  }, [scheduler, commitDebounce, commit]);
 
   /**
    * Validates the value. If it fails, it calls the function in the second
@@ -783,4 +768,20 @@ function useMemoizedOpts(
     }),
     [opts.allowIncomplete, opts.noWebSocket, opts.newResource],
   );
+}
+
+/** Immutable persistence status, independent from resource read readiness. */
+export function useSaveState(resource: Resource) {
+  const store = useStore();
+  const stable = resource.__internalObject;
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribeSaveState(stable, callback),
+    [store, stable],
+  );
+  const snapshot = useCallback(
+    () => store.getSaveState(stable),
+    [store, stable],
+  );
+
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
 }

--- a/browser/react/src/useDebounce.ts
+++ b/browser/react/src/useDebounce.ts
@@ -1,7 +1,7 @@
 import { Resource } from '@tomic/lib';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { useStore } from './hooks.js';
+import { useSaveState, useStore } from './hooks.js';
 
 // T is a generic type for value parameter, our case this will be string
 export function useDebounce<T>(value: T, delay: number): T {
@@ -33,38 +33,26 @@ export function useDebouncedSave(
   timeout: number,
   onError?: (error: Error) => void,
 ): [save: () => void, savePending: boolean] {
-  const timeoutId = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const [savePending, setSavePending] = useState(false);
   const store = useStore();
+  const stable = resource.__internalObject;
+  const scheduler = useMemo(
+    () => store.createSaveScheduler(stable),
+    [store, stable],
+  );
+  useEffect(() => {
+    scheduler.setErrorHandler(onError ?? (error => store.notifyError(error)));
+  }, [scheduler, onError, store]);
+  useEffect(
+    () => () => {
+      void scheduler.flush();
+    },
+    [scheduler],
+  );
+  const save = useCallback(
+    () => scheduler.schedule(timeout),
+    [scheduler, timeout],
+  );
+  const state = useSaveState(stable);
 
-  const save = useCallback(() => {
-    // Report the debounce window to the store so sync status counts the
-    // not-yet-executed save (see Store.startScheduledSave).
-    if (timeoutId.current !== undefined) {
-      clearTimeout(timeoutId.current);
-    } else {
-      store.startScheduledSave();
-    }
-
-    timeoutId.current = setTimeout(async () => {
-      timeoutId.current = undefined;
-
-      try {
-        await resource.__internalObject.save();
-        setSavePending(false);
-      } catch (e) {
-        if (onError) {
-          onError(e instanceof Error ? e : new Error(String(e)));
-        } else {
-          throw e;
-        }
-      } finally {
-        store.finishScheduledSave();
-      }
-    }, timeout);
-
-    setSavePending(true);
-  }, [resource.__internalObject, timeout, onError, store]);
-
-  return [save, savePending];
+  return [save, state.kind === 'scheduled' || state.kind === 'saving'];
 }

--- a/planning/README.md
+++ b/planning/README.md
@@ -63,7 +63,7 @@ browser flow; standalone recovery remains self-managed.
 | [`content-i18n.md`](./content-i18n.md) | **LocalizedText + template locales shipped.** Remaining: TranslationsBar, `useTranslation`, `/query` `lang`, search language filter. |
 | [`website-templates.md`](./website-templates.md) | Template repair complete (DID). Remaining CMS product: drafts-from-site, i18n tooling, canonical paths. |
 | [`structural-problems-index.md`](./structural-problems-index.md) | **Live index.** Highest remaining: React Compiler / Resource proxy (#1), audit not started while the compiler is on. #6 mostly shipped; #2/#3 server side done 2026-09-04. |
-| [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Planned, audit not started.** Stale UI from Compiler memoizing Resource proxy reads; compiler on since 2026-08-19, field instance M15a. |
+| [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Partial.** Immutable read/save status hooks and the data-inspector subscription shipped; remaining render-time property getters need incremental regression-driven migration. |
 | [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md) | Phase A + C landed (browser). Phase B (Flutter action-stack removal) open. |
 | [`index-performance.md`](./index-performance.md) | First tranche shipped. Structural permission-check fix is `zones.md`, not built. |
 | [`disk-storage-and-persistence-optimization.md`](./disk-storage-and-persistence-optimization.md) | **Proposal.** Full-snapshot writes, no auto-compaction, O(file) open fsync. |

--- a/planning/react-compiler-resource-proxy.md
+++ b/planning/react-compiler-resource-proxy.md
@@ -13,6 +13,10 @@ the snapshot fields. AgentProfileHeader no longer needs `use no memo`; productio
 E2E verifies profile editing, invitations, and live username updates. Library
 tests check stable mutation identity and immutable status across notifications.
 
+The data inspector also uses `useSaveState`: a production regression verifies
+its warning appears for an offline edit and clears after synchronization without
+replacing the Resource. Save status remains independent of read readiness.
+
 ## Remaining audit
 
 A direct `resource.get(...)`, `resource.props.foo`, or `resource.isReady()` read

--- a/planning/unify-resource-dirty-signals.md
+++ b/planning/unify-resource-dirty-signals.md
@@ -1,88 +1,16 @@
-# Unify resource "dirty" signals
+# Resource save state
 
-> Status: planned 2026-05-28. Correctness.. **not started as of 2026-09-04 (`getSaveState` does not exist; `_loading` / `_dirty` / `_saveDepth` and the outbox are still four separate signals).**
->
-> This is one slice of [`unified-data-layer.md`](./unified-data-layer.md)
-> (the "one outbox + saveState" part of the proposed redesign). It can
-> ship in isolation as a self-contained step toward that bigger plan —
-> the resulting `SaveState` API is the public surface the broader plan
-> assumes.
+The browser exposes `Store.getSaveState(resource)` and `useSaveState(resource)` as
+immutable persistence snapshots. Read readiness stays in `useResourceSnapshot`;
+a queued offline edit can remain readable. Save kinds are idle, dirty, scheduled,
+saving, queued, and error.
 
-## Problem
+`Store.createSaveScheduler` owns a debounce slot and counts each started save
+until it settles. React value/debounced-save hooks and virtual table rows use it.
+Rescheduling coalesces queued work, cancellation cannot uncount an in-flight save,
+and unmount flushes edits that would otherwise only exist in memory.
 
-A resource on the client can be in one of several "in-flight" states
-that are tracked in **three different places**:
-
-1. **Outbox** (`local-outbox.ts`) — has an entry for this subject if a
-   commit is queued / retrying / stuck.
-2. **`Resource._loading`** — true while a network GET is in flight.
-3. **`Resource._error`** — last GET / commit error message.
-
-Plus implicit state in:
-4. **Loro snapshot present** vs **absent** in `LoroLoader.docs.get(s)`.
-5. **`store._fetching`** map — subjects currently being fetched.
-
-UI components want to display "saving…", "save failed", "loading…",
-"offline (queued)" — they have to look in different places, miss
-states, and fall over when two states overlap (e.g., loading *and*
-queued commit).
-
-## Symptom
-
-- The "saving" indicator on the document toolbar lags behind the
-  outbox by ~1 render because it watches `_loading` not the outbox.
-- The error toast for a stuck genesis commit fires from the outbox
-  drain loop, separately from `Resource._error`, and the resource
-  body still renders as if nothing is wrong.
-- `useResource` consumers don't know to re-render when the outbox
-  drops a stuck commit.
-
-## Proposal
-
-Single source of truth, derived:
-
-```ts
-type SaveState =
-  | { kind: 'idle' }
-  | { kind: 'loading' }
-  | { kind: 'saving'; attempts: number }
-  | { kind: 'queued'; reason: 'offline' | 'retry' }
-  | { kind: 'error'; message: string; recoverable: boolean };
-
-store.getSaveState(subject: string): SaveState;
-store.subscribeSaveState(subject, cb): Unsubscribe;
-```
-
-Implementation: a small reducer fed by outbox events + Resource
-mutations + store fetch start/end. The hook layer exposes
-`useSaveState(subject)`, components stop reading `_loading` / `_error`
-directly.
-
-## Why this is hard
-
-- Touches every screen that shows a saving indicator (Document
-  toolbar, Sidebar items, Resource page).
-- Requires deciding which existing fields become *derived* vs.
-  retained. Recommended: keep `_loading` (network in-flight) as a
-  raw input, derive `SaveState` from it; deprecate ad-hoc reads.
-
-## Risk
-
-- Medium. Wrong derivation could make the indicator stick on
-  "saving…" forever. Mitigate with property-based tests that drive a
-  resource through every transition.
-
-## Effort
-
-- 1 day for the reducer + hook.
-- 1 day to migrate consumers.
-
-## Concrete steps
-
-1. Inventory current consumers: `rg 'resource.loading\|resource.error'
-   browser/data-browser/src`.
-2. Design the state machine (transitions table).
-3. Implement `getSaveState`/`subscribeSaveState` alongside the
-   existing fields (no breakage).
-4. Migrate one screen (Document toolbar) as a canary.
-5. Migrate the rest, delete direct reads.
+Remaining migration: other screens with bespoke saving UI can adopt the hook
+incrementally. Legacy global start/finish methods remain for compatibility and
+non-save pending writes such as deletion. The outbox remains the durable queue;
+this API derives state rather than keeping a second persistence engine.


### PR DESCRIPTION
CI kept superseded feature-branch jobs running and its static lint stage depended on JS and WASM builds. Resource save timers were independently managed by hooks and table rows, and the data inspector could miss an offline edit because it rendered a mutable dirty-state getter.

This series cancels obsolete feature-branch runs while preserving develop/tag validation, runs static lint from installed sources, and attaches bounded resource/save/WebSocket metadata before E2E teardown. Payloads and resource values are excluded from those attachments.

A shared scheduled-save owner now handles coalescing, cancellation, flushing and in-flight accounting. Immutable save snapshots feed React separately from read readiness. The data inspector uses that subscription; its production regression failed before the migration and passes afterward, including clearing the warning after reconnection.

Validation:
- actionlint passes; staged source-only workspace lint passes.
- 450 library tests and 850 app tests pass; workspace type checks pass.
- Scheduler tests cover cancellation, flushing, concurrent work, failures and synchronous subscriber reentrancy; store tests cover immutable snapshots, genesis identity renaming and offline queueing.
- Compiled data-inspector and localized-text checks pass. Failure metadata checks pass, including inspecting a real WebSocket attachment for metadata and absence of payload text.
- Final fresh-stack production Chromium suite on `5f338b9ceb259a70dc017be7b95e872e5c9ed66f`: **209 passed, 8 skipped, zero retries (13.4 minutes)**. JS, WASM and the native server were rebuilt from this checkout. Skips include the two real Cloud Vault tests, which require an explicitly configured external portal.

Docker and the generated Dagger SDK are unavailable locally, so the Dagger container pipeline itself remains a CI validation. The broader rendered-property audit and other bespoke save-status UIs remain incremental.
