### PR TITLE
Release v0.41.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+## [v0.41.0-beta.7] - 2026-09-12
+
+- Store hosted files in S3 without silently falling back to node-local storage.
+- Fix stale collection queries bringing deleted sidebar resources back.
+- Improve browser database durability and resource save-state handling.
+- Isolate E2E shard state and simplify local test tooling; full develop CI passes on the release base.
+
 - Add drive-scoped authenticated browser peer sessions; subscription-independent signaling and optional temporary TURN credentials are provided by Atomic SaaS ([#1396](https://github.com/ontola/atomic-server/issues/1396)).
 
 ## [v0.41.0-beta.6] - 2026-09-09

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 dependencies = [
  "assert_cmd",
  "async-recursion",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 dependencies = [
  "actix",
  "actix-cors",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-server-tauri"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 dependencies = [
  "actix-rt",
  "android_system_properties",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "atomic_lib"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 dependencies = [
  "anyhow",
  "argon2",

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,14 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+## [v0.41.0-beta.7] - 2026-09-12
+
+- Add template onboarding with editable previews and consistent mobile UI.
+- Prevent Cloud Vault growth on refresh and download vault objects concurrently.
+- Connect the selected hosted drive before falling back to vault restore during sign-in.
+- Preserve editor selection during remote updates and improve focus, table selection and save-state feedback.
+- Fix deleted sidebar items returning from stale queries.
+
 - Add peer rooms for up to eight simultaneous browsers on the Sync page with WebRTC collaboration, OPFS reconciliation and attachment sync without a Cloud subscription. Discovery defaults to shared Atomic SaaS signaling, independent of the drive’s data node. Export `BrowserPeerSync`, `WebRtcPeer` and `WebRtcTransport` from `@tomic/lib` ([#1396](https://github.com/ontola/atomic-server/issues/1396)).
 - Portal Open links select their workspace; ordinary resource links keep the current drive.
 - Sync distinguishes remote node data from Cloud Server enrollment, explains drive-specific plans, and refreshes account/recovery status after portal sign-in.

--- a/browser/cli/package.json
+++ b/browser/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/js-cli",
   "repository": {

--- a/browser/create-template/package.json
+++ b/browser/create-template/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "author": "Polle Pas",
   "homepage": "https://docs.atomicdata.dev/create-template/atomic-template",
   "repository": {

--- a/browser/create-template/templates/nextjs-site/package.json
+++ b/browser/create-template/templates/nextjs-site/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.11.1",
-    "@tomic/lib": "^0.41.0-beta.6",
-    "@tomic/react": "^0.41.0-beta.6",
+    "@tomic/lib": "^0.41.0-beta.7",
+    "@tomic/react": "^0.41.0-beta.7",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "loro-crdt": "^1.12.1",
@@ -25,7 +25,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@tomic/cli": "^0.41.0-beta.6",
+    "@tomic/cli": "^0.41.0-beta.7",
     "@types/node": "^20",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/browser/create-template/templates/sveltekit-site/package.json
+++ b/browser/create-template/templates/sveltekit-site/package.json
@@ -18,7 +18,7 @@
 		"@sveltejs/adapter-node": "^5.2.9",
 		"@sveltejs/kit": "^2.7.3",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
-		"@tomic/cli": "^0.41.0-beta.6",
+		"@tomic/cli": "^0.41.0-beta.7",
 		"@types/eslint": "^9.6.1",
 		"eslint": "^9.13.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -37,8 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@tomic/lib": "^0.41.0-beta.6",
-		"@tomic/svelte": "^0.41.0-beta.6",
+		"@tomic/lib": "^0.41.0-beta.7",
+		"@tomic/svelte": "^0.41.0-beta.7",
 		"loro-crdt": "^1.12.1",
 		"svelte-markdown": "^0.4.1"
 	}

--- a/browser/data-browser/package.json
+++ b/browser/data-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "author": {
     "email": "joep@ontola.io",
     "name": "Joep Meindertsma"

--- a/browser/e2e/package.json
+++ b/browser/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/e2e",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "private": true,
   "homepage": "https://atomicdata.dev/",
   "license": "MIT",

--- a/browser/edit-mode/package.json
+++ b/browser/edit-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/edit-mode",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "description": "Turn any page rendered from Atomic Data into an editable local-first clone: 'Edit this page' for visitors (guest agent + local-only drive, zero server writes) and inline-editing UI chrome.",
   "type": "module",
   "license": "MIT",

--- a/browser/lib/package.json
+++ b/browser/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/lib",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "author": "Joep Meindertsma",
   "homepage": "https://docs.atomicdata.dev/js",
   "repository": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -14,7 +14,7 @@
     "vitest": "^4.1.7"
   },
   "name": "@tomic/root",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/browser/plugin/package.json
+++ b/browser/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tomic/plugin",
   "type": "module",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "description": "Utils for building UI plugins for AtomicServer",
   "author": "Polle Pas <polle@ontola.io>",
   "license": "MIT",

--- a/browser/react/package.json
+++ b/browser/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tomic/react",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "author": "Joep Meindertsma",
   "description": "Atomic Data React library",
   "homepage": "https://docs.atomicdata.dev/usecases/react",

--- a/browser/svelte/package.json
+++ b/browser/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ontola, Polle Pas",
   "name": "@tomic/svelte",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "license": "MIT",
   "homepage": "https://docs.atomicdata.dev/svelte",
   "repository": {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT"
 name = "atomic-cli"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 
 [dependencies]
 async-recursion = "1.1.1"
-atomic_lib = { version = "0.41.0-beta.6", path = "../lib", features = [
+atomic_lib = { version = "0.41.0-beta.7", path = "../lib", features = [
     "config",
     "rdf",
 ] }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ name = "atomic-server-tauri"
 # crates.io forbids — see the note on `publish` in ../wasm/Cargo.toml.
 publish = false
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Atomic Server",
-  "version": "0.41.0-beta.6",
+  "version": "0.41.0-beta.7",
   "identifier": "io.ontola.atomicserver",
   "build": {
     "frontendDist": "../browser/data-browser/dist-tauri",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "atomic_lib"
 readme = "README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "atomic-server"
 readme = "./README.md"
 repository = "https://github.com/atomicdata-dev/atomic-server"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 
 [[bin]]
 name = "atomic-server"
@@ -170,7 +170,7 @@ version = "4.13.0"
 # present, so it adds no runtime cost for fresh installs.
 features = ["config", "db-redb", "db-sled", "rdf", "discovery", "iroh", "ring", "ws"]
 path = "../lib"
-version = "0.41.0-beta.6"
+version = "0.41.0-beta.7"
 
 [dependencies.clap]
 features = ["derive", "env", "cargo"]


### PR DESCRIPTION
Prepare v0.41.0-beta.7 from develop commit a608c3308, whose full CI passed in run 34694139457. Update release versions and lockfiles together and document changes since beta.6.

Validation: version consistency check, Cargo workspace lock regeneration, pnpm lock regeneration, and diff review. No product code changes. Tagging triggers release assets and package publishing; beta tags do not deploy production.
