### PR TITLE
Fix formatting of durable snapshot regression test

### DIFF
--- a/browser/lib/src/store.test.ts
+++ b/browser/lib/src/store.test.ts
@@ -433,53 +433,50 @@ describe('Store', () => {
     expect(persisted.get(core.properties.name)).toBe('After');
   });
 
-  it(
-    'an acknowledged edit waits for its durable snapshot before save resolves',
-    async () => {
-      const { expect } = await import('vitest');
-      const { store } = await testStore();
-      const drive = await store.createDrive('Home');
-      store.setDrive(drive.subject);
-      const resource = await store.newResource({
-        isA: 'https://atomicdata.dev/classes/Folder',
-        parent: drive.subject,
-        propVals: { [core.properties.name]: 'Before' },
-      });
-      await resource.save();
-      let release!: () => void;
-      const pendingWrite = new Promise<void>(resolve => {
-        release = resolve;
-      });
-      const putResourceWithSnapshot = vi.fn(() => pendingWrite);
-      const flush = vi.fn(() => Promise.reject(new Error('worker destroyed')));
-      store.setClientDb({
-        isReady: true,
-        flush,
-        putResourceWithSnapshot,
-      } as unknown as Parameters<Store['setClientDb']>[0]);
-      await resource.set(core.properties.name, 'After', false);
-      let finished = false;
-      const saving = resource.save().then(() => {
-        finished = true;
-      });
+  it('an acknowledged edit waits for its durable snapshot before save resolves', async () => {
+    const { expect } = await import('vitest');
+    const { store } = await testStore();
+    const drive = await store.createDrive('Home');
+    store.setDrive(drive.subject);
+    const resource = await store.newResource({
+      isA: 'https://atomicdata.dev/classes/Folder',
+      parent: drive.subject,
+      propVals: { [core.properties.name]: 'Before' },
+    });
+    await resource.save();
+    let release!: () => void;
+    const pendingWrite = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const putResourceWithSnapshot = vi.fn(() => pendingWrite);
+    const flush = vi.fn(() => Promise.reject(new Error('worker destroyed')));
+    store.setClientDb({
+      isReady: true,
+      flush,
+      putResourceWithSnapshot,
+    } as unknown as Parameters<Store['setClientDb']>[0]);
+    await resource.set(core.properties.name, 'After', false);
+    let finished = false;
+    const saving = resource.save().then(() => {
+      finished = true;
+    });
 
-      try {
-        await vi.waitFor(() =>
-          expect(putResourceWithSnapshot).toHaveBeenCalled(),
-        );
-        // The server is already mocked as acknowledged; only the local write
-        // remains blocked. Leaving now must not expose the pre-edit cache.
-        await new Promise(resolve => setTimeout(resolve, 20));
-        expect(finished).toBe(false);
-      } finally {
-        release();
-        await saving;
-      }
+    try {
+      await vi.waitFor(() =>
+        expect(putResourceWithSnapshot).toHaveBeenCalled(),
+      );
+      // The server is already mocked as acknowledged; only the local write
+      // remains blocked. Leaving now must not expose the pre-edit cache.
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(finished).toBe(false);
+    } finally {
+      release();
+      await saving;
+    }
 
-      expect(finished).toBe(true);
-      expect(flush).not.toHaveBeenCalled();
-    },
-  );
+    expect(finished).toBe(true);
+    expect(flush).not.toHaveBeenCalled();
+  });
 
   it('does not write to a database in unsupported server-only mode', async ({
     expect,


### PR DESCRIPTION
The merged CI pipeline stopped at the library formatting check because the new durable-snapshot regression test was not formatted with the package configuration. Apply the formatter without changing test behavior.

Validation: the library, data-browser, and E2E package format-check commands all pass.