### PR TITLE
Fix PluginPage subscriptions and offline config saves

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -618,7 +618,7 @@ This does not yet prove restoration of the user's private staging workspace.
 
 ## Plugin UI sandbox and private assets
 
-- `browser/e2e/tests/plugin.spec.ts`: private plugin assets load through signed parent requests; custom rendering and RPC still work.
+- `browser/e2e/tests/plugin.spec.ts`: private plugin assets load through signed parent requests; custom rendering and RPC still work. The compiled PluginPage flow checks client metadata updates without replacing its mounted resource, active draft preservation, valid/invalid config, Save completion and offline save/reconnect persistence.
 - The bootstrap test opens the shell directly and verifies its server-enforced opaque origin, independently of iframe attributes.
 - `signout-signin-data.spec.ts` uses fresh persistent profiles on macOS WebKit because ephemeral contexts reject OPFS; these remain browser tests, not native Tauri acceptance.
 

--- a/browser/data-browser/src/views/Plugin/PluginPage.tsx
+++ b/browser/data-browser/src/views/Plugin/PluginPage.tsx
@@ -13,6 +13,7 @@ import {
   server,
   useCanWrite,
   useString,
+  useSaveState,
   useValue,
   type Server,
 } from '@tomic/react';
@@ -45,8 +46,14 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
   const [config, setConfig] = useValue(resource, server.properties.config);
   const [permissions] = useValue(resource, server.properties.pluginPermissions);
   const [configValid, setConfigValid] = useState(true);
+  const [configSyntaxValid, setConfigSyntaxValid] = useState(true);
+  const [configEdited, setConfigEdited] = useState(false);
   const title = `${namespace ? `${namespace}/` : ''}${name}`;
-  const parent = resource.props.parent;
+  const [version] = useString(resource, server.properties.version);
+  const [author] = useString(resource, server.properties.pluginAuthor);
+  const [description] = useString(resource, core.properties.description);
+  const [schema] = useValue(resource, server.properties.jsonSchema);
+  const saveState = useSaveState(resource);
 
   const { uninstallPlugin } = useCreatePlugin();
 
@@ -58,9 +65,9 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
         <div>
           <Row justify='space-between'>
             <PluginName>{title}</PluginName>
-            <span>v{resource.props.version}</span>
+            <span>v{version}</span>
           </Row>
-          <PluginAuthor>by {resource.props.pluginAuthor}</PluginAuthor>
+          <PluginAuthor>by {author}</PluginAuthor>
         </div>
         <Column>
           {canWrite && (
@@ -72,9 +79,9 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
               </Button>
             </Row>
           )}
