### PR TITLE
Speed up CI with immediate replication verification and prebuilt wasm-pack

### DIFF
--- a/.dagger/scripts/install-wasm-pack.sh
+++ b/.dagger/scripts/install-wasm-pack.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Install the same version as workspace.metadata.bin in Cargo.toml. Keep the
+# binary in the container layer, not a mutable cache mount: a cached install
+# must still contain its executable after Dagger evicts cache volumes.
+set -eu
+
+version=0.15.0
+case "$(uname -m)" in
+  x86_64)
+    target=x86_64-unknown-linux-musl
+    checksum=c09f971ecaed9a2efc80fdcea7a00ef6b53c7fadc8c57d1f61b53a6aa66b668a
+    ;;
+  aarch64)
+    target=aarch64-unknown-linux-musl
+    checksum=e17ef0806381c3a0acb9c9ddad643a49facaa5a2ecf657a421d4d8f3357a24b7
+    ;;
+  *) echo "Unsupported wasm-pack build architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+archive="wasm-pack-v${version}-${target}"
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT HUP INT TERM
+curl --fail --location --silent --show-error --retry 3 \
+  "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}.tar.gz" \
+  --output "$scratch/wasm-pack.tar.gz"
+printf '%s  %s\n' "$checksum" "$scratch/wasm-pack.tar.gz" | sha256sum --check
+tar -xzf "$scratch/wasm-pack.tar.gz" -C "$scratch"
+install -d "${1:-/usr/local/bin}"
+install -m 755 "$scratch/$archive/wasm-pack" "${1:-/usr/local/bin}/wasm-pack"
+"${1:-/usr/local/bin}/wasm-pack" --version

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -601,23 +601,15 @@ export class AtomicServer {
         dag.container().from(RUST_IMAGE),
         CARGO_HOME_BOOKWORM,
       )
