### PR TITLE
Extract E2E diagnostic collectors with explicit cleanup

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -737,7 +737,9 @@ check; real refresh/query timing remains a browser acceptance check.
 ## CI quality and failure evidence
 
 - `failure-state.spec.ts` checks bounded failure metadata and omission of resource
-  values and signed payloads. The diagnostic fixture attaches this before closing pages.
+  values and signed payloads, including real WebSocket metadata retained after page close.
+- `collector-lifecycle.spec.ts` checks idempotent start/disposal, detached context/page/socket
+  listeners, stable captured evidence, exact expectations and the 30-frame metadata cap.
 - CI lint uses installed sources without JS/WASM builds; feature-branch pushes cancel
   superseded runs while develop and tags retain completed validation for deployment.
 

--- a/browser/e2e/tests/collector-lifecycle.spec.ts
+++ b/browser/e2e/tests/collector-lifecycle.spec.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events';
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+import { DiagnosticCollector } from './diagnostic-collector';
+import { TransportCollector } from './transport-collector';
+
+function surfaces() {
+  const page = new EventEmitter();
+  const context = Object.assign(new EventEmitter(), { pages: () => [page] });
+
+  return {
+    page,
+    context,
+    browserContext: context as unknown as BrowserContext,
+  };
+}
+
+const warning = (text: string) => ({
+  type: () => 'warning',
+  text: () => text,
+  location: () => ({ url: 'https://example.test/' }),
+});
+
+test('diagnostic collector start and disposal are idempotent and preserve snapshots', () => {
+  const { context, browserContext } = surfaces();
+  const collector = new DiagnosticCollector();
+  collector.expect(
+    'warning',
+    /^Expected$/g,
+    'Exercise lifecycle',
+    2,
+    /example/g,
+  );
+  collector.start(browserContext);
+  collector.start(browserContext);
+  context.emit('console', warning('Expected'));
+  const first = collector.snapshot();
+  expect(first.entries).toHaveLength(1);
+  expect(first.missing[0].seen).toBe(1);
+  collector.dispose();
+  collector.dispose();
+  expect(context.listenerCount('console')).toBe(0);
+  expect(context.listenerCount('weberror')).toBe(0);
+  context.emit('console', warning('Detached'));
+  expect(collector.snapshot()).toEqual(first);
+  collector.start(browserContext);
+  context.emit('console', warning('Expected'));
+  context.emit('console', warning('Expected'));
+  const last = collector.snapshot();
+  expect(last.missing).toEqual([]);
+  expect(last.unexpected).toHaveLength(1);
+  expect(first.entries).toHaveLength(1);
+  expect(first.missing[0].seen).toBe(1);
+  collector.dispose();
+});
+
+test('transport collector bounds metadata and detaches context, page and socket listeners', () => {
+  const { context, page, browserContext } = surfaces();
+  const collector = new TransportCollector();
+  const socket = new EventEmitter();
+  collector.start(browserContext);
+  collector.start(browserContext);
+  page.emit('websocket', socket);
+
+  for (let i = 0; i < 40; i++) {
+    socket.emit('framesent', { payload: 'DO_NOT_ATTACH' });
+  }
+
+  const handle = page as unknown as Page;
+  expect(collector.snapshot(handle)).toHaveLength(30);
+  expect(JSON.stringify(collector.snapshot(handle))).not.toContain(
+    'DO_NOT_ATTACH',
+  );
+  expect(socket.listenerCount('framesent')).toBe(1);
+  socket.emit('close');
+  expect(socket.listenerCount('framesent')).toBe(0);
+  expect(socket.listenerCount('framereceived')).toBe(0);
+  expect(socket.listenerCount('close')).toBe(0);
+  expect(collector.snapshot(handle).at(-1)?.direction).toBe('closed');
+  const liveSocket = new EventEmitter();
+  page.emit('websocket', liveSocket);
+  page.emit('close');
+  const evidence = collector.snapshot(handle);
+  expect(collector.pages()).toContain(handle);
+  collector.dispose();
+  collector.dispose();
+  expect(context.listenerCount('page')).toBe(0);
+  expect(page.listenerCount('websocket')).toBe(0);
+
+  for (const event of ['framesent', 'framereceived', 'close']) {
+    expect(liveSocket.listenerCount(event)).toBe(0);
+  }
+
+  liveSocket.emit('framesent', { payload: 'Detached' });
+  expect(collector.snapshot(handle)).toEqual(evidence);
+  collector.start(browserContext);
+  expect(page.listenerCount('websocket')).toBe(1);
+  collector.dispose();
+});

