### PR TITLE
fix: verify local copy before sharing unenrolled drives

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -885,3 +885,5 @@ Onboarding dialog feedback: the authorization/invite and chatroom cases in
 `e2e.spec.ts` verify Continue remains clickable while feedback is offered.
 `onboarding-storage.spec.ts` checks feedback availability;
 `drive-template-onboarding.spec.ts` checks mobile creation and dismissal.
+
+`prepareDriveSharing.test.ts` covers verified local transition before peer invitation, rejection on failed verification, preservation of an enrolled drive connection, and isolation from another drive enrollment. `local-drive-copy.test.ts` covers missing history, incomplete inventory, and missing or corrupt attachments. Full sharing UI acceptance remains pending.

--- a/browser/data-browser/src/components/InviteForm.tsx
+++ b/browser/data-browser/src/components/InviteForm.tsx
@@ -3,7 +3,6 @@ import {
   useResource,
   useResourceSnapshot,
   useString,
-  useBoolean,
   useStore,
   Resource,
   urls,
@@ -13,8 +12,9 @@ import {
   dataBrowser,
 } from '@tomic/react';
 import { generateInviteToken } from '@tomic/lib';
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { Dialog } from './Dialog';
+import { prepareDriveSharing } from '../helpers/managed/prepareDriveSharing';
 import { managedFetch } from '../helpers/managed/api';
 import {
   automaticPeerRoom,
@@ -75,7 +75,6 @@ function InviteFormContent({
   const invite = useResource(subject, {
     newResource: true,
   });
-  const [allowEdits] = useBoolean(invite, server.properties.write);
   const isSaas = !!getManagedPortalUrl();
   const [err, setErr] = useState<Error | undefined>(undefined);
   const [agent] = useCurrentAgent();
@@ -83,8 +82,54 @@ function InviteFormContent({
   const [saved, setSaved] = useState(false);
   const [inviteUrl, setInviteUrl] = useState<string | undefined>(undefined);
 
+  const [creating, setCreating] = useState(false);
+  const [seats, setSeats] = useState<{
+    drive: string;
+    used?: number;
+    included?: number;
+  }>();
+
+  useEffect(() => {
+    setSeats(undefined);
+    if (!isSaas) return;
+    const controller = new AbortController();
+    const drive = target.hasClasses(server.classes.drive)
+      ? target.subject
+      : store.getDrive();
+    if (!drive) return;
+    void managedFetch(
+      `/billing/subscription?${new URLSearchParams({ drive })}`,
+      {
+        signal: controller.signal,
+      },
+    )
+      .then(async response => {
+        if (!response.ok || response.status === 204) return;
+        const subscription = await response.json();
+        if (
+          controller.signal.aborted ||
+          subscription.plan !== 'server' ||
+          subscription.status === 'canceled'
+        )
+          return;
+        setSeats({
+          drive,
+          used: subscription.editors_used,
+          included: subscription.editors_included,
+        });
+      })
+      .catch(() => {
+        /* Do not imply hosting when billing is unavailable. */
+      });
+
+    return () => controller.abort();
+  }, [isSaas, target, store]);
+
   /** Generates the signed token and constructs the invite URL */
   const createInvite = useCallback(async () => {
+    setCreating(true);
+    setErr(undefined);
+
     try {
       if (!agent) {
         throw new Error('No agent found');
@@ -108,14 +153,10 @@ function InviteFormContent({
         const enrollments = Array.isArray(body) ? body : body.enrollments;
         if (!Array.isArray(enrollments))
           throw new Error('Could not check Cloud Server status. Try again.');
-        browserPeer = !enrollments.some(
-          e => e.drive_subject === target.subject && e.status !== 'Disabled',
-        );
-      }
-
-      if (browserPeer && !store.isLocalOnlyDrive(target.subject)) {
-        throw new Error(
-          'This drive still uses a data server. A complete local copy must be verified before switching it to browser-only sharing. Its existing server connection has been kept.',
+        browserPeer = await prepareDriveSharing(
+          store,
+          target.subject,
+          enrollments,
         );
       }
 
@@ -158,6 +199,8 @@ function InviteFormContent({
       toast.success('Copied to clipboard');
     } catch (e) {
       setErr(e);
+    } finally {
+      setCreating(false);
     }
   }, [invite, agent, target, store, isSaas]);
 
@@ -176,7 +219,11 @@ function InviteFormContent({
     return (
       <InviteFormLayout
         inDialog={inDialog}
-        actions={<Button onClick={createInvite}>Create</Button>}
+        actions={
+          <Button disabled={creating} onClick={createInvite}>
+            {creating ? 'Preparing invite…' : 'Create'}
+          </Button>
+        }
       >
         <Column gap='1rem'>
           <ResourceField
@@ -184,13 +231,19 @@ function InviteFormContent({
             propertyURL={server.properties.write}
             resource={invite}
           />
-          {isSaas && (
-            <p>
-              {allowEdits
-                ? 'Cloud Server: each editor uses one seat on this drive. An existing editor on this drive counts once. Viewers are free.'
-                : 'Browser collaboration is free. Editor seats apply only when this drive uses Cloud Server.'}
-            </p>
-          )}
+          {seats &&
+            seats.drive ===
+              (target.hasClasses(server.classes.drive)
+                ? target.subject
+                : store.getDrive()) && (
+              <p>
+                {Number.isSafeInteger(seats.used) &&
+                Number.isSafeInteger(seats.included)
+                  ? `${Math.max(0, seats.included! - seats.used!)} of ${seats.included} editor seats available on this drive.`
+                  : 'Editor seat availability for this drive is unavailable.'}{' '}
+                Viewers are free.
+              </p>
+            )}
           <ResourceField
             label={'Invite text (optional)'}
             propertyURL={core.properties.description}

--- a/browser/data-browser/src/helpers/managed/prepareDriveSharing.test.ts
+++ b/browser/data-browser/src/helpers/managed/prepareDriveSharing.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { prepareDriveSharing } from './prepareDriveSharing';
+
+const drive = 'did:ad:drive';
+
+function setup(local = false) {
+  return {
+    isLocalOnlyDrive: () => local,
+    makeDriveLocal: vi.fn(async () => {}),
+  };
+}
+
+describe('sharing an unenrolled drive with a saved server connection', () => {
+  it('verifies and switches the complete local copy before creating a peer invite', async () => {
+    const store = setup();
+    expect(await prepareDriveSharing(store, drive, [])).toBe(true);
+    expect(store.makeDriveLocal).toHaveBeenCalledWith(drive);
+  });
+  it('preserves a verification failure instead of issuing an invite', async () => {
+    const store = setup();
+    store.makeDriveLocal.mockRejectedValue(new Error('Missing attachment'));
+    await expect(prepareDriveSharing(store, drive, [])).rejects.toThrow(
+      'Missing attachment',
+    );
+  });
+  it('does not use another drive enrollment to route this drive', async () => {
+    const store = setup();
+    expect(
+      await prepareDriveSharing(store, drive, [
+        { drive_subject: 'did:ad:other', status: 'Active' },
+      ]),
+    ).toBe(true);
+    expect(store.makeDriveLocal).toHaveBeenCalledOnce();
+  });
+  it('preserves an enrolled drive connection', async () => {
+    const store = setup();
+    expect(
+      await prepareDriveSharing(store, drive, [
+        { drive_subject: drive, status: 'Active' },
+      ]),
+    ).toBe(false);
+    expect(store.makeDriveLocal).not.toHaveBeenCalled();
+  });
+  it('does not migrate an already local drive', async () => {
+    const store = setup(true);
+    expect(await prepareDriveSharing(store, drive, [])).toBe(true);
+    expect(store.makeDriveLocal).not.toHaveBeenCalled();
+  });
+});

--- a/browser/data-browser/src/helpers/managed/prepareDriveSharing.ts
+++ b/browser/data-browser/src/helpers/managed/prepareDriveSharing.ts
@@ -1,0 +1,20 @@
+type SharingStore = {
+  isLocalOnlyDrive(drive: string): boolean;
+  makeDriveLocal(drive: string): Promise<void>;
+};
+
+/** Resolve routing without interpreting a failed account lookup as no hosting. */
+export async function prepareDriveSharing(
+  store: SharingStore,
+  drive: string,
+  enrollments: { drive_subject: string; status: string }[],
+): Promise<boolean> {
+  if (store.isLocalOnlyDrive(drive)) return true;
+  if (
+    enrollments.some(e => e.drive_subject === drive && e.status !== 'Disabled')
+  )
+    return false;
+  await store.makeDriveLocal(drive);
+
+  return true;
+}

--- a/planning/README.md
+++ b/planning/README.md
@@ -31,6 +31,8 @@ now live in [`completed/`](./completed/):
 
 ## Active
 
+- [Drive sharing and hosting state](drive-sharing-state.md) — verified transition for unenrolled drives; authoritative seat counts and staging acceptance remain.
+
 Remaining work, not "this file exists."
 
 Cross-repository account recovery: the canonical active plan is

--- a/planning/drive-sharing-state.md
+++ b/planning/drive-sharing-state.md
@@ -1,0 +1,14 @@
+# Drive sharing and hosting state
+
+Status: in progress; not deployed.
+
+- [x] Inspect the reported staging drive: sync connection active without confirmed Cloud Server hosting.
+- [x] Replace the unconditional sharing refusal with the existing full local-copy verification and browser-only transition.
+- [x] Preserve server routing when local history or attachment verification fails.
+- [x] Gate seat messaging on the target drive subscription, never account-wide availability.
+- [x] Add routing regression tests, including another drive enrollment and incomplete local copies.
+- [ ] Supply authoritative per-drive editor usage from the backend. Current drive-scoped billing intentionally omits editors_used; the UI must not manufacture a number from account membership or direct ACLs.
+- [ ] Trace why the historical drive retained remote routing without an enrollment. This change repairs it when sharing; it does not establish the original cause or proactively migrate all drives.
+- [ ] Validate the full sharing flow with real browser persistence and attachments, then CI and staging acceptance.
+
+The source connection must survive a failed completeness check. Vault existence or a cached root snapshot is not proof that all history and attachments are local.


### PR DESCRIPTION
An unenrolled drive can retain a server connection from earlier routing state. Sharing previously interpreted the missing enrollment as browser sharing, then refused unconditionally because the connection was still present.

Use the existing complete-local-copy verification before switching this device to browser sharing. Missing history or attachments keeps the source connected and blocks invite generation. Show seat information only from the target drive subscription, with a numeric counter only when the API supplies both usage and capacity.

Validation: 9 focused tests pass; current-source TypeScript check passes using local source path mappings (the shared installed packages are stale); focused lint has no errors and one set-state-in-effect warning. Full browser/CI acceptance pending.

Remaining: the drive-scoped billing response omits editor usage, so authoritative counts need backend work. The original reason for the historical remote registration remains unproven; this patch repairs it when sharing rather than proactively migrating every drive. Tracked in planning/drive-sharing-state.md.
