### PR TITLE
Store hosted files in S3 without node-local fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "lol_html",
  "mainline",
  "objc",
+ "object_store",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -9569,14 +9570,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
  "http 1.4.0",
+ "http-body-util",
  "humantime",
+ "hyper",
  "itertools 0.14.0",
+ "md-5",
  "parking_lot 0.12.5",
  "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10455,7 +10468,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -11003,6 +11016,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quick-xml"

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -762,3 +762,15 @@ page, never payload contents. A real local WebSocket exercises this collection.
 - `save-status-coordinator.test.ts` exercises narrow injected dependencies without a
   Store: overlapping owners, idempotent observer disposal, resource renaming, cached
   immutable snapshots, current outbox/connection state and failure accounting.
+
+## S3 hosted file storage
+
+`server/src/blob_storage.rs` tests node replacement with no local blob copies,
+verified/resumable migration, storage failures with no fallback, peer BLOB frames,
+and invalid configuration. Its ignored S3 round-trip runs against a scratch
+bucket; SaaS representative CI supplies MinIO. `server/src/tests.rs` checks
+remote multipart upload/download and image renditions, asserting Tree::Blobs
+stays empty. Standalone local storage still runs through the original tests.
+
+Not covered here: live Hetzner rollout, arbitrary large-file memory limits,
+blob garbage collection, or encrypted Vault attachment recovery.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -774,3 +774,8 @@ stays empty. Standalone local storage still runs through the original tests.
 
 Not covered here: live Hetzner rollout, arbitrary large-file memory limits,
 blob garbage collection, or encrypted Vault attachment recovery.
+
+`shared_files_count_once_per_drive_independently_of_other_owners` proves that
+one physical object shared by two owners counts once in each drive, repeated
+references within one drive do not inflate usage, and report ordering,
+co-location and removal of another owner's references do not change attribution.

--- a/browser/lib/src/client-db.worker.test.ts
+++ b/browser/lib/src/client-db.worker.test.ts
@@ -27,6 +27,7 @@ it.each([false, true])(
     vi.stubGlobal('self', worker);
     await import('./client-db.worker.js');
     let id = 0;
+
     async function send(message: object) {
       const requestId = ++id;
       const response = new Promise<Record<string, unknown>>(resolve => {
@@ -35,8 +36,10 @@ it.each([false, true])(
         });
       });
       worker.onmessage({ data: { ...message, id: requestId } });
+
       return response;
     }
