### PR TITLE
Fix deleted sidebar items returning from stale queries

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -513,6 +513,15 @@ mounts without resetting or re-registering the global parser.
 
 ### Save durability and identity lifecycle regressions
 
+- `collection-page-assemble.test.ts` holds a local query in flight while a
+  member is deleted, then releases the stale result. It checks membership,
+  counts, skipped hydration, optimistic additions, and subsequent readmission.
+- The `delete resource` smoke E2E requires a known sidebar link to disappear
+  before reload; a success toast no longer substitutes for this assertion.
+  Local Chromium verification passed using the existing Rust/WASM builds.
+  One run timed out at the separate child-cascade store-removal barrier;
+  a subsequent run passed, so cascade timing remains an intermittent gap.
+
 - `client-db.worker.test.ts` requires vault cursor commits to flush before the
   worker acknowledges backup completion, and propagates flush failures. The
   SaaS `vault-refresh.spec.ts` checks stored objects and bytes across reloads.

--- a/browser/e2e/tests/e2e.spec.ts
+++ b/browser/e2e/tests/e2e.spec.ts
@@ -671,6 +671,19 @@ test.describe('data-browser', async () => {
 
   test('delete resource', smoke, async ({ page }) => {
     await newResource('folder', page);
+    await setTitle(page, 'Deletion parent');
+    await expect(
+      page.getByTestId('sidebar').getByText('Deletion parent', { exact: true }),
+    ).toBeVisible();
+    const parentHref = await page
+      .getByTestId('sidebar')
+      .getByText('Deletion parent', { exact: true })
+      .locator('xpath=ancestor::a[1]')
+      .getAttribute('href');
+    expect(parentHref).toBeTruthy();
+    const sidebarParent = page
+      .getByTestId('sidebar')
+      .locator(`a[href=${JSON.stringify(parentHref)}]`);
     const parentResource = await getCurrentSubject(page);
     // Empty-folder quick-create now renders dedicated "New Folder" / "New
     // Document" buttons instead of a generic "New Resource" + class picker.
@@ -698,39 +711,13 @@ test.describe('data-browser', async () => {
     // some renders before it unmounts, leading to flaky no-ops.
     await page.locator('dialog[open] button:has-text("Delete")').click();
 
-    // Wait for the destroy to actually land before reloading. The reload is
-    // what makes this a barrier and not a nicety: it abandons whatever the
-    // page still had in flight, so returning too early cancels the destroy and
-    // the resource is simply still there afterwards.
-    //
-    // This used to wait on the "Resource deleted" toast alone, which is why
-    // the test was marked flaky. A success toast expires after about two
-    // seconds, so under suite load it can be raised and gone before the first
-    // poll — the delete having worked perfectly — and the assertion then waits
-    // out its timeout on an element that will never come back.
-    //
-    // So accept either signal: the toast if we catch it, or the sidebar having
-    // dropped the folder, which is the same fact in a form that does not
-    // expire. Whichever arrives first, the destroy has been applied.
-    await expect
-      .poll(
-        async () => {
-          const toast = await page.locator('text=Resource deleted').count();
-          const listed = await page
-            .getByTestId('sidebar')
-            .getByText('Folder')
-            .count();
+    // A success toast proves the command completed, not that the UI updated.
+    // Require removal from the mounted sidebar before any reload.
+    await expect(sidebarParent).toHaveCount(0);
 
-          return toast > 0 || listed === 0;
-        },
-        { timeout: 15000, message: 'Destroy never landed' },
-      )
-      .toBe(true);
-
-    // Neither signal above says anything about the child. `destroy()` posts the
-    // parent's commit and awaits it, so the toast means the server applied
-    // THAT; the child is removed by the server's cascade, and this client only
-    // learns of it when that removal arrives over its drive subscription.
+    // Sidebar removal says nothing about the child. `destroy()` posts the
+    // parent's commit and awaits it; the server cascades to the child. This
+    // client learns of that removal through its drive subscription.
     // Until then the child is still in the store, still in the local database,
     // and a reload brings it back.
     await page.waitForFunction(
@@ -746,6 +733,7 @@ test.describe('data-browser', async () => {
     await waitForSynced(page);
 
     await page.reload();
+    await expect(sidebarParent).toHaveCount(0);
     await openSubject(page, nestedResource);
 
     // ErrorPage renders `Could not open <subject>` for missing resources.

--- a/browser/lib/src/collection-page-assemble.test.ts
+++ b/browser/lib/src/collection-page-assemble.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, vi, expect as assert } from 'vitest';
 import { Collection } from './collection.js';
 import type { ClientDbQueryResult, ClientDbWorker } from './client-db.js';
 import { commits, core, dataBrowser, collections } from './index.js';
@@ -233,6 +233,67 @@ describe('collection page assemble does not flash unsorted members', () => {
     expect(members.slice(0, 2)).toEqual([ALICE, BOB]);
     expect(members).toContain(created);
   });
+
+  it.each([false, true])(
+    'does not restore a deleted member from an in-flight query (optimistic=%s)',
+    async optimistic => {
+      const store = new Store({ serverUrl: 'https://example.com' });
+      store.setDrive(DRIVE);
+      store.finishDriveSync(DRIVE, 2, Date.now());
+      const stale = {
+        subjects: [ALICE, BOB],
+        resources: [jsonAd(ALICE, 1000), jsonAd(BOB, 2000)],
+        count: 2,
+      };
+      let release!: (result: ClientDbQueryResult) => void;
+      let delayed = false;
+      store.setClientDb(
+        mockClientDb(async () =>
+          delayed
+            ? new Promise(resolve => {
+                release = resolve;
+              })
+            : stale,
+        ),
+      );
+      const collection = new Collection(
+        store,
+        'https://example.com',
+        {
+          page_size: '30',
+          include_nested: false,
+          property: core.properties.parent,
+          value: TABLE,
+          drive: DRIVE,
+        },
+        true,
+      );
+      await collection.refresh();
+
+      if (optimistic) {
+        collection.applyResourceChange(ALICE, undefined);
+        collection.applyResourceChange(ALICE, store.resources.get(ALICE));
+      }
+
+      delayed = true;
+      const refreshing = collection.refresh();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      collection.applyResourceChange(ALICE, undefined);
+      const hydrate = vi.spyOn(store, 'hydrateResourceFromJsonAd');
+      release(stale);
+      await refreshing;
+      assert(await collection.getMembersOnPage(0)).toEqual([BOB]);
+      assert(collection.totalMembers).toBe(1);
+      assert(hydrate.mock.calls.map(([subject]) => subject)).toEqual([BOB]);
+      hydrate.mockRestore();
+      // A real resource update can admit a subsequently restored member.
+      assert(
+        collection.applyResourceChange(ALICE, store.resources.get(ALICE)),
+      ).toBe('member-added');
+      assert(await collection.getMembersOnPage(0)).toEqual([BOB, ALICE]);
+      assert(collection.totalMembers).toBe(2);
+    },
+  );
 
   it('treats a missing sort key as missing, not the string "undefined"', async ({
     expect,

--- a/browser/lib/src/collection.ts
+++ b/browser/lib/src/collection.ts
@@ -264,6 +264,9 @@ export class Collection {
    * that says "0 members" silently wipes the optimistic add and the
    * UI loses the just-created resource until the next reload. */
   private _optimisticAdds = new Set<string>();
+  /** Removals survive stale queries until a matching resource event admits
+   * the subject again. */
+  private _removedSubjects = new Set<string>();
   private server: string;
   private params: CollectionParams;
 
@@ -439,6 +442,24 @@ export class Collection {
     pageIdx: number,
     resource: Resource<Collections.Collection>,
   ): void {
+    const incomingMembers = resource.getSubjects(
+      collections.properties.members,
+    );
+    const retained = incomingMembers.filter(s => !this._removedSubjects.has(s));
+
+    if (retained.length !== incomingMembers.length) {
+      const total = resource.get(collections.properties.totalMembers);
+      this.writePageMembers(
+        resource,
+        retained,
+        Math.max(
+          0,
+          (typeof total === 'number' ? total : incomingMembers.length) -
+            (incomingMembers.length - retained.length),
+        ),
+      );
+    }
+
     // Drop the old page's members from the index first, then re-add the
     // new page's. Members can move between pages on `refresh`, so we
     // can't just additively merge.
@@ -577,6 +598,15 @@ export class Collection {
           constraintMatches(resource, f.property, f.value, f.operator ?? 'eq'),
       );
 
+    if (!resource) {
+      // refresh clears the index before awaiting its query. Remember deletion
+      // even when the subject is temporarily absent from that index.
+      this._removedSubjects.add(subject);
+      this._optimisticAdds.delete(subject);
+    } else if (matches && !resource.new && !this._assemblingPage) {
+      this._removedSubjects.delete(subject);
+    }
+
     // O(1) lookup via the maintained subject→page index instead of
     // scanning every loaded page on every incoming event. The within-
     // page `indexOf` for the remove path stays — that's the array
@@ -711,6 +741,7 @@ export class Collection {
     // Share the index too — both clones look at the same `pages` Map,
     // so they should observe the same membership.
     collection._memberIndex = this._memberIndex;
+    collection._removedSubjects = this._removedSubjects;
 
     return collection;
   }
@@ -1014,6 +1045,7 @@ export class Collection {
       result.resources.length === result.subjects.length
     ) {
       for (let i = 0; i < result.subjects.length; i++) {
+        if (this._removedSubjects.has(result.subjects[i]!)) continue;
         this.store.hydrateResourceFromJsonAd(
           result.subjects[i]!,
           result.resources[i]!,
@@ -1027,7 +1059,9 @@ export class Collection {
     // `TableResource` and react-window render an empty `TableRow` slot
     // for the missing index that gets stuck on a loading shimmer. Stripping
     // here keeps the count and the addressable members consistent.
-    result.subjects = filterIndexLeakage(result.subjects);
+    result.subjects = filterIndexLeakage(result.subjects).filter(
+      subject => !this._removedSubjects.has(subject),
+    );
     result.count = result.subjects.length;
 
     if (result.subjects.length === 0) {


### PR DESCRIPTION
Deleting a resource while a collection query is in flight can put it back in the sidebar: refresh clears the membership index, the removal is treated as irrelevant, and the stale query restores the member. Preserve removals across query completion, skip deleted-member hydration, and allow a subsequent matching resource update to readmit the subject.

The deletion smoke test previously accepted a success toast **or** sidebar disappearance before reloading. It now verifies that a known sidebar link disappears before reload and remains absent afterward. Deterministic unit tests cover the in-flight query race, including optimistic additions, counts, hydration, and readmission.

## Validation

- Latest `develop`: 8 focused collection tests pass; browser workspace lint and library typecheck pass.
- Before updating the PR branch to latest `develop`: full library suite passed (434 tests), followed by the expanded regression tests; the strengthened Chromium deletion E2E passed with existing Rust/WASM builds.
- One browser run timed out at the separate child-cascade removal barrier before a subsequent pass. E2E typechecking in the original checkout also encountered an unrelated existing import error in `browser-invite.spec.ts`. The full browser suite and fresh-build E2E have not been run for this PR.

## Checklist

- [x] Add regression tests and strengthen the deletion smoke test
- [x] Update the testing coverage map
- No public API changes