-        // Cache `cargo install`-built binaries (wasm-pack here). Without
-        // this, each CI run recompiled wasm-pack from source (~2 min).
-        // Routed through `CARGO_INSTALL_ROOT` to a non-default path so
-        // the cache mount can't hide the rust image's preinstalled
-        // \`cargo\`/\`rustc\` at \`/usr/local/cargo/bin\`. Adding the
-        // install root's \`bin\` to \`PATH\` makes \`wasm-pack\` resolvable.
-        // \`cargo install\` no-ops when the latest version is already
-        // present.
-        .withMountedCache('/opt/cargo-bin', dag.cacheVolume('cargo-bin'), {
-          // Shared so wasm-pack and mdbook installs can proceed in parallel.
-          sharing: CacheSharingMode.Shared,
-        })
-        .withEnvVariable('CARGO_INSTALL_ROOT', '/opt/cargo-bin')
-        .withEnvVariable(
-          'PATH',
-          '/opt/cargo-bin/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        // Use the pinned upstream executable instead of compiling wasm-pack
+        // on every cold runner. Install before source inputs so Rust edits
+        // cannot invalidate this layer; no mutable volume hides the binary.
+        .withFile(
+          '/tmp/install-wasm-pack.sh',
+          this.source.file('.dagger/scripts/install-wasm-pack.sh'),
         )
+        .withExec(['sh', '/tmp/install-wasm-pack.sh'])
+        .withoutFile('/tmp/install-wasm-pack.sh')
         .withFile('/code/Cargo.toml', this.source.file('Cargo.toml'))
         .withFile('/code/Cargo.lock', this.source.file('Cargo.lock'))
         // wasm-pack runs `cargo metadata` which validates every workspace
@@ -637,29 +629,17 @@ export class AtomicServer {
           this.source.directory('atomic-plugin'),
         )
         .withDirectory('/code/tools', this.source.directory('tools'))
-        .withMountedCache('/code/target', dag.cacheVolume('rust-wasm-target-v3'))
+        .withMountedCache(
+          '/code/target',
+          dag.cacheVolume('rust-wasm-target-v3'),
+        )
         .withExec(TOUCH_WORKSPACE_SOURCES)
         .withWorkdir('/code/wasm')
-        // Install + build in a single exec so the install is part of the
-        // build step's own cache key. Splitting them lets dagger cache the
-        // `cargo install` step as "already ran" while the mounted
-        // `cargo-bin` cache volume can be cleared by the engine (e.g. after
-        // a restart with `Locked` sharing), leaving wasm-pack missing from
-        // PATH on replay ("executable file not found in $PATH"). Bundling
-        // makes any cache hit imply the binary is present too; `cargo
-        // install` no-ops when the binary is current.
-        //
-        // `CARGO_ENCODED_RUSTFLAGS` is exported INLINE so it only applies
-        // to the wasm-pack build. Setting it at container scope leaks into
-        // `cargo install wasm-pack` (which compiles wasm-pack for the host
-        // triple, not wasm32) and trips getrandom's
-        //   "wasm_js backend can be enabled only for OS-less WASM targets!"
-        // compile_error. The `\x1f` is the encoded-rustflags arg separator.
+        // The encoded-rustflags separator applies only to the WASM build.
         .withExec([
           'sh',
           '-c',
-          'cargo install wasm-pack --quiet && ' +
-            'CARGO_ENCODED_RUSTFLAGS=\'--cfg\x1fgetrandom_backend="wasm_js"\' ' +
+          'CARGO_ENCODED_RUSTFLAGS=\'--cfg\x1fgetrandom_backend="wasm_js"\' ' +
             'wasm-pack build --target web --out-dir pkg',
         ])
         .directory('/code/wasm/pkg')

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -915,3 +915,21 @@ Cloud Vault download concurrency: `helpers/managed/vault.test.ts` holds network
 responses open to verify concurrent downloads are bounded at four and that
 reverse completion preserves listing order at import. Existing progress and
 failure checks also pass. Actual staging phone restore latency remains unmeasured.
+
+## Replication completion and CI tool installation
+
+`lib/src/sync/replicate.rs` has five scripted WebSocket peer tests covering
+resource-only completion without the idle timeout, acknowledgement of every
+chunk, unrelated-drive acknowledgements, an independently mismatching hash,
+trailing blob requests and asynchronous storage errors, and the fallback for
+peers without keepalive support. They exercise the real Rust WebSocket client
+and snapshot/chunk encoding with an isolated in-memory source; the peer scripts
+simulate replies and do not validate authentication or remote import policy.
+The real-server `server/tests/it/replicate.rs` tests retain destination-data,
+repeat-push, boot-reconcile and export-authorization assertions.
+
+The pinned wasm-pack installer was executed in Dagger's `rust:bookworm` image
+on Linux x86_64, including a cached install followed by changed downstream
+source input and execution of the retained binary. Its aarch64 archive digest
+is pinned to the upstream release; native aarch64 execution is not covered by
+that check. Full CI wall-time savings require a completed hosted run.

--- a/docs/src/websockets.md
+++ b/docs/src/websockets.md
@@ -696,6 +696,15 @@ the **chunk, not its contents**: individual entries may still be skipped
 (tombstoned locally, unreadable, a failed Loro import). A sender that needs
 proof re-probes.
 
+The Rust drive-replication client counts all chunk acknowledgements before
+re-probing. On a WebSocket peer advertising `keepalive`, it then sends a
+`KEEPALIVE` and reads through the echo to drain blob requests queued after
+those acknowledgements. If no blob was requested, it can re-probe immediately
+instead of waiting for 30 seconds of silence. The echo does not acknowledge
+asynchronous blob storage: transfers with blob requests, and peers without
+`keepalive`, retain the idle wait. Only the independent matching-hash response
+sets the replication result's `in_sync` flag.
+
 A push refused **as a whole** is answered with `ERROR`, `request_id = 0`,
 code `SYNC_REJECTED (6)`, message
 `SYNC_PUSH rejected for drive <drive>: <reason>`, and **no `SYNC_OK`**.

--- a/lib/src/sync/replicate.rs
+++ b/lib/src/sync/replicate.rs
@@ -149,8 +149,8 @@ pub async fn replicate_drive_to_remote(
     Ok(outcome)
 }
 
-/// Read frames until the remote goes quiet, answering as we go. Returns how
-/// many resources we pushed in this round.
+/// Read replies until the acknowledged resource-only exchange is drained, or
+/// the remote goes quiet. Returns how many resources we pushed in this round.
 async fn drive_exchange(
     client: &WsClient,
     rx: &mut Receiver<WsMessage>,
@@ -161,6 +161,13 @@ async fn drive_exchange(
     started: std::time::Instant,
 ) -> AtomicResult<usize> {
     let mut sent_this_round = 0;
+    let mut pending_chunks = 0;
+    let mut draining = false;
+    let mut requested_blob = false;
+    let echoes_keepalive = client
+        .server_capabilities()
+        .iter()
+        .any(|c| c == "keepalive");
 
     loop {
         if started.elapsed() > TOTAL_TIMEOUT {
@@ -176,14 +183,32 @@ async fn drive_exchange(
         };
 
         match msg {
-            // A SYNC_OK arriving before we pushed anything means our hashes
-            // already match. One arriving *after* is just a per-chunk ack —
-            // it says the chunk was admitted, not that every subject in it
-            // was kept — so those fall through and we keep listening.
-            WsMessage::SyncOk { drive: d } if d == drive && sent_this_round == 0 => {
-                outcome.in_sync = true;
-
-                break;
+            WsMessage::SyncOk { drive: d } if d == drive => {
+                if sent_this_round == 0 {
+                    outcome.in_sync = true;
+                    break;
+                }
+                // Each accepted chunk has its own ack. None proves matching
+                // state: only the separate SYNC probe may set in_sync.
+                if pending_chunks > 0 {
+                    pending_chunks -= 1;
+                    if pending_chunks == 0 && echoes_keepalive {
+                        // The server queues blob requests AFTER the chunk ack.
+                        // Its WS keepalive echo drains those trailing frames;
+                        // it is not a barrier for asynchronous blob writes.
+                        client.send_keepalive().await?;
+                        draining = true;
+                    }
+                }
+            }
+            WsMessage::Keepalive if draining => {
+                draining = false;
+                if !requested_blob {
+                    break;
+                }
+                // Blob writes have no completion ack. Preserve the existing
+                // idle grace period (also used for older peers without the
+                // keepalive capability) rather than racing their storage.
             }
             WsMessage::SyncDiff { drive: d, pull, .. } if d == drive => {
                 if pull.is_empty() {
@@ -210,7 +235,9 @@ async fn drive_exchange(
                     .map(|(s, b)| (s.as_str(), b.as_slice()))
                     .collect();
 
-                for chunk in protocol::encode_sync_push_chunks(drive, &refs) {
+                let chunks = protocol::encode_sync_push_chunks(drive, &refs);
+                pending_chunks += chunks.len();
+                for chunk in chunks {
                     client.send_binary(chunk).await?;
                 }
 
@@ -219,6 +246,7 @@ async fn drive_exchange(
                 tracing::info!("[replicate] pushed {} resources of {drive}", entries.len());
             }
             WsMessage::BlobRequest { hash } => {
+                requested_blob = true;
                 // The remote imported a resource referencing a blob it lacks.
                 // Blobs are only ever served on request — it will not accept an
                 // unsolicited one.
@@ -283,4 +311,222 @@ async fn build_sync_frame(store: &Db, drive: &str) -> Vec<u8> {
     }
 
     protocol::encode_sync(drive, &drive_hash, &peers, &resources)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_tungstenite::{accept_async, tungstenite::Message, WebSocketStream};
+
+    type Peer = WebSocketStream<TcpStream>;
+
+    async fn receive(peer: &mut Peer, tag: u8) -> Vec<u8> {
+        let frame = peer.next().await.unwrap().unwrap().into_data().to_vec();
+        assert_eq!(frame.first(), Some(&tag), "unexpected frame: {frame:?}");
+        frame
+    }
+
+    async fn send(peer: &mut Peer, frame: Vec<u8>) {
+        peer.send(Message::Binary(frame.into())).await.unwrap();
+    }
+
+    async fn source() -> (Db, String) {
+        let db = Db::init_memory(Some("https://localhost".into()))
+            .await
+            .unwrap();
+        let (_, drive) = db.setup("Replication test").await.unwrap();
+        (db, drive)
+    }
+
+    async fn accept_peer(listener: TcpListener, caps: &[&str]) -> Peer {
+        let mut peer = accept_async(listener.accept().await.unwrap().0)
+            .await
+            .unwrap();
+        // This scripted peer tests exchange ordering, not AUTH verification.
+        receive(&mut peer, protocol::tag::HELLO).await;
+        receive(&mut peer, protocol::tag::AUTH).await;
+        send(&mut peer, protocol::encode_auth_ok_with_caps(caps)).await;
+        receive(&mut peer, protocol::tag::SYNC).await;
+        peer
+    }
+
+    fn request(drive: &str, count: usize) -> Vec<u8> {
+        protocol::encode_sync_diff(
+            drive,
+            &vec![drive.to_owned(); count],
+            &[],
+            &[],
+            &Default::default(),
+            &Default::default(),
+        )
+    }
+
+    async fn with_peer<F, Fut>(
+        caps: &'static [&'static str],
+        script: F,
+    ) -> AtomicResult<ReplicateOutcome>
+    where
+        F: FnOnce(Peer, String) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        let (db, drive) = source().await;
+        db.put_blob(blake3::hash(b"attachment").as_bytes(), b"attachment")
+            .await
+            .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}/ws", listener.local_addr().unwrap());
+        let remote_drive = drive.clone();
+        let peer = tokio::spawn(async move {
+            let peer = accept_peer(listener, caps).await;
+            script(peer, remote_drive).await;
+        });
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            replicate_drive_to_remote(
+                &db,
+                &drive,
+                &url,
+                &ForAgent::Sudo,
+                ReplicateAuth::PreSigned(vec![protocol::tag::AUTH]),
+            ),
+        )
+        .await
+        .expect("replication waited for the 30-second idle timeout");
+        peer.await.unwrap();
+        outcome
+    }
+
+    async fn drain(peer: &mut Peer) {
+        receive(peer, protocol::tag::KEEPALIVE).await;
+        send(peer, protocol::encode_keepalive()).await;
+    }
+
+    async fn assert_waiting(peer: &mut Peer) {
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(150), peer.next())
+                .await
+                .is_err(),
+            "client advanced before the exchange was complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn acknowledged_push_is_verified_without_waiting_for_idle() {
+        let outcome = with_peer(&["keepalive"], |mut peer, drive| async move {
+            send(&mut peer, request(&drive, 1)).await;
+            receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            drain(&mut peer).await;
+            receive(&mut peer, protocol::tag::SYNC).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+        })
+        .await
+        .unwrap();
+        assert_eq!(outcome.pushed, 1);
+        assert!(outcome.in_sync);
+    }
+
+    #[tokio::test]
+    async fn waits_for_every_chunk_ack_and_ignores_other_drives() {
+        let outcome = with_peer(&["keepalive"], |mut peer, drive| async move {
+            // Repeating one readable snapshot exercises the real chunk encoder
+            // without creating 101 unrelated resources in the test fixture.
+            send(
+                &mut peer,
+                request(&drive, protocol::SYNC_PUSH_MAX_ENTRIES + 1),
+            )
+            .await;
+            let first = receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            assert!(!protocol::decode_sync_push(&first[1..]).unwrap().last);
+            let last = receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            assert!(protocol::decode_sync_push(&last[1..]).unwrap().last);
+            send(&mut peer, protocol::encode_sync_ok("did:ad:another-drive")).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            assert_waiting(&mut peer).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            drain(&mut peer).await;
+            receive(&mut peer, protocol::tag::SYNC).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+        })
+        .await
+        .unwrap();
+        assert_eq!(outcome.pushed, protocol::SYNC_PUSH_MAX_ENTRIES + 1);
+        assert!(outcome.in_sync);
+    }
+
+    #[tokio::test]
+    async fn chunk_ack_does_not_prove_the_final_hash_matches() {
+        let outcome = with_peer(&["keepalive"], |mut peer, drive| async move {
+            send(&mut peer, request(&drive, 1)).await;
+            receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            drain(&mut peer).await;
+            receive(&mut peer, protocol::tag::SYNC).await;
+            // The remote still differs, even though it acknowledged the push.
+            send(
+                &mut peer,
+                protocol::encode_sync_diff(
+                    &drive,
+                    &[],
+                    &[drive.clone()],
+                    &[],
+                    &Default::default(),
+                    &Default::default(),
+                ),
+            )
+            .await;
+        })
+        .await
+        .unwrap();
+        assert_eq!(outcome.pushed, 1);
+        assert!(!outcome.in_sync);
+    }
+
+    #[tokio::test]
+    async fn trailing_blob_request_keeps_the_storage_grace_period() {
+        let error = with_peer(&["keepalive"], |mut peer, drive| async move {
+            send(&mut peer, request(&drive, 1)).await;
+            receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            receive(&mut peer, protocol::tag::KEEPALIVE).await;
+            let hash = *blake3::hash(b"attachment").as_bytes();
+            // The engine sends blob requests after the corresponding ack.
+            send(&mut peer, protocol::encode_blob_request(&hash)).await;
+            send(&mut peer, protocol::encode_keepalive()).await;
+            let frame = receive(&mut peer, protocol::tag::BLOB_RESPONSE).await;
+            let response = protocol::decode_blob_response(&frame[1..]).unwrap();
+            assert_eq!(response.hash, hash);
+            assert_eq!(response.bytes, b"attachment");
+            assert_waiting(&mut peer).await;
+            // Asynchronous remote storage failure must still reach the caller.
+            send(
+                &mut peer,
+                protocol::encode_error(0, protocol::error_code::UNKNOWN, "Blob storage failed"),
+            )
+            .await;
+        })
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("Blob storage failed"));
+    }
+
+    #[tokio::test]
+    async fn older_peer_without_keepalive_keeps_the_idle_fallback() {
+        let error = with_peer(&[], |mut peer, drive| async move {
+            send(&mut peer, request(&drive, 1)).await;
+            receive(&mut peer, protocol::tag::SYNC_PUSH).await;
+            send(&mut peer, protocol::encode_sync_ok(&drive)).await;
+            assert_waiting(&mut peer).await;
+            send(
+                &mut peer,
+                protocol::encode_error(0, protocol::error_code::SYNC_REJECTED, "Import refused"),
+            )
+            .await;
+        })
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("Import refused"));
+    }
 }

--- a/lib/src/sync/replicate.rs
+++ b/lib/src/sync/replicate.rs
@@ -470,7 +470,7 @@ mod tests {
                 protocol::encode_sync_diff(
                     &drive,
                     &[],
-                    &[drive.clone()],
+                    std::slice::from_ref(&drive),
                     &[],
                     &Default::default(),
                     &Default::default(),


### PR DESCRIPTION
Resource-only drive replication waited for 30 seconds of silence after a successful push, and cold CI runners compiled wasm-pack from source before building the app's WASM bundle.

This change counts every SYNC_PUSH chunk acknowledgement, drains trailing responses with the peer's advertised WebSocket KEEPALIVE echo, and immediately performs the independent hash probe when no blob was requested. Chunk acknowledgements still cannot set `in_sync`. Blob transfers and peers without keepalive support retain the existing idle grace period because the echo does not acknowledge asynchronous blob storage.

The Dagger WASM build now installs upstream wasm-pack 0.15.0 binaries with pinned SHA-256 checksums for Linux x86_64/aarch64. Installation precedes source inputs and stores the executable in the container layer, so source changes can reuse it without depending on a mutable cargo-bin cache volume.

Validation:
- Reproduced the idle wait with a failing scripted WebSocket test before changing production code; all five protocol regressions now pass (2.50s including fixture setup).
- Same real-server replication test on Mancave: **41.83s before → 11.26s after**, excluding compilation (73% shorter). This is one comparison, not an end-to-end CI estimate.
- Installer executed inside Dagger's `rust:bookworm` image: **1.1s**; subsequent install was **CACHED** and the binary executed after changed downstream source input.
- Dagger TypeScript typecheck, shell syntax check, Rust formatting and whitespace checks passed.
- All five real-server replication integration tests passed (58.74s, serial).
- Focused Clippy check passed with existing warnings; no warnings remain in the changed replication file. Hosted CI is pending completion.

Linux aarch64 execution and the complete hosted CI duration remain unverified. Coverage and protocol documentation describe the retained blob/legacy fallback.