+
     await send({
       type: 'init',
       wasmUrl: 'data:text/javascript,export default async function() {}',

--- a/docs/src/files.md
+++ b/docs/src/files.md
@@ -104,3 +104,8 @@ node replacements, and use an S3-capable binary for rollback after migration.
 This is primary storage for hosted files. It does not provide client-encrypted
 Vault backups, and the server still buffers file contents in memory while
 proxying requests.
+
+Drive usage counts each referenced blob once within that drive. When two drives
+reference identical content, each drive counts its full size toward its quota,
+while the shared S3 namespace stores one object. Account/drive usage totals
+therefore describe logical usage, not the physical size of the bucket.

--- a/docs/src/files.md
+++ b/docs/src/files.md
@@ -81,3 +81,26 @@ A consequence of content-addressed storage is that an attacker who already knows
 - [Discussion on specification](https://github.com/ontola/atomic-data-docs/issues/57)
 - [Discussion on Rust server implementation](https://github.com/atomicdata-dev/atomic-server/issues/72)
 - [Discussion on Typescript client implementation](https://github.com/atomicdata-dev/atomic-data-browser/issues/121)
+
+## Server file storage
+
+By default, file bytes are stored in the local database. Operators can select
+S3-compatible storage with `ATOMIC_BLOB_BACKEND=s3`, `ATOMIC_S3_BUCKET`,
+`ATOMIC_S3_REGION`, and optionally `ATOMIC_S3_ENDPOINT`. Set the paired
+`ATOMIC_S3_ACCESS_KEY_ID` / `ATOMIC_S3_SECRET_ACCESS_KEY` credentials, or use
+instance credentials. `ATOMIC_S3_PREFIX` defaults to `blobs`;
+`ATOMIC_S3_PATH_STYLE=true` selects path-style addressing for services such as
+MinIO. HTTPS is required unless `ATOMIC_S3_ALLOW_HTTP=true` is explicitly set
+for local testing.
+
+Uploads, downloads, peer sync and image renditions all use the selected
+backend. In S3 mode there is no local file cache or fallback: an unavailable
+object store causes an error. The server checks read/write access before
+serving traffic, then migrates existing database blobs one at a time, verifying
+each remote copy before removing its local row. Database pages become reusable
+but the database file may not shrink. Keep the bucket and prefix stable across
+node replacements, and use an S3-capable binary for rollback after migration.
+
+This is primary storage for hosted files. It does not provide client-encrypted
+Vault backups, and the server still buffers file contents in memory while
+proxying requests.

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -1,6 +1,7 @@
 //! Persistent, ACID compliant, threadsafe to-disk store.
 //! Powered by Sled - an embedded database.
 
+pub mod blob_backend;
 pub mod btreemap_store;
 mod encoding;
 #[cfg(feature = "db-redb")]
@@ -288,6 +289,8 @@ pub struct Db {
     /// The key-value store backend. Abstracted behind a trait so different
     /// backends (sled, BTreeMap, etc.) can be used interchangeably.
     pub kv: Arc<dyn KvStore>,
+    /// Optional remote file storage. Configure before sharing this Db.
+    pub blob_backend: Option<Arc<dyn blob_backend::BlobBackend>>,
     default_agent: Arc<Mutex<Option<crate::agents::Agent>>>,
     /// Endpoints are checked whenever a resource is requested. They calculate (some properties of) the resource and return it.
     endpoints: Vec<Endpoint>,
@@ -440,6 +443,7 @@ impl Db {
 
         let store = Db {
             path: path.into(),
+            blob_backend: None,
             kv: Arc::new(sled_store),
             default_agent: Arc::new(Mutex::new(None)),
             endpoints: vec![],
@@ -479,6 +483,7 @@ impl Db {
     pub async fn init_memory(base_domain: Option<String>) -> AtomicResult<Db> {
         let store = Db {
             path: std::path::PathBuf::new(),
+            blob_backend: None,
             kv: Arc::new(btreemap_store::BTreeMapStore::new()),
             default_agent: Arc::new(Mutex::new(None)),
             endpoints: vec![],
@@ -514,6 +519,7 @@ impl Db {
 
         let store = Db {
             path: std::path::PathBuf::new(),
+            blob_backend: None,
             kv: Arc::new(redb_store),
             default_agent: Arc::new(Mutex::new(None)),
             endpoints: vec![],
@@ -610,6 +616,7 @@ impl Db {
 
         let store = Db {
             path: path.to_path_buf(),
+            blob_backend: None,
             kv: Arc::new(redb_store),
             default_agent: Arc::new(Mutex::new(None)),
             endpoints: vec![],
@@ -762,6 +769,7 @@ impl Db {
 
         let store = Db {
             path: std::path::PathBuf::new(),
+            blob_backend: None,
             kv: Arc::new(redb_store),
             default_agent: Arc::new(Mutex::new(None)),
             endpoints: vec![],
@@ -1245,8 +1253,8 @@ impl Db {
             if !seen_blobs.insert(hash) {
                 continue;
             }
-            if let Ok(Some(bytes)) = self.kv.get(Tree::Blobs, &hash) {
-                row.blob_bytes += bytes.len() as u64;
+            if let Some(size) = self.blob_size(&hash).await? {
+                row.blob_bytes += size;
             }
         }
 

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -1170,8 +1170,9 @@ impl Db {
     ///
     /// Cost is O(the drives' resources), not O(store): it resolves each drive's
     /// subjects and point-looks-up their propvals/snapshots. Blobs are
-    /// content-addressed and counted once — a blob shared across drives is
-    /// attributed to whichever drive's resource is visited first.
+    /// content-addressed and counted once per drive. Each drive pays its own
+    /// logical quota usage even when another owner's drive shares the same
+    /// physical object. These counters must not be used as bucket-size totals.
     pub async fn per_drive_usage(
         &self,
         drive_subjects: &[String],
@@ -1215,7 +1216,9 @@ impl Db {
         // drive makes this O(store) rather than O(drive) — measured at ~4s for a
         // 43-resource drive on a multi-GB store, and it is paid on every Sync
         // page load.
-        let mut seen_blobs: HashSet<[u8; 32]> = HashSet::new();
+        let mut seen_blobs: HashSet<(&str, [u8; 32])> = HashSet::new();
+        // Share metadata lookups, not quota attribution, across drives.
+        let mut blob_sizes: HashMap<[u8; 32], Option<u64>> = HashMap::new();
 
         for (subject, drive) in &subject_to_drive {
             let Some(row) = usage.get_mut(drive) else {
@@ -1250,10 +1253,18 @@ impl Db {
             }
             let mut hash = [0u8; 32];
             hash.copy_from_slice(&hash_bytes);
-            if !seen_blobs.insert(hash) {
+            if !seen_blobs.insert((drive.as_str(), hash)) {
                 continue;
             }
-            if let Some(size) = self.blob_size(&hash).await? {
+            let size = match blob_sizes.get(&hash) {
+                Some(size) => *size,
+                None => {
+                    let size = self.blob_size(&hash).await?;
+                    blob_sizes.insert(hash, size);
+                    size
+                }
+            };
+            if let Some(size) = size {
                 row.blob_bytes += size;
             }
         }

--- a/lib/src/db/blob_backend.rs
+++ b/lib/src/db/blob_backend.rs
@@ -1,0 +1,63 @@
+//! File bytes have independent storage from transactional graph state.
+use super::{trees::Tree, Db};
+use crate::errors::AtomicResult;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait BlobBackend: Send + Sync {
+    async fn get(&self, key: &[u8]) -> AtomicResult<Option<Vec<u8>>>;
+    async fn put(&self, key: &[u8], bytes: &[u8]) -> AtomicResult<()>;
+    /// Metadata only: usage accounting must not download every file.
+    async fn size(&self, key: &[u8]) -> AtomicResult<Option<u64>>;
+}
+
+impl Db {
+    pub async fn get_blob(&self, key: &[u8]) -> AtomicResult<Option<Vec<u8>>> {
+        match &self.blob_backend {
+            Some(backend) => backend.get(key).await,
+            None => self.kv.get(Tree::Blobs, key),
+        }
+    }
+
+    pub async fn put_blob(&self, key: &[u8], bytes: &[u8]) -> AtomicResult<()> {
+        match &self.blob_backend {
+            Some(backend) => backend.put(key, bytes).await,
+            None => self.kv.insert(Tree::Blobs, key, bytes),
+        }
+    }
+
+    pub async fn blob_size(&self, key: &[u8]) -> AtomicResult<Option<u64>> {
+        match &self.blob_backend {
+            Some(backend) => backend.size(key).await,
+            None => Ok(self.kv.get(Tree::Blobs, key)?.map(|b| b.len() as u64)),
+        }
+    }
+
+    pub async fn has_blob(&self, key: &[u8]) -> AtomicResult<bool> {
+        Ok(self.blob_size(key).await?.is_some())
+    }
+
+    /// Run before starting transports. Copy and verify each existing local blob
+    /// before removing it. A failed/interrupted migration is safe to retry.
+    /// Never fall back to local storage after selecting a remote backend.
+    pub async fn migrate_blobs_to_backend(&self) -> AtomicResult<usize> {
+        let Some(backend) = &self.blob_backend else {
+            return Ok(0);
+        };
+        let mut migrated = 0;
+        while let Some((key, bytes)) = self.kv.first_entry(Tree::Blobs)? {
+            backend.put(&key, &bytes).await?;
+            let stored = backend
+                .get(&key)
+                .await?
+                .ok_or("Blob migration verification: object missing")?;
+            if stored != bytes {
+                return Err("Blob migration verification: contents differ".into());
+            }
+            self.kv.remove(Tree::Blobs, &key)?;
+            self.kv.flush()?;
+            migrated += 1;
+        }
+        Ok(migrated)
+    }
+}

--- a/lib/src/db/kv_store.rs
+++ b/lib/src/db/kv_store.rs
@@ -39,6 +39,12 @@ pub trait KvStore: Send + Sync {
     /// Iterate over all entries in a tree, ordered by key.
     fn iter_tree(&self, tree: Tree) -> KvIter;
 
+    /// Read one entry without materializing the whole tree. Used when moving
+    /// large blob tables out of local storage before transports start.
+    fn first_entry(&self, tree: Tree) -> AtomicResult<Option<KvPair>> {
+        self.iter_tree(tree).next().transpose()
+    }
+
     /// Remove all entries from a specific tree.
     fn clear_tree(&self, tree: Tree) -> AtomicResult<()>;
 

--- a/lib/src/db/redb_store.rs
+++ b/lib/src/db/redb_store.rs
@@ -397,6 +397,20 @@ impl KvStore for RedbStore {
         }
     }
 
+    fn first_entry(&self, tree: Tree) -> AtomicResult<Option<KvPair>> {
+        let tx = self
+            .db
+            .begin_read()
+            .map_err(|e| format!("redb read tx: {e}"))?;
+        let table = tx
+            .open_table(table_def(tree))
+            .map_err(|e| format!("redb open table: {e}"))?;
+        let first = table
+            .first()
+            .map_err(|e| format!("redb first entry: {e}"))?;
+        Ok(first.map(|(key, value)| (key.value().to_vec(), value.value().to_vec())))
+    }
+
     fn iter_tree(&self, tree: Tree) -> KvIter {
         let tx = match self.db.begin_read() {
             Ok(tx) => tx,

--- a/lib/src/sync/browser_peer.rs
+++ b/lib/src/sync/browser_peer.rs
@@ -165,7 +165,7 @@ impl BrowserPeerSession {
                                 .and_then(|hex| hex::decode(hex).ok())
                                 .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
                             {
-                                if db.kv.get(Tree::Blobs, &hash)?.is_none() {
+                                if !db.has_blob(&hash).await? {
                                     self.pending_blobs.insert(hash);
                                     out.frames.push(protocol::encode_blob_request(&hash));
                                     requested += 1;
@@ -291,7 +291,7 @@ impl BrowserPeerSession {
                 }
                 // A partial replica may not have the bytes yet. The requester
                 // retries other edges without tearing down healthy connections.
-                if let Some(bytes) = db.kv.get(Tree::Blobs, &hash)? {
+                if let Some(bytes) = db.get_blob(&hash).await? {
                     out.frames
                         .push(protocol::encode_blob_response(&hash, &bytes));
                 }
@@ -304,7 +304,7 @@ impl BrowserPeerSession {
                 }
                 let requested = self.pending_blobs.remove(&response.hash);
                 // Concurrent edges can answer the same content-addressed request.
-                if db.kv.get(Tree::Blobs, &response.hash)?.is_some() {
+                if db.has_blob(&response.hash).await? {
                     return Ok(out);
                 }
                 if !requested {
@@ -314,7 +314,7 @@ impl BrowserPeerSession {
                     return Err("Drive not admitted for sync".into());
                 }
                 db.take_pending_blob_request(&response.hash);
-                db.kv.insert(Tree::Blobs, &response.hash, &response.bytes)?;
+                db.put_blob(&response.hash, &response.bytes).await?;
             }
             protocol::tag::EPHEMERAL => {
                 let message = protocol::decode_ephemeral(payload).ok_or("Invalid EPHEMERAL")?;
@@ -608,6 +608,6 @@ mod tests {
         let frame = protocol::encode_blob_response(&hash, bytes);
         assert!(first.handle(&db, &frame).await.unwrap().frames.is_empty());
         assert!(second.handle(&db, &frame).await.unwrap().frames.is_empty());
-        assert_eq!(db.kv.get(Tree::Blobs, &hash).unwrap().unwrap(), bytes);
+        assert_eq!(db.get_blob(&hash).await.unwrap().unwrap(), bytes);
     }
 }

--- a/lib/src/sync/engine.rs
+++ b/lib/src/sync/engine.rs
@@ -407,7 +407,7 @@ pub async fn handle_frame_full(
 
         protocol::tag::BLOB_REQUEST => {
             if let Some(hash) = protocol::decode_blob_request(payload) {
-                match store.kv.get(Tree::Blobs, &hash) {
+                match store.get_blob(&hash).await {
                     Ok(Some(bytes)) => vec![protocol::encode_blob_response(&hash, &bytes)],
                     _ => vec![protocol::encode_error(
                         0,
@@ -446,8 +446,17 @@ pub async fn handle_frame_full(
                         vec![]
                     }
                     Some(drive) if store.sync_policy().admit_drive_write(&drive) => {
-                        let _ = store.kv.insert(Tree::Blobs, &resp.hash, &resp.bytes);
-                        vec![]
+                        match store.put_blob(&resp.hash, &resp.bytes).await {
+                            Ok(()) => vec![],
+                            Err(error) => {
+                                tracing::warn!("BLOB_RESPONSE: storage failed: {error}");
+                                vec![protocol::encode_error(
+                                    0,
+                                    protocol::error_code::UNKNOWN,
+                                    "Blob storage failed",
+                                )]
+                            }
+                        }
                     }
                     Some(drive) => {
                         tracing::warn!(
@@ -1173,7 +1182,7 @@ pub async fn handle_sync_vv_filtered(
                         if hash_bytes.len() == 32 {
                             let mut hash = [0u8; 32];
                             hash.copy_from_slice(&hash_bytes);
-                            if !store.kv.contains_key(Tree::Blobs, &hash).unwrap_or(false) {
+                            if !store.has_blob(&hash).await.unwrap_or(false) {
                                 // If we don't have the blob, add to pull so the server requests it
                                 if !pull.contains(subject) {
                                     pull.push(subject.clone());
@@ -1613,7 +1622,7 @@ pub async fn import_sync_push(
                     if hash_bytes.len() == 32 {
                         let mut hash = [0u8; 32];
                         hash.copy_from_slice(&hash_bytes);
-                        if !store.kv.contains_key(Tree::Blobs, &hash).unwrap_or(false) {
+                        if !store.has_blob(&hash).await.unwrap_or(false) {
                             // Record which (already-admitted, see the top of
                             // this fn) drive this hash belongs to so the
                             // BLOB_RESPONSE handler can gate the write

--- a/lib/src/sync/replicate.rs
+++ b/lib/src/sync/replicate.rs
@@ -28,7 +28,7 @@
 use crate::{
     agents::{Agent, ForAgent},
     client::ws::{WsClient, WsMessage},
-    db::{trees::Tree, Db},
+    db::Db,
     errors::{AtomicError, AtomicResult},
     sync::{engine, protocol},
     Storelike,
@@ -222,7 +222,7 @@ async fn drive_exchange(
                 // The remote imported a resource referencing a blob it lacks.
                 // Blobs are only ever served on request — it will not accept an
                 // unsolicited one.
-                match store.kv.get(Tree::Blobs, &hash) {
+                match store.get_blob(&hash).await {
                     Ok(Some(bytes)) => {
                         client
                             .send_binary(protocol::encode_blob_response(&hash, &bytes))

--- a/planning/README.md
+++ b/planning/README.md
@@ -78,7 +78,7 @@ browser flow; standalone recovery remains self-managed.
 | [`social-apps.md`](./social-apps.md) | Requirements for social-network-shaped apps. Companion to `zones.md`. |
 | [`android-data-reuse.md`](./android-data-reuse.md) | **Draft.** One store/agent/Iroh node per Android device. Supersedes `on-device-atomic-daemon.md` (deleted 2026-09-01; desktop remainder is a note in `virtual-drive.md`). |
 | [`nextgraph-interop.md`](./nextgraph-interop.md) | **Proposal.** `did:ng:` via a scheme-routed Store backend. |
-| [`s3-blob-storage.md`](./s3-blob-storage.md) | Pluggable blob backend (redb/S3/hybrid). |
+| [`s3-blob-storage.md`](./s3-blob-storage.md) | **Partial.** Server-wide S3, verified migration and SaaS enforcement implemented. Streaming, GC, per-tenant configuration and encrypted Vault attachments remain. |
 | [`atomic-assistant-browser-extension.md`](./atomic-assistant-browser-extension.md) | **Proposal.** Local-first Chromium extension. |
 | [`tours.md`](./tours.md) | Design, not built. |
 | [`local-search.md`](./local-search.md) | **Landed.** KV inverted index in `atomic_lib` (redb/OPFS/sled): BM25 + prefix + 1-edit prefix-fuzzy + PropValSub filters. Hosted `/search` is the same engine; Tantivy is gone. |

--- a/planning/s3-blob-storage.md
+++ b/planning/s3-blob-storage.md
@@ -1,3 +1,39 @@
+# Implementation status — September 12
+
+Server-wide S3 file storage is implemented; the original roadmap below contains
+future phases and is not an as-built specification.
+
+- [x] Async blob backend, default local database for standalone/browser use.
+- [x] S3 backend for all server upload/download, preview, plugin and peer-sync paths.
+- [x] Fail startup on invalid S3 config or failed read/write readiness.
+- [x] Verified, resumable migration of local blobs at startup, one blob in memory
+  at a time, before serving requests. No local fallback/cache in S3 mode.
+- [x] Remote HEAD for size accounting instead of downloading file contents.
+- [x] SaaS requires S3; deployment and provisioning share a hosted-blobs namespace.
+- [x] Tests for HTTP upload/download, image previews, peer frames, node replacement,
+  migration verification, and storage failure without local writes.
+- [ ] Streaming/proxy range requests and direct presigned downloads.
+- [ ] Blob garbage collection and per-tenant buckets.
+- [ ] Encrypted Vault attachment backup/recovery (separate from hosted primary storage).
+
+Configuration: `ATOMIC_BLOB_BACKEND=redb|s3` (default redb), `ATOMIC_S3_BUCKET`,
+`ATOMIC_S3_REGION`, `ATOMIC_S3_ENDPOINT`, paired `ATOMIC_S3_ACCESS_KEY_ID` /
+`ATOMIC_S3_SECRET_ACCESS_KEY`, optional `ATOMIC_S3_PREFIX` (default blobs),
+`ATOMIC_S3_PATH_STYLE=true|false`, `ATOMIC_S3_ALLOW_HTTP=true|false` (test only).
+Credentials may be omitted for the object store instance credential provider.
+No hybrid mode or disk cache is implemented. Files remain normal hosted bytes;
+this is not client-side Vault encryption. Keep hosted prefixes outside Vault GC.
+
+When migration removes local rows, redb can reuse the pages; physical file
+shrinking and old filesystem backups require separate operator maintenance.
+New large uploads and downloads still buffer one object in RAM.
+
+The ignored `s3_files_survive_node_replacement` test takes the above environment
+pointing to a scratch S3 bucket. Standard tests use an in-memory object service;
+SaaS representative CI runs the real S3-compatible test against MinIO.
+
+---
+
 # S3-compatible Blob Storage
 
 **Status:** Proposal. Nothing built.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,6 +33,7 @@ static-files = "0.3.1"
 walkdir = "2"
 
 [dependencies]
+object_store = { version = "0.12", features = ["aws"] }
 async-trait = "0.1.89"
 actix = "0.13.5"
 actix-cors = "0.7.1"

--- a/server/src/appstate.rs
+++ b/server/src/appstate.rs
@@ -60,6 +60,8 @@ impl AppState {
         )
         .await?;
 
+        crate::blob_storage::configure(&mut store).await?;
+
         // Drop the persisted watched-query registry on startup. Every
         // entry was registered by a now-dead WS connection; live
         // subscribers re-register on reconnect. Without this, e2e

--- a/server/src/bin.rs
+++ b/server/src/bin.rs
@@ -4,6 +4,7 @@ use std::{fs::File, io::Write};
 
 mod actor_messages;
 mod appstate;
+mod blob_storage;
 mod commit_monitor;
 pub mod config;
 mod content_types;

--- a/server/src/blob_storage.rs
+++ b/server/src/blob_storage.rs
@@ -170,6 +170,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_files_count_once_per_drive_independently_of_other_owners() {
+        use atomic_lib::{urls, Storelike, Value};
+        use futures::TryStreamExt;
+        let objects = Arc::new(object_store::memory::InMemory::new());
+        let mut db = Db::init_redb(None).await.unwrap();
+        db.blob_backend = Some(Arc::new(
+            ObjectBlobBackend::new(objects.clone(), "files").unwrap(),
+        ));
+        let bytes = b"the same file uploaded by two different users";
+        let hash = blake3::hash(bytes);
+        let blob = format!("did:ad:blob:{}", hash.to_hex());
+        let mut drives = Vec::new();
+        let mut references = Vec::new();
+        for (owner, copies) in [("alice", 2), ("bob", 1)] {
+            let (_, drive) = db.setup(owner).await.unwrap();
+            for copy in 0..copies {
+                db.put_blob(hash.as_bytes(), bytes).await.unwrap();
+                let subject = db
+                    .create_resource(urls::FILE, &drive, &format!("copy-{copy}"), None)
+                    .await
+                    .unwrap();
+                let mut file = db.get_resource(&subject.as_str().into()).await.unwrap();
+                file.set_unsafe(urls::BLOB.into(), Value::AtomicUrl(blob.as_str().into()))
+                    .unwrap();
+                db.add_resource_opts(&file, false, true, true)
+                    .await
+                    .unwrap();
+                references.push(file.get_subject().clone());
+            }
+            drives.push(drive);
+        }
+        assert_ne!(drives[0], drives[1]);
+        // Actual storage contains one object despite three file references.
+        let stored: Vec<_> = objects.list(None).try_collect().await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].size, bytes.len() as u64);
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 0);
+        // Co-location, report order and reporting just one hosted drive must
+        // never change either owner's quota usage.
+        for report in [
+            drives.clone(),
+            vec![drives[1].clone(), drives[0].clone()],
+            vec![drives[0].clone()],
+            vec![drives[1].clone()],
+        ] {
+            let usage = db.per_drive_usage(&report).await.unwrap();
+            assert_eq!(usage.len(), report.len());
+            for row in usage {
+                assert_eq!(row.blob_bytes, bytes.len() as u64, "{}", row.drive_subject);
+            }
+        }
+        // Removing Alice's two references must not transfer any usage to Bob.
+        for reference in &references[..2] {
+            db.remove_resource(reference).await.unwrap();
+        }
+        let usage = db.per_drive_usage(&drives).await.unwrap();
+        assert_eq!(
+            usage
+                .iter()
+                .find(|r| r.drive_subject == drives[0])
+                .unwrap()
+                .blob_bytes,
+            0
+        );
+        assert_eq!(
+            usage
+                .iter()
+                .find(|r| r.drive_subject == drives[1])
+                .unwrap()
+                .blob_bytes,
+            bytes.len() as u64
+        );
+    }
+
+    #[tokio::test]
     async fn peer_sync_uses_remote_storage_and_reports_failed_writes() {
         use atomic_lib::{
             agents::ForAgent,

--- a/server/src/blob_storage.rs
+++ b/server/src/blob_storage.rs
@@ -1,0 +1,282 @@
+//! Optional S3-compatible storage for hosted file bytes. No disk cache/fallback.
+use async_trait::async_trait;
+use atomic_lib::{db::blob_backend::BlobBackend, errors::AtomicResult};
+use object_store::{aws::AmazonS3Builder, path::Path, ObjectStore};
+use std::sync::Arc;
+
+pub struct ObjectBlobBackend {
+    store: Arc<dyn ObjectStore>,
+    prefix: Path,
+}
+
+impl ObjectBlobBackend {
+    pub fn new(store: Arc<dyn ObjectStore>, prefix: &str) -> AtomicResult<Self> {
+        Ok(Self {
+            store,
+            prefix: Path::parse(prefix).map_err(|e| e.to_string())?,
+        })
+    }
+    fn path(&self, key: &[u8]) -> Path {
+        self.prefix.child(hex::encode(key))
+    }
+}
+
+#[async_trait]
+impl BlobBackend for ObjectBlobBackend {
+    async fn get(&self, key: &[u8]) -> AtomicResult<Option<Vec<u8>>> {
+        match self.store.get(&self.path(key)).await {
+            Ok(object) => Ok(Some(
+                object.bytes().await.map_err(|e| e.to_string())?.to_vec(),
+            )),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(error) => Err(error.to_string().into()),
+        }
+    }
+    async fn put(&self, key: &[u8], bytes: &[u8]) -> AtomicResult<()> {
+        self.store
+            .put(&self.path(key), bytes.to_vec().into())
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+    async fn size(&self, key: &[u8]) -> AtomicResult<Option<u64>> {
+        match self.store.head(&self.path(key)).await {
+            Ok(meta) => Ok(Some(meta.size)),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(error) => Err(error.to_string().into()),
+        }
+    }
+}
+
+/// Explicit config, usable by embedders without changing process environment.
+/// Values (especially credentials) must never be logged.
+pub fn from_config(
+    mut env: impl FnMut(&str) -> Option<String>,
+) -> AtomicResult<Option<Arc<dyn BlobBackend>>> {
+    let mode = env("ATOMIC_BLOB_BACKEND").unwrap_or_else(|| "redb".into());
+    match mode.as_str() {
+        "redb" => return Ok(None),
+        "s3" => {}
+        _ => return Err("ATOMIC_BLOB_BACKEND must be redb or s3".into()),
+    }
+    let bucket = env("ATOMIC_S3_BUCKET")
+        .filter(|v| !v.trim().is_empty())
+        .ok_or("ATOMIC_S3_BUCKET is required for S3 blob storage")?;
+    let mut builder = AmazonS3Builder::new().with_bucket_name(bucket);
+    if let Some(v) = env("ATOMIC_S3_REGION") {
+        builder = builder.with_region(v);
+    }
+    if let Some(v) = env("ATOMIC_S3_ENDPOINT") {
+        builder = builder.with_endpoint(v);
+    }
+    let access = env("ATOMIC_S3_ACCESS_KEY_ID");
+    let secret = env("ATOMIC_S3_SECRET_ACCESS_KEY");
+    match (access, secret) {
+        (Some(a), Some(s)) if !a.is_empty() && !s.is_empty() => {
+            builder = builder.with_access_key_id(a).with_secret_access_key(s);
+        }
+        (None, None) => {} // Object store's instance credential provider.
+        _ => return Err("Set both ATOMIC_S3_ACCESS_KEY_ID and ATOMIC_S3_SECRET_ACCESS_KEY".into()),
+    }
+    if let Some(v) = env("ATOMIC_S3_PATH_STYLE") {
+        builder = builder.with_virtual_hosted_style_request(
+            !v.parse::<bool>()
+                .map_err(|_| "ATOMIC_S3_PATH_STYLE must be true or false")?,
+        );
+    }
+    if let Some(v) = env("ATOMIC_S3_ALLOW_HTTP") {
+        builder = builder.with_allow_http(
+            v.parse::<bool>()
+                .map_err(|_| "ATOMIC_S3_ALLOW_HTTP must be true or false")?,
+        );
+    }
+    let prefix = env("ATOMIC_S3_PREFIX").unwrap_or_else(|| "blobs".into());
+    Ok(Some(Arc::new(ObjectBlobBackend::new(
+        Arc::new(builder.build().map_err(|e| e.to_string())?),
+        &prefix,
+    )?)))
+}
+
+pub async fn configure(store: &mut atomic_lib::Db) -> AtomicResult<()> {
+    store.blob_backend = from_config(|key| std::env::var(key).ok())?;
+    if let Some(backend) = &store.blob_backend {
+        // Read/write readiness, including on an empty node. A fixed harmless
+        // marker avoids leaving one object behind for every restart.
+        let key = blake3::hash(b"atomic-blob-storage-readiness-v1");
+        let bytes = b"atomic-blob-storage-readiness-v1";
+        backend
+            .put(key.as_bytes(), bytes)
+            .await
+            .map_err(|e| e.to_string())?;
+        if backend.get(key.as_bytes()).await?.as_deref() != Some(bytes.as_slice()) {
+            return Err("S3 blob storage readiness verification failed".into());
+        }
+        let count = store
+            .migrate_blobs_to_backend()
+            .await
+            .map_err(|e| e.to_string())?;
+        tracing::info!(
+            migrated_blobs = count,
+            "S3 file storage ready; local blob storage disabled"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atomic_lib::{db::trees::Tree, Db};
+
+    async fn exercise_remote_storage(backend: Arc<dyn BlobBackend>) {
+        let mut first = Db::init_redb(None).await.unwrap();
+        first.blob_backend = Some(backend.clone());
+        let bytes = b"file contents survive replacement of the server node";
+        let hash = blake3::hash(bytes);
+        first.put_blob(hash.as_bytes(), bytes).await.unwrap();
+        first.put_blob(hash.as_bytes(), bytes).await.unwrap();
+        assert_eq!(first.kv.len(Tree::Blobs).unwrap(), 0);
+        assert_eq!(
+            first.blob_size(hash.as_bytes()).await.unwrap(),
+            Some(bytes.len() as u64)
+        );
+        drop(first);
+        let mut replacement = Db::init_redb(None).await.unwrap();
+        replacement.blob_backend = Some(backend);
+        assert_eq!(
+            replacement
+                .get_blob(hash.as_bytes())
+                .await
+                .unwrap()
+                .unwrap(),
+            bytes
+        );
+        assert_eq!(replacement.kv.len(Tree::Blobs).unwrap(), 0);
+    }
+
+    fn remote() -> Arc<dyn BlobBackend> {
+        Arc::new(
+            ObjectBlobBackend::new(
+                Arc::new(object_store::memory::InMemory::new()),
+                "hosted-blobs",
+            )
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn files_survive_node_replacement_without_local_copies() {
+        exercise_remote_storage(remote()).await;
+    }
+
+    #[tokio::test]
+    async fn peer_sync_uses_remote_storage_and_reports_failed_writes() {
+        use atomic_lib::{
+            agents::ForAgent,
+            sync::{engine::handle_frame, protocol},
+        };
+        let mut db = Db::init_redb(None).await.unwrap();
+        db.blob_backend = Some(remote());
+        let bytes = b"file received through peer sync";
+        let hash = blake3::hash(bytes);
+        db.note_pending_blob_request(*hash.as_bytes(), "test-drive".into());
+        let response = protocol::encode_blob_response(hash.as_bytes(), bytes);
+        assert!(handle_frame(&response, &db, &mut ForAgent::Sudo)
+            .await
+            .is_empty());
+        assert_eq!(db.get_blob(hash.as_bytes()).await.unwrap().unwrap(), bytes);
+        let reply = handle_frame(
+            &protocol::encode_blob_request(hash.as_bytes()),
+            &db,
+            &mut ForAgent::Sudo,
+        )
+        .await;
+        assert_eq!(reply, vec![response.clone()]);
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 0);
+
+        db.blob_backend = Some(Arc::new(FailedBackend { corrupt: false }));
+        db.note_pending_blob_request(*hash.as_bytes(), "test-drive".into());
+        let failed = handle_frame(&response, &db, &mut ForAgent::Sudo).await;
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0][0], protocol::tag::ERROR);
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn existing_blobs_are_verified_and_removed_from_local_storage() {
+        let mut db = Db::init_redb(None).await.unwrap();
+        let bytes = b"existing uploaded file";
+        let hash = blake3::hash(bytes);
+        db.put_blob(hash.as_bytes(), bytes).await.unwrap();
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 1);
+        db.blob_backend = Some(remote());
+        assert_eq!(db.migrate_blobs_to_backend().await.unwrap(), 1);
+        assert_eq!(db.migrate_blobs_to_backend().await.unwrap(), 0);
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 0);
+        assert_eq!(db.get_blob(hash.as_bytes()).await.unwrap().unwrap(), bytes);
+    }
+
+    struct FailedBackend {
+        corrupt: bool,
+    }
+    #[async_trait]
+    impl BlobBackend for FailedBackend {
+        async fn put(&self, _: &[u8], _: &[u8]) -> AtomicResult<()> {
+            if self.corrupt {
+                Ok(())
+            } else {
+                Err("storage unavailable".into())
+            }
+        }
+        async fn get(&self, _: &[u8]) -> AtomicResult<Option<Vec<u8>>> {
+            if self.corrupt {
+                Ok(Some(b"corrupted".to_vec()))
+            } else {
+                Err("storage unavailable".into())
+            }
+        }
+        async fn size(&self, _: &[u8]) -> AtomicResult<Option<u64>> {
+            Err("storage unavailable".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_failure_never_falls_back_to_local_disk() {
+        let mut db = Db::init_redb(None).await.unwrap();
+        db.blob_backend = Some(Arc::new(FailedBackend { corrupt: false }));
+        assert!(db.put_blob(&[1; 32], b"new file").await.is_err());
+        assert!(db.get_blob(&[1; 32]).await.is_err());
+        assert!(db.has_blob(&[1; 32]).await.is_err());
+        assert_eq!(db.kv.len(Tree::Blobs).unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn failed_migration_preserves_original_bytes() {
+        for corrupt in [false, true] {
+            let mut db = Db::init_redb(None).await.unwrap();
+            db.put_blob(&[1; 32], b"original").await.unwrap();
+            db.blob_backend = Some(Arc::new(FailedBackend { corrupt }));
+            assert!(db.migrate_blobs_to_backend().await.is_err());
+            assert_eq!(
+                db.kv.get(Tree::Blobs, &[1; 32]).unwrap().unwrap(),
+                b"original"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_or_invalid_config_cannot_select_a_local_fallback() {
+        assert!(from_config(|k| (k == "ATOMIC_BLOB_BACKEND").then(|| "s3".into())).is_err());
+        assert!(from_config(|k| (k == "ATOMIC_BLOB_BACKEND").then(|| "typo".into())).is_err());
+        assert!(from_config(|_| None).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires ATOMIC_BLOB_BACKEND=s3 and ATOMIC_S3_* pointing at a test bucket"]
+    async fn s3_files_survive_node_replacement() {
+        let backend = from_config(|key| std::env::var(key).ok())
+            .unwrap()
+            .expect("S3 config required");
+        exercise_remote_storage(backend).await;
+    }
+}

--- a/server/src/handlers/blob.rs
+++ b/server/src/handlers/blob.rs
@@ -98,9 +98,7 @@ pub async fn put_blob(
         });
     }
 
-    store
-        .kv
-        .insert(atomic_lib::db::trees::Tree::Blobs, &hash_bytes, &body)?;
+    store.put_blob(&hash_bytes, &body).await?;
 
     Ok(HttpResponse::NoContent().finish())
 }

--- a/server/src/handlers/download.rs
+++ b/server/src/handlers/download.rs
@@ -43,7 +43,7 @@ pub async fn handle_download(
     // uploads have DID resources, and peers can hold the blob without metadata.
     if let Some(hash_hex) = subject_path.strip_prefix("/files/") {
         if hash_hex.len() == 64 && hex::decode(hash_hex).is_ok() {
-            let bytes = match blob_by_hash_hex(hash_hex, &appstate)? {
+            let bytes = match blob_by_hash_hex(hash_hex, &appstate).await? {
                 Some(bytes) => Some(bytes),
                 None => chunked_file_by_internal_id(hash_hex, &appstate).await?,
             };
@@ -54,7 +54,7 @@ pub async fn handle_download(
                 return Ok(user_blob_response("application/octet-stream", bytes));
             }
             let hash_bytes = hex::decode(hash_hex).expect("validated hash");
-            return serve_processed_image(&bytes, &hash_bytes, &params, &appstate);
+            return serve_processed_image(&bytes, &hash_bytes, &params, &appstate).await;
         }
     }
 
@@ -63,7 +63,7 @@ pub async fn handle_download(
     // Support did:ad:blob: subjects directly in /download
     if subject.is_blob_did() {
         if let Some(hash_hex) = subject.blob_hash_hex() {
-            if let Some(bytes) = blob_by_hash_hex(hash_hex, &appstate)? {
+            if let Some(bytes) = blob_by_hash_hex(hash_hex, &appstate).await? {
                 return Ok(user_blob_response("application/octet-stream", bytes));
             }
         }
@@ -79,7 +79,7 @@ pub async fn handle_download(
         .await?
         .to_single();
 
-    download_file_handler_partial(&resource, &req, &params, &appstate)
+    download_file_handler_partial(&resource, &req, &params, &appstate).await
 }
 
 /// Serves user-uploaded blob bytes as a forced download rather than rendering
@@ -110,23 +110,26 @@ fn user_blob_response(content_type: impl AsRef<str>, bytes: Vec<u8>) -> HttpResp
 
 /// Look up a blob by its hex-encoded BLAKE3 hash. Returns `None` if the input
 /// is not a 64-char hex string or no blob is stored under that hash.
-fn blob_by_hash_hex(hash_hex: &str, appstate: &AppState) -> AtomicServerResult<Option<Vec<u8>>> {
+async fn blob_by_hash_hex(
+    hash_hex: &str,
+    appstate: &AppState,
+) -> AtomicServerResult<Option<Vec<u8>>> {
     if hash_hex.len() != 64 {
         return Ok(None);
     }
     let Ok(hash_bytes) = hex::decode(hash_hex) else {
         return Ok(None);
     };
-    Ok(appstate
-        .store
-        .kv
-        .get(atomic_lib::db::trees::Tree::Blobs, &hash_bytes)?)
+    Ok(appstate.store.get_blob(&hash_bytes).await?)
 }
 
 /// The bytes of a File: concatenated chunk blobs when it is chunked (its `chunks`
 /// property is a non-empty ordered list of `did:ad:blob:` refs), otherwise the
 /// single blob referenced by `internalId`.
-fn reconstruct_file_bytes(resource: &Resource, appstate: &AppState) -> AtomicServerResult<Vec<u8>> {
+async fn reconstruct_file_bytes(
+    resource: &Resource,
+    appstate: &AppState,
+) -> AtomicServerResult<Vec<u8>> {
     if let Ok(Value::ResourceArray(chunks)) = resource.get(urls::CHUNKS) {
         if !chunks.is_empty() {
             let mut out = Vec::new();
@@ -137,7 +140,8 @@ fn reconstruct_file_bytes(resource: &Resource, appstate: &AppState) -> AtomicSer
                 let hash_hex = subject
                     .blob_hash_hex()
                     .ok_or_else(|| format!("Invalid chunk reference: {did}"))?;
-                let bytes = blob_by_hash_hex(hash_hex, appstate)?
+                let bytes = blob_by_hash_hex(hash_hex, appstate)
+                    .await?
                     .ok_or_else(|| format!("Chunk blob not found: {hash_hex}"))?;
                 out.extend_from_slice(&bytes);
             }
@@ -162,8 +166,8 @@ fn reconstruct_file_bytes(resource: &Resource, appstate: &AppState) -> AtomicSer
 
     appstate
         .store
-        .kv
-        .get(atomic_lib::db::trees::Tree::Blobs, &hash_bytes)?
+        .get_blob(&hash_bytes)
+        .await?
         .ok_or_else(|| format!("Blob not found: {}", internal_id).into())
 }
 
@@ -181,20 +185,20 @@ async fn chunked_file_by_internal_id(
 
     for resource in result.resources {
         if matches!(resource.get(urls::CHUNKS), Ok(Value::ResourceArray(c)) if !c.is_empty()) {
-            return Ok(Some(reconstruct_file_bytes(&resource, appstate)?));
+            return Ok(Some(reconstruct_file_bytes(&resource, appstate).await?));
         }
     }
 
     Ok(None)
 }
 
-pub fn download_file_handler_partial(
+pub async fn download_file_handler_partial(
     resource: &Resource,
     _req: &HttpRequest,
     params: &web::Query<DownloadParams>,
     appstate: &AppState,
 ) -> AtomicServerResult<HttpResponse> {
-    let bytes = reconstruct_file_bytes(resource, appstate)?;
+    let bytes = reconstruct_file_bytes(resource, appstate).await?;
 
     // The source hash for the image-rendition cache key is the whole-file hash.
     let internal_id = resource
@@ -213,15 +217,15 @@ pub fn download_file_handler_partial(
         return Ok(user_blob_response(mimetype, bytes));
     }
 
-    // With image params: serve a processed rendition. Cache it in Tree::Blobs
+    // With image params: serve a processed rendition. Cache it in the blob backend
     // under a deterministic synthetic hash so future requests with the same
     // params hit the cache and any peer that has produced the same rendition
     // can serve it content-addressably.
-    serve_processed_image(&bytes, &hash_bytes, params, appstate)
+    serve_processed_image(&bytes, &hash_bytes, params, appstate).await
 }
 
 #[cfg(feature = "img")]
-fn serve_processed_image(
+async fn serve_processed_image(
     source_bytes: &[u8],
     source_hash: &[u8],
     params: &web::Query<DownloadParams>,
@@ -234,11 +238,7 @@ fn serve_processed_image(
     let format = get_format(params)?;
     let cache_key = processed_cache_key(source_hash, &format, params);
 
-    if let Some(cached) = appstate
-        .store
-        .kv
-        .get(atomic_lib::db::trees::Tree::Blobs, &cache_key)?
-    {
+    if let Some(cached) = appstate.store.get_blob(&cache_key).await? {
         return Ok(user_blob_response(mimetype_for(&format), cached));
     }
 
@@ -247,16 +247,13 @@ fn serve_processed_image(
     }
 
     let encoded = process_image_bytes(source_bytes, params, &format)?;
-    appstate
-        .store
-        .kv
-        .insert(atomic_lib::db::trees::Tree::Blobs, &cache_key, &encoded)?;
+    appstate.store.put_blob(&cache_key, &encoded).await?;
 
     Ok(user_blob_response(mimetype_for(&format), encoded))
 }
 
 #[cfg(not(feature = "img"))]
-fn serve_processed_image(
+async fn serve_processed_image(
     _source_bytes: &[u8],
     _source_hash: &[u8],
     _params: &web::Query<DownloadParams>,

--- a/server/src/handlers/upload.rs
+++ b/server/src/handlers/upload.rs
@@ -19,7 +19,7 @@ pub struct UploadQuery {
 /// A parent Query parameter is required for checking rights and for placing the file in a Hierarchy.
 /// Creates new File resources for every submitted file.
 /// Submission is done using multipart/form-data.
-/// The file is stored in the `/uploads` directory.
+/// File bytes go to the configured blob backend (S3 or local database).
 #[tracing::instrument(skip(appstate, req, body))]
 pub async fn upload_handler(
     mut body: Multipart,
@@ -99,12 +99,10 @@ async fn save_file_and_create_resource(
     let hash_str = hash.to_hex().to_string();
     let hash_bytes = hash.as_bytes();
 
-    // Bytes are stored content-addressed in Tree::Blobs. The capability to
+    // Bytes are stored content-addressed in the configured blob backend. The capability to
     // fetch them is the hash itself; no filesystem copy is needed. See
     // docs/src/files.md.
-    store
-        .kv
-        .insert(atomic_lib::db::trees::Tree::Blobs, hash_bytes, &buffer)?;
+    store.put_blob(hash_bytes, &buffer).await?;
 
     let byte_count: i64 = buffer.len() as i64;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ See https://github.com/atomicdata-dev/atomic-server/tree/master/src-tauri
 */
 mod actor_messages;
 pub mod appstate;
+pub mod blob_storage;
 mod commit_monitor;
 pub mod config;
 mod content_types;

--- a/server/src/plugins/plugin.rs
+++ b/server/src/plugins/plugin.rs
@@ -173,10 +173,10 @@ async fn do_install_plugin(
     };
 
     let bytes = if let Some(internal_id) = internal_id_str {
-        // Files are stored content-addressed in `Tree::Blobs` (the kv store),
+        // Files are stored content-addressed in the configured blob backend,
         // keyed by the blake3 hash hex digest. The legacy `uploads_dir/<id>`
         // filesystem path was retired with the content-addressed migration —
-        // see server/src/handlers/upload.rs which inserts into `Tree::Blobs`.
+        // see server/src/handlers/upload.rs which writes to that backend.
         let hash_bytes = match hex::decode(&internal_id) {
             Ok(b) if b.len() == 32 => b,
             _ => {
@@ -198,21 +198,18 @@ async fn do_install_plugin(
             }
         };
 
-        match store
-            .kv
-            .get(atomic_lib::db::trees::Tree::Blobs, &hash_bytes)
-        {
+        match store.get_blob(&hash_bytes).await {
             Ok(Some(bytes)) => {
-                info!("Reading plugin from kv blob store ({} bytes)", bytes.len());
+                info!("Reading plugin from blob backend ({} bytes)", bytes.len());
                 bytes
             }
             Ok(None) => {
                 error!(
-                    "Plugin file {} blob not found in kv store for hash {}",
+                    "Plugin file {} blob not found in blob backend for hash {}",
                     plugin_file_subject, internal_id
                 );
                 return Err(AtomicError::from(format!(
-                    "Plugin file blob not found in kv store: {}",
+                    "Plugin file blob not found in blob backend: {}",
                     internal_id
                 )));
             }

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -543,6 +543,17 @@ fn get_body(resp: ServiceResponse) -> String {
 #[cfg(feature = "img")]
 #[actix_rt::test]
 async fn content_addressed_image_download() {
+    content_addressed_image_with_storage(false).await;
+}
+
+#[cfg(feature = "img")]
+#[actix_rt::test]
+async fn remote_image_renditions_never_write_local_blobs() {
+    content_addressed_image_with_storage(true).await;
+}
+
+#[cfg(feature = "img")]
+async fn content_addressed_image_with_storage(remote: bool) {
     use clap::Parser;
     let dir = std::path::PathBuf::from(format!("./.temp/{}", atomic_lib::utils::random_string(10)));
     let opts = Opts::parse_from([
@@ -556,7 +567,17 @@ async fn content_addressed_image_download() {
     let mut config = config::build_config(opts).unwrap();
     config.search_index_path = dir.join("search");
     config.vector_search_index_path = dir.join("vectors");
-    let appstate = AppState::init(config).await.unwrap();
+    let mut appstate = AppState::init(config).await.unwrap();
+    if remote {
+        appstate.store.blob_backend = Some(std::sync::Arc::new(
+            crate::blob_storage::ObjectBlobBackend::new(
+                std::sync::Arc::new(object_store::memory::InMemory::new()),
+                "files",
+            )
+            .unwrap(),
+        ));
+    }
+    let store = appstate.store.clone();
     let mut png = std::io::Cursor::new(Vec::new());
     image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
         2,
@@ -569,8 +590,8 @@ async fn content_addressed_image_download() {
     let hash = blake3::hash(&bytes);
     appstate
         .store
-        .kv
-        .insert(atomic_lib::db::trees::Tree::Blobs, hash.as_bytes(), &bytes)
+        .put_blob(hash.as_bytes(), &bytes)
+        .await
         .unwrap();
     let app = test::init_service(
         App::new()
@@ -631,10 +652,29 @@ async fn content_addressed_image_download() {
             "missing blobs must not become HTTP 500"
         );
     }
+    if remote {
+        assert_eq!(store.kv.len(atomic_lib::db::trees::Tree::Blobs).unwrap(), 0);
+    }
 }
 
 #[actix_rt::test]
 async fn upload_download_test() {
+    upload_download_with_backend(None).await;
+}
+
+#[actix_rt::test]
+async fn remote_upload_download_never_stores_bytes_locally() {
+    let backend = crate::blob_storage::ObjectBlobBackend::new(
+        std::sync::Arc::new(object_store::memory::InMemory::new()),
+        "files",
+    )
+    .unwrap();
+    upload_download_with_backend(Some(std::sync::Arc::new(backend))).await;
+}
+
+async fn upload_download_with_backend(
+    backend: Option<std::sync::Arc<dyn atomic_lib::db::blob_backend::BlobBackend>>,
+) {
     let unique_string = atomic_lib::utils::random_string(10);
     use clap::Parser;
     let opts = Opts::parse_from([
@@ -651,10 +691,14 @@ async fn upload_download_test() {
     // server tests set this; without it, parallel runs share the default
     // search-index dir and trip Tantivy's `LockBusy` on the second test.
     config.search_index_path = format!("./.temp/{}/search_index", unique_string).into();
-    let appstate = crate::appstate::AppState::init(config.clone())
+    let mut appstate = crate::appstate::AppState::init(config.clone())
         .await
         .expect("failed init appstate");
 
+    if backend.is_some() {
+        appstate.store.blob_backend = backend;
+    }
+    let remote = appstate.store.blob_backend.is_some();
     let data = Data::new(appstate.clone());
     let app = test::init_service(
         App::new()
@@ -708,11 +752,21 @@ async fn upload_download_test() {
     let hash_bytes = blake3::hash(test_content);
     let blob = appstate
         .store
-        .kv
-        .get(atomic_lib::db::trees::Tree::Blobs, hash_bytes.as_bytes())
+        .get_blob(hash_bytes.as_bytes())
+        .await
         .unwrap()
         .unwrap();
     assert_eq!(blob, test_content);
+    if remote {
+        assert_eq!(
+            appstate
+                .store
+                .kv
+                .len(atomic_lib::db::trees::Tree::Blobs)
+                .unwrap(),
+            0
+        );
+    }
 
     // 3. Download
     let req = build_request_authenticated(&format!("/download/files/{}", expected_hash), &appstate)


### PR DESCRIPTION
Hosted file bytes currently live in the node's redb database, making node storage grow with attachments and requiring file copies when replacing a node. This adds S3-compatible primary file storage behind an async blob interface, while standalone and browser databases retain the existing local default.

Uploads, downloads, image renditions, plugin reads and peer-sync blob frames all use the selected backend. S3 mode has no disk cache or local fallback; startup verifies read/write access and migrates existing blobs one at a time, reading each remote copy back before deleting the local row. Usage and presence checks use object metadata. The paired SaaS change (https://github.com/ontola/atomic-saas/pull/83) requires this mode for managed nodes and configures the existing and newly provisioned nodes consistently.

Validation:
- Server library suite with image support: 75 passed before the final peer test; that additional peer-storage test passes, as do all six focused storage tests.
- Real HTTP multipart upload/download and replacement-node reads pass against a local Moto S3 service, with an empty local blob table.
- Sync suite: 182 passed, one ignored, one presence test failed under concurrency and passed when rerun alone.
- Paired SaaS: 363 tests and 19 managed-node tests pass; real managed subprocess starts with S3 and heartbeats successfully.
- Formatting passes. Strict Clippy/pre-commit remain blocked by existing workspace warnings (including tools/cargo-bin's nested format and existing type-complexity/clone warnings). The failing hook was bypassed for this commit; CI is not claimed green.

Rollout: migration can delay startup; old binaries cannot read migrated files. SaaS prevents automatic rollback to a pre-S3 node binary. Deleted redb rows free reusable pages but do not necessarily shrink the database file or remove old filesystem backups.

This is hosted primary storage, not encrypted Vault attachment backup. Streaming/direct URLs, blob GC and Vault attachment recovery remain separate work. No live deployment was performed.


### Follow-up: shared-file quota accounting

Quota usage is now deduplicated within each drive, never across different owners' drives. Two owners with the same 100 MB file each use 100 MB of their drive quota, while the shared S3 namespace stores one object. Summing logical drive/account counters does not measure physical bucket size. Within a node report, blob-size metadata is cached so shared content only needs one S3 size lookup.

The regression reproduced the old zero-byte attribution before the fix and now passes. It covers duplicate references within one drive, two different owners, combined/reversed/separate reports, one physical object, and removing one owner's references without changing the other's usage. The companion SaaS regression verifies independent owner counters and idempotent reports.

Validation for this follow-up: both new regressions, the existing HTTP drive-usage test and all three existing usage-report tests pass; formatting and diff checks pass. The previously documented workspace lint blocker remains; the server commit uses the same hook bypass. No deployment was performed.