-          {resource.props.description && (
+          {description && (
             <DescriptionWrapper aria-label='Plugin Description'>
-              <Markdown text={resource.props.description!} />
+              <Markdown text={description} />
             </DescriptionWrapper>
           )}
         </Column>
@@ -90,8 +97,18 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
               </Row>
             </h3>
             <Button
-              disabled={!configValid || !resource.hasUnsavedChanges()}
-              onClick={() => resource.save()}
+              disabled={
+                !configValid ||
+                !configSyntaxValid ||
+                saveState.kind === 'saving' ||
+                saveState.kind === 'scheduled' ||
+                (!configEdited && saveState.kind !== 'dirty')
+              }
+              onClick={() => {
+                setConfigEdited(false);
+
+                return resource.save();
+              }}
             >
               <FaFloppyDisk />
               <span>Save</span>
@@ -103,18 +120,18 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
             onChange={v => {
               try {
                 setConfig(JSON.parse(v));
+                setConfigEdited(true);
+                setConfigSyntaxValid(true);
               } catch (e) {
-                // Do nothing
+                setConfigSyntaxValid(false);
               }
             }}
-            schema={resource.props.jsonSchema as JSONSchema7}
+            schema={schema as JSONSchema7}
             showErrorStyling={!configValid}
             onValidationChange={setConfigValid}
           />
         </Column>
-        {resource.props.jsonSchema && (
-          <ConfigReference schema={resource.props.jsonSchema as JSONSchema7} />
-        )}
+        {schema && <ConfigReference schema={schema as JSONSchema7} />}
         {isPluginPermissions(permissions) && (
           <PluginPermissions permissions={permissions} />
         )}
@@ -126,6 +143,7 @@ export const PluginPage: React.FC<ResourcePageProps<Server.Plugin>> = ({
         confirmLabel='Uninstall'
         bindShow={setShowUninstallDialog}
         onConfirm={async () => {
+          const parent = resource.props.parent;
           await uninstallPlugin(resource);
           navigate(constructOpenURL(parent));
           toast.success('Plugin uninstalled');

--- a/browser/e2e/tests/plugin.spec.ts
+++ b/browser/e2e/tests/plugin.spec.ts
@@ -11,6 +11,7 @@ import {
   sidebarDriveButtonId,
   signIn,
   testFilePath,
+  waitForSynced,
 } from './test-utils';
 
 const BIRD =
@@ -19,7 +20,7 @@ const BIRD =
 test.describe('Plugins', () => {
   test.beforeEach(before);
 
-  test('install a plugin', async ({ page }) => {
+  test('install a plugin', async ({ page, context }) => {
     // Two upload + commit + plugin-install chains, a full bird-creation
     // form, an iframe-driven picker, plus a reload-and-verify. The test
     // routinely needs 40-50s on a dev machine even when nothing is wrong.
@@ -184,6 +185,92 @@ test.describe('Plugins', () => {
     // Plugins section state can collapse after reloads; expand it again.
     await page.getByRole('main').getByText('Plugins', { exact: true }).click();
     await page.getByRole('link', { name: 'ontola/test-plugin' }).click();
+
+    // Keep the mounted resource identity while changing metadata and saving config.
+    const saveConfig = page.getByRole('button', { name: 'Save', exact: true });
+    await expect(saveConfig).toBeDisabled();
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix":"Draft"}');
+    await expect(saveConfig).toBeEnabled();
+    await page.getByLabel('Config', { exact: true }).fill('{');
+    await expect(saveConfig).toBeDisabled();
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix":"Draft"}');
+    await expect(saveConfig).toBeEnabled();
+    await page.evaluate(async () => {
+      const subject = new URL(location.href).searchParams.get('subject')!;
+      const resource = window.store.getResourceLoading(subject);
+      await resource.set(
+        'https://atomicdata.dev/properties/version',
+        '1.0.1',
+        false,
+      );
+      await resource.set(
+        'https://atomicdata.dev/properties/pluginAuthor',
+        'Updated author',
+        false,
+      );
+      await resource.set(
+        'https://atomicdata.dev/properties/description',
+        'Updated description',
+        false,
+      );
+    });
+    await expect(page.getByText('v1.0.1', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText('by Updated author', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByLabel('Plugin Description')).toHaveText(
+      'Updated description',
+    );
+    await expect(page.getByLabel('Config', { exact: true })).toContainText(
+      'Draft',
+    );
+    await saveConfig.click();
+    await expect(saveConfig).toBeDisabled();
+    await waitForSynced(page);
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix": 5}');
+    await expect(saveConfig).toBeDisabled();
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix":"Final"}');
+    await expect(saveConfig).toBeEnabled();
+    await saveConfig.click();
+    await expect(saveConfig).toBeDisabled();
+    await waitForSynced(page);
+
+    await page.evaluate(() => window.store.disconnect());
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.store.getSyncStatus().serverConnected),
+      )
+      .toBe(false);
+    await context.setOffline(true);
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix":"Offline"}');
+    await expect(saveConfig).toBeEnabled();
+    await saveConfig.click();
+    await expect(saveConfig).toBeDisabled();
+    // A queued save must not prevent saving a later offline draft.
+    await page
+      .getByLabel('Config', { exact: true })
+      .fill('{"folderPrefix":"Offline latest"}');
+    await expect(saveConfig).toBeEnabled();
+    await saveConfig.click();
+    await expect(saveConfig).toBeDisabled();
+    await context.setOffline(false);
+    await page.evaluate(() => window.store.reconnect());
+    await waitForSynced(page);
+    await page.reload();
+    await expect(page.getByLabel('Config', { exact: true })).toContainText(
+      'Offline latest',
+    );
+    await expect(saveConfig).toBeDisabled();
 
     // Uninstall the plugin
     await page.getByRole('button', { name: 'Uninstall' }).click();

--- a/planning/README.md
+++ b/planning/README.md
@@ -63,7 +63,7 @@ browser flow; standalone recovery remains self-managed.
 | [`content-i18n.md`](./content-i18n.md) | **LocalizedText + template locales shipped.** Remaining: TranslationsBar, `useTranslation`, `/query` `lang`, search language filter. |
 | [`website-templates.md`](./website-templates.md) | Template repair complete (DID). Remaining CMS product: drafts-from-site, i18n tooling, canonical paths. |
 | [`structural-problems-index.md`](./structural-problems-index.md) | **Live index.** React subscription audit is partial; save-state APIs shipped. Browser metadata cleanup and subject-brand consumers remain; server subscription work is complete. |
-| [`js-maintainability.md`](./js-maintainability.md) | **Planned.** PluginPage subscriptions, diagnostic collector lifecycles, then Store save-status coordination; three separately validated PRs. |
+| [`js-maintainability.md`](./js-maintainability.md) | **In progress.** PluginPage subscriptions implemented; diagnostic collector lifecycles and Store save-status coordination remain. |
 | [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Partial.** Immutable read/save status hooks and the data-inspector subscription shipped; remaining render-time property getters need incremental regression-driven migration. |
 | [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md) | Phase A + C landed (browser). Phase B (Flutter action-stack removal) open. |
 | [`index-performance.md`](./index-performance.md) | First tranche shipped. Structural permission-check fix is `zones.md`, not built. |

--- a/planning/js-maintainability.md
+++ b/planning/js-maintainability.md
@@ -1,7 +1,7 @@
 # JavaScript maintainability follow-ups
 
-> **Status: planned, 2026-09-11.** None of the three refactors below is implemented
-> by this document. Baseline: `develop` at `6045bff3a`, following PRs
+> **Status: in progress, 2026-09-11.** PluginPage subscriptions are implemented;
+> diagnostic collectors and Store coordination remain. Baseline: `develop` at `6045bff3a`, following PRs
 > [#1450](https://github.com/ontola/atomic-server/pull/1450) and
 > [#1451](https://github.com/ontola/atomic-server/pull/1451).
 
@@ -26,23 +26,32 @@ in [unified-data-layer.md](./unified-data-layer.md),
 ## 1. PluginPage subscriptions
 
 Start in [PluginPage.tsx](../browser/data-browser/src/views/Plugin/PluginPage.tsx).
-Name, namespace, config and permissions already use hooks. Version, author,
-description, JSON schema and parent still come from `resource.props`; the Save
-button reads `hasUnsavedChanges()` during render. These are audit candidates,
-not individually confirmed bugs.
+Version, author, description and JSON schema now use property hooks; Save uses
+`useSaveState`. Parent is read when uninstall starts, before destruction. The
+production regression reproduced valid config leaving Save disabled on the
+previous implementation. JSONEditor keeps its mounted draft; metadata changes
+do not reset it. Save enables for valid dirty state or a new config edit since the previous Save,
+including a later offline draft. In-flight and scheduled saves stay disabled;
+a queued/failed write alone does not enable another Save. A separate attempted real plugin-update regression still showed the old version
+on the updating client after refresh. Manifest metadata is GET enrichment; its
+interaction with Loro hydration and cross-client invalidation needs investigation
+in a separate change. The retained test mutates the mounted client resource and
+verifies metadata subscriptions and preservation of an active config draft.
 
-- [ ] Reproduce a stale render or Save-button transition while retaining the same
+- [x] Reproduce a stale render or Save-button transition while retaining the same
   Resource object. Use the cheapest failing layer; verify compiler behavior in a
   production Playwright build when a helper/unit test cannot exercise it.
-- [ ] Replace rendered scalar reads with `useString` and structured reads with
+- [x] Replace rendered scalar reads with `useString` and structured reads with
   `useValue`; use the existing save-state subscription for persistence status.
-- [ ] Define the Save-button policy explicitly: invalid JSON cannot save; in-flight
+- [x] Define the Save-button policy explicitly: invalid JSON cannot save; in-flight
   saving cannot submit twice; queued/offline/failed writes remain distinguishable
   from new unsaved config. Do not assume every non-idle state should enable Save.
-- [ ] Check `JSONEditor`'s `initialValue` behavior before changing schema/config
+- [x] Check `JSONEditor`'s `initialValue` behavior before changing schema/config
   subscriptions. A remote update must not reset an active local edit.
-- [ ] Verify remote metadata updates, valid/invalid config, save completion and
-  offline retry. Keep uninstall/update permissions unchanged.
+- [x] Verify client metadata updates, valid/invalid config, save completion and
+  repeated offline saves. Keep uninstall/update permissions unchanged.
+- [ ] Follow up on remote manifest metadata refresh in `react-compiler-resource-proxy.md`;
+  the real Update flow did not display its new version on the updating client.
 
 Acceptance: the reproduced failure passes without a compiler opt-out or replacing
 Resource identity. Limit the PR to this flow; event-handler reads need not become

--- a/planning/react-compiler-resource-proxy.md
+++ b/planning/react-compiler-resource-proxy.md
@@ -33,6 +33,16 @@ render-time property getters incrementally, with a reproduced stale-UI test
 before migrating each flow. Saving/outbox state is separate from read readiness;
 see `unify-resource-dirty-signals.md`.
 
-Next bounded slice: PluginPage metadata and Save-button subscriptions, with a
-reproduction before migration. Its checklist and delivery order live in
+PluginPage now subscribes to metadata and save status. A production test reproduced
+valid config leaving Save disabled and covers save completion, client metadata updates,
+draft preservation and offline recovery. Remaining JS work lives in
 [js-maintainability.md](./js-maintainability.md).
+
+### Plugin manifest metadata follow-up
+
+- [ ] Investigate real plugin Update leaving the old version on the updating client
+  after refresh (observed during the subscription work). `on_resource_get` enriches
+  manifest fields in `server/src/plugins/plugin.rs`; check how the response and
+  Loro snapshot are reconciled before deciding where metadata should be persisted.
+- [ ] Add a real two-client plugin-update regression, including active config drafts.
+  Client-store mutation coverage alone does not verify remote manifest refresh.


### PR DESCRIPTION
Valid edits in the compiled Plugin page could leave Save disabled because it read mutable resource state during render. Subscribe to save status and rendered metadata, and track config edits made since the last Save so a later offline draft remains saveable while an earlier write is queued.

The production regression covers valid/invalid config, client metadata updates without remounting, draft preservation, save completion, repeated offline saves and reload persistence. Existing install, custom-view and uninstall checks remain in the flow. Workspace typecheck and lint pass.

An attempted real remote plugin-update check exposed a separate manifest metadata refresh issue (old version remains after Update). Record that explicitly in planning; this PR does not claim remote manifest propagation is fixed.

Scope: this is the legacy WASM PluginPage, which remains on `feat/plugin-model` (#1307). That branch's separate `chunks/PluginRuns/PluginPage` is not changed or validated here. The legacy component and E2E spec merge cleanly in a three-way file check; this is not a full integration test of #1307.
