### PR TITLE
Fix stale meeting and right-side panels across sessions

### DIFF
--- a/TESTING_COVERAGE.md
+++ b/TESTING_COVERAGE.md
@@ -915,3 +915,9 @@ Cloud Vault download concurrency: `helpers/managed/vault.test.ts` holds network
 responses open to verify concurrent downloads are bounded at four and that
 reverse completion preserves listing order at import. Existing progress and
 failure checks also pass. Actual staging phone restore latency remains unmeasured.
+
+## Right-panel lifecycle
+
+`components/RightPanel/panelState.test.ts` covers session-local initial state, exclusive panels, cleared meeting selection, account/drive scoping, stale callbacks, and missing/unauthorized versus temporarily unavailable targets.
+
+`e2e/tests/right-panel-lifecycle.spec.ts` asserts visible panel state with legacy localStorage values for meeting/comments/AI, SPA navigation away from commentable resources, deletion of an explicitly opened meeting, and switching drives and back without resurrecting the panel. Existing `meetings.spec.ts` agenda/start/end coverage verifies that minutes and explicitly opened meeting chat still work.

--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 
 ## UNRELEASED
 
+- Stop restoring stale right-side panels across sessions, accounts and drives; close meeting/comments panels when their target disappears.
+
 ## [v0.41.0-beta.7] - 2026-09-12
 
 - Add template onboarding with editable previews and consistent mobile UI.

--- a/browser/data-browser/src/components/CommentsPanel/CommentsPanelContainer.tsx
+++ b/browser/data-browser/src/components/CommentsPanel/CommentsPanelContainer.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { dataBrowser, useResource, useStore } from '@tomic/react';
 import { styled } from 'styled-components';
 import { RightPanel } from '../RightPanel/RightPanel';
-import { useRightPanel } from '../RightPanel/RightPanelContext';
+import { useContextualPanel } from '../RightPanel/useContextualPanel';
 import { useCurrentSubject } from '../../helpers/useCurrentSubject';
 import { useLastSeenComments } from '../../hooks/useLastSeenComments';
 import { getResourcesDrive } from '../../helpers/getResourcesDrive';
