### PR TITLE
fix: use Cloud Server before Vault during session restore

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -885,3 +885,9 @@ Onboarding dialog feedback: the authorization/invite and chatroom cases in
 `e2e.spec.ts` verify Continue remains clickable while feedback is offered.
 `onboarding-storage.spec.ts` checks feedback availability;
 `drive-template-onboarding.spec.ts` checks mobile creation and dismissal.
+
+Session restore routing: `helpers/managed/reconcile.test.ts` covers connecting the
+exact hosted drive before availability checks, clearing local-only routing,
+skipping Pending/Disabled placements and other drives, and ignoring discovery
+that completes after its deadline. Staging phone restore latency and end-to-end
+WebSocket query delivery remain unverified.

--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import {
   evaluateServerReconciliation,
+  connectHostedDrive,
   localAgentIsDisposable,
 } from './reconcile';
 import type { ManagedEnrollmentSummary } from './enrollmentApi';
@@ -65,6 +66,85 @@ describe('evaluateServerReconciliation', () => {
   afterEach(() => {
     globalThis.fetch = realFetch;
     vi.restoreAllMocks();
+  });
+
+  it('connects the restored drive before reading it and clears local-only routing', async () => {
+    mockFetch({
+      account: { email: 'a@example.com' },
+      enrollments: [enrollment({})],
+    });
+    const events: string[] = [];
+    const store = {
+      waitForServerConnected: vi.fn().mockResolvedValue(true),
+      setServerUrl: (url: string) => events.push(url),
+      unregisterLocalOnlyDrive: (drive: string) => events.push(drive),
+    };
+    const persist = vi.fn();
+    expect(await connectHostedDrive(store, 'did:ad:drive1', persist)).toBe(
+      true,
+    );
+    expect(events).toEqual(['did:ad:drive1', 'https://node1.atomicserver.eu']);
+    expect(persist).toHaveBeenCalledWith('https://node1.atomicserver.eu');
+  });
+
+  it.each(['Pending', 'Disabled'])(
+    'does not connect a %s placement',
+    async status => {
+      mockFetch({
+        account: { email: 'a@example.com' },
+        enrollments: [enrollment({ status })],
+      });
+      const store = {
+        waitForServerConnected: vi.fn().mockResolvedValue(true),
+        setServerUrl: vi.fn(),
+        unregisterLocalOnlyDrive: vi.fn(),
+      };
+      expect(await connectHostedDrive(store, 'did:ad:drive1', vi.fn())).toBe(
+        false,
+      );
+      expect(store.setServerUrl).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not switch to another subscribed drive', async () => {
+    mockFetch({
+      account: { email: 'a@example.com' },
+      enrollments: [enrollment({})],
+    });
+    const store = {
+      waitForServerConnected: vi.fn(),
+      setServerUrl: vi.fn(),
+      unregisterLocalOnlyDrive: vi.fn(),
+    };
+    expect(await connectHostedDrive(store, 'did:ad:other', vi.fn())).toBe(
+      false,
+    );
+    expect(store.setServerUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not switch servers when discovery completes after its deadline', async () => {
+    let resolve!: (response: Response) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise<Response>(done => {
+          resolve = done;
+        }),
+    );
+    const store = {
+      waitForServerConnected: vi.fn(),
+      setServerUrl: vi.fn(),
+      unregisterLocalOnlyDrive: vi.fn(),
+    };
+    expect(await connectHostedDrive(store, 'did:ad:drive1', vi.fn(), 1)).toBe(
+      false,
+    );
+    mockFetch({
+      account: { email: 'a@example.com' },
+      enrollments: [enrollment({})],
+    });
+    resolve(new Response(JSON.stringify({ email: 'a@example.com' })));
+    await new Promise(done => setTimeout(done, 0));
+    expect(store.setServerUrl).not.toHaveBeenCalled();
   });
 
   it('is ok with no managed session (self-hosted / local-only)', async () => {

--- a/browser/data-browser/src/helpers/managed/reconcile.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.ts
@@ -1,4 +1,5 @@
 import { core } from '@tomic/react';
+import { withDeadline } from '../withDeadline';
 import { PRODUCT_NAME } from './product';
 import {
   clearManagedAccountBinding,
@@ -156,14 +157,13 @@ export type ServerReconcileResult =
  * stale). `enrollment.http_origin` is the source of truth for "where does
  * this drive actually live right now."
  */
-export async function evaluateServerReconciliation(
-  currentServerUrl: string,
+async function resolveHostedDriveOrigin(
   currentDriveSubject: string | undefined,
-): Promise<ServerReconcileResult> {
+): Promise<string | undefined> {
   const managedAccount = await getManagedAccount().catch(() => null);
 
   if (!managedAccount) {
-    return { ok: true };
+    return undefined;
   }
 
   const enrollments = await getManagedEnrollments().catch(
@@ -189,15 +189,59 @@ export async function evaluateServerReconciliation(
       ? withOrigin[0]
       : undefined;
 
-  if (!match?.http_origin) {
-    return { ok: true };
+  if (!match?.http_origin) return undefined;
+
+  try {
+    const url = new URL(match.http_origin);
+
+    return ['http:', 'https:'].includes(url.protocol) ? url.origin : undefined;
+  } catch {
+    return undefined;
   }
+}
+
+/** Connect before sign-in checks data, rather than waiting for the app gate. */
+export async function connectHostedDrive(
+  store: {
+    setServerUrl(url: string): void;
+    unregisterLocalOnlyDrive(drive: string): void;
+    waitForServerConnected(timeoutMs: number): Promise<boolean>;
+  },
+  drive: string,
+  persistServer: (url: string) => void,
+  lookupTimeoutMs = 8_000,
+): Promise<boolean> {
+  // Only race the read: a late lookup must never switch an already restored session.
+  const origin = await withDeadline(
+    resolveHostedDriveOrigin(drive),
+    lookupTimeoutMs,
+    undefined,
+  );
+
+  if (!origin) return false;
+
+  store.unregisterLocalOnlyDrive(drive);
+  store.setServerUrl(origin);
+  persistServer(origin);
+  // Let the first resource/query use WS; HTTP remains available if WS cannot connect.
+  await store.waitForServerConnected(3_000);
+
+  return true;
+}
+
+export async function evaluateServerReconciliation(
+  currentServerUrl: string,
+  currentDriveSubject: string | undefined,
+): Promise<ServerReconcileResult> {
+  const origin = await resolveHostedDriveOrigin(currentDriveSubject);
+
+  if (!origin) return { ok: true };
 
   let expectedOrigin: string;
   let actualOrigin: string;
 
   try {
-    expectedOrigin = new URL(match.http_origin).origin;
+    expectedOrigin = new URL(origin).origin;
     actualOrigin = new URL(currentServerUrl).origin;
   } catch {
     // A malformed URL on either side isn't this function's problem to fix.

--- a/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
+++ b/browser/data-browser/src/views/getting-started/GettingStartedFlow.tsx
@@ -17,6 +17,7 @@ import { useSettings } from '../../helpers/AppSettings';
 import { saveAgentToIDB } from '../../helpers/agentStorage';
 import { beat } from '../../helpers/deviceLock';
 import { fetchPrivateDriveSubject } from '../../helpers/privateDrive';
+import { connectHostedDrive } from '../../helpers/managed/reconcile';
 import { deviceHasDriveData } from '../../helpers/driveData';
 import { withDeadline } from '../../helpers/withDeadline';
 import { constructOpenURL } from '../../helpers/navigation';
@@ -129,7 +130,7 @@ export function GettingStartedFlow({
   useWelcomeLayoutEffect();
   const store = useStore();
   const navigate = useNavigateWithTransition();
-  const { setAgent, setDrive, baseURL } = useSettings();
+  const { setAgent, setDrive, setServer, baseURL } = useSettings();
   // When the connected node is "managed" (reports a dashboard/portal URL via
   // /node-info), account creation goes through the portal (email
   // verification). Self-hosted / FOSS nodes report nothing here, so we keep the
@@ -643,6 +644,11 @@ export function GettingStartedFlow({
           undefined,
         ));
 
+      // Resolve hosting before a failed read sends this device to Cloud Vault.
+      const hosted = target
+        ? await connectHostedDrive(store, target, setServer)
+        : false;
+
       // A secret restores who you are, not what you have. So the app only
       // opens once the workspace is here to read: opening one we cannot read
       // shows an empty shell wearing its name, which reads as data loss.
@@ -650,9 +656,9 @@ export function GettingStartedFlow({
       // Asked before anything writes the drive, deliberately. Materializing it
       // first — which is what this flow used to do — makes every "do I have my
       // data?" check answer yes about data the device does not have.
-      const canRead = (subject: string) =>
+      const canRead = (subject: string, refresh = hosted) =>
         withDeadline(
-          deviceHasDriveData(store, subject),
+          deviceHasDriveData(store, subject, { refresh }),
           SIGN_IN_LOOKUP_TIMEOUT_MS,
           false,
         );
@@ -696,7 +702,7 @@ export function GettingStartedFlow({
         );
 
         if (restored.status === 'restored') {
-          hasData = await canRead(target);
+          hasData = await canRead(target, false);
         } else if (restored.status === 'no-backup') {
           vaultReason = restored.reason;
         } else {


### PR DESCRIPTION
## Problem and change
On a fresh device, sign-in checked the current server and fell back to Cloud Vault before discovering the drive's Cloud Server. Resolve the exact drive's hosted origin first, clear local-only routing, update the Store immediately, and allow the WebSocket to connect before refreshing availability. Vault remains the fallback when data cannot be read.

Reuse the existing placement filters and bound discovery without allowing late responses to switch a session that has already fallen back.

## Validation
- 103 focused tests passed across reconciliation, Vault, drive availability, and automatic Vault backup in the source checkout.
- Frontend typecheck and formatting passed.
- Added routing, placement, drive isolation, and late-discovery regressions.
- Phone/staging latency and end-to-end WebSocket query delivery are not yet verified.
