### PR TITLE
Prevent Cloud Vault growth on browser refresh

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -513,6 +513,12 @@ mounts without resetting or re-registering the global parser.
 
 ### Save durability and identity lifecycle regressions
 
+- `client-db.worker.test.ts` requires vault cursor commits to flush before the
+  worker acknowledges backup completion, and propagates flush failures. The
+  SaaS `vault-refresh.spec.ts` checks stored objects and bytes across reloads.
+- `synthetic_agent_reads_have_stable_history_without_persisting` checks that
+  fallback agent lookups neither invent creation timestamps nor generate new
+  CRDT history or persist a resource merely by reading it.
 - `client-db.test.ts` verifies that cold worker initialization does not steal
   its own Web Lock or emit a false ghost-leader warning.
 - `store.private-drive.test.ts` verifies that linking a private drive on a

--- a/browser/lib/src/client-db.worker.test.ts
+++ b/browser/lib/src/client-db.worker.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, it, vi } from 'vitest';
+
+const db = vi.hoisted(() => ({
+  vaultCommitSegment: vi.fn(),
+  flush: vi.fn(),
+}));
+vi.mock('./client-db-open.js', () => ({
+  openClientDb: async () => ({ db }),
+  isStorageBlockedDbError: () => false,
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.resetModules();
+  vi.resetAllMocks();
+});
+
+it.each([false, true])(
+  'acknowledges a vault cursor only after durable flush (failure=%s)',
+  async fail => {
+    vi.useFakeTimers();
+    const worker = {
+      onmessage: null as unknown as (event: unknown) => void,
+      postMessage: vi.fn(),
+    };
+    vi.stubGlobal('self', worker);
+    await import('./client-db.worker.js');
+    let id = 0;
+    async function send(message: object) {
+      const requestId = ++id;
+      const response = new Promise<Record<string, unknown>>(resolve => {
+        worker.postMessage.mockImplementation(value => {
+          if (value.id === requestId) resolve(value);
+        });
+      });
+      worker.onmessage({ data: { ...message, id: requestId } });
+      return response;
+    }
+    await send({
+      type: 'init',
+      wasmUrl: 'data:text/javascript,export default async function() {}',
+    });
+    const order: string[] = [];
+    db.vaultCommitSegment.mockImplementation(() => order.push('commit'));
+    db.flush.mockImplementation(() => {
+      order.push('flush');
+      if (fail) throw new Error('disk unavailable');
+    });
+    // No timer advances: a reload can kill the worker before its periodic tick.
+    const response = await send({
+      type: 'vaultCommitSegment',
+      drivePseudonym: 'drive',
+      devicePubkey: 'device',
+      segment: 1,
+    });
+    expect(order).toEqual(['commit', 'flush']);
+    expect(response.type).toBe(fail ? 'error' : 'ok');
+    if (fail) expect(response.message).toBe('disk unavailable');
+  },
+);

--- a/browser/lib/src/client-db.worker.ts
+++ b/browser/lib/src/client-db.worker.ts
@@ -428,10 +428,13 @@ async function handleMessage(msg: WorkerRequest): Promise<unknown> {
     case 'vaultCommitSegment': {
       await ensureInit();
       db!.vaultCommitSegment(msg.drivePseudonym, msg.devicePubkey, msg.segment);
-      // Lane bookkeeping is a normal write behind `Durability::None`; without
-      // this the next tick's flush is what persists it, and a reload in between
-      // would re-report an already-committed segment as pending.
+      // Backup completion must survive an immediate reload. Waiting for the
+      // periodic tick loses the cursor and uploads the same data again.
+      // Keep the retry armed if flush fails, but propagate that failure so
+      // the caller cannot report a durably completed backup.
       dirty = true;
+      db!.flush();
+      dirty = false;
 
       return undefined;
     }

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -3441,7 +3441,23 @@ impl Storelike for Db {
                     };
                     if let Some(pubkey) = lookup.strip_prefix("did:ad:agent:") {
                         if let Ok(agent) = crate::agents::Agent::new_from_public_key(pubkey) {
-                            if let Ok(resource) = agent.to_resource() {
+                            if let Ok(mut resource) = agent.to_resource() {
+                                // A lookup is not creation of an agent. There is
+                                // no known creation date or signed history yet.
+                                // Seed the same fallback ops on every read and
+                                // device, otherwise a refresh replaces the cached
+                                // profile with new ops and grows its vault backup.
+                                resource.remove_propval(crate::urls::CREATED_AT)?;
+                                let doc = crate::loro::AtomicLoroDoc::new();
+                                doc.set_peer_id(0)?;
+                                let ordered: std::collections::BTreeMap<_, _> =
+                                    resource.get_propvals().iter().collect();
+                                for (property, value) in ordered {
+                                    doc.set_property(property, value)?;
+                                }
+                                doc.doc()
+                                    .commit_with(loro::CommitOptions::new().timestamp(0));
+                                resource.apply_state_doc(doc)?;
                                 return Ok(resource);
                             }
                         }

--- a/lib/src/db/test.rs
+++ b/lib/src/db/test.rs
@@ -15,6 +15,24 @@ use tokio::sync::OnceCell;
 
 static DB: OnceCell<Mutex<Db>> = OnceCell::const_new();
 
+#[tokio::test]
+async fn synthetic_agent_reads_have_stable_history_without_persisting() {
+    let db = Db::init_temp("synthetic_agent_read").await.unwrap();
+    let agent = crate::agents::Agent::new(None).unwrap();
+    let first = db.get_resource(&agent.subject).await.unwrap();
+    let second = db.get_resource(&agent.subject).await.unwrap();
+    assert!(first.get(urls::CREATED_AT).is_err());
+    assert_eq!(
+        serde_json::to_value(first.get_propvals()).unwrap(),
+        serde_json::to_value(second.get_propvals()).unwrap()
+    );
+    assert_eq!(
+        first.build_state_doc().unwrap().doc().oplog_vv(),
+        second.build_state_doc().unwrap().doc().oplog_vv()
+    );
+    assert!(!db.has_stored_resource(&agent.subject));
+}
+
 /// Share the Db instance between tests. Otherwise, all tests try to init the same location on disk and throw errors.
 /// Note that not all behavior can be properly tested with a shared database.
 /// If you need a clean one, juts call init("someId").


### PR DESCRIPTION
Refreshing an unchanged workspace could upload another Cloud Vault object. Fallback agent lookups minted a fresh creation timestamp and CRDT history on every read, while backup completion acknowledged cursor changes before the browser database flushed them.

Make fallback profiles deterministic without persisting a resource on read, and flush the backup cursor before reporting success. Flush failures propagate to the caller. Add regression coverage for stable agent history and successful/failed durable cursor commits.

Companion SaaS regression PR: https://github.com/ontola/atomic-saas/pull/82. Both use the same `fix/vault-refresh-growth` branch so paired CI tests the two together. Merge this server PR first.

Validation: the Rust synthetic-agent regression, five focused browser-library tests and formatting pass on this branch. The end-to-end regression passed against an isolated local API, node and S3-compatible service: three reloads added zero bytes or objects. That browser run preceded rebasing onto current develop; paired CI checks the final branches.