--- a/browser/e2e/tests/diagnostic-collector.ts
+++ b/browser/e2e/tests/diagnostic-collector.ts
@@ -1,0 +1,112 @@
+import type {
+  BrowserContext,
+  ConsoleMessage,
+  WebError,
+} from '@playwright/test';
+
+export type DiagnosticKind = 'warning' | 'error' | 'pageerror';
+type Entry = {
+  kind: DiagnosticKind;
+  message: string;
+  url: string;
+  expected: boolean;
+};
+type Expected = {
+  kind: DiagnosticKind;
+  message: RegExp;
+  reason: string;
+  count: number;
+  seen: number;
+  url?: RegExp;
+};
+
+/** Per-test expectations, with no global allowlist. Disposal preserves evidence. */
+export class DiagnosticCollector {
+  private entries: Entry[] = [];
+  private expected: Expected[] = [];
+  private contexts = new Map<BrowserContext, () => void>();
+
+  expect(
+    kind: DiagnosticKind,
+    message: RegExp,
+    reason: string,
+    count = 1,
+    url?: RegExp,
+  ): void {
+    if (!reason.trim() || !Number.isInteger(count) || count < 1) {
+      throw new Error(
+        'Expected diagnostics require a reason and a positive integer count',
+      );
+    }
+
+    this.expected.push({ kind, message, reason, count, url, seen: 0 });
+  }
+
+  start(context: BrowserContext): void {
+    if (this.contexts.has(context)) return;
+
+    const onConsole = (message: ConsoleMessage) => {
+      const kind = message.type();
+
+      if (kind === 'warning' || kind === 'error') {
+        this.record({
+          kind,
+          message: message.text(),
+          url: message.location().url,
+        });
+      }
+    };
+
+    const onError = (event: WebError) => {
+      this.record({
+        kind: 'pageerror',
+        message: event.error().stack ?? event.error().message,
+        url: event.page()?.url() ?? '',
+      });
+    };
+
+    context.on('console', onConsole);
+    context.on('weberror', onError);
+    this.contexts.set(context, () => {
+      context.off('console', onConsole);
+      context.off('weberror', onError);
+    });
+  }
+
+  private record(entry: Omit<Entry, 'expected'>): void {
+    const match = this.expected.find(rule => {
+      rule.message.lastIndex = 0;
+      if (rule.url) rule.url.lastIndex = 0;
+
+      return (
+        rule.kind === entry.kind &&
+        rule.seen < rule.count &&
+        rule.message.test(entry.message) &&
+        (!rule.url || rule.url.test(entry.url))
+      );
+    });
+    if (match) match.seen++;
+    this.entries.push({ ...entry, expected: !!match });
+  }
+
+  snapshot() {
+    const entries = this.entries.map(entry => ({ ...entry }));
+    const expectations = this.expected.map(rule => ({
+      ...rule,
+      message: rule.message.source,
+      url: rule.url?.source,
+    }));
+
+    return {
+      entries,
+      expectations,
+      unexpected: entries.filter(entry => !entry.expected),
+      missing: expectations.filter(rule => rule.seen !== rule.count),
+    };
+  }
+
+  dispose(): void {
+    this.contexts.forEach(cleanup => cleanup());
+    this.contexts.clear();
+  }
+}

--- a/browser/e2e/tests/failure-state.spec.ts
+++ b/browser/e2e/tests/failure-state.spec.ts
@@ -41,48 +41,53 @@ test('failure state is bounded and excludes values and signed payloads', async (
   expect(JSON.stringify(state)).not.toContain('DO_NOT_ATTACH');
 });
 
