### PR TITLE
Fix redundant staging requests and first Cloud Server upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [STATUS.md](server/STATUS.md) to learn more about which features will remain
 
 ## UNRELEASED
 
+- Allow authenticated, admitted drives to bootstrap through hash-first sync on an empty destination, retaining signed import and existing-drive read checks.
+
 ## [v0.41.0-beta.7] - 2026-09-12
 
 - Store hosted files in S3 without silently falling back to node-local storage.

--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -915,3 +915,13 @@ Cloud Vault download concurrency: `helpers/managed/vault.test.ts` holds network
 responses open to verify concurrent downloads are bounded at four and that
 reverse completion preserves listing order at import. Existing progress and
 failure checks also pass. Actual staging phone restore latency remains unmeasured.
+
+## Staging idle requests and first Cloud Server upload
+
+- `helpers/managed/reconcile.test.ts`: a compound identity check uses one account request; catalog before/after identity checks remain intact.
+- `helpers/managed/session.test.ts`: concurrent account checks share only in-flight work; subsequent reads remain fresh, and logout/provider/token changes discard old responses.
+- `helpers/visiblePolling.test.ts`: hidden tabs pause refresh, focus/online resume it, slow requests do not overlap, failures retry, and cleanup prevents restart.
+- `e2e/tests/sync-devices.spec.ts`: two real node polls do not refetch enrollment; returning focus still refreshes account hosting for the same email.
+- `lib/src/sync/tests.rs::sync_probe_bootstraps_admitted_missing_drive_without_exposing_private_data`: hash probe and RBSR accept an empty admitted destination, signed import stores document content, and anonymous/unadmitted/existing-private reads remain denied.
+
+Live staging request counts were measured before these fixes. Deployment and post-deployment request measurement remain outstanding; the local browser test mocks the SaaS control plane and uses a real AtomicServer.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Reduce redundant Cloud Server account/enrollment requests and pause status/catalog polling in hidden tabs.
+
 ## [v0.41.0-beta.7] - 2026-09-12
 
 - Add template onboarding with editable previews and consistent mobile UI.

--- a/browser/data-browser/src/helpers/managed/enrollmentApi.ts
+++ b/browser/data-browser/src/helpers/managed/enrollmentApi.ts
@@ -7,7 +7,7 @@
 // against the control-plane `GET /api/sync-enrollments` route.
 
 import { managedFetch } from './api';
-import { getManagedAccount } from './session';
+import { getManagedAccount, type ManagedAccount } from './session';
 
 export type ManagedEnrollmentStatus = 'Active' | 'Disabled' | string;
 
@@ -34,8 +34,9 @@ export type ManagedEnrollmentSummary = {
  */
 export async function getManagedEnrollments(
   strict = false,
+  account?: ManagedAccount | null,
 ): Promise<ManagedEnrollmentSummary[]> {
-  if (!(await getManagedAccount())) {
+  if (!(account === undefined ? await getManagedAccount() : account)) {
     if (strict) throw new Error('Sign in to check Cloud Server hosting.');
 
     return [];

--- a/browser/data-browser/src/helpers/managed/reconcile.test.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import {
   evaluateServerReconciliation,
+  evaluateIdentityReconciliation,
   connectHostedDrive,
   localAgentIsDisposable,
 } from './reconcile';
@@ -349,4 +350,31 @@ describe('localAgentIsDisposable', () => {
 
     expect(await localAgentIsDisposable(store, 'did:ad:agent:a')).toBe(true);
   });
+});
+
+it('shares the account check within one identity reconciliation', async () => {
+  vi.stubEnv('VITE_MANAGED_API_BASE', 'https://portal.example/api');
+  const fetcher = vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/me'))
+        return Response.json({ email: 'one@example.com' });
+      if (url.endsWith('/recovery-secret'))
+        return new Response(null, { status: 204 });
+      if (url.endsWith('/sync-enrollments')) return Response.json([]);
+      throw new Error(`Unexpected request ${url}`);
+    });
+
+  try {
+    await expect(
+      evaluateIdentityReconciliation(undefined),
+    ).resolves.toMatchObject({ ok: true });
+    expect(
+      fetcher.mock.calls.filter(([url]) => String(url).endsWith('/me')),
+    ).toHaveLength(1);
+  } finally {
+    fetcher.mockRestore();
+    vi.unstubAllEnvs();
+  }
 });

