### PR TITLE
Fix release CI by locking documentation tool dependencies

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -36,6 +36,12 @@ const TOUCH_WORKSPACE_SOURCES = [
 const NODE_IMAGE = 'node:22';
 const RUST_IMAGE = 'rust:bookworm';
 
+// Pin the tools and their published dependency locks. Unlocked linkcheck
+// installation picked up jiff 0.2.36, whose packaged doc includes are broken.
+const INSTALL_DOCS_TOOLS =
+  'cargo install mdbook --version 0.5.4 --locked --quiet && ' +
+  'cargo install mdbook-linkcheck --version 0.7.7 --locked --quiet';
+
 // Must match `@playwright/test` in `browser/e2e/package.json`.
 //
 // The image bakes in the browser builds its own Playwright wants, and each
@@ -350,7 +356,8 @@ export class AtomicServer {
           'echo "=== mdbook install ===" && ' +
             'if [ -x /opt/cargo-bin/bin/mdbook ] && [ -x /opt/cargo-bin/bin/mdbook-linkcheck ]; then echo "cache_hit=1"; fi && ' +
             'START=$(date +%s) && ' +
-            'cargo install mdbook mdbook-linkcheck --quiet && ' +
+            INSTALL_DOCS_TOOLS +
+            ' && ' +
             'END=$(date +%s) && ' +
             'echo "elapsed_s=$((END-START))" && ' +
             'mdbook --version && mdbook-linkcheck --version',
@@ -965,7 +972,7 @@ export class AtomicServer {
         .withExec([
           'sh',
           '-c',
-          'cargo install mdbook mdbook-linkcheck --quiet && mdbook build',
+          INSTALL_DOCS_TOOLS + ' && mdbook build',
         ])
         .directory('/docs/build')
     );

--- a/planning/beta7-docs-ci.md
+++ b/planning/beta7-docs-ci.md
@@ -1,0 +1,9 @@
+# Beta 7 documentation CI
+
+- [x] Diagnose release CI 34701516468: installing mdbook-linkcheck without a lock resolves jiff 0.2.36, whose crate references missing documentation files.
+- [x] Inspect the published crate to confirm broken include paths; linkcheck 0.7.7's published lock does not contain jiff.
+- [x] Pin mdbook and mdbook-linkcheck and use their published locks in docs builds and cache benchmarks.
+- [x] Fresh installation of mdbook 0.5.4 and mdbook-linkcheck 0.7.7 with --locked succeeded on Mancave; the current documentation built successfully.
+- [ ] Merge after validation, verify release CI, and tag beta 7 at the corrected release commit.
+
+The original release candidate d6320ccc0 must not be tagged after its failed CI. No beta tag has been published.


### PR DESCRIPTION
Release CI failed while installing mdbook-linkcheck: unlocked dependency resolution selected jiff 0.2.36, whose published crate includes nonexistent documentation paths. Pin mdbook 0.5.4 and mdbook-linkcheck 0.7.7 and install using their published lockfiles in both the docs build and cache benchmark.

Verified a fresh installation of both tools and a build of the current documentation on Mancave. Dagger TypeScript syntax and diff checks passed. The beta tag remains held pending CI validation.
