### PR TITLE
Plan incremental JS refactors and update lifecycle planning

### DIFF
--- a/planning/README.md
+++ b/planning/README.md
@@ -47,7 +47,7 @@ browser flow; standalone recovery remains self-managed.
 | [`serverless-p2p.md`](./serverless-p2p.md) | **Planned.** Device sync without a hub (written same-agent-first; admission is rights-based since 2026-07-17). AUTH-before-SYNC and the `AUTH.requestedSubject`↔drive binding landed 2026-09-01 (Iroh). Live-link destroys travel as signed `COMMIT` frames since 2026-09-03. P0 remaining: require envelopes on every `remove[]` once `Tree::Envelopes` exists. `AtomicTransport` / `SyncSession::serve` first slice landed 2026-09-05; outbox port and the remaining `sync_drive_with_peer*` collapse are open. |
 | [`foss-public-host-mode.md`](./foss-public-host-mode.md) | **Partial.** Phase 1–2 built; OQ5 library path closed 2026-09-05 (`admit_unknown_drive`: Public never creates, Owner enrolls only the owner). Phase 3 (rate limits, Iroh stream refusal) is untouched. |
 | [`authorization-sync.md`](./authorization-sync.md) | **Draft.** Signed commit authorization, grant-chain evidence, peer-sync trust boundaries. |
-| [`unified-data-layer.md`](./unified-data-layer.md) | **Partial.** Browser/JS: one ingress, one outbox, one subscription model. Atomic writes and the single outbox shipped; the ingress/subscription half and `SaveState` are open. |
+| [`unified-data-layer.md`](./unified-data-layer.md) | **Partial.** Browser/JS: one ingress, one outbox, one subscription model. Atomic writes, outbox, ingress entry points and immutable read/save subscriptions shipped. Remaining: consumer migration and boundary extraction. |
 | [`loro-source-of-truth.md`](./loro-source-of-truth.md) | **Partial.** Sparse `datatypes` map + Phase 2a–2c shipped (`Tree::Resources` is a derived cache). Remaining: drop the untagged heuristic, Phase 1.6 `Value` reshape, Flutter undo. |
 | [`atomic-lib-runtime.md`](./atomic-lib-runtime.md) | **Partial.** `AtomicNode` is the binding runtime; the WASM `ClientDb` is its only adapter and the unused surface was cut back 2026-09-04. Open: the other bindings. Local KV FTS landed in [`local-search.md`](./local-search.md). |
 | [`genesis-self-verifying.md`](./genesis-self-verifying.md) | **Partial.** Server and browser mint and verify inline genesis certs. Remaining: DataRoute verify UI, `genesis` propval immutability. |
@@ -62,7 +62,8 @@ browser flow; standalone recovery remains self-managed.
 | [`dashboards.md`](./dashboards.md) | **First slice shipped.** Remaining: the sixth action verb, parameters, reaching a dashboard from its table. |
 | [`content-i18n.md`](./content-i18n.md) | **LocalizedText + template locales shipped.** Remaining: TranslationsBar, `useTranslation`, `/query` `lang`, search language filter. |
 | [`website-templates.md`](./website-templates.md) | Template repair complete (DID). Remaining CMS product: drafts-from-site, i18n tooling, canonical paths. |