--- a/browser/data-browser/src/helpers/managed/reconcile.ts
+++ b/browser/data-browser/src/helpers/managed/reconcile.ts
@@ -59,8 +59,10 @@ export async function evaluateIdentityReconciliation(
   }
 
   const [recovery, enrollments] = await Promise.all([
-    getRecoverySecret().catch(() => null),
-    getManagedEnrollments().catch(() => [] as ManagedEnrollmentSummary[]),
+    getRecoverySecret(managedAccount).catch(() => null),
+    getManagedEnrollments(false, managedAccount).catch(
+      () => [] as ManagedEnrollmentSummary[],
+    ),
   ]);
 
   const binding = readManagedAccountBinding();
@@ -166,7 +168,7 @@ async function resolveHostedDriveOrigin(
     return undefined;
   }
 
-  const enrollments = await getManagedEnrollments().catch(
+  const enrollments = await getManagedEnrollments(false, managedAccount).catch(
     () => [] as ManagedEnrollmentSummary[],
   );
 

--- a/browser/data-browser/src/helpers/managed/recovery.ts
+++ b/browser/data-browser/src/helpers/managed/recovery.ts
@@ -1,5 +1,5 @@
 import { accountPasskey } from './accountPasskey';
-import { getManagedAccount } from './session';
+import { getManagedAccount, type ManagedAccount } from './session';
 import { isRunningInTauri } from '../tauri';
 import { wasmBinaryUrl, wasmJsUrl } from '../wasmUrls';
 import { PRODUCT_NAME } from './product';
@@ -1386,8 +1386,13 @@ export async function saveRecoverySecret(input: RecoverySecretInput) {
   return saved;
 }
 
-export async function getRecoverySecret(): Promise<RecoverySecret | null> {
-  if (!(await getManagedAccount())) return null;
+export async function getRecoverySecret(
+  // A caller performing a compound read may reuse its freshly checked account.
+  // The endpoint still authenticates this request; no settled session is cached.
+  account?: ManagedAccount | null,
+): Promise<RecoverySecret | null> {
+  if (!(account === undefined ? await getManagedAccount() : account))
+    return null;
   // [RECOVERY-RECONSTRUCTED] body — only this function's signature survived in
   // the transcripts. Reconstructed as the GET counterpart of saveRecoverySecret
   // (PUT) above; 204/401/404 all mean "no recovery secret stored".

--- a/browser/data-browser/src/helpers/managed/session.test.ts
+++ b/browser/data-browser/src/helpers/managed/session.test.ts
@@ -3,10 +3,14 @@ const fetchMock = vi.hoisted(() => vi.fn());
 // Logout also drops the device token (and the portal it was issued by).
 const setTokenMock = vi.hoisted(() => vi.fn());
 const configured = vi.hoisted(() => vi.fn(() => true));
+const portal = vi.hoisted(() => vi.fn(() => 'https://portal.example/api'));
+const token = vi.hoisted(() => vi.fn(() => null as string | null));
 vi.mock('./api', () => ({
   managedFetch: fetchMock,
   setManagedDeviceToken: setTokenMock,
   hasManagedApi: configured,
+  getManagedApiBase: portal,
+  getManagedDeviceToken: token,
 }));
 import { getManagedAccount, logoutManagedSession } from './session';
 it('discards a session response that arrives after logout', async () => {
@@ -38,4 +42,50 @@ it('does not probe for an account without a configured control plane', async () 
   fetchMock.mockClear();
   expect(await getManagedAccount()).toBeNull();
   expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it('shares concurrent account reads but checks the next request freshly', async () => {
+  fetchMock.mockClear();
+  const pending = Promise.withResolvers<Response>();
+  fetchMock.mockReturnValueOnce(pending.promise);
+  const one = getManagedAccount();
+  const two = getManagedAccount();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  pending.resolve(Response.json({ email: 'first@example.com' }));
+  expect(await one).toEqual(await two);
+  fetchMock.mockResolvedValueOnce(
+    Response.json({ email: 'second@example.com' }),
+  );
+  expect(await getManagedAccount()).toEqual({ email: 'second@example.com' });
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it.each(['portal', 'token'])(
+  'does not reuse an in-flight read after a %s change',
+  async credential => {
+    fetchMock.mockClear();
+    const old = Promise.withResolvers<Response>();
+    fetchMock.mockReturnValueOnce(old.promise);
+    const first = getManagedAccount();
+    if (credential === 'portal')
+      portal.mockReturnValue('https://other.example/api');
+    else token.mockReturnValue('new-device-session');
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ email: 'new@example.com' }),
+    );
+    expect(await getManagedAccount()).toEqual({ email: 'new@example.com' });
+    old.resolve(Response.json({ email: 'old@example.com' }));
+    expect(await first).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    portal.mockReturnValue('https://portal.example/api');
+    token.mockReturnValue(null);
+  },
+);
+it('retries after a rejected account request', async () => {
+  fetchMock.mockRejectedValueOnce(new Error('offline'));
+  await expect(getManagedAccount()).rejects.toThrow('offline');
+  fetchMock.mockResolvedValueOnce(
+    Response.json({ email: 'online@example.com' }),
+  );
+  expect(await getManagedAccount()).toEqual({ email: 'online@example.com' });
 });

--- a/browser/data-browser/src/helpers/managed/session.ts
+++ b/browser/data-browser/src/helpers/managed/session.ts
@@ -4,7 +4,13 @@
 // route. Mirrors the captured `getManagedUser()` in helpers/managedUsage.ts.
 
 import { PRODUCT_NAME } from './product';
-import { hasManagedApi, managedFetch, setManagedDeviceToken } from './api';
+import {
+  getManagedApiBase,
+  getManagedDeviceToken,
+  hasManagedApi,
+  managedFetch,
+  setManagedDeviceToken,
+} from './api';
 
 export type ManagedAccount = {
   email: string;
@@ -18,23 +24,42 @@ let pendingLogouts = 0;
  * The signed-in Managed Sync account (cookie session against the control plane),
  * or null when not signed in. 204/401 both mean "no session".
  */
+let pendingRead:
+  | { key: string; promise: Promise<ManagedAccount | null> }
+  | undefined;
+const readKey = () =>
+  JSON.stringify([
+    sessionGeneration,
+    getManagedApiBase(),
+    getManagedDeviceToken(),
+  ]);
+
 export async function getManagedAccount(): Promise<ManagedAccount | null> {
   if (pendingLogouts > 0 || !hasManagedApi()) return null;
-  const generation = sessionGeneration;
-  const response = await managedFetch(`/me`, {});
-  if (generation !== sessionGeneration) return null;
+  const key = readKey();
+  if (pendingRead?.key === key) return pendingRead.promise;
 
-  if (response.status === 204 || response.status === 401) {
-    return null;
+  const read = async () => {
+    const response = await managedFetch('/me', {});
+    if (key !== readKey()) return null;
+    if (response.status === 204 || response.status === 401) return null;
+    if (!response.ok)
+      throw new Error(`Could not check ${PRODUCT_NAME} session.`);
+    const account = (await response.json()) as ManagedAccount;
+
+    return key === readKey() ? account : null;
+  };
+
+  const request = { key, promise: read() };
+  pendingRead = request;
+
+  try {
+    return await request.promise;
+  } finally {
+    // Share only in-flight reads. A later check must see account switches,
+    // and completion of an old credential's request must not clear a new one.
+    if (pendingRead === request) pendingRead = undefined;
   }
-
-  if (!response.ok) {
-    throw new Error(`Could not check ${PRODUCT_NAME} session.`);
-  }
-
-  const account = (await response.json()) as ManagedAccount;
-
-  return generation === sessionGeneration ? account : null;
 }
 
 const logoutListeners = new Set<() => void>();

--- a/browser/data-browser/src/helpers/visiblePolling.test.ts
+++ b/browser/data-browser/src/helpers/visiblePolling.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { startVisiblePolling } from './visiblePolling';
+let doc: EventTarget & { visibilityState: string };
+beforeEach(() => {
+  vi.useFakeTimers();
+  doc = Object.assign(new EventTarget(), { visibilityState: 'visible' });
+  vi.stubGlobal('document', doc);
+  vi.stubGlobal('window', new EventTarget());
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+it('pauses hidden tabs and refreshes once when they become visible', async () => {
+  const poll = vi.fn().mockResolvedValue(undefined);
+  const stop = startVisiblePolling(poll, 5000);
+  await vi.advanceTimersByTimeAsync(10000);
+  expect(poll).toHaveBeenCalledTimes(3);
+  doc.visibilityState = 'hidden';
+  doc.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('focus'));
+  await vi.advanceTimersByTimeAsync(60000);
+  expect(poll).toHaveBeenCalledTimes(3);
+  doc.visibilityState = 'visible';
+  doc.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(poll).toHaveBeenCalledTimes(4);
+  stop();
+  await vi.advanceTimersByTimeAsync(60000);
+  window.dispatchEvent(new Event('online'));
+  expect(poll).toHaveBeenCalledTimes(4);
+});
+it('does not overlap slow refreshes or restart after disposal', async () => {
+  const pending = Promise.withResolvers<void>();
+  const poll = vi.fn(() => pending.promise);
+  const stop = startVisiblePolling(poll, 5000);
+  await vi.advanceTimersByTimeAsync(20000);
+  window.dispatchEvent(new Event('online'));
+  expect(poll).toHaveBeenCalledTimes(1);
+  stop();
+  pending.resolve();
+  await vi.advanceTimersByTimeAsync(20000);
+  expect(poll).toHaveBeenCalledTimes(1);
+});
+it('retries a failed refresh', async () => {
+  const poll = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValue(undefined);
+  const stop = startVisiblePolling(poll, 5000);
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(poll).toHaveBeenCalledTimes(2);
+  stop();
+});

--- a/browser/data-browser/src/helpers/visiblePolling.ts
+++ b/browser/data-browser/src/helpers/visiblePolling.ts
@@ -1,0 +1,49 @@
+/** One refresh at a time, only while visible. Resume promptly after focus/online. */
+export function startVisiblePolling(
+  poll: () => Promise<unknown>,
+  intervalMs: number,
+): () => void {
+  let stopped = false;
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const clear = () => {
+    clearTimeout(timer);
+    timer = undefined;
+  };
+
+  const isVisible = () => document.visibilityState !== 'hidden';
+
+  const refresh = async () => {
+    if (stopped || running || !isVisible()) return;
+    clear();
+    running = true;
+
+    try {
+      await poll();
+    } catch {
+      // A failed refresh must not disable retries. The caller owns error UI.
+    } finally {
+      running = false;
+      if (!stopped && isVisible()) timer = setTimeout(refresh, intervalMs);
+    }
+  };
+
+  const visibility = () => {
+    clear();
+    void refresh();
+  };
+
+  document.addEventListener('visibilitychange', visibility);
+  window.addEventListener('focus', refresh);
+  window.addEventListener('online', refresh);
+  void refresh();
+
+  return () => {
+    stopped = true;
+    clear();
+    document.removeEventListener('visibilitychange', visibility);
+    window.removeEventListener('focus', refresh);
+    window.removeEventListener('online', refresh);
+  };
+}

--- a/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
+++ b/browser/data-browser/src/hooks/useAccountDriveCatalog.ts
@@ -1,3 +1,4 @@
+import { startVisiblePolling } from '../helpers/visiblePolling';
 import { useEffect, useState } from 'react';
 import { core, server, useStore } from '@tomic/react';
 import { driveDisplayMetadata } from '../helpers/managed/driveDisplayMetadata';
@@ -108,10 +109,7 @@ export function useAccountDriveCatalog(local: string[]) {
       }
     };
 
-    void refresh();
-    const interval = window.setInterval(refresh, 30000);
-    window.addEventListener('focus', refresh);
-    window.addEventListener('online', refresh);
+    const stopPolling = startVisiblePolling(refresh, 30000);
     const logout = onManagedLogout(() => {
       if (sync.snapshot) {
         try {
@@ -128,9 +126,7 @@ export function useAccountDriveCatalog(local: string[]) {
       stopped = true;
       sync.reset();
       logout();
-      window.clearInterval(interval);
-      window.removeEventListener('focus', refresh);
-      window.removeEventListener('online', refresh);
+      stopPolling();
     };
   }, [store, agent, key]);
   const current = snapshot?.agent === agent ? snapshot : null;

--- a/browser/data-browser/src/routes/SyncRoute.tsx
+++ b/browser/data-browser/src/routes/SyncRoute.tsx
@@ -1,3 +1,4 @@
+import { startVisiblePolling } from '../helpers/visiblePolling';
 import {
   ServiceGroup,
   ServiceSection,
@@ -839,16 +840,14 @@ function SyncPage() {
         if (!cancelled) setManagedInfo(info);
       });
 
-    void poll();
-
     // Re-poll so a device connecting or dropping shows up without a reload —
     // `peer/live` is a moment-to-moment fact, not a one-time read. Version and
     // node id don't change, so this is cheap and idempotent.
-    const timer = setInterval(poll, 5000);
+    const stopPolling = startVisiblePolling(poll, 5000);
 
     return () => {
       cancelled = true;
-      clearInterval(timer);
+      stopPolling();
     };
   }, [status.serverUrl]);
 
@@ -967,13 +966,17 @@ function SyncPage() {
       .catch(() => {});
   }, []);
 
+  // Node liveness changes every poll; hosting belongs to the provider/account,
+  // not to the identity of a freshly parsed node metadata object.
+  const cloudPortal = getManagedPortalUrl(managedInfo);
+
   // Does the active drive already have a Cloud Server enrollment? Drives the
   // Cloud Server CTA below. Skips entirely when no control plane is
   // reachable (pure self-hosted), so the CTA never shows there.
   useEffect(() => {
     const drive = status.drive;
 
-    if (!drive || !isCloudSyncAvailable(managedInfo)) {
+    if (!drive || !cloudPortal) {
       setCloudEnrollment(null);
 
       return;
@@ -992,7 +995,7 @@ function SyncPage() {
     return () => {
       cancelled = true;
     };
-  }, [status.drive, status.serverUrl, managedInfo, managedAccount]);
+  }, [status.drive, status.serverUrl, cloudPortal, managedAccount]);
 
   useEffect(() => {
     const refresh = () => setStatus(store.getSyncStatus());

--- a/browser/e2e/tests/sync-devices.spec.ts
+++ b/browser/e2e/tests/sync-devices.spec.ts
@@ -89,6 +89,59 @@ test.describe('sync page devices', () => {
     await expect(page.getByTestId('link-provider-panel')).not.toBeVisible();
   });
 
+  test('idle node polls do not recheck account hosting', async ({ page }) => {
+    let nodeReads = 0;
+    let enrollmentReads = 0;
+    await page.route('**/server', async route => {
+      const response = await route.fetch({
+        url: nodeReachableServerUrl(route.request().url()),
+      });
+      nodeReads++;
+      await route.fulfill({
+        json: {
+          ...(await response.json()),
+          'https://atomicdata.dev/properties/server/managed': true,
+          'https://atomicdata.dev/properties/server/portalUrl':
+            'http://localhost:49237',
+        },
+      });
+    });
+    await page.route('**/api/**', route => {
+      const path = new URL(route.request().url()).pathname;
+      if (path === '/api/sync-enrollments') enrollmentReads++;
+
+      return route.fulfill({
+        json:
+          path === '/api/me'
+            ? { email: 'polling-test@example.com' }
+            : path === '/api/drives/catalog'
+              ? { drives: [], removed: [] }
+              : [],
+      });
+    });
+    await gotoSync(page);
+    await expect(
+      page.getByTestId('cloud-server-row').getByRole('button', {
+        name: 'Set up Cloud Server',
+        exact: true,
+      }),
+    ).toBeVisible();
+    // Let the initial account/enrollment effects finish, then observe two real
+    // liveness polls, shorter than the independent 30-second catalog interval.
+    await page.waitForTimeout(300);
+    const baseline = { nodeReads, enrollmentReads };
+    await expect
+      .poll(() => nodeReads, { timeout: 14000 })
+      .toBeGreaterThanOrEqual(baseline.nodeReads + 2);
+    await page.waitForTimeout(300);
+    expect(enrollmentReads).toBe(baseline.enrollmentReads);
+    // Returning from portal sign-in must still refresh even for the same email.
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await expect
+      .poll(() => enrollmentReads)
+      .toBeGreaterThan(baseline.enrollmentReads);
+  });
+
   test('the pairing code on screen is a routable envelope', async ({
     page,
   }) => {

--- a/lib/src/sync/engine.rs
+++ b/lib/src/sync/engine.rs
@@ -972,10 +972,23 @@ pub async fn drive_items_for(
     agent: &crate::agents::ForAgent,
 ) -> Result<Vec<crate::sync::rbsr::Item>, String> {
     let drive_subject = crate::Subject::from_raw(drive, store.get_base_domain().as_deref());
-    let drive_resource = store
-        .get_resource(&drive_subject)
-        .await
-        .map_err(|_| "not readable".to_string())?;
+    let drive_resource = match store.get_resource(&drive_subject).await {
+        Ok(resource) => resource,
+        Err(error) => {
+            // A first upload has no remote root to authorize a read against.
+            // Expose only an empty destination to authenticated writers whose
+            // drive is admitted (or may be enrolled). Do not enroll on a read:
+            // SYNC_PUSH still verifies admission, genesis and signed snapshots.
+            let policy = store.sync_policy();
+            if error.error_type == crate::errors::AtomicErrorType::NotFoundError
+                && !matches!(agent, crate::agents::ForAgent::Public)
+                && (policy.admit_drive_write(drive) || policy.may_enroll_drive(drive, agent))
+            {
+                return Ok(Vec::new());
+            }
+            return Err("not readable".to_string());
+        }
+    };
     crate::hierarchy::check_read(store, &drive_resource, agent)
         .await
         .map_err(|e| e.to_string())?;

--- a/lib/src/sync/tests.rs
+++ b/lib/src/sync/tests.rs
@@ -2109,6 +2109,124 @@ mod peer_sync_tests {
         assert!(err.message.contains("SYNC refused"), "{}", err.message);
     }
 
+    #[tokio::test]
+    async fn sync_probe_bootstraps_admitted_missing_drive_without_exposing_private_data() {
+        use crate::sync::engine::{drive_items_for, handle_frame};
+        use crate::sync::policy::SyncPolicy;
+        use crate::sync::protocol::{encode_sync_probe, tag};
+        struct Admission {
+            allowed: String,
+        }
+        impl SyncPolicy for Admission {
+            fn drive_is_allowed(&self, drive: &str) -> bool {
+                drive == self.allowed
+            }
+            fn drive_within_quota(&self, _: &str) -> bool {
+                true
+            }
+            fn may_enroll_drive(&self, _: &str, _: &ForAgent) -> bool {
+                false
+            }
+        }
+        let source = Db::init_temp("probe_source").await.unwrap();
+        let (alice, drive) = source.setup("Alice").await.unwrap();
+        let destination = Db::init_temp("probe_destination").await.unwrap();
+        destination.set_sync_policy(std::sync::Arc::new(Admission {
+            allowed: drive.clone(),
+        }));
+        let mut owner = ForAgent::AgentSubject(alice.subject.clone());
+        let reply = handle_frame(
+            &encode_sync_probe(&drive, "nonempty"),
+            &destination,
+            &mut owner,
+        )
+        .await;
+        assert_eq!(
+            reply[0][0],
+            tag::SYNC_RESEND,
+            "a newly admitted drive must reach bootstrap"
+        );
+        assert!(
+            drive_items_for(&destination, &drive, &owner)
+                .await
+                .unwrap()
+                .is_empty(),
+            "RBSR must also see the empty destination"
+        );
+        assert!(
+            drive_items_for(&destination, &drive, &ForAgent::Public)
+                .await
+                .is_err(),
+            "anonymous callers cannot probe even an admitted missing drive"
+        );
+        // The normal signed import path remains authoritative after the empty
+        // fingerprint. Verify real content reaches the previously empty node.
+        let document = source
+            .create_resource(
+                "https://atomicdata.dev/classes/Document",
+                &drive,
+                "First upload",
+                None,
+            )
+            .await
+            .unwrap();
+        let frames = crate::sync::engine::handle_sync_vv(
+            &drive,
+            "",
+            &[],
+            &std::collections::HashMap::new(),
+            &source,
+            &owner,
+        )
+        .await;
+        let mut imported = 0;
+        for frame in frames {
+            if frame[0] == tag::SYNC_PUSH {
+                let push = crate::sync::protocol::decode_sync_push(&frame[1..]).unwrap();
+                imported +=
+                    crate::sync::engine::import_sync_push(&push, &destination, &owner, false)
+                        .await
+                        .unwrap()
+                        .0;
+            }
+        }
+        assert!(imported >= 2);
+        let saved = destination
+            .get_resource(&document.as_str().into())
+            .await
+            .unwrap();
+        assert_eq!(
+            saved.get(crate::urls::NAME).unwrap().to_string(),
+            "First upload"
+        );
+        let mut public = ForAgent::Public;
+        assert_eq!(
+            handle_frame(
+                &encode_sync_probe(&drive, "nonempty"),
+                &destination,
+                &mut public
+            )
+            .await[0][0],
+            tag::ERROR
+        );
+        let (_, other_drive) = source.setup("Other").await.unwrap();
+        assert_eq!(
+            handle_frame(
+                &encode_sync_probe(&other_drive, "nonempty"),
+                &destination,
+                &mut owner
+            )
+            .await[0][0],
+            tag::ERROR
+        );
+        assert!(
+            drive_items_for(&source, &other_drive, &owner)
+                .await
+                .is_err(),
+            "an existing private drive must stay unreadable even on an open node"
+        );
+    }
+
     /// The hash-first probe answers "in sync" purely from `drive_sync_hash`.
     /// For that to ever say yes, the standalone hash MUST equal the hash
     /// `handle_sync_vv` compares against — and it MUST change when the drive's

--- a/planning/README.md
+++ b/planning/README.md
@@ -17,6 +17,10 @@ Protocol reference lives in the public docs:
 discuss how that protocol is used internally, but should not duplicate the
 wire reference.
 
+## Staging investigations
+
+- [Idle request amplification and first Cloud Server upload](staging-request-audit.md): reproduced on staging; fixes and regression coverage prepared, deployment verification pending.
+
 ## Decisions
 
 Decision documents: one question each, written as an RFC with a recommendation.

--- a/planning/staging-request-audit.md
+++ b/planning/staging-request-audit.md
@@ -1,0 +1,86 @@
+# Staging idle request audit — 2026-09-12
+
+## Reproduction
+
+- [x] Create a fresh staging account: `staging-e2e+requests-1789235386688@ontola.io`.
+- [x] Create local data: **Request audit document**, with a description identifying this investigation.
+- [x] Grant Cloud Server access through the existing audited per-drive admin API. No Stripe purchase or production change.
+- [x] Accept hosting consent in the real deployed app.
+- [x] Capture two 60-second idle windows (Sync page and document page), after a 10-second settling period, using Chromium DevTools Protocol.
+- [x] Diagnose initial hosting failure and exercise the existing full-VV fallback in the disposable browser.
+- [x] Verify managed-node import logs and signed HTTP document readback; UI shows **In sync**, 3 resources, 6.3 KB.
+
+Deployed browser identifies itself as `0.41.0-beta.7`, commit `e110aa4`.
+Account/browser state is isolated in `/tmp/staging-request-audit/profile` (parent directory mode 0700). No existing user drives were changed. The test account and its granted drive remain available for regression testing. Browser processes used by the test are closed when measurements finish.
+
+## Healthy-state measurements
+
+After successful remote readback, each window was 60 seconds with no user actions. These count observed HTTP requests, including preflights; WebSocket frames are separate.
+
+| Request | Sync page | Document page |
+| --- | ---: | ---: |
+| Account `/me` | 31 | 18 |
+| Enrollments | 17 | 5 |
+| Recovery backup | 5 | 5 |
+| Node metadata | 12 | 0 |
+| Catalog POST + preflight | 4 | 4 |
+| **Total (including Vault status requests)** | **72** | **33** |
+
+Raw sanitized request URLs, times and initiator stacks: `/tmp/staging-request-audit/network.json`. No request bodies, credentials, or response bodies were recorded in that trace.
+
+## Root causes
+
+### 1. Node liveness polling retriggers account/enrollment checks
+
+`browser/data-browser/src/routes/SyncRoute.tsx` polls `fetchManagedInfo(serverUrl)` every 5 seconds and calls `setManagedInfo(info)`. Every parsed response is a new object. The Cloud Server enrollment effect depends on the entire `managedInfo` object, rather than the provider/drive identity. Consequently, unchanged node metadata reruns `driveHasCloudEnrollment`, which calls `getManagedEnrollments(true)`, which first calls `/api/me` and then `/api/sync-enrollments`.
+
+Result: every 5 seconds there is a `/server` → `/me` → `/sync-enrollments` sequence. This continues after successful sync. Node peer liveness changing does not imply account hosting enrollment changed.
+
+### 2. Catalog refresh performs full identity reconciliation twice
+
+`hooks/useAccountDriveCatalog.ts` refreshes every 30 seconds and on focus/online. `helpers/managed/driveCatalog.ts:DriveCatalogSync.refresh` calls its identity callback before and after POSTing the catalog. The callback runs `evaluateIdentityReconciliation`.
+
+Each reconciliation calls `/me`, then both `getRecoverySecret` and `getManagedEnrollments`; each of those independently calls `/me` again. Thus one catalog refresh triggers **6 account checks + 2 recovery reads + 2 enrollment reads + 1 catalog POST**, plus the observed CORS OPTIONS preflight. These extra `/me` calls are not authorization requirements of the endpoints: each API request already authenticates on the server. Nevertheless, any optimization must preserve the before/after account-change and logout protections.
+
+### 3. Backup watchers add periodic account checks
+
+`components/CloudVaultWatcher.tsx` and `helpers/managed/vaultAutoBackup.ts` have 60-second retry paths. Backup work checks the account and may perform additional reconciliation/enrollment checks. These overlap the catalog refresh. They must continue to detect late account linking and data arrival, but should share work where safe and avoid uploading unchanged data.
+
+### 4. Separate first-upload failure in hash-first sync
+
+The UI accepted hosting setup and the managed node received the agent resource, but the new drive and document did not arrive. Signed HTTP readback returned 404. WebSocket diagnostics showed:
+
+```
+SYNC refused for <new-drive>: not readable
+RBSR_FP refused for <new-drive>: not readable
+```
+
+`lib/src/sync/engine.rs:drive_items_for` requires the drive to exist and be readable before computing the hash-first probe. A drive being uploaded for the first time does not exist there yet. The client never reaches normal bootstrap through this rejected probe, leaving the UI at **Finish Cloud Server setup / Syncing**.
+
+Diagnostic intervention was limited to this test browser: invoke its existing `sendReducedSyncState` path for the pending drive. RBSR timed out, then its existing catch branch sent a full version-vector SYNC. Normal server admission and signed import checks remained active. Server logs at `2026-09-12T18:00:56Z` confirmed **3 resources imported**, including the document. Signed HTTP readback succeeded and the UI showed **In sync**. No server binary or production setting was modified.
+
+This establishes a first-sync regression in the hash/probe optimization, separate from the repeated HTTP metadata reads. It is not evidence of a PKARR/DHT failure.
+
+## Fixes prepared for review
+
+- [x] Scope enrollment refresh to provider URL, account refresh, drive and server; unchanged node metadata no longer retriggers it.
+- [x] Reuse a freshly checked account inside compound reconciliation (three `/me` reads become one), while retaining both before/after catalog identity checks.
+- [x] Share concurrent account reads without caching settled results; discard responses after logout, provider or device-token changes.
+- [x] Pause node/catalog polling in hidden tabs, resume on visibility/focus/online, and prevent overlapping slow requests.
+- [x] Let authenticated admitted/may-enroll missing drives start hash-first sync. Existing private roots still require read access; import still requires admission and valid signed data.
+- [x] Cover account request counts, credential races, polling lifecycle and retries with Vitest.
+- [x] Cover repeated live node polls and same-account focus refresh in Playwright against a real local server with a mocked SaaS API.
+- [x] Cover first upload into an empty destination through signed import, asserting document content and denied anonymous/unadmitted/private access.
+
+The 30-second visible catalog interval and its before/after identity checks remain intentional. Vault's backup retry lifecycle is unchanged. General rejected-probe timeout handling is a separate transport improvement; this fix addresses the verified first-upload refusal at its source.
+
+## Validation and rollout
+
+- Data-browser TypeScript check and local library builds pass.
+- Managed-helper and polling tests: 226 passed across 18 files, with two Vitest workers.
+- Rust sync tests: 56 passed, including empty-destination bootstrap and access checks.
+- Focused Chromium regression: one worker; two real five-second polls plus focus refresh. The local server uses an isolated data directory.
+- [ ] Merge/deploy after review and green CI.
+- [ ] Repeat the two 60-second staging measurements on the deployed fix. Pre-fix counts above must not be presented as post-fix results.
+
+No source fixes have been deployed by this task. The temporary staging test account and granted drive remain available for this final verification.


### PR DESCRIPTION
An idle staging Sync page made 72 HTTP requests/minute, including repeated account and enrollment checks after every node-status poll. A separate hash-first sync regression refused newly admitted drives because their root had not reached the destination yet.

Scope enrollment refresh to stable provider/drive/server values while retaining account and focus refreshes. Reuse the fresh account within compound reconciliation and share only in-flight account requests, with logout/provider/token invalidation. Node and catalog polling pauses in hidden tabs and never overlaps slow refreshes; catalog identity checks before and after updates remain intact.

Allow authenticated admitted (or eligible-to-enroll) missing drives to report an empty hash/RBSR destination so their first upload can proceed. Existing private roots still require read access; signed import, genesis and admission checks remain authoritative. Anonymous and unadmitted probes remain denied.

Validation:
- 226 managed-helper/polling tests passed across 18 files, two workers.
- 56 Rust sync tests passed, including signed document import into an empty destination and access-denial regressions.
- Focused Chromium test passed (one worker, 13.9 seconds): two real status polls do not refetch enrollment; focus still refreshes the same account. Real local server, mocked SaaS control plane.
- Data-browser typecheck and local library builds pass; changed-file lint has no errors (existing React warnings remain).

The staging reproduction, measured request breakdown, and remaining rollout checks are in `planning/staging-request-audit.md`. No deployment or full E2E-suite run is claimed. Post-deployment idle request measurement is still required; the 30-second visible catalog interval and Vault retry lifecycle remain unchanged.