-test('failure attachments retain transport metadata without frame payloads', async ({
-  page,
-}) => {
-  test.fail(
-    true,
-    'The synthetic warning triggers diagnostic attachment teardown',
-  );
-  const server = createServer();
-  const sockets = new Set<Duplex>();
-  server.on('upgrade', (request, socket) => {
-    sockets.add(socket);
-    const accept = createHash('sha1')
-      .update(
-        `${request.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
-      )
-      .digest('base64');
-    socket.write(
-      `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+for (const closePage of [false, true]) {
+  test(`failure attachments retain transport metadata without frame payloads (closed=${closePage})`, async ({
+    page,
+  }) => {
+    test.fail(
+      true,
+      'The synthetic warning triggers diagnostic attachment teardown',
     );
-    const payload = Buffer.from('DO_NOT_ATTACH');
-    socket.write(Buffer.concat([Buffer.from([0x81, payload.length]), payload]));
+    const server = createServer();
+    const sockets = new Set<Duplex>();
+    server.on('upgrade', (request, socket) => {
+      sockets.add(socket);
+      const accept = createHash('sha1')
+        .update(
+          `${request.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
+        )
+        .digest('base64');
+      socket.write(
+        `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+      );
+      const payload = Buffer.from('DO_NOT_ATTACH');
+      socket.write(
+        Buffer.concat([Buffer.from([0x81, payload.length]), payload]),
+      );
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('Missing test socket');
+
+    try {
+      await page.evaluate(async port => {
+        await new Promise<void>(resolve => {
+          const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+          socket.onopen = () => socket.send('DO_NOT_ATTACH');
+
+          socket.onmessage = () => {
+            console.warn('Synthetic transport failure');
+            socket.close();
+            resolve();
+          };
+        });
+      }, address.port);
+      if (closePage) await page.close();
+    } finally {
+      sockets.forEach(socket => socket.destroy());
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
   });
-  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  if (!address || typeof address === 'string')
-    throw new Error('Missing test socket');
-
-  try {
-    await page.evaluate(async port => {
-      await new Promise<void>(resolve => {
-        const socket = new WebSocket(`ws://127.0.0.1:${port}`);
-        socket.onopen = () => socket.send('DO_NOT_ATTACH');
-
-        socket.onmessage = () => {
-          console.warn('Synthetic transport failure');
-          socket.close();
-          resolve();
-        };
-      });
-    }, address.port);
-  } finally {
-    sockets.forEach(socket => socket.destroy());
-    await new Promise<void>(resolve => server.close(() => resolve()));
-  }
-});
+}

--- a/browser/e2e/tests/fixtures.ts
+++ b/browser/e2e/tests/fixtures.ts
@@ -1,96 +1,27 @@
-import {
-  test as base,
-  expect,
-  type BrowserContext,
-  type Page,
-} from '@playwright/test';
+import { test as base, expect, type BrowserContext } from '@playwright/test';
 
 import { collectFailureState } from './failure-state';
+import { DiagnosticCollector } from './diagnostic-collector';
+import { TransportCollector } from './transport-collector';
 
 export * from '@playwright/test';
 
-type Kind = 'warning' | 'error' | 'pageerror';
-type Entry = { kind: Kind; message: string; url: string };
-type Expected = {
-  kind: Kind;
-  message: RegExp;
-  reason: string;
-  count: number;
-  seen: number;
-  url?: RegExp;
-};
-
 /** No global allowlist: expected failures belong to the test that causes them. */
 export const test = base.extend<{
-  browserDiagnostics: {
-    expect: (
-      kind: Kind,
-      message: RegExp,
-      reason: string,
-      count?: number,
-      url?: RegExp,
-    ) => void;
-  };
+  browserDiagnostics: Pick<DiagnosticCollector, 'expect'>;
 }>({
   browserDiagnostics: [
     async ({ browser, context: defaultContext }, use, testInfo) => {
-      const entries: (Entry & { expected: boolean })[] = [];
-      const expected: Expected[] = [];
-      const cleanups: (() => void)[] = [];
+      const diagnostics = new DiagnosticCollector();
+      const transport = new TransportCollector();
       const watched = new Set<BrowserContext>();
       const ownedContexts = new Set<BrowserContext>();
-      const transportEvents = new Map<Page, unknown[]>();
-
-      const watchPage = (page: Page) => {
-        if (transportEvents.has(page)) return;
-        const events: unknown[] = [];
-        transportEvents.set(page, events);
-
-        const recordFrame = (direction: string, payload: string | Buffer) => {
-          events.push({
-            at: Date.now(),
-            direction,
-            bytes: Buffer.byteLength(payload),
-            tag: typeof payload === 'string' ? 'text' : payload[0],
-          });
-          if (events.length > 30) events.shift();
-        };
-
-        const onSocket = (socket: import('@playwright/test').WebSocket) => {
-          // Payloads can contain signed edits or authentication. Keep only frame metadata.
-          socket.on('framesent', ({ payload }) => recordFrame('sent', payload));
-          socket.on('framereceived', ({ payload }) =>
-            recordFrame('received', payload),
-          );
-          socket.on('close', () => recordFrame('closed', ''));
-        };
-
-        page.on('websocket', onSocket);
-        cleanups.push(() => page.off('websocket', onSocket));
-      };
-
-      const record = (entry: Entry) => {
-        const match = expected.find(rule => {
-          rule.message.lastIndex = 0;
-          if (rule.url) rule.url.lastIndex = 0;
-
-          return (
-            rule.kind === entry.kind &&
-            rule.seen < rule.count &&
-            rule.message.test(entry.message) &&
-            (!rule.url || rule.url.test(entry.url))
-          );
-        });
-        if (match) match.seen++;
-        entries.push({ ...entry, expected: !!match });
-      };
 
       const watch = async (context: BrowserContext) => {
         if (watched.has(context)) return;
         watched.add(context);
-        context.pages().forEach(watchPage);
-        context.on('page', watchPage);
-        cleanups.push(() => context.off('page', watchPage));
+        diagnostics.start(context);
+        transport.start(context);
 
         // General UI tests use an empty discovery room, independent of public
         // service availability. verify-peer-mesh.mjs separately exercises real
@@ -110,29 +41,6 @@ export const test = base.extend<{
             });
           },
         );
-
-        const onConsole = (msg: import('@playwright/test').ConsoleMessage) => {
-          const kind = msg.type();
-
-          if (kind === 'warning' || kind === 'error') {
-            record({ kind, message: msg.text(), url: msg.location().url });
-          }
-        };
-
-        const onError = (event: import('@playwright/test').WebError) => {
-          record({
-            kind: 'pageerror',
-            message: event.error().stack ?? event.error().message,
-            url: event.page()?.url() ?? '',
-          });
-        };
-
-        context.on('console', onConsole);
-        context.on('weberror', onError);
-        cleanups.push(() => {
-          context.off('console', onConsole);
-          context.off('weberror', onError);
-        });
       };
 
       // Depend on context so assertions run BEFORE Playwright closes it. The
@@ -148,32 +56,40 @@ export const test = base.extend<{
         return context;
       };
 
-      await watch(defaultContext);
-      await Promise.all(browser.contexts().map(watch));
-
       try {
+        await watch(defaultContext);
+        await Promise.all(browser.contexts().map(watch));
         await use({
-          expect(kind, message, reason, count = 1, url) {
-            if (!reason.trim() || !Number.isInteger(count) || count < 1) {
-              throw new Error(
-                'Expected diagnostics require a reason and a positive integer count',
-              );
-            }
-
-            expected.push({ kind, message, reason, count, url, seen: 0 });
-          },
+          expect: (...args) => diagnostics.expect(...args),
         });
       } finally {
         browser.newContext = newContext;
-        cleanups.forEach(cleanup => cleanup());
-        const unexpected = entries.filter(entry => !entry.expected);
-        const missing = expected.filter(rule => rule.seen !== rule.count);
+        diagnostics.dispose();
+        transport.dispose();
+        const { entries, expectations, unexpected, missing } =
+          diagnostics.snapshot();
 
         if (
           testInfo.status !== testInfo.expectedStatus ||
           unexpected.length ||
           missing.length
         ) {
+          const closedPages = transport
+            .pages()
+            .filter(page => page.isClosed())
+            .slice(0, 5);
+
+          if (closedPages.length) {
+            await testInfo.attach('closed-page-transports', {
+              body: JSON.stringify(
+                closedPages.map(page => ({
+                  transportEvents: transport.snapshot(page),
+                })),
+              ),
+              contentType: 'application/json',
+            });
+          }
+
           for (const [index, page] of [...watched]
             .flatMap(c => c.pages())
             .slice(0, 5)
@@ -193,7 +109,7 @@ export const test = base.extend<{
               ]);
               await testInfo.attach(`failure-state-${index}`, {
                 body: JSON.stringify(
-                  { state, transportEvents: transportEvents.get(page) ?? [] },
+                  { state, transportEvents: transport.snapshot(page) },
                   null,
                   2,
                 ),
@@ -209,18 +125,18 @@ export const test = base.extend<{
 
         // Match Playwright's default-context teardown for extra test-owned
         // contexts. Otherwise their live tabs leak into the next test.
-        await Promise.all([...ownedContexts].map(context => context.close()));
+        await Promise.all(
+          [...ownedContexts].map(context =>
+            context.close().catch(() => undefined),
+          ),
+        );
 
-        if (entries.length || expected.length) {
+        if (entries.length || expectations.length) {
           await testInfo.attach('browser-diagnostics', {
             body: JSON.stringify(
               {
                 entries,
-                expectations: expected.map(rule => ({
-                  ...rule,
-                  message: rule.message.source,
-                  url: rule.url?.source,
-                })),
+                expectations,
               },
               null,
               2,

--- a/browser/e2e/tests/transport-collector.ts
+++ b/browser/e2e/tests/transport-collector.ts
@@ -1,0 +1,87 @@
+import type { BrowserContext, Page, WebSocket } from '@playwright/test';
+
+type FrameMetadata = {
+  at: number;
+  direction: 'sent' | 'received' | 'closed';
+  bytes: number;
+  tag: number | 'text' | undefined;
+};
+
+/** Retains bounded frame metadata, including closed pages, never frame contents. */
+export class TransportCollector {
+  private events = new Map<Page, FrameMetadata[]>();
+  private contexts = new Set<BrowserContext>();
+  private watchedPages = new Set<Page>();
+  private cleanups = new Set<() => void>();
+
+  start(context: BrowserContext): void {
+    if (this.contexts.has(context)) return;
+    this.contexts.add(context);
+    const watchPage = (page: Page) => this.watchPage(page);
+    context.pages().forEach(watchPage);
+    context.on('page', watchPage);
+    this.cleanups.add(() => context.off('page', watchPage));
+  }
+
+  private watchPage(page: Page): void {
+    if (this.watchedPages.has(page)) return;
+    this.watchedPages.add(page);
+    if (!this.events.has(page)) this.events.set(page, []);
+
+    const record = (
+      direction: FrameMetadata['direction'],
+      payload: string | Buffer,
+    ) => {
+      const events = this.events.get(page)!;
+      events.push({
+        at: Date.now(),
+        direction,
+        bytes: Buffer.byteLength(payload),
+        tag: typeof payload === 'string' ? 'text' : payload[0],
+      });
+      if (events.length > 30) events.shift();
+    };
+
+    const onSocket = (socket: WebSocket) => {
+      const sent = ({ payload }: { payload: string | Buffer }) =>
+        record('sent', payload);
+      const received = ({ payload }: { payload: string | Buffer }) =>
+        record('received', payload);
+
+      const cleanup = () => {
+        socket.off('framesent', sent);
+        socket.off('framereceived', received);
+        socket.off('close', closed);
+        this.cleanups.delete(cleanup);
+      };
+
+      const closed = () => {
+        record('closed', '');
+        cleanup();
+      };
+
+      socket.on('framesent', sent);
+      socket.on('framereceived', received);
+      socket.on('close', closed);
+      this.cleanups.add(cleanup);
+    };
+
+    page.on('websocket', onSocket);
+    this.cleanups.add(() => page.off('websocket', onSocket));
+  }
+
+  snapshot(page: Page): FrameMetadata[] {
+    return (this.events.get(page) ?? []).map(event => ({ ...event }));
+  }
+
+  pages(): Page[] {
+    return [...this.events.keys()];
+  }
+
+  dispose(): void {
+    this.cleanups.forEach(cleanup => cleanup());
+    this.cleanups.clear();
+    this.contexts.clear();
+    this.watchedPages.clear();
+  }
+}

--- a/planning/README.md
+++ b/planning/README.md
@@ -63,7 +63,7 @@ browser flow; standalone recovery remains self-managed.
 | [`content-i18n.md`](./content-i18n.md) | **LocalizedText + template locales shipped.** Remaining: TranslationsBar, `useTranslation`, `/query` `lang`, search language filter. |
 | [`website-templates.md`](./website-templates.md) | Template repair complete (DID). Remaining CMS product: drafts-from-site, i18n tooling, canonical paths. |
 | [`structural-problems-index.md`](./structural-problems-index.md) | **Live index.** React subscription audit is partial; save-state APIs shipped. Browser metadata cleanup and subject-brand consumers remain; server subscription work is complete. |
-| [`js-maintainability.md`](./js-maintainability.md) | **In progress.** PluginPage subscriptions implemented; diagnostic collector lifecycles and Store save-status coordination remain. |
+| [`js-maintainability.md`](./js-maintainability.md) | **In progress.** PluginPage subscriptions and diagnostic collectors implemented; Store save-status coordination remains. |
 | [`react-compiler-resource-proxy.md`](./react-compiler-resource-proxy.md) | **Partial.** Immutable read/save status hooks and the data-inspector subscription shipped; remaining render-time property getters need incremental regression-driven migration. |
 | [`canvas-undo-consolidation.md`](./canvas-undo-consolidation.md) | Phase A + C landed (browser). Phase B (Flutter action-stack removal) open. |
 | [`index-performance.md`](./index-performance.md) | First tranche shipped. Structural permission-check fix is `zones.md`, not built. |

--- a/planning/e2e-light-heavy.md
+++ b/planning/e2e-light-heavy.md
@@ -367,6 +367,9 @@ with zero retries by default. External Cloud Vault tests require an explicit
 `ATOMIC_VAULT_PORTAL_URL`; managed mocks do not depend on a portal.
 
 Failures also attach bounded resource/save and WebSocket frame metadata before
-page teardown. Extracting the collectors into explicit lifecycles is planned in
-[js-maintainability.md](./js-maintainability.md); retaining payload-free metadata
-and existing diagnostic strictness is part of its acceptance criteria.
+page teardown. `DiagnosticCollector` and `TransportCollector` have explicit,
+idempotent start/snapshot/dispose lifecycles. Disposal detaches socket listeners
+as well as page/context listeners. Closed-page transport evidence is retained
+(up to five closed pages); live state reads remain capped at five pages and two
+seconds each. Lifecycle checks and real open/closed WebSocket checks preserve
+payload-free metadata and diagnostic strictness.

--- a/planning/js-maintainability.md
+++ b/planning/js-maintainability.md
@@ -1,7 +1,7 @@
 # JavaScript maintainability follow-ups
 
 > **Status: in progress, 2026-09-11.** PluginPage subscriptions are implemented;
-> diagnostic collectors and Store coordination remain. Baseline: `develop` at `6045bff3a`, following PRs
+> diagnostic collectors are extracted; Store coordination remains. Baseline: `develop` at `6045bff3a`, following PRs
 > [#1450](https://github.com/ontola/atomic-server/pull/1450) and
 > [#1451](https://github.com/ontola/atomic-server/pull/1451).
 
@@ -59,27 +59,33 @@ subscriptions unless they are demonstrably stale.
 
 ## 2. E2E diagnostic collectors
 
-[fixtures.ts](../browser/e2e/tests/fixtures.ts) currently owns context interception,
-console matching, WebSocket observation, attachments and teardown.
+[fixtures.ts](../browser/e2e/tests/fixtures.ts) now orchestrates context interception,
+attachments and teardown. `DiagnosticCollector` and `TransportCollector` own
+matching and observation with idempotent lifecycle methods.
 [failure-state.ts](../browser/e2e/tests/failure-state.ts) already separates the
 browser-side state snapshot. Extract the remaining collectors without changing
 which diagnostics fail a test.
 
-- [ ] Extract console/error expectations and WebSocket metadata into independent
+- [x] Extract console/error expectations and WebSocket metadata into independent
   collectors with explicit `start`, `snapshot`, and `dispose` lifecycles.
-- [ ] Let the fixture wire collectors to existing/new contexts, attach evidence,
+- [x] Let the fixture wire collectors to existing/new contexts, attach evidence,
   restore `browser.newContext`, and close only contexts it owns.
-- [ ] Make start/dispose idempotent and detach page, context **and socket** listeners.
+- [x] Make start/dispose idempotent and detach page, context **and socket** listeners.
   Preserve evidence collected before a page closes; tolerate crashed pages.
-- [ ] Preserve limits: at most five live pages sampled, two seconds per state read,
+- [x] Preserve limits: at most five live pages sampled, two seconds per state read,
   50 relevant resources, 50 property keys per resource, 20 commits and 30 frame
   metadata records per page. Keep payloads, resource values and secrets excluded.
-- [ ] Exercise unexpected/missing/excess diagnostics, multiple contexts, repeated
+- [x] Exercise unexpected/missing/excess diagnostics, multiple contexts, repeated
   start/dispose, closed pages and bounded attachments. Keep one real WebSocket
   check; mocked routing alone did not emit the transport events being tested.
 
 Acceptance: current diagnostic self-checks and attachment inspection pass; teardown
 cannot replace the original failure with a collector error or leak into the next test.
+
+Validation: all 14 diagnostic/collector checks pass with zero retries. Inspected
+JSON attachments from real open and closed WebSocket pages: frame metadata is
+retained and test payloads are absent. E2E typecheck and lint pass. The full
+production suite will validate this together with the Store coordinator slice.
 
 ## 3. Extract Store save-status coordination
 

--- a/planning/structural-problems-index.md
+++ b/planning/structural-problems-index.md
@@ -6,11 +6,11 @@
 
 This index tracks structural work rather than individual failures. The next bounded
 JS slices and acceptance checks are in [js-maintainability.md](./js-maintainability.md):
-PluginPage subscriptions, E2E diagnostic collectors, then Store save-status coordination.
+PluginPage subscriptions and E2E diagnostic collectors are implemented; Store save-status coordination is next.
 
 | # | Plan | Current state | Next step |
 | --- | --- | --- | --- |
-| 1 | [React Compiler / Resources](./react-compiler-resource-proxy.md) | Partial: stable Resource handles, immutable read/save snapshots and initial UI migrations shipped. | Reproduce and migrate PluginPage rendered getters; continue one flow at a time. |
+| 1 | [React Compiler / Resources](./react-compiler-resource-proxy.md) | Partial: stable Resource handles, immutable read/save snapshots and initial UI migrations shipped. | PluginPage migrated; investigate derived plugin manifest metadata refresh, then continue one flow at a time. |
 | 2 | [Subscription primitives](./unify-subscription-primitives.md) | Server work completed in reduced form; the original filter-scope design was not implemented. | Browser subscription changes belong in the data-layer plan, not a repeat of the server migration. |
 | 3 | Subscription actors | Done: `LoroSyncBroadcaster` folded into `CommitMonitor`; original plan removed. | None in this slice. |
 | 5 | [Resource save state](./unify-resource-dirty-signals.md) | API, scheduler and initial consumers shipped. | Migrate remaining save UIs and extract internal coordination without changing the public API. |


### PR DESCRIPTION
Separate browser console/error expectations and bounded WebSocket metadata from the E2E fixture. The fixture retains context ownership, routing, attachments and teardown; collectors expose explicit start/snapshot/dispose lifecycles.

Disposal now detaches socket listeners too. Closed-page transport evidence survives teardown, and setup failures restore context interception. Existing warning/error strictness and live-page limits remain unchanged.

Validation: 14 diagnostic/lifecycle tests pass with zero retries, E2E typecheck and lint pass. Inspected JSON attachments from real open and closed WebSocket pages: metadata is present and payloads are absent. Full production E2E on the combined #1454/#1455 tree: 212 passed, eight skipped, zero retries (13.4 minutes).