-| [`structural-problems-index.md`](./structural-problems-index.md) | **Live index.** Highest remaining: React Compiler / Resource proxy (#1), audit not started while the compiler is on. #6 mostly shipped; #2/#3 server side done 2026-09-04. |
+| [`structural-problems-index.md`](./structural-problems-index.md) | **Live index.** React subscription audit is partial; save-state APIs shipped. Browser metadata cleanup and subject-brand consumers remain; server subscription work is complete. |
+| [`js-maintainability.md`](./js-maintainability.md) | **Planned.** PluginPage subscriptions, diagnostic collector lifecycles, then Store save-status coordination; three separately validated PRs. |
 | [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Partial.** Immutable read/save status hooks and the data-inspector subscription shipped; remaining render-time property getters need incremental regression-driven migration. |
 | [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md) | Phase A + C landed (browser). Phase B (Flutter action-stack removal) open. |
 | [`index-performance.md`](./index-performance.md) | First tranche shipped. Structural permission-check fix is `zones.md`, not built. |
@@ -91,7 +92,7 @@ Not top-level plans. Indexed so they do not go missing.
 | --- | --- |
 | [`unify-subscription-primitives.md`](./unify-subscription-primitives.md) | **Done in reduced form (2026-09-04).** One `SUB <subject>` frame; `SUBSCRIBE` and `SUBSCRIBE_QUERY` removed. Design text kept as the record. |
 | [`unify-resource-representations.md`](./unify-resource-representations.md) | **Mostly shipped.** `Resource#cache` is derived from the Loro doc. Remaining: the `_auxValues` overlay. |
-| [`unify-resource-dirty-signals.md`](./unify-resource-dirty-signals.md) | Planned, not started. Single `getSaveState(subject)` enum. |
+| [`unify-resource-dirty-signals.md`](./unify-resource-dirty-signals.md) | **Partial.** `getSaveState(resource)`, the React hook and scheduled-save ownership shipped; other save UIs and internal coordinator extraction remain. |
 | [`subject-types-end-to-end.md`](./subject-types-end-to-end.md) | Partial. Rust `DidKind` shipped; the browser brand still has no consumer. |
 | [`arc-actor-message-payloads.md`](./arc-actor-message-payloads.md) | Partial. WS encode-once shipped; `CommitMessage` Arc-wrap deferred. |
 | [`sync-onboarding-ux.md`](./sync-onboarding-ux.md) | Reference. Cross-client copy for what can reach what. Companion to [`device-pairing.md`](./device-pairing.md). |

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -1,6 +1,6 @@
 # Light vs heavy E2E, and where unit tests should grow
 
-**Status: landing.** Tags, `test-e2e:light`, Dagger `--playwright-mode`, and
+**Status: partial, updated 2026-09-11.** Tags, `test-e2e:light`, Dagger `--playwright-mode`, and
 `main.yml` gating are in. Remaining: grow `jsTestIntegration`, stop adding
 heavy-only variants as Playwright, then drop redundant heavy specs.
 
@@ -34,7 +34,7 @@ browser.
 
 ---
 
-## What is expensive today
+## Earlier timing baseline (re-measure before tuning)
 
 Playwright is the slow lane. Counts from this tree (2026-08-20):
 
@@ -113,7 +113,7 @@ integration tests.
 
 ---
 
-## Proposed model
+## Implemented model
 
 Three layers. **Only Playwright splits.** Lint, Rust, vitest, JS integration,
 and Flutter stay on every run.
@@ -134,11 +134,11 @@ later: `@perf` excluded from both default jobs and run on a schedule.
 
 **Partial by default. Full when we are about to ship, or when someone asks.**
 
-Today every origin push runs the full Playwright suite (`main.yml` is
-`on: [push, workflow_dispatch]`; there is no `pull_request` trigger). That
-is why Mancave queues: agent branches and feature branches compete with
-`develop` for the same box. The split only pays off if feature-branch
-pushes stop launching 8 browsers.
+Feature-branch pushes now run the light suite; develop and release validation
+use the full suite according to the policy below. Superseded feature-branch
+runs cancel within their ref; develop and tag runs finish because deployment
+consumes their results. `jsLint` uses installed sources without JS or WASM builds.
+Full Dagger execution and queue timing must still be measured in CI.
 
 | Trigger | Unit / integration / lint | Playwright |
 |---|---|---|
@@ -303,18 +303,19 @@ that can fail.
 
 ---
 
-## CI / Dagger shape (when building)
+## CI / Dagger shape
 
 Today `ci()` takes `--playwright-mode light|full` and passes it to `endToEnd`.
 The workflow decides the mode; Dagger does not guess the branch.
 
 - `endToEnd` / `ci` take `--playwright-mode light|full` (not `--e2e-mode`:
   Dagger camelCases that to `e2EMode` and the call fails).
-- `main.yml` passes `full` when `github.ref == develop` or the ref is a
-  stable `v*` tag, or when dispatch / a `full-e2e` label (or boolean
-  input) asks. Everything else passes `light`.
-- Light: `--grep @smoke`, 1–2 shards, `PLAYWRIGHT_RETRIES=1`,
-  `PLAYWRIGHT_WORKERS=2` on Mancave.
+- `main.yml` defaults to `full` on `refs/heads/develop` and all `v*` tags.
+  Feature branches use `light` unless `[full-e2e]` in the commit message or a
+  `full-e2e` PR label requests full. An explicit workflow-dispatch `e2e_mode`
+  overrides the default; release validation still needs the full suite.
+- Light: `--grep @smoke`, two Mancave shards or one hosted shard,
+  `PLAYWRIGHT_RETRIES=1`; workers follow the selected Dagger host profile.
 - Full: current command, current shards/retries.
 - `pnpm` scripts: `test-e2e:light` / keep `test-e2e` = full.
 - Do not grep-exclude by filename forever; tags survive file splits.
@@ -357,3 +358,15 @@ Optional later, not required for the split to pay off:
 
 Step 1–3 is the split (landed). Step 4–6 is how the heavy suite stops growing
 faster than the product.
+
+## Local reproduction and diagnostics
+
+`pnpm test-e2e:local` builds JS, WASM and the native backend from the checkout,
+uses fresh data on matching free ports, and retains failure traces. It runs
+with zero retries by default. External Cloud Vault tests require an explicit
+`ATOMIC_VAULT_PORTAL_URL`; managed mocks do not depend on a portal.
+
+Failures also attach bounded resource/save and WebSocket frame metadata before
+page teardown. Extracting the collectors into explicit lifecycles is planned in
+[js-maintainability.md](./js-maintainability.md); retaining payload-free metadata
+and existing diagnostic strictness is part of its acceptance criteria.

--- a/planning/js-maintainability.md
+++ b/planning/js-maintainability.md
@@ -1,0 +1,112 @@
+# JavaScript maintainability follow-ups
+
+> **Status: planned, 2026-09-11.** None of the three refactors below is implemented
+> by this document. Baseline: `develop` at `6045bff3a`, following PRs
+> [#1450](https://github.com/ontola/atomic-server/pull/1450) and
+> [#1451](https://github.com/ontola/atomic-server/pull/1451).
+
+## Existing boundaries to preserve
+
+- `Resource` is a stable mutation handle. `useResourceSnapshot` exposes immutable
+  read status; property hooks subscribe to rendered values.
+- `Store.getSaveState(resource)` / `useSaveState(resource)` expose immutable save
+  status independently of read readiness. A queued offline edit can remain readable.
+- `ScheduledSave` already owns debounce slots, cancellation and flushing.
+  `Store.createSaveScheduler` connects it to pending-work accounting.
+- Local JSON and Loro snapshots are hydrated before publication. Loro remains
+  authoritative; the outbox remains the single durable outbound queue.
+- E2E failures already attach bounded resource/save metadata and recent WebSocket
+  frame metadata before context teardown. Payloads and resource values are excluded.
+
+This plan owns the next implementation slices. The architectural constraints remain
+in [unified-data-layer.md](./unified-data-layer.md),
+[react-compiler-resource-proxy.md](./react-compiler-resource-proxy.md), and
+[unify-resource-dirty-signals.md](./unify-resource-dirty-signals.md).
+
+## 1. PluginPage subscriptions
+
+Start in [PluginPage.tsx](../browser/data-browser/src/views/Plugin/PluginPage.tsx).
+Name, namespace, config and permissions already use hooks. Version, author,
+description, JSON schema and parent still come from `resource.props`; the Save
+button reads `hasUnsavedChanges()` during render. These are audit candidates,
+not individually confirmed bugs.
+
+- [ ] Reproduce a stale render or Save-button transition while retaining the same
+  Resource object. Use the cheapest failing layer; verify compiler behavior in a
+  production Playwright build when a helper/unit test cannot exercise it.
+- [ ] Replace rendered scalar reads with `useString` and structured reads with
+  `useValue`; use the existing save-state subscription for persistence status.
+- [ ] Define the Save-button policy explicitly: invalid JSON cannot save; in-flight
+  saving cannot submit twice; queued/offline/failed writes remain distinguishable
+  from new unsaved config. Do not assume every non-idle state should enable Save.
+- [ ] Check `JSONEditor`'s `initialValue` behavior before changing schema/config
+  subscriptions. A remote update must not reset an active local edit.
+- [ ] Verify remote metadata updates, valid/invalid config, save completion and
+  offline retry. Keep uninstall/update permissions unchanged.
+
+Acceptance: the reproduced failure passes without a compiler opt-out or replacing
+Resource identity. Limit the PR to this flow; event-handler reads need not become
+subscriptions unless they are demonstrably stale.
+
+## 2. E2E diagnostic collectors
+
+[fixtures.ts](../browser/e2e/tests/fixtures.ts) currently owns context interception,
+console matching, WebSocket observation, attachments and teardown.
+[failure-state.ts](../browser/e2e/tests/failure-state.ts) already separates the
+browser-side state snapshot. Extract the remaining collectors without changing
+which diagnostics fail a test.
+
+- [ ] Extract console/error expectations and WebSocket metadata into independent
+  collectors with explicit `start`, `snapshot`, and `dispose` lifecycles.
+- [ ] Let the fixture wire collectors to existing/new contexts, attach evidence,
+  restore `browser.newContext`, and close only contexts it owns.
+- [ ] Make start/dispose idempotent and detach page, context **and socket** listeners.
+  Preserve evidence collected before a page closes; tolerate crashed pages.
+- [ ] Preserve limits: at most five live pages sampled, two seconds per state read,
+  50 relevant resources, 50 property keys per resource, 20 commits and 30 frame
+  metadata records per page. Keep payloads, resource values and secrets excluded.
+- [ ] Exercise unexpected/missing/excess diagnostics, multiple contexts, repeated
+  start/dispose, closed pages and bounded attachments. Keep one real WebSocket
+  check; mocked routing alone did not emit the transport events being tested.
+
+Acceptance: current diagnostic self-checks and attachment inspection pass; teardown
+cannot replace the original failure with a collector error or leak into the next test.
+
+## 3. Extract Store save-status coordination
+
+[store.ts](../browser/lib/src/store.ts) still owns scheduling integration, snapshot
+caching and save-state subscriptions alongside loading, hydration, sync and logging.
+Start with that small responsibility; do not split the entire Store in one PR.
+
+- [ ] Inventory `scheduledByResource`, `saveSnapshots`, `createSaveScheduler`,
+  `getSaveState` and `subscribeSaveState`, plus their event inputs and cleanup.
+- [ ] Move their implementation behind an internal coordinator. Retain existing
+  Store methods as delegates so React and downstream callers do not change.
+- [ ] Inject narrow access to outbox entries, connection state and pending-work
+  notifications. The coordinator must not fetch resources, sign commits, drain the
+  outbox or keep a second copy of persistence truth.
+- [ ] Preserve Resource identity through `_new:` → DID renaming, cached immutable
+  snapshot identity, overlapping owners and exact in-flight accounting.
+- [ ] Keep legacy global start/finish methods compatible. Deletion uses them for
+  non-save writes; removing them needs its own caller audit.
+- [ ] Run scheduler/store regressions, types and compiled inspector/table/offline
+  flows. Test that disposing one observer cannot cancel another owner's save.
+
+Acceptance: public APIs and behavior remain unchanged, the extracted module can
+be tested with narrow dependencies, and no circular Store import is introduced.
+Hydration, sync and commit-log extraction remain future candidates requiring their
+own evidence and boundary review.
+
+## Delivery and verification
+
+Ship in order: PluginPage, collectors, then Store coordination, as separate PRs.
+Record each reproduction and focused validation; run the full production E2E suite
+for shared lifecycle changes. Update [TESTING_COVERAGE.md](../TESTING_COVERAGE.md)
+when coverage changes. Local passing tests, hosted CI and deployment are separate
+results—do not infer one from another.
+
+The prior implementation's local baseline was 450 library tests, 850 app tests,
+and 209 Chromium tests passed with eight skips (including external Cloud Vault).
+Those counts are historical evidence, not permanent acceptance thresholds or proof
+of CI success. Remove this plan when all three slices are complete and place any
+remaining follow-ups in their owning plans.

--- a/planning/react-compiler-resource-proxy.md
+++ b/planning/react-compiler-resource-proxy.md
@@ -1,5 +1,8 @@
 # React Compiler and mutable Resources
 
+> **Status: partial, 2026-09-11.** Read/save status boundaries and initial consumers
+> shipped; rendered-property migration continues incrementally.
+
 ## Current boundary
 
 `Resource` remains a stable mutation handle. `Store.getResourceSnapshot` captures
@@ -29,3 +32,7 @@ that would change effect dependencies throughout the app. Audit remaining
 render-time property getters incrementally, with a reproduced stale-UI test
 before migrating each flow. Saving/outbox state is separate from read readiness;
 see `unify-resource-dirty-signals.md`.
+
+Next bounded slice: PluginPage metadata and Save-button subscriptions, with a
+reproduction before migration. Its checklist and delivery order live in
+[js-maintainability.md](./js-maintainability.md).

--- a/planning/structural-problems-index.md
+++ b/planning/structural-problems-index.md
@@ -1,49 +1,34 @@
-# Structural problems audit (2026-05-28)
+# Structural problems audit
 
-> **Status:** Live index (audit 2026-05-28). #4, #9 and #10 done and their docs deleted; #7 largely landed; #6 (browser `Resource` cache dual) largely shipped, see `unify-resource-representations.md`. Still open: #1 React Compiler / Resource proxy (audit not started while the compiler is on), #2 / #3 subscription unification (server side done 2026-09-04, actors not folded), #5 dirty signals, #8 subject types.
+> **Status: live index, reconciled 2026-09-11.** Original audit: 2026-05-28.
+> Read/save subscription boundaries and scheduled-save ownership have shipped.
+> Consumer migration, metadata representation cleanup and subject-brand adoption remain.
 
-Working list of structural issues surfaced during the QUERY_UPDATE /
-canvas-genesis-save / outbox / live-Loro debugging arc of late May 2026.
-Ranked by load-bearing impact (1 = most bugs traced back to it).
+This index tracks structural work rather than individual failures. The next bounded
+JS slices and acceptance checks are in [js-maintainability.md](./js-maintainability.md):
+PluginPage subscriptions, E2E diagnostic collectors, then Store save-status coordination.
 
-Items #4 (opfs-double-rehydrate), #9 (connection-close-cleanup), and
-#10 (dev-cargo-lock-contention) have been fully implemented and their
-plan docs removed.
+| # | Plan | Current state | Next step |
+| --- | --- | --- | --- |
+| 1 | [React Compiler / Resources](./react-compiler-resource-proxy.md) | Partial: stable Resource handles, immutable read/save snapshots and initial UI migrations shipped. | Reproduce and migrate PluginPage rendered getters; continue one flow at a time. |
+| 2 | [Subscription primitives](./unify-subscription-primitives.md) | Server work completed in reduced form; the original filter-scope design was not implemented. | Browser subscription changes belong in the data-layer plan, not a repeat of the server migration. |
+| 3 | Subscription actors | Done: `LoroSyncBroadcaster` folded into `CommitMonitor`; original plan removed. | None in this slice. |
+| 5 | [Resource save state](./unify-resource-dirty-signals.md) | API, scheduler and initial consumers shipped. | Migrate remaining save UIs and extract internal coordination without changing the public API. |
+| 6 | [Resource representations](./unify-resource-representations.md) | Mostly shipped: browser `Resource#cache` derives from Loro. | Review `_auxValues` and preserved server-managed metadata; preserve causal hydration. |
+| 7 | [Actor payloads](./arc-actor-message-payloads.md) | Encode-once and zero-copy WS frames shipped; `CommitMessage` Arc wrapping deferred. | Measure a remaining high-fanout cost before further work. |
+| 8 | [Subject types](./subject-types-end-to-end.md) | Rust `DidKind` and browser branding helpers shipped. | Browser consumer migration remains. |
 
-Several open items overlap with broader existing plans:
+Items #4 (double hydration), #9 (connection-close cleanup) and #10 (Cargo lock
+contention) were closed and their original plan documents removed. Recent lifecycle
+work additionally restores snapshot-backed hydration before publication and cancels
+asynchronous socket work across reconnects; that does not imply all sync work is done.
 
-- **#2, #5, #6** are slices of [`unified-data-layer.md`](./unified-data-layer.md)
-  — the browser data-layer redesign. Doing those three in isolation
-  risks landing partial layouts that the bigger plan then has to undo.
-- **#6** has a Rust/Flutter dual in [`loro-source-of-truth.md`](./loro-source-of-truth.md).
-  The sparse `datatypes` map and `Tree::Resources` derived cache shipped on
-  the Rust side. The browser `Resource._cache` dual
-  ([unify-resource-representations.md](./unify-resource-representations.md))
-  is still open.
+## Ownership and order
 
-The remaining standalone items (#1 react-compiler, #3 subscription
-actors, #7 arc-wrap, #8 subject types) don't overlap with the broader
-plans and can be tackled independently.
-
-| # | Plan | Class | Risk | First step |
-|---|---|---|---|---|
-| 1 | [react-compiler-resource-proxy.md](./react-compiler-resource-proxy.md) | Correctness | High | 🔴 **Still open as of 2026-08.** The compiler is now *on* in data-browser (`224bd4816`, 2026-08-19, via `oxc-transform-react` in `vite.config.ts`), and a live instance of the class was hit in the field on 2026-08-16 — [`pairing-ux-field-test.md`](./completed/pairing-ux-field-test.md) M15a, a table not re-rendering after a peer row arrived. The audit of `.props.X` / `.isReady()` / `.loading` reads in render has not started. |
-| 2 | [unify-subscription-primitives.md](./unify-subscription-primitives.md) | Cleanup | Medium | Single `Subscription` shape with `Match::{Subject, Drive, Filter}` |
-| 3 | Unify subscription actors | Cleanup | Done 2026-09-05 | Folded `LoroSyncBroadcaster` into `CommitMonitor`; planning doc removed |
-| 5 | [unify-resource-dirty-signals.md](./unify-resource-dirty-signals.md) | Correctness | Medium | Single `getSaveState(subject)` enum |
-| 6 | [unify-resource-representations.md](./unify-resource-representations.md) | Correctness | High | 🟡 Rust `datatypes` map + derived `Tree::Resources` cache shipped. Browser `_cache` dual still open. |
-| 7 | [arc-actor-message-payloads.md](./arc-actor-message-payloads.md) | Performance | Low | ✅ Stretch landed — `SendFrame` + encode-once + `Bytes::from_owner` zero-copy at WS write. `MembershipNotification` already Arc-wrapped. `CommitMessage` Arc-wrap (`atomic_lib` change) deferred. |
-| 8 | [subject-types-end-to-end.md](./subject-types-end-to-end.md) | Correctness | High | 🟡 Started — `Subject` brand + `asSubject`/`tryAsSubject`/`isValidSubject` in `browser/lib/src/subject.ts`. Rust `DidKind` classifier shipped. Consumer migration not started. |
-
-## Suggested execution order
-
-**Highest leverage** — 1 (React Compiler) is the highest bug density
-in the codebase (~280 suspect sites) and won't get easier as the
-codebase ages.
-
-**Opportunistic cleanups** — 2 and 3 reduce mental overhead but are
-not blocking anything. 7 remaining (CommitMessage Arc-wrap) is a
-small perf win for high-fanout drives.
-
-**Defer the invasive ones** — 5, 6, 8 need design alignment before
-implementation. Each warrants its own RFC-style discussion.
+- #2, #5 and #6 share constraints with [unified-data-layer.md](./unified-data-layer.md).
+  #6 also shares the Rust/Flutter direction in [loro-source-of-truth.md](./loro-source-of-truth.md).
+- Start with the regression-driven UI slice, then diagnostics, then the narrow Store
+  extraction. Do not replace every Resource identity or rewrite Store wholesale.
+- Treat representation changes and subject-brand migration as separate work with
+  explicit compatibility and persistence tests. Completed server subscription work
+  is not a prerequisite to redo before starting these browser slices.

--- a/planning/unified-data-layer.md
+++ b/planning/unified-data-layer.md
@@ -1,585 +1,105 @@
-# Unified data layer — proposal
-
-> **Status:** Partial. The atomic-write core landed 2026-07-07: `OpfsPersistor` atomic writes, `local-outbox.ts` as the single durable outbox, most of the resource-save decomposition. Open: the one-ingress / one-subscription-model half and the `SaveState` surface, tracked in the slices `unify-resource-dirty-signals.md`, `unify-resource-representations.md`, `unify-subscription-primitives.md`.
-
-> Scope note: this proposal focuses on the browser/JS data layer and the OPFS
-> flakes that exposed it. The broader runtime direction is in
-> [`atomic-lib-runtime.md`](./atomic-lib-runtime.md) (`AtomicNode` API). Transport
-> and multi-device sync (WS / Iroh, Flutter) are in
-> [`unified-sync.md`](./unified-sync.md). This document is the browser
-> cache/reactivity layer on top of that node surface.
-
-The data-layer flakes we keep landing on (genesis double-POST,
-collection drops members during init, leadership-election timeout,
-sidebar-not-visible-after-reload) are all symptoms of the same
-root shape: **a logical "resource changed" passes through multiple
-independent paths**, each writing to overlapping state with no
-shared lock or sequencer. This document proposes a unified
-data-layer design that collapses those paths into one.
-
-It's a target architecture, not a rewrite plan. The current code
-can converge on it incrementally; each section calls out the
-mechanical migration step.
-
----
-
-## The problems, in one paragraph each
-
-**P1 — many ingresses.** A resource update can land via WS UPDATE
-(pending-GET response or subscription push), WS SYNC_PUSH, WS
-QUERY_UPDATE, local `pushCommits` (pre- and post-POST `addResource`),
-offline replay (`applyPendingCommitsLocally`), HTTP `fetchResource`,
-or a third party calling `addResources`. Each path sets up
-`source`/`sourceTimestamp`/`loading` differently, decides
-independently whether to skip the commit-id compare, persists
-to OPFS independently, and fires `notify` independently.
-
-**P2 — split persistence.** A WS UPDATE writes JSON-AD via
-`Store.addResource` AND writes the Loro snapshot via
-`WSClient.persistToClientDb`. Two worker round-trips, two error
-paths, no atomic coupling. `Resource.applyPendingCommitsLocally`
-is the only path that does both from one place.
-
-**P3 — three subscription channels.** Every `useResource` subscribes
-to per-subject callbacks + `ResourceEvents.LocalChange` +
-`ResourceEvents.LoadingChange`. Same logical change → up to three
-re-renders. `proxyResource()` is an empty Proxy whose only role is
-to defeat `Object.is` so React re-renders — which kills
-`React.memo`, breaks `useEffect` deps, and reallocates per notify.
-
-**P4 — pending writes in three stores.** `Resource._pendingCommits`,
-`localStorage['atomic.offline.<subject>']`, and `Store.dirtyForSync`
-must stay in sync manually. `_lastLocalSignature` is in-memory only,
-so reload partially forgets the commit chain.
-
-**P5 — leader-election fragility.** Two contexts on one origin
-coordinate OPFS via `navigator.locks` + `BroadcastChannel` + a
-ping/announce handshake with a 5s timeout. Under dagger CPU
-pressure the handshake exceeds the budget and the second context
-dies silently (`role = 'failed'`, every RPC throws).
-
-**P6 — drive sync parallel to dirty drain.** On WS reconnect,
-`syncDirtyResources` (HTTP /commit drain) and `startVVSync` (WS
-SYNC_VV) run in sequence "by convention" but with no transactional
-boundary. A reconnect flap can run `syncDirtyResources` twice in
-parallel.
-
----
-
-## The unified design
-
-### Core idea: **one queue in, one queue out, one subscription channel**
-
-```
-                ┌──────────────────────────────────────────┐
-                │            ResourceCache                 │  in-memory
-                │   subject → Resource (one source of truth)│
-                └────────────┬─────────────────────────────┘
-                             │ snapshot
-                             ▼
-                ┌──────────────────────────────────────────┐
-                │          subscribeStore (USES)            │
-                │   useSyncExternalStore-style getSnapshot  │
-                └──────────────────────────────────────────┘
-       ▲                                                ▲
-       │ applyIncoming(...)                             │ enqueueOutbound(...)
-       │                                                │
-┌──────┴───────┐                              ┌─────────┴───────┐
-│  Inbox       │                              │  Outbox         │
-│  ────────    │                              │  ────────       │
-│  WS UPDATE   │                              │  local commits  │
-│  WS SYNC_*   │                              │  blob uploads   │
-│  HTTP fetch  │                              │                 │
-│  offline-replay (rehydrated from outbox)    │  one persisted  │
-└──────────────┘                              │  durable queue  │
-       │                                      └────────┬────────┘
-       │                                               │
-       ▼                                               ▼
-┌──────────────────────────────────────────┐    ┌──────────────┐
-│         OPFS Persistor (one file)         │    │  ws/http hub │
-│  putResource() = jsonAd + snapshot atomic │    └──────────────┘
-└──────────────────────────────────────────┘
-```
-
-Five components instead of "everything inside `Store`". Each has
-one responsibility and a small public surface.
-
----
-
-### S1: One ingress — `applyIncoming(change, source)`
-
-Replaces P1. Every code path that learns of a new
-authoritative-or-local version of a resource calls exactly:
-
-```ts
-type ChangeSource =
-  | 'ws-pending-get'   // response to our own GET
-  | 'ws-sub-push'      // subscription push from someone else
-  | 'ws-sync-push'     // drive sync delta
-  | 'http-fetch'       // GET via HTTP fallback
-  | 'local-pre-push'   // signed locally, not yet on server
-  | 'local-acked'      // server confirmed our commit
-  | 'offline-replay';  // rehydrated from outbox
-
-interface IncomingChange {
-  subject: string;            // already normalised
-  loroBytes?: Uint8Array;     // exclusive with jsonAd
-  jsonAd?: string;            //   (one wire format per source)
-  commitId: string;           // for dedup
-  source: ChangeSource;
-  receivedAt: number;
-}
-
-ResourceCache.applyIncoming(change: IncomingChange): void
-```
-
-The cache:
-1. Normalises subject (one place).
-2. Dedups by `commitId` against the existing resource's
-   `lastCommit` — replaces the four ad-hoc echo checks.
-3. Imports loro/jsonAd into the in-memory `Resource`.
-4. Schedules persistence via the OPFS Persistor (S2).
-5. Fires exactly one notification with `change.source` attached
-   so listeners can decide whether they care.
-
-**What dies**: `addResource`'s `skipCommitCompare` flag, the
-`isEcho` block in `websockets.ts:548`, the
-`_lastLocalSignature` rehydrate special-case, the
-"persistToClientDb at one specific call site" pattern.
-
-**Migration**: introduce `applyIncoming` alongside `addResource`,
-move the WS handlers over one Tag at a time, then `addResource`
-becomes a thin shim that calls `applyIncoming({ source:
-'http-fetch' })`. Delete when no callers remain.
-
----
-
-### S2: One persistence chokepoint — `OpfsPersistor`
-
-Replaces P2.
-
-> **Status (2026-07-07): the atomic-write core has effectively landed.**
-> `ClientDbWorker.putResourceWithSnapshot` is a single `postMessage` that
-> writes the JSON-AD index entry + the Loro snapshot in one serialised worker
-> op (then a synchronous `flush()` for offline durability — see the
-> local-cache durability fix in [`unified-sync.md`](./unified-sync.md)). Both
-> primary write paths already go through it: `resource.ts::persistToClientDb`
-> and `store.ts::addResource`. So the P2 "two round-trips, no atomic coupling"
-> risk is closed on the paths that mattered. **Still not done** (the formalizing
-> part of this section): there's no `OpfsPersistor` *class* — the atomic method
-> lives on `ClientDb` directly — and the bare `putResource`/`putLoroSnapshot`
-> worker ops remain public (still used for index-only seeding in
-> `initClientDb`/`devtools`). Making those private behind an `OpfsPersistor`
-> facade is the remaining, low-value cleanup; the correctness win is banked.
-
-```ts
-class OpfsPersistor {
-  // The ONLY way to write a resource. Both forms land atomically
-  // (worker queues guarantee ordering inside a single
-  // `putResource` message; transactions across keys are a future
-  // upgrade).
-  async putResource(args: {
-    subject: string;
-    jsonAd: string;          // for index/search
-    loroSnapshot: Uint8Array;// for CRDT replay
-  }): Promise<void>;
-
-  async putBlob(hash: Uint8Array, data: Uint8Array): Promise<void>;
-  async removeResource(subject: string): Promise<void>;
-  async getResourceWithSnapshot(subject: string): Promise<...>;
-}
-```
-
-The current `clientDb.putResource` and `clientDb.putLoroSnapshot`
-become private — only `OpfsPersistor` calls them, in the right
-order, in the same worker message. No caller of the data layer
-ever sees them.
-
-**What dies**: `WSClient.persistToClientDb`, the
-`putLoroSnapshot` call inside `applyPendingCommitsLocally`, the
-direct `clientDb.putResource` in `addResource`.
-
-**Migration**: change the worker protocol to accept a single
-`putResource` with both forms. Update the four call sites that
-write OPFS to go through `OpfsPersistor`. Worker keeps its
-serialised queue, so atomicity-within-message is automatic.
-
----
-
-### S3: One subscription model — `useSyncExternalStore`
-
-Replaces P3 + P4 (the `proxyResource` bit).
-
-```ts
-// react/src/useResource.ts
-export function useResource<T>(subject: string): Resource<T> {
-  const store = useStore();
-  return useSyncExternalStore(
-    store.subscribe.bind(store, subject),  // one subscribe
-    () => store.getSnapshot(subject),       // returns the same
-                                            //   instance until the
-                                            //   resource genuinely
-                                            //   changes
-  );
-}
-```
-
-The cache assigns a NEW `Resource` instance only when the
-underlying state changes (new commit applied, new property set,
-loading flipped). Same instance ⇒ React's identity check decides
-not to re-render. `React.memo`, `useEffect([resource])`,
-`useMemo([resource])` all work as expected.
-
-`useValue` and `useTitle` move to per-property subscriptions:
-
-```ts
-useValue(subject, property)  // subscribes to one (subject,property) key
-useTitle(subject)            // subscribes to (name|shortname|filename)
-```
-
-So a chatroom that reads 200 messages doesn't re-render when
-`message[42].name` changes — only that one row does.
-
-**What dies**: `proxyResource()`, the three-`useEffect` setup in
-`useResource`, the per-property `LocalChange` listener that exists
-to work around proxy identity. The `track` parameter on
-`useResource` becomes obsolete.
-
-**Migration**: implement `useSyncExternalStore`-based hooks
-behind a flag (`useResourceV2`), port the data-browser hot paths
-first (TableEditor, SidebarTree), measure with the perf trace,
-remove the old hooks once parity is reached.
-
----
-
-### S4: One outbox — `LocalOutbox`
-
-Replaces P4 fully.
-
-```ts
-interface OutboxEntry {
-  subject: string;
-  commits: Commit[];        // ordered, includes signature chain
-  blobs?: Array<{           // optional referenced blobs
-    hash: Uint8Array;
-    bytes: Uint8Array;
-  }>;
-  enqueuedAt: number;
-  lastAttemptAt?: number;
-  lastAttemptError?: string;
-}
-
-class LocalOutbox {
-  enqueue(entry: OutboxEntry): void;
-  // Drains the queue against the server. Idempotent — a
-  // re-entrance returns the in-flight promise instead of
-  // double-draining (S0 bug, fixed in 5c168355).
-  drain(): Promise<void>;
-  pending(): readonly OutboxEntry[];
-}
-```
-
-Persistence: one `localStorage['atomic.outbox']` JSON blob (or
-one OPFS file once we go multi-tab safely). One source of truth
-for "what hasn't been pushed yet".
-
-The `Resource` does **not** keep a post-sign queue. It owns only
-the local editable Loro doc, derived cache, and "dirty since last
-export" bookkeeping. Saving a resource exports a Loro update,
-wraps it in a signed commit certificate, and hands that certificate
-directly to `LocalOutbox`. After that point the outbox is the only
-owner of "this write still needs to reach the server".
-
-The outbox stores signed commits, not bare Loro bytes. The Loro
-bytes are the state transition, but the signed envelope is the
-authorization boundary: subject, signer, timestamp, signature,
-genesis/destroy flags, and optional audit metadata such as
-`previousCommit`. Re-signing raw bytes later would change the
-certificate and breaks DID genesis, retry idempotency, and
-debug/audit semantics.
-
-After `drain()` succeeds, the outbox entry is removed and
-`applyIncoming({source: 'local-acked'})` fires for the accepted
-resource state. Acceptance does not require the remote node to
-retain the commit as a retrievable resource; it only requires the
-node to verify and apply the signed certificate.
-
-**What dies**: `Store.dirtyForSync`, `localStorage['atomic.offline.*']`,
-`hydrateCommitLogFromOffline`, `Resource._pendingCommits`,
-`Resource.pushCommits`, the manual `_lastLocalSignature`
-rehydration in `signChanges`, and the local paths that materialize
-commit resources only so they can be drained later.
-
-**Migration**: first make the current outbox the durable source of
-truth while keeping the old methods as shims. Then move signing to
-write directly to the outbox instead of `_pendingCommits`. Then
-delete the parallel state stores and the Resource-owned drain path.
-
-#### Provenance: only a user edit may enqueue
-
-Under sign-at-drain the outbox holds a dirty bit, so "is this a write we
-should push?" is decided when a Loro op fires rather than when a commit is
-signed. That makes the *provenance* of every op load-bearing, and for a long
-time it was approximated by `store.isOwnedSubject(subject)` — a check that
-answers "same domain", not "may we write this". Every `did:ad:` subject
-passed it, including resources on other people's drives.
-
-The failure was not theoretical: merely OPENING a resource you can read but
-not write enqueued a commit for it. `getLoroDoc`'s heal pass writes propvals
-that arrived in the JSON-AD payload but are missing from the accompanying
-Loro snapshot, and `applyHydratedValues` writes a fetch response through a
-doc that already exists. Both are *hydration* — replaying state the server
-already has — but both produced local ops indistinguishable from typing. The
-resulting commits were rejected `Unauthorized` forever, retried through the
-whole backoff ladder, and then parked as blocked entries the user never
-asked for.
-
-The rule, enforced at the Loro boundary rather than by a subject-shape
-guess:
-
-> A local Loro change enqueues a write **only** if it is `by: 'local'` and
-> carries no `atomic:system` origin. Peer ops arrive as `by: 'import'`;
-> history scrubs as `by: 'checkout'`; every runtime housekeeping write —
-> hydration, heal, datatype tags, post-ack bookkeeping — is committed under
-> `SYSTEM_COMMIT_ORIGIN`.
-
-This also removes a slice of write amplification: healed propvals are no
-longer re-exported to the server that sent them.
-
-#### S4a: Resource save decomposition
-
-`browser/lib/src/resource.ts` is currently the knot: it holds the
-Loro doc, derived prop cache, validation, commit-building state,
-in-memory commit queue, offline persistence, post-ack blob upload,
-and store notification. The cleanup should split those jobs without
-changing the public `resource.save()` call.
-
-Target responsibilities:
-
-| Owner | Responsibility |
-| --- | --- |
-| `Resource` | Edit Loro state, rebuild derived cache, expose reads, track local dirty state. |
-| `signLoroCommit` helper | Build and sign one commit certificate from `{subject, loroUpdate, previousCommit, isGenesis, destroy}`. |
-| `LocalOutbox` | Own every signed commit after signing; persist, retry, classify terminal failures. |
-| `Store` / future `DriveSync` | Drain outbox, POST commits, apply acks, push referenced blobs. |
-| Optional audit layer | Materialize retained commit resources for commit detail/feed UI only. |
-
-Aight Concrete cleanup sequence:
-
-- [x] Add a pure browser signing helper alongside `CommitBuilder`
-      that signs a Loro update without storing mutable builder state
-      on `Resource`.
-- [ ] Change `Resource.save()` to export the current Loro delta,
-      call the helper, enqueue the signed commit in `store.outbox`,
-      persist local state for offline durability, and request a
-      drain when online.
-- [ ] Move post-ack work out of `Resource.pushCommits` into the
-      outbox drain path: set `lastCommit`, call
-      `applyIncoming({source: 'local-acked'})`, subscribe newly
-      created subjects, save batched children, and push referenced
-      blobs.
-- [ ] Delete `Resource._pendingCommits`, `setPendingCommits`,
-      `hasPendingCommits`, `_lastLocalSignature`, `pushCommits`,
-      `_drainPendingCommits`, `saveOffline`, and
-      `applyPendingCommitsLocally` after their behaviour exists in
-      the outbox/store path.
-- [ ] Shrink `CommitBuilder` to a compatibility/test helper, or
-      remove it from the browser public API if no downstream caller
-      needs it. The server-side Rust `CommitBuilder` can remain as a
-      separate legacy/native-resource builder until the Rust resource
-      API has its own cleanup pass.
-- [ ] Stop treating commit resources as required local state.
-      Continue to synthesize them only for pending/audit UI when the
-      UI explicitly needs `CommitDetail`; resource history must come
-      from the Loro oplog.
-
-Retry/save cursor invariants:
-
-- [ ] Do not repair `previousCommit` failures by clearing
-      `_loroVersionAtLastSave` to `undefined`. That turns a rejected
-      delta into a full snapshot export and mixes retry logic with
-      genesis/update detection, server-managed metadata, and unrelated
-      pending saves.
-- [ ] Treat a signed commit as immutable. If it was rejected because it
-      was built against stale metadata, discard that certificate and
-      re-sign from a known Loro export baseline; do not mutate and
-      retry the same signed object.
-- [ ] Persist the signed certificate to `LocalOutbox` before considering
-      the exported Loro version durable. Once the outbox owns it,
-      retrying is an outbox concern, not `Resource` state surgery.
-- [ ] Serialize per-resource saves around the outbox enqueue boundary so
-      two debounced saves cannot both sign against the same local export
-      cursor and then race each other through the retry path.
-- [ ] Long term: remove the browser `previousCommit` retry branch. Modern
-      servers do not use `previousCommit` as the causal validation gate;
-      Loro op IDs and the server causality guard do that work.
-
-Non-goals for this cleanup:
-
-- Do not remove signed commits from the transport. `COMMIT` remains
-  the write authorization boundary.
-- Do not make the outbox store only raw Loro updates. It must store
-  signed certificates.
-- Do not make commit retention decisions in the browser. Retention is
-  node policy; the browser should work whether accepted commits are
-  later retrievable or not.
-
----
-
-### S5: SharedWorker for OPFS — `OpfsCoordinator`
-
-Replaces P5.
-
-A single `SharedWorker` per origin owns the WASM DB and OPFS
-handle. Every browsing context (tab, iframe, e2e page2) connects
-to it via `MessagePort`. The browser handles lifecycle: when the
-last connection closes, the worker is reaped.
-
-No leader election. No `BroadcastChannel`. No 5s timeout. No
-"the leader tab unloaded, who's next" dance.
-
-```ts
-// Inside the SharedWorker
-self.onconnect = (event) => {
-  const port = event.ports[0];
-  port.onmessage = (msg) => routeRpc(msg.data, port);
-  // Each port is just another caller; the worker has one DB
-  // instance and serialises operations on its internal queue.
-};
-
-// In each tab
-const port = new SharedWorker('client-db.shared-worker.js').port;
-port.postMessage({ id, type: 'putResource', ... });
-```
-
-**What dies**: `client-db.ts`'s entire leader-election state
-machine (`Role`, `LEADERSHIP_TIMEOUT_MS`, `becomeLeader`,
-`handleBroadcast`, `leadershipGained`/`leaderObserved`). About
-200 lines.
-
-**Migration cost**: SharedWorker has minor browser differences
-from Worker (no `WorkerGlobalScope`, different module loading on
-Safari). Fastest path is a 1:1 conversion of the existing
-`client-db.worker.ts` + a small `SharedWorker` shell.
-
-**Caveat**: Some sandboxed contexts disallow SharedWorker (some
-extensions, certain iframes). Fallback: per-context Worker that
-talks directly to OPFS, no leader election needed because OPFS
-file locks are per-origin and the WASM DB itself can detect
-contention. That's still simpler than the current handshake.
-
----
-
-### S6: One sync orchestrator — `DriveSync`
-
-Replaces P6.
-
-The drive-sync state machine owns reconnect:
-
-```
-States: disconnected → authenticating → draining-outbox →
-        sending-vv → applying-diff → connected → (notify subscribers)
-
-On reconnect: enter `authenticating`. On AUTH_OK,
-  transition to `draining-outbox` (LocalOutbox.drain()).
-  Once empty, transition to `sending-vv`.
-  On SYNC_OK or SYNC_DIFF resolution, transition to `connected`.
-
-Re-entrance: if a flap interrupts mid-transition, the new
-  `connect` call observes the existing in-flight state and
-  joins it (analogous to S4's outbox.drain idempotency).
-```
-
-`syncDirtyResources` and `startVVSync` become internal steps of
-this state machine, not parallel operations. The dirty-drain
-race we fixed in `5c168355` is structurally impossible.
-
-**What dies**: `Store.startDriveSync`, `Store.finishDriveSync`,
-`Store.dirtySyncInProgress`, `Store.driveSyncInProgress`, the
-`Promise.race` of independent flags inside
-`getSyncStatus`. Replaced by one `driveSync.state` enum.
-
----
-
-## The shape of the new public API
-
-```ts
-import { Store, useResource, useChildren, useTitle } from '@tomic/lib';
-
-const store = new Store({ serverUrl, agent });
-
-// Reads
-useResource(subject)        // one subscription, one identity per change
-useTitle(subject)           // per-(name|shortname|filename) subscription
-useChildren(subject)        // collection-style, S1 ingress feeds it
-useArray(resource, prop)    // per-(subject,prop) subscription
-
-// Writes
-const r = await store.newResource(...)
-r.set(prop, value)          // local edit, dirty in-memory only
-await r.save()              // signs, enqueues to LocalOutbox, kicks DriveSync
-
-// Status
-store.driveSync.state       // one enum, replaces 5 boolean flags
-store.outbox.pending()      // canonical "what isn't pushed yet"
-```
-
-The **caller-visible** changes are mostly negative-space — the
-proxy weirdness and the multiple sync flags go away. The names
-mostly stay.
-
----
-
-## Migration order (smallest-blast-radius first)
-
-1. **`OpfsPersistor`** — ✅ *atomic-write core landed (2026-07-07):*
-   `putResourceWithSnapshot` is the single atomic worker op on both primary
-   write paths; the P2 correctness risk is closed. Only the `OpfsPersistor`
-   *class* facade + making `putResource`/`putLoroSnapshot` private remains, and
-   that's optional cleanup. (S2)
-2. **`LocalOutbox`** — ✅ *landed.* `local-outbox.ts` is the single durable
-   queue; `Store.dirtyForSync`, `atomic.dirtyForSync` and
-   `atomic.offline.<subject>` are gone. It diverged from the S4 sketch below
-   in one deliberate way: it queues **dirty subjects and signs at drain**
-   rather than storing signed commits (see the file header for why). That
-   divergence moved the "should this ever be pushed?" decision to the moment
-   a Loro op fires, which is what made **provenance** the load-bearing part —
-   see the provenance rule under S4. (S4)
-3. **Resource save decomposition** — ✅ *mostly landed.* `_pendingCommits`,
-   `pushCommits`, `_drainPendingCommits`, `setPendingCommits`,
-   `_lastLocalSignature` and `hydrateCommitLogFromOffline` no longer exist;
-   `hasPendingCommits` is now a thin delegate to `outbox.hasPending`. Still
-   open: shrinking `CommitBuilder` to a test helper (43 references), and the
-   `previousCommit` retry branch. (S4a)
-4. **`applyIncoming` chokepoint** — move WS handlers over one
-   Tag at a time, then HTTP fetch, then local-commit paths.
-   Each Tag move is independently testable. (S1)
-5. **`DriveSync` state machine** — once `applyIncoming` is the
-   only ingress, the orchestrator can be added without
-   surprising the rest of the code. (S6)
-6. **`useSyncExternalStore` hooks** — biggest perf win, biggest
-   surface area on `data-browser`. Do behind a flag. (S3)
-7. **SharedWorker** — last, because it touches the worker
-   protocol and needs cross-browser smoke tests. (S5)
-
-Each step is independently shippable. Steps 1 and 2 can land in
-the next two weeks without breaking any public API. Step 3 is
-the structural one — a few weeks of focused work. Steps 5 and 6
-are major-version-bump material.
-
----
-
-## What the four flake fixes from this session preview
-
-Every fix has been a localised version of one of these:
-
-| Commit | Fixes symptom of | Structural version |
-|---|---|---|
-| `5c168355` (pushCommits guard) | P1 + P4 (no shared lock across ingresses, queue split across stores) | S1 + S4 |
-| `73fecf18` (collection.ts refresh-init) | P1 (event path drops members while initial fetch is on a different path) | S1 |
-| `74f0834b` (leadership timeout 30s) | P5 (BroadcastChannel handshake fragility) | S5 |
-| `cc66e88e` (nextest filter `package()`) | unrelated (test infra) | n/a |
-
-Each was the right tactical fix; none addresses the underlying
-architecture. The proposal above closes the structural gap that
-keeps producing one of these per week.
+# Unified browser data layer
+
+> **Status: partial, reconciled 2026-09-11.** Atomic snapshot writes, the durable
+> outbox, unified ingress entry points, React subscription hooks, immutable read/save
+> snapshots and scheduled-save ownership have shipped. Remaining work is incremental
+> boundary extraction and consumer migration; broader worker/sync proposals are below.
+
+This is the browser cache/reactivity layer. The binding runtime is owned by
+[atomic-lib-runtime.md](./atomic-lib-runtime.md); transport and multi-device sync by
+[unified-sync.md](./unified-sync.md). The next small implementation slices are in
+[js-maintainability.md](./js-maintainability.md).
+
+## Current implementation
+
+### Ingress and causal state
+
+`Store.applyIncoming` is the source-aware ingress for resource objects and Loro
+bytes. `addResource` remains a public compatibility/merge path; its callers and
+notification/persistence behavior still need an audit before claiming that every
+producer uses exactly one path.
+
+Local hydration restores JSON and its Loro snapshot before publishing through
+`hydrateOfflineReplay`. It protects existing unsaved edits. Preserve that ordering
+and snapshot causality when extracting modules; JSON must not seed a competing
+fresh document before an authoritative snapshot is restored.
+
+### Persistence and the outbound queue
+
+`ClientDb.putResourceWithSnapshot` atomically writes JSON-AD plus the Loro snapshot
+through the worker. There is no separate `OpfsPersistor` class. Low-level index-only
+and snapshot operations remain available; a facade is optional cleanup, not an
+unimplemented atomicity fix.
+
+`LocalOutbox` holds dirty subjects and signs at drain time, with pre-signed genesis
+and destroy exceptions. It does **not** hold an ordered list of signed commits per
+resource. See [sign-at-drain.md](./sign-at-drain.md) for that decision. Do not restore
+the superseded signed-at-every-save queue design.
+
+Only user-origin local edits enqueue work. Imports, history checkouts and runtime
+housekeeping must retain their provenance; `SYSTEM_COMMIT_ORIGIN` prevents hydration
+or datatype maintenance from becoming unintended writes. Signed transport envelopes
+remain the authorization boundary. Retry and Loro export cursors must preserve edits
+that arrive during signing or an in-flight drain.
+
+The Resource-owned pending-commit queue and `pushCommits` machinery have been removed.
+`hasPendingCommits` delegates to the outbox; `saveOffline` still exists for local
+persistence. `CommitBuilder` remains in genesis/signing paths. Any further reduction
+must audit real callers and retry invariants rather than deleting methods from an
+old checklist. Browser commit history must not require every accepted envelope to
+remain fetchable as a resource; retention is node policy.
+
+### React and save ownership
+
+`Resource` stays a stable mutation handle. `Store.getResourceSnapshot` publishes an
+immutable outer snapshot; `useResourceSnapshot` reads status, while `useValue`,
+`useString`, `useArray` and other property hooks observe values. The property hooks
+combine store notifications with property-level local-change events. Replacing every
+Resource instance or deleting those listeners is not the accepted design.
+
+`Store.getSaveState(resource)` and `useSaveState(resource)` expose idle, dirty,
+scheduled, saving, queued and error states independently of loading/read errors.
+`ScheduledSave` owns debounce slots and in-flight completion; hooks and virtual table
+rows use `Store.createSaveScheduler`. Unmount flushes pending edits rather than
+silently discarding them. Legacy start/finish accounting also covers non-save writes.
+See [unify-resource-dirty-signals.md](./unify-resource-dirty-signals.md).
+
+## Remaining work
+
+- [ ] Extract Store save-status coordination behind the existing public API after
+  the focused UI and diagnostic cleanups in [js-maintainability.md](./js-maintainability.md).
+- [ ] Migrate additional rendered getters and bespoke save indicators with a failing
+  regression before each flow change. Keep read and persistence state separate.
+- [ ] Audit direct `addResource` producers before further ingress consolidation.
+  Preserve normalization, alias handling, echo imports/dedup, unsaved local state,
+  atomic persistence and notification ordering.
+- [ ] Review remaining Resource signing/retry responsibilities and `CommitBuilder`
+  consumers as a separate change. Preserve immutable signed envelopes and export
+  baselines; do not conflate queued writes with persisted local durability.
+- [ ] Evaluate whether a persistence facade removes meaningful duplication. Existing
+  atomic writes must remain intact; index-only seeding needs an explicit path.
+
+## Deferred proposals requiring separate decisions
+
+**One drive-sync orchestrator.** Authentication, outbox drain and reconciliation
+could share an explicit lifecycle. Connection-scoped cancellation already guards
+late work after reconnect; that does not mean a `DriveSync` class has shipped.
+Any orchestrator must handle offline/blocked outbox entries without preventing reads
+or reconciliation forever. The authoritative sync checklist stays in
+[unified-sync.md](./unified-sync.md).
+
+**SharedWorker ownership of OPFS.** A SharedWorker could reduce per-tab leader
+coordination, but it is not the current architecture. Validate browser, Tauri and
+sandbox support, worker shutdown, account isolation and lock ownership before
+choosing it. A per-context fallback must still coordinate exclusive OPFS access;
+file locks alone are not a demonstrated replacement for leader election. Retain
+existing cross-browser storage and multi-context tests during any migration.
+
+## Guardrails and evidence
+
+Keep stable public APIs and extract one responsibility at a time. No parallel
+property store, durable queue or sync engine should be introduced by a cleanup.
+Start regressions in Rust/JS units or real-server integration where possible, then
+use production Playwright for compiled subscriptions, multiple tabs, reload/offline
+persistence and rapid table entry. Coverage is tracked in
+[TESTING_COVERAGE.md](../TESTING_COVERAGE.md).

--- a/planning/unify-resource-dirty-signals.md
+++ b/planning/unify-resource-dirty-signals.md
@@ -1,5 +1,8 @@
 # Resource save state
 
+> **Status: partial, 2026-09-11.** Public API, scheduler and initial consumers shipped;
+> additional consumer migration and internal coordinator extraction remain.
+
 The browser exposes `Store.getSaveState(resource)` and `useSaveState(resource)` as
 immutable persistence snapshots. Read readiness stays in `useResourceSnapshot`;
 a queued offline edit can remain readable. Save kinds are idle, dirty, scheduled,
@@ -14,3 +17,9 @@ Remaining migration: other screens with bespoke saving UI can adopt the hook
 incrementally. Legacy global start/finish methods remain for compatibility and
 non-save pending writes such as deletion. The outbox remains the durable queue;
 this API derives state rather than keeping a second persistence engine.
+
+The data inspector now subscribes to this state; its production regression covers
+an offline edit and clearing the warning after reconnection. Next: PluginPage and
+extracting Store coordination behind the same public methods, as specified in
+[js-maintainability.md](./js-maintainability.md). `ScheduledSave` itself already
+exists; the extraction must not implement a second scheduler.


### PR DESCRIPTION
The JS planning documents still described save-state APIs as unimplemented and proposed replacing Resource identities and queueing signed commits at every save, contradicting the current implementation.

Add an incremental plan for PluginPage subscriptions, E2E diagnostic collectors, and extracting Store save-status coordination. Each slice has a checklist, boundaries, regression requirements, and acceptance criteria, with separate implementation PRs in that order.

Reconcile the planning index, structural audit, read/save-state notes, and E2E policy. Condense the outdated data-layer proposal into current behavior and explicit remaining work, retaining SharedWorker and sync orchestration as deferred decisions. PluginPage getters are identified as audit candidates, not confirmed bugs.

Documentation only. Verified relative file-link targets in all seven documents, checked for broken inbound links to removed section anchors, compared API and CI statements with source, and ran `git diff --check`. No runtime tests were needed.
