### PR TITLE
Fix Resource.save acknowledgement after rejected commits

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -513,6 +513,12 @@ mounts without resetting or re-registering the global parser.
 
 ### Save durability and identity lifecycle regressions
 
+- `save-acknowledgement.test.ts` exercises `Resource.save()` through the real
+  outbox with a stubbed commit transport: server refusals (including terminal
+  drops), backoff, blocked entries and cancellation cannot report persistence.
+  It also covers offline transport failures, successful retries, unrelated
+  subjects and edits arriving during an acknowledged save (#1388).
+
 - `client-db.worker.test.ts` requires vault cursor commits to flush before the
   worker acknowledges backup completion, and propagates flush failures. The
   SaaS `vault-refresh.spec.ts` checks stored objects and bytes across reloads.

--- a/browser/lib/src/local-outbox.ts
+++ b/browser/lib/src/local-outbox.ts
@@ -43,6 +43,9 @@ export interface OutboxEntry {
   baseVersion?: string;
   lastAttemptAt?: number;
   lastAttemptError?: string;
+  /** In-memory cause, retained on this entry even if a terminal failure drops
+   * it from the queue. Explicit saves hold the entry across a drain. */
+  lastAttemptFailure?: { cause: unknown };
   /** Consecutive failed drain attempts. Drives exponential backoff so a
    *  persistently-failing commit (e.g. a parent not yet synced) stops
    *  hammering the server. Reset to 0 on success. */
@@ -652,12 +655,15 @@ export class LocalOutbox {
 
       try {
         await ctx.drainSubject(live.subject);
+        live.lastAttemptFailure = undefined;
+        live.lastAttemptError = undefined;
         // Success — clear the failure counter. The entry itself is usually
         // already removed by `drainSubject`; this handles the genesis-acked-
         // but-still-dirty leftover case.
         const stillLive = this.entries.get(entry.subject);
         if (stillLive) stillLive.failures = 0;
       } catch (e) {
+        live.lastAttemptFailure = { cause: e };
         // Explicit disconnect cancels the attempt, not the durable write.
         // Keep it queued for reconnect without escalating retry failures.
         if (e instanceof RequestCancelledError) return;

--- a/browser/lib/src/resource.ts
+++ b/browser/lib/src/resource.ts
@@ -93,11 +93,14 @@ export const unknownSubject = 'unknown-subject';
 
 /**
  * Outcome of {@link Resource.save}:
- *  - `'persisted'` — the server acknowledged the commit.
+ *  - `'persisted'` — the server acknowledged the commit (or a local-only
+ *                    resource was durably saved to the local database).
  *  - `'offline'`   — server unreachable; saved locally, drain retries
  *                    on reconnect (also returned for a child queued
  *                    behind an unsaved parent).
  *  - `'noop'`      — nothing to save.
+ * Server refusals and queued writes without acknowledgement reject; background
+ * retries continue according to the outbox policy.
  */
 export type SaveResult = 'persisted' | 'offline' | 'noop';
 
@@ -3116,7 +3119,8 @@ export class Resource<C extends OptionalClass = any> {
   /**
    * Persist this resource. Resolves once the change is durable:
    *
-   *  - `'persisted'` — the server acknowledged the commit.
+   *  - `'persisted'` — the server acknowledged the commit (or a local-only
+   *                    resource was durably saved to the local database).
    *  - `'offline'`   — server unreachable; saved to clientDb, the drain
    *                    retries on reconnect.
    *  - `'noop'`      — nothing to save (no unsaved changes, nothing
@@ -3357,12 +3361,39 @@ export class Resource<C extends OptionalClass = any> {
       // 100 ms before calling `save()`, and the drain coalesces; the
       // await matters for explicit saves (blur, Enter, programmatic)
       // that need "is it safe to leave?" before proceeding.
+      // Retain the entry itself: a terminal refusal removes it from the queue,
+      // which must never be mistaken for acknowledgement. Capture this save's
+      // version too; edits made during the POST may legitimately remain queued.
+      const entry = this.store.outbox.getEntry(this.subject);
+      const savingVersion = this._loroDoc?.oplogVersion().toJSON();
       await this.store.syncDirtyResources();
+
+      if (entry?.lastAttemptFailure) {
+        throw entry.lastAttemptFailure.cause;
+      }
+
+      if (this.store.outbox.hasPending(this.subject)) {
+        const savedVersion = this._loroVersionAtLastSave?.toJSON();
+        const acknowledged =
+          !entry?.signedGenesis &&
+          savingVersion &&
+          savedVersion &&
+          [...savingVersion].every(
+            ([peer, counter]) => (savedVersion.get(peer) ?? 0) >= counter,
+          );
+
+        if (!acknowledged) {
+          throw new Error(
+            'Save is still queued; the server has not acknowledged it.',
+          );
+        }
+      }
 
       // The server acknowledgement does not make the OPFS cache durable.
       // Explicit saves must survive an immediate reload for existing resources
       // too (for example a dashboard block renamed in its config dialog).
       await this.persistToClientDb();
+      this.commitError = undefined;
 
       return 'persisted';
     } catch (e) {

--- a/browser/lib/src/save-acknowledgement.test.ts
+++ b/browser/lib/src/save-acknowledgement.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { core } from './ontologies/core.js';
+import { testStore } from './test-store.js';
+import { RequestCancelledError } from './error.js';
+import { BLOCK_AFTER_FAILURES } from './local-outbox.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('explicit save acknowledgement', () => {
+  it.each([
+    'Unauthorized: no write rights in parent',
+    'Property content missing. Is required in class Message',
+    'is_genesis: true, but the resource already exists',
+  ])('rejects a server refusal: %s', async message => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+      propVals: { [core.properties.name]: 'Rejected' },
+    });
+    const error = new Error(message);
+    postCommitSpy.mockRejectedValue(error);
+
+    await expect(doc.save()).rejects.toBe(error);
+    expect(doc.commitError).toBe(error);
+    store.setServerConnected(false);
+  });
+
+  it('does not report a backed-off retry as persisted', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    const error = new Error('server temporarily unavailable');
+    postCommitSpy.mockRejectedValue(error);
+    await doc.save().catch(() => undefined);
+    const attempts = postCommitSpy.mock.calls.length;
+
+    await expect(doc.save()).rejects.toBe(error);
+    expect(postCommitSpy).toHaveBeenCalledTimes(attempts);
+    store.setServerConnected(false);
+  });
+
+  it('keeps transport failures queued and returns offline', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    postCommitSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(doc.save()).resolves.toBe('offline');
+    expect(store.outbox.hasPending(doc.subject)).toBe(true);
+    expect(store.serverConnected).toBe(false);
+  });
+  it('clears the error after a successful retry', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    const error = new Error('temporary refusal');
+    postCommitSpy.mockRejectedValueOnce(error);
+    await expect(doc.save()).rejects.toBe(error);
+    store.outbox.getEntry(doc.subject)!.lastAttemptAt = 0;
+
+    await expect(doc.save()).resolves.toBe('persisted');
+    expect(doc.commitError).toBeUndefined();
+    expect(store.outbox.hasPending(doc.subject)).toBe(false);
+    store.setServerConnected(false);
+  });
+
+  it('rejects a blocked entry without posting again', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    const error = new Error('Unauthorized: no write rights in parent');
+    postCommitSpy.mockRejectedValue(error);
+    await expect(doc.save()).rejects.toBe(error);
+    const entry = store.outbox.getEntry(doc.subject)!;
+    entry.failures = BLOCK_AFTER_FAILURES;
+    entry.blocked = true;
+    const attempts = postCommitSpy.mock.calls.length;
+
+    await expect(doc.save()).rejects.toBe(error);
+    expect(postCommitSpy).toHaveBeenCalledTimes(attempts);
+    store.setServerConnected(false);
+  });
+
+  it('does not let an unrelated failure reject an acknowledged save', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const rejected = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    const accepted = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    postCommitSpy.mockRejectedValueOnce(new Error('temporary refusal'));
+    await rejected.save().catch(() => undefined);
+
+    await expect(accepted.save()).resolves.toBe('persisted');
+    expect(store.outbox.hasPending(rejected.subject)).toBe(true);
+    store.setServerConnected(false);
+  });
+
+  it('rejects cancellation without losing the queued write', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    const error = new RequestCancelledError();
+    postCommitSpy.mockRejectedValue(error);
+
+    await expect(doc.save()).rejects.toBe(error);
+    expect(store.outbox.hasPending(doc.subject)).toBe(true);
+    store.setServerConnected(false);
+  });
+
+  it('allows an acknowledged save while a newer edit remains dirty', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    await doc.save();
+    await doc.set(core.properties.name, 'Saved edit', false);
+    postCommitSpy.mockImplementationOnce(async commit => {
+      await doc.set(core.properties.name, 'Newer edit', false);
+
+      return {
+        ...commit,
+        id: `https://example.com/commits/${commit.signature}`,
+      };
+    });
+
+    await expect(doc.save()).resolves.toBe('persisted');
+    expect(doc.get(core.properties.name)).toBe('Newer edit');
+    expect(doc.hasOpsPastSaveCursor()).toBe(true);
+    store.setServerConnected(false);
+  });
+
+  it('rejects a failed update to an existing resource', async () => {
+    const { store, postCommitSpy } = await testStore();
+    const doc = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Drive',
+      noParent: true,
+    });
+    await doc.save();
+    await doc.set(core.properties.name, 'Rejected update', false);
+    const error = new Error('Unauthorized: no write rights');
+    postCommitSpy.mockRejectedValue(error);
+
+    await expect(doc.save()).rejects.toBe(error);
+    expect(doc.hasOpsPastSaveCursor()).toBe(true);
+    expect(store.outbox.hasPending(doc.subject)).toBe(true);
+    store.setServerConnected(false);
+  });
+});

--- a/planning/unified-sync.md
+++ b/planning/unified-sync.md
@@ -305,6 +305,22 @@ that turned out to be already done, or blocked by a finding, say so inline.
 
 ## Outbox modernization
 
+### Explicit save acknowledgement (#1388)
+
+- [x] Reproduce false `persisted` results through the public `Resource.save()` API.
+- [x] Preserve per-entry failure causes across terminal removal and propagate
+  them to explicit saves; background drains retain their retry policy.
+- [x] Check queued saves against the captured Loro version so an acknowledged
+  save can finish while newer edits remain queued. Preserve offline and
+  local-only durability semantics.
+- [x] Cover refusals, retries, cancellation and concurrent edits in library tests.
+- [ ] Merge after PR validation.
+
+An attempted drain is not an acknowledgement. Callers must handle rejected
+saves and distinguish `offline` from `persisted` before starting server work
+that depends on the resource. `persisted` also denotes local database durability
+for local-only resources, which have no server acknowledgement.
+
 The dirty-bit sign-at-drain core is the right design — keep it. What needs work is the
 plumbing around it, which still carries HTTP-era shapes:
 


### PR DESCRIPTION
Fixes #1388.

`await resource.save()` could return `persisted` after the server rejected the commit, allowing dependent operations to run before their resources existed. Explicit saves now propagate their outbox entry's failure, including terminal failures that remove the entry. Backed-off and blocked writes cannot silently succeed. Network failures retain the existing `offline` result and durable queue behavior.

The save captures its Loro version so newer edits made during an acknowledged POST can remain queued without rejecting the completed save. Successful retries clear the resource's previous commit error. The sync plan and testing coverage document the contract, including local-only persistence.

Validation: reproduced five failing cases before the fix; all 468 library tests pass afterward, including 11 acknowledgement regressions. Library TypeScript, build, lint and formatting pass; the pre-commit hook also passed workspace lint. Browser E2E and hosted CI have not been run locally for this change.
