### PR TITLE
fix: speed up Cloud Vault restore with bounded parallel downloads

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -885,3 +885,8 @@ Onboarding dialog feedback: the authorization/invite and chatroom cases in
 `e2e.spec.ts` verify Continue remains clickable while feedback is offered.
 `onboarding-storage.spec.ts` checks feedback availability;
 `drive-template-onboarding.spec.ts` checks mobile creation and dismissal.
+
+Cloud Vault download concurrency: `helpers/managed/vault.test.ts` holds network
+responses open to verify concurrent downloads are bounded at four and that
+reverse completion preserves listing order at import. Existing progress and
+failure checks also pass. Actual staging phone restore latency remains unmeasured.

--- a/browser/data-browser/src/helpers/managed/vault.test.ts
+++ b/browser/data-browser/src/helpers/managed/vault.test.ts
@@ -548,6 +548,65 @@ describe('backupDrive', () => {
 });
 
 describe('restoreDrive', () => {
+  it('downloads concurrently with a bound and preserves listing order', async () => {
+    const objects = Array.from({ length: 9 }, (_, i) => ({
+      object_id: String(i),
+      object_key: `pack-${i}`,
+    }));
+    let active = 0;
+    let peak = 0;
+    const releases: (() => void)[] = [];
+    const db = {
+      vaultExport: vi.fn(),
+      vaultCommitSegment: vi.fn(),
+      vaultImport: vi.fn(),
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/objects'))
+        return new Response(JSON.stringify(objects));
+      if (url.endsWith('/download-urls'))
+        return new Response(
+          JSON.stringify({
+            downloads: objects.map(o => ({
+              ...o,
+              url: `https://s3.test/${o.object_id}`,
+            })),
+          }),
+        );
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise<void>(resolve => releases.push(resolve));
+      active--;
+
+      return new Response(new Uint8Array([1]));
+    });
+    const restoring = restoreDrive({
+      db,
+      drivePseudonym: PSEUDONYM,
+      devicePubkey: DEVICE,
+      driveKey: KEY,
+    });
+    await vi.waitFor(() => expect(releases.length).toBeGreaterThan(1));
+
+    while (releases.length < objects.length || active > 0) {
+      releases
+        .splice(0)
+        .reverse()
+        .forEach(release => release());
+      await new Promise(resolve => setTimeout(resolve, 0));
+      if (db.vaultImport.mock.calls.length) break;
+    }
+
+    await restoring;
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(
+      db.vaultImport.mock.calls[0][4].map(
+        (o: { objectKey: string }) => o.objectKey,
+      ),
+    ).toEqual(objects.map(o => o.object_key));
+  });
+
   it('reports nothing when the vault is empty', async () => {
     const db: VaultCapableDb = {
       vaultExport: vi.fn(),

--- a/browser/data-browser/src/helpers/managed/vault.ts
+++ b/browser/data-browser/src/helpers/managed/vault.ts
@@ -765,29 +765,46 @@ export async function restoreDrive({
   // Preserve the server's ordering: `download-urls` answers per request and is
   // not required to echo the order back.
   const urlByKey = new Map(downloads.map(d => [d.object_key, d.url]));
-  const fetched: { objectKey: string; sealed: Uint8Array }[] = [];
+  const fetched = new Array<{ objectKey: string; sealed: Uint8Array }>(
+    objects.length,
+  );
+  let next = 0;
+  let completed = 0;
+  let failed = false;
 
-  for (const [index, object] of objects.entries()) {
-    const url = urlByKey.get(object.object_key);
+  // Hide per-object network latency without opening unbounded requests on a
+  // phone. Write by listing index, never completion order.
+  await Promise.all(
+    Array.from({ length: Math.min(4, objects.length) }, async () => {
+      while (!failed && next < objects.length) {
+        const index = next++;
+        const object = objects[index];
 
-    if (!url) {
-      throw new Error(`No download URL issued for ${object.object_key}`);
-    }
+        try {
+          const url = urlByKey.get(object.object_key);
+          if (!url)
+            throw new Error(`No download URL issued for ${object.object_key}`);
+          const response = await fetch(url);
 
-    const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(
+              `Vault download failed for ${object.object_key} (${response.status})`,
+            );
+          }
 
-    if (!response.ok) {
-      throw new Error(
-        `Vault download failed for ${object.object_key} (${response.status})`,
-      );
-    }
-
-    fetched.push({
-      objectKey: object.object_key,
-      sealed: new Uint8Array(await response.arrayBuffer()),
-    });
-    onProgress?.(index + 1, objects.length);
-  }
+          fetched[index] = {
+            objectKey: object.object_key,
+            sealed: new Uint8Array(await response.arrayBuffer()),
+          };
+          completed++;
+          if (!failed) onProgress?.(completed, objects.length);
+        } catch (error) {
+          failed = true;
+          throw error;
+        }
+      }
+    }),
+  );
 
   // Every lane, not just this device's: each device appends only to its own,
   // so importing one would silently drop the rest of the drive's history.


### PR DESCRIPTION
## Problem and change
Cloud Vault restore downloaded each backup object serially, accumulating a network round trip per object even for small backups. Download up to four objects concurrently, retaining listing order for import and stopping new work after a failure. Import still happens only after every download succeeds.

## Validation
- Added a regression that holds downloads open and completes batches in reverse order, checking concurrency, its bound, and stable import ordering.
- 103 focused tests passed across Vault, reconciliation, drive availability, and automatic backup in the source checkout.
- Frontend typecheck and formatting passed.
- Actual staging phone restore latency remains unmeasured.