@@ -21,8 +21,8 @@ import { Column } from '../Row';
  * is just a regular client-signed commit.
  */
 export const CommentsPanelContainer: React.FC = () => {
-  const { activePanel } = useRightPanel();
-  const isOpen = activePanel === 'comments';
+  const [subject] = useCurrentSubject();
+  const isOpen = useContextualPanel('comments', subject);
 
   return (
     <RightPanel isOpen={isOpen} testId='comments-panel'>

--- a/browser/data-browser/src/components/Navigation.tsx
+++ b/browser/data-browser/src/components/Navigation.tsx
@@ -85,7 +85,9 @@ export function NavWrapper({ children }: NavWrapperProps): JSX.Element {
   );
 
   return (
-    <RightPanelProvider>
+    <RightPanelProvider
+      scope={JSON.stringify([agent?.subject, drive, hideGlobalChrome])}
+    >
       <AISidebarContextProvider>
         {/* The single app-wide resource context menu (right-click). Mounted here
          * so its actions have the AI-sidebar, dialog, and router contexts. */}

--- a/browser/data-browser/src/components/Presence/FollowSessionPanelContainer.tsx
+++ b/browser/data-browser/src/components/Presence/FollowSessionPanelContainer.tsx
@@ -3,6 +3,7 @@ import { useCurrentAgent, useDrivePresence, useResource } from '@tomic/react';
 import { styled, css } from 'styled-components';
 import { FaNoteSticky, FaVideo } from 'react-icons/fa6';
 import { RightPanel } from '../RightPanel/RightPanel';
+import { useContextualPanel } from '../RightPanel/useContextualPanel';
 import { useRightPanel } from '../RightPanel/RightPanelContext';
 import { useFollow } from './FollowContext';
 import { PresenceAvatarMenu } from './PresenceAvatarMenu';
@@ -23,30 +24,19 @@ const ConferenceRoom = lazy(
  * joined (following its leader) or the one you're leading.
  */
 export const FollowSessionPanelContainer: React.FC = () => {
-  const { activePanel } = useRightPanel();
-  const isOpen = activePanel === 'followSession';
+  const { followedSession, activeMeeting } = useFollow();
+  const { selectedMeeting } = useRightPanel();
+  const subject = selectedMeeting ?? followedSession ?? activeMeeting;
+  const isOpen = useContextualPanel('followSession', subject);
 
   return (
     <RightPanel isOpen={isOpen} testId='follow-session-panel'>
-      {isOpen && <FollowSessionPanel />}
+      {isOpen && subject && (
+        <FollowSessionChat subject={subject} key={subject} />
+      )}
     </RightPanel>
   );
 };
-
-function FollowSessionPanel() {
-  const { followedSession, activeMeeting } = useFollow();
-  const { selectedMeeting } = useRightPanel();
-  const liveSubject = followedSession ?? activeMeeting;
-  const chatroomSubject = selectedMeeting ?? liveSubject;
-
-  if (!chatroomSubject) {
-    return null;
-  }
-
-  // Keyed so per-meeting state (like an ongoing call) resets when the
-  // panel switches to a different meeting.
-  return <FollowSessionChat subject={chatroomSubject} key={chatroomSubject} />;
-}
 
 function FollowSessionChat({ subject }: { subject: string }) {
   const chatroom = useResource(subject);

--- a/browser/data-browser/src/components/RightPanel/RightPanelContext.tsx
+++ b/browser/data-browser/src/components/RightPanel/RightPanelContext.tsx
@@ -5,9 +5,14 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import { useLocalStorage } from '../../hooks/useLocalStorage';
 
-export type RightPanelId = 'ai' | 'comments' | 'followSession';
+import {
+  emptyPanelState,
+  updatePanelState,
+  type RightPanelId,
+} from './panelState';
+
+export type { RightPanelId } from './panelState';
 
 /**
  * Manages which panel occupies the right side of the screen. Panels are
@@ -32,29 +37,29 @@ const RightPanelContext = createContext<{
 
 export const useRightPanel = () => useContext(RightPanelContext);
 
-export const RightPanelProvider: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
-  const [activePanel, setActivePanel] = useLocalStorage<RightPanelId | null>(
-    'atomic.rightPanel.active',
-    null,
-  );
-  const [selectedMeeting, setSelectedMeeting] = useState<string>();
+export const RightPanelProvider: React.FC<
+  React.PropsWithChildren<{ scope: string }>
+> = ({ children, scope }) => {
+  // Open panels are transient context, not a browser preference. Persisting only
+  // the panel ID resurrected empty meeting drawers after a new session.
+  const [state, setState] = useState(() => emptyPanelState(scope));
+  const current = state.scope === scope ? state : emptyPanelState(scope);
+  if (state.scope !== scope) setState(current);
+  const { activePanel, selectedMeeting } = current;
+
+  useEffect(() => {
+    try {
+      window.localStorage.removeItem('atomic.rightPanel.active');
+    } catch {
+      // Panel state also works when browser storage is unavailable.
+    }
+  }, []);
 
   const setPanelOpen = useCallback(
     (panel: RightPanelId, action: React.SetStateAction<boolean>) => {
-      setActivePanel(prev => {
-        const isOpen = prev === panel;
-        const open = typeof action === 'function' ? action(isOpen) : action;
-
-        if (open) {
-          return panel;
-        }
-
-        return isOpen ? null : prev;
-      });
+      setState(previous => updatePanelState(previous, scope, panel, action));
     },
-    [setActivePanel],
+    [scope],
   );
 
   const togglePanel = useCallback(
@@ -64,17 +69,18 @@ export const RightPanelProvider: React.FC<React.PropsWithChildren> = ({
 
   const openMeetingPanel = useCallback(
     (subject: string) => {
-      setSelectedMeeting(subject);
-      setPanelOpen('followSession', true);
+      setState(previous =>
+        previous.scope === scope
+          ? {
+              scope,
+              activePanel: 'followSession',
+              selectedMeeting: subject,
+            }
+          : previous,
+      );
     },
-    [setPanelOpen],
+    [scope],
   );
-
-  useEffect(() => {
-    if (activePanel !== 'followSession') {
-      setSelectedMeeting(undefined);
-    }
-  }, [activePanel]);
 
   return (
     <RightPanelContext.Provider

--- a/browser/data-browser/src/components/RightPanel/panelState.test.ts
+++ b/browser/data-browser/src/components/RightPanel/panelState.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { AtomicError, ErrorType } from '@tomic/react';
+import {
+  emptyPanelState,
+  updatePanelState,
+  type PanelState,
+} from './panelState';
+import { panelTargetAvailable } from './useContextualPanel';
+
+const meeting: PanelState = {
+  scope: 'alice/drive-one',
+  activePanel: 'followSession',
+  selectedMeeting: 'did:ad:meeting',
+};
+
+describe('right panel lifecycle', () => {
+  it('starts closed and without a selected meeting', () => {
+    expect(emptyPanelState('alice/drive-one')).toEqual({
+      scope: 'alice/drive-one',
+      activePanel: null,
+    });
+  });
+  it('clears the meeting when another panel opens or it is closed', () => {
+    expect(updatePanelState(meeting, meeting.scope, 'comments', true)).toEqual({
+      scope: meeting.scope,
+      activePanel: 'comments',
+      selectedMeeting: undefined,
+    });
+    expect(
+      updatePanelState(meeting, meeting.scope, 'followSession', false)
+        .selectedMeeting,
+    ).toBeUndefined();
+  });
+  it('closing an inactive panel does not close the current one', () => {
+    expect(updatePanelState(meeting, meeting.scope, 'comments', false)).toEqual(
+      meeting,
+    );
+  });
+  it.each(['bob/drive-one', 'alice/drive-two'])(
+    'does not carry panel context into %s or accept an old callback',
+    scope => {
+      const switched = emptyPanelState(scope);
+      expect(switched.activePanel).toBeNull();
+      expect(switched.selectedMeeting).toBeUndefined();
+      expect(
+        updatePanelState(switched, meeting.scope, 'followSession', true),
+      ).toBe(switched);
+      expect(
+        updatePanelState(switched, scope, 'followSession', true)
+          .selectedMeeting,
+      ).toBeUndefined();
+    },
+  );
+  it('toggle operations use the current state', () => {
+    const open = updatePanelState(
+      emptyPanelState('a'),
+      'a',
+      'ai',
+      value => !value,
+    );
+    expect(open.activePanel).toBe('ai');
+    expect(
+      updatePanelState(open, 'a', 'ai', value => !value).activePanel,
+    ).toBeNull();
+  });
+  it('closes targets that disappeared or lost access, without treating offline/loading as deletion', () => {
+    expect(panelTargetAvailable()).toBe(false);
+    expect(panelTargetAvailable('meeting')).toBe(true);
+    for (const type of [ErrorType.NotFound, ErrorType.Unauthorized])
+      expect(
+        panelTargetAvailable('meeting', new AtomicError('gone', type)),
+      ).toBe(false);
+    for (const type of [ErrorType.Transport, ErrorType.Server])
+      expect(
+        panelTargetAvailable('meeting', new AtomicError('retry', type)),
+      ).toBe(true);
+  });
+});

--- a/browser/data-browser/src/components/RightPanel/panelState.ts
+++ b/browser/data-browser/src/components/RightPanel/panelState.ts
@@ -1,0 +1,31 @@
+export type RightPanelId = 'ai' | 'comments' | 'followSession';
+export type PanelState = {
+  scope: string;
+  activePanel: RightPanelId | null;
+  selectedMeeting?: string;
+};
+export const emptyPanelState = (scope: string): PanelState => ({
+  scope,
+  activePanel: null,
+});
+
+export function updatePanelState(
+  previous: PanelState,
+  scope: string,
+  panel: RightPanelId,
+  action: boolean | ((open: boolean) => boolean),
+): PanelState {
+  // Ignore callbacks from a meeting/account operation started in an old scope.
+  if (previous.scope !== scope) return previous;
+  const current = previous;
+  const isOpen = current.activePanel === panel;
+  const open = typeof action === 'function' ? action(isOpen) : action;
+  const activePanel = open ? panel : isOpen ? null : current.activePanel;
+
+  return {
+    scope,
+    activePanel,
+    selectedMeeting:
+      activePanel === 'followSession' ? current.selectedMeeting : undefined,
+  };
+}

--- a/browser/data-browser/src/components/RightPanel/useContextualPanel.ts
+++ b/browser/data-browser/src/components/RightPanel/useContextualPanel.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import {
+  isNotFound,
+  isUnauthorized,
+  StoreEvents,
+  useStore,
+  useResourceSnapshot,
+} from '@tomic/react';
+import { useRightPanel } from './RightPanelContext';
+import type { RightPanelId } from './panelState';
+
+/** A loading/offline resource may recover; a missing/inaccessible target cannot. */
+export function panelTargetAvailable(subject?: string, error?: Error): boolean {
+  return !!subject && !(error && (isNotFound(error) || isUnauthorized(error)));
+}
+
+export function useContextualPanel(
+  panel: RightPanelId,
+  subject?: string,
+): boolean {
+  const { activePanel, setPanelOpen } = useRightPanel();
+  const store = useStore();
+  const { error } = useResourceSnapshot(
+    activePanel === panel ? subject : undefined,
+  );
+  const available = panelTargetAvailable(subject, error);
+  useEffect(() => {
+    if (activePanel === panel && !available) setPanelOpen(panel, false);
+  }, [activePanel, available, panel, setPanelOpen]);
+  useEffect(() => {
+    if (activePanel !== panel || !subject) return;
+
+    // Deletion evicts the resource; it need not produce a fetch/error snapshot.
+    return store.on(StoreEvents.ResourceRemoved, removed => {
+      if (store.normalizeSubject(removed) === store.normalizeSubject(subject)) {
+        setPanelOpen(panel, false);
+      }
+    });
+  }, [store, activePanel, panel, subject, setPanelOpen]);
+
+  return activePanel === panel && available;
+}

--- a/browser/e2e/tests/right-panel-lifecycle.spec.ts
+++ b/browser/e2e/tests/right-panel-lifecycle.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from './fixtures';
+import { before } from './test-utils';
+
+for (const panel of ['followSession', 'comments', 'ai']) {
+  test(`does not restore stale ${panel} panel from another session`, async ({
+    page,
+  }) => {
+    await before({ page });
+    await page.evaluate(
+      value =>
+        localStorage.setItem('atomic.rightPanel.active', JSON.stringify(value)),
+      panel,
+    );
+    await page.reload();
+    await expect(
+      page.getByRole('button', { name: 'More', exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '[data-testid="follow-session-panel"][data-open], [data-testid="comments-panel"][data-open], [data-testid="ai-sidebar"][data-open]',
+      ),
+    ).toHaveCount(0);
+  });
+}
+
+test('comments close when navigating to a page without a resource', async ({
+  page,
+}) => {
+  await before({ page });
+  await page.getByTestId('navbar-comments-button').click();
+  await expect(page.getByTestId('comments-panel')).toHaveAttribute(
+    'data-open',
+    '',
+  );
+  await page.getByRole('link', { name: /Sync$/ }).click();
+  await expect(page.getByTestId('comments-panel')).not.toHaveAttribute(
+    'data-open',
+    '',
+  );
+  await page.goBack();
+  await expect(page.getByTestId('navbar-comments-button')).toBeVisible();
+  await expect(page.getByTestId('comments-panel')).not.toHaveAttribute(
+    'data-open',
+    '',
+  );
+});
+
+test('deleting an explicitly opened meeting closes its panel', async ({
+  page,
+}) => {
+  await before({ page });
+  await page.getByRole('button', { name: 'New Meeting' }).first().click();
+  await page.getByRole('button', { name: 'Open chat', exact: true }).click();
+  await expect(page.getByTestId('follow-session-panel')).toHaveAttribute(
+    'data-open',
+    '',
+  );
+  await page.evaluate(async () => {
+    const subject = new URL(location.href).searchParams.get('subject')!;
+    await window.store.getResourceLoading(subject).destroy();
+  });
+  await expect(page.getByTestId('follow-session-panel')).not.toHaveAttribute(
+    'data-open',
+    '',
+  );
+});
+
+test('switching drives closes a panel without resurrecting it on return', async ({
+  page,
+}) => {
+  await before({ page });
+  const original = await page.evaluate(() => window.store.getDrive());
+  await page.getByTestId('navbar-comments-button').click();
+  await expect(page.getByTestId('comments-panel')).toHaveAttribute(
+    'data-open',
+    '',
+  );
+  await page.evaluate(async () => {
+    const drive = await window.store.createDrive('Second panel test drive', {
+      personal: false,
+    });
+    window.store.setDrive(drive.subject);
+  });
+  await expect(page.getByTestId('comments-panel')).not.toHaveAttribute(
+    'data-open',
+    '',
+  );
+  await page.evaluate(drive => window.store.setDrive(drive), original);
+  await expect(page.getByTestId('comments-panel')).not.toHaveAttribute(
+    'data-open',
+    '',
+  );
+});


### PR DESCRIPTION
The right panel persisted its type in localStorage while keeping the selected meeting only in memory. Reloading or starting a new session could therefore reopen a blank meeting sidebar. The same global setting carried comments and AI panels between accounts and drives.

Keep open state and meeting selection together in memory, clear the legacy key, and reset panel state when the account, drive, or onboarding visibility changes. Ignore callbacks from an old scope. Meeting/comments panels close when their target is absent, deleted or inaccessible; transient network errors and loading do not count as deletion. Comments close on navigation to non-resource pages. Explicit meeting chat and the existing agenda/start/end flow remain available.

Validation:
- Reproduced before the fix: legacy meeting state restored one open panel when zero was expected.
- 7 unit tests passed for panel transitions, scoping/stale callbacks and target availability.
- 7 Chromium tests passed with one worker in 14.8 seconds: three legacy panel values across reload, comments navigation, actual meeting deletion, drive switch/back, and the existing agenda/start/end test.
- Data-browser typecheck and changed-file lint/format passed.

Uses a real local AtomicServer and isolated test data. No full E2E run or staging deployment is claimed. Separate from request-polling PR #1474.
